### PR TITLE
Added the bwa short alignment (bwa mem) module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 work/
 data/
 results/
+tools/bwa/mem_ignore
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 work/
 data/
 results/
-tools/bwa/mem_ignore
 .DS_Store

--- a/tools/bwa/mem/Dockerfile
+++ b/tools/bwa/mem/Dockerfile
@@ -1,0 +1,9 @@
+FROM nfcore/base
+LABEL authors="Jeremy Guntoro" \
+      description="Docker image containing all requirements for nf-core/modules/bwa/mem module"
+
+COPY environment.yml /
+RUN conda env create -f /environment.yml && conda clean -a
+ENV PATH /opt/conda/envs/nf-core-bwa-mem/bin:$PATH
+
+

--- a/tools/bwa/mem/environment.yml
+++ b/tools/bwa/mem/environment.yml
@@ -1,0 +1,10 @@
+# You can use this file to create a conda environment for this pipeline:
+#   conda env create -f environment.yml
+name: nf-core-bwa-mem
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::bwa=0.7.17
+  - bioconda::samtools=1.9

--- a/tools/bwa/mem/main.nf
+++ b/tools/bwa/mem/main.nf
@@ -1,0 +1,27 @@
+params.bwa_options = "-M -B 2"
+params.sequencer = "ILLUMINA"
+
+process bwa_mem {
+    tag {id}
+
+    publishDir "${params.outdir}/bwa_mem", mode: 'copy'
+
+    //TO-DO: Change container declaration, for now a test container is present in my personal docker acccount
+    container 'jeremy1805/bwa-mem-img'
+
+    input:
+        tuple val(id), path(reads)
+        path genomeindex
+        val indexprefix
+
+    output:
+        tuple path("*.bam"), path("*.bai")
+
+    script:
+    """
+    bwa mem -t ${task.cpus} -R "@RG\\tID:${id}\\tLB:${id}\\tSM:${id}\\tPL:${params.sequencer}" \\
+    ${params.bwa_options} ${indexprefix} ${reads} | samtools sort -@8 -O BAM -o ${id}.bam -
+
+    samtools index ${id}.bam
+    """
+}

--- a/tools/bwa/mem/meta.yml
+++ b/tools/bwa/mem/meta.yml
@@ -15,19 +15,18 @@ input:
     -
         - id:
             type: val
-            description: read id for paired-end sequences
+            description: read/read pair id
         - reads:
             type: file
             description: Input fastq file
             pattern: *.{fastq,fq}
-        - genome:
-            type: file
-            description: Input fasta reference genome
-            pattern: *.{fasta,fa}
         - index:
             type: file
             description: bwa indexes file
             pattern: *.{fasta,fa}.{amb,ann,bwt,pac,sa}
+        - prefix:
+            type: val
+            description: bwa index prefix, equivalent to index file names without extensions. Usually the reference genome file name unless otherwise specified.
 output:
     -
         - bam:

--- a/tools/bwa/mem/meta.yml
+++ b/tools/bwa/mem/meta.yml
@@ -23,7 +23,7 @@ input:
         - index:
             type: file
             description: bwa indexes file
-            pattern: *.{fasta,fa}.{amb,ann,bwt,pac,sa}
+            pattern: *.{amb,ann,bwt,pac,sa}
         - prefix:
             type: val
             description: bwa index prefix, equivalent to index file names without extensions. Usually the reference genome file name unless otherwise specified.

--- a/tools/bwa/mem/meta.yml
+++ b/tools/bwa/mem/meta.yml
@@ -1,0 +1,43 @@
+name: bwa mem
+description: Performs fastq alignment to a fasta reference using the burrows-wheeler aligner
+keywords:
+    - mem
+    - bwa
+    - alignment
+tools:
+    - bwa:
+        description: |
+            BWA is a software package for mapping DNA sequences against a large reference genome, such as the human genome.
+        homepage: http://bio-bwa.sourceforge.net/
+        documentation: http://www.htslib.org/doc/samtools.html
+        arxiv: arXiv:1303.3997
+input:
+    -
+        - id:
+            type: val
+            description: read id for paired-end sequences
+        - reads:
+            type: file
+            description: Input fastq file
+            pattern: *.{fastq,fq}
+        - genome:
+            type: file
+            description: Input fasta reference genome
+            pattern: *.{fasta,fa}
+        - index:
+            type: file
+            description: bwa indexes file
+            pattern: *.{fasta,fa}.{amb,ann,bwt,pac,sa}
+output:
+    -
+        - bam:
+            type: file
+            description: Output bam file
+            pattern: *.bam
+        - bamindex:
+            type: file
+            description: Output bam index file
+            pattern: *.bai
+
+authors:
+    - @jeremy1805

--- a/tools/bwa/mem/test/main.nf
+++ b/tools/bwa/mem/test/main.nf
@@ -1,0 +1,13 @@
+#!/usr/bin/env nextflow
+nextflow.preview.dsl = 2
+include '../../../../nf-core/module_testing/check_process_outputs.nf' params(params)
+include '../main.nf' params(params)
+
+reads = '../../../../test-datasets/tools/bwa/mem/reads/*_R{1,2}_001.fastq.gz'
+index = '../../../../test-datasets/tools/bwa/mem/index/H3N2.{amb,ann,bwt,pac,sa}'
+prefix = 'H3N2'
+
+workflow {
+  read_input=Channel.fromFilePairs(reads)
+  bwa_mem(read_input,file(index),prefix)
+}

--- a/tools/bwa/mem/test/nextflow.config
+++ b/tools/bwa/mem/test/nextflow.config
@@ -1,0 +1,2 @@
+docker.enabled = true
+params.outdir = './results'


### PR DESCRIPTION
I stuck to the standard alignment process format, where a single reference is assumed. However, I was a bit conflicted as to whether a multi-reference approach would be more appropriate, as this would be less intuitive, but more general. I envision doing this by making the process accept a single tuple containing (read id, fastq read files, index prefix, index files) as input. For the multi-reference case, read_ch.combine(index_ch) can then be implemented as an input to the module.  This would also allow  individual samples to be aligned to different references. 

I bundled alignment with samtools indexing, as the two steps are usually performed together. This requires a custom container with both tools. A dockerfile of the container I used has been attached. I have also included the container under my personal docker repository within the process, but this will change once the standard approach for multi-tool  processes has been decided. 

Finally, I don't know whether including the readId in the process output would be a good idea.   