### PR TITLE
Added DSL2 module for MultiQC

### DIFF
--- a/tools/multiqc/main.nf
+++ b/tools/multiqc/main.nf
@@ -1,0 +1,32 @@
+nextflow.preview.dsl=2
+
+process MULTIQC {
+	
+    // tag "FastQC - $sample_id"
+    
+    input:
+	    path (file)
+		val (outdir)
+		val (multiqc_args)
+        // multiqc_args are best passed into the workflow in the following manner:
+        // --multiqc_args="--exlude STAR --title custom_report_title"
+		val (verbose)
+
+	output:
+	    path "*html",       emit: html
+
+	publishDir "${outdir}/multiqc",
+		mode: "copy", overwrite: true
+
+    script:
+
+		if (verbose){
+			println ("[MODULE] MULTIQC ARGS: " + multiqc_args)
+		}
+
+		"""
+		module load multiqc
+		multiqc $multiqc_args -x work . 
+		"""
+
+}

--- a/tools/multiqc/main.nf
+++ b/tools/multiqc/main.nf
@@ -25,7 +25,6 @@ process MULTIQC {
 		}
 
 		"""
-		module load multiqc
 		multiqc $multiqc_args -x work . 
 		"""
 

--- a/tools/multiqc/meta.yml
+++ b/tools/multiqc/meta.yml
@@ -1,0 +1,26 @@
+name: MultiQC
+description: Aggregate results from bioinformatics analyses across many samples into a single report
+keywords:
+    - QC
+    - bioinformatics tools
+    - Beautiful stand-alone HTML report
+tools:
+    - fastqc:
+        description: |
+            MultiQC searches a given directory for analysis logs and compiles a HTML report.
+            It's a general use tool, perfect for summarising the output from numerous bioinformatics tools.
+        homepage: https://multiqc.info/
+        documentation: https://multiqc.info/docs/
+input:
+    -
+        - reads:
+            type: file
+            description: List of report file(s)
+output:
+    -
+        - multiqc_report:
+            type: file
+            description: MultiQC report
+            pattern: *multiqc*.html
+authors:
+    - @FelixKrueger

--- a/tools/multiqc/test/main.nf
+++ b/tools/multiqc/test/main.nf
@@ -1,0 +1,44 @@
+#!/usr/bin/env nextflow
+nextflow.preview.dsl=2
+
+params.outdir = "."
+params.verbose = false
+params.multiqc_args = ''
+
+// include '../../../nf-core/module_testing/check_process_outputs.nf'
+include '../main.nf'
+
+if (params.verbose){
+    println ("[WORKFLOW] MULTIQC ARGS: "          + params.multiqc_args)
+}
+
+multiqc_ch = Channel
+  .fromPath( ['../../../test-datasets/*trimming_report.txt','../../../test-datasets/*fastqc.zip','../../../test-datasets/*screen.txt','../../../test-datasets/*bowtie2_stats.txt'] )
+  .collect()   // collect() flattens all channels to single list
+  // .view()   // view the files in the channel
+  
+
+// Run the workflow
+workflow {
+
+    main:
+        // This is an example workflow for real reads aligned with Bowtie2. Just for illustration purposes
+        
+        // FASTQC          (file_ch, params.outdir, params.fastqc_args, params.verbose)
+        // FASTQ_SCREEN    (file_ch, params.outdir, params.fastq_screen_args, params.verbose)
+        // TRIM_GALORE     (file_ch, params.outdir, params.trim_galore_args, params.verbose)
+        // FASTQC2         (TRIM_GALORE.out.reads, params.outdir, params.fastqc_args, params.verbose)
+        // BOWTIE2         (TRIM_GALORE.out.reads, params.outdir, params.bowtie2_args, params.verbose)
+     
+        // merging channels for MultiQC
+        // multiqc_ch = FASTQC.out.report.mix(
+        //     TRIM_GALORE.out.report,
+        //     FASTQ_SCREEN.out.report,
+        //     FASTQC2.out.report,
+        //     BOWTIE2.out.stats,
+        // ).collect()     
+
+        MULTIQC                          (multiqc_ch, params.outdir, params.multiqc_args, params.verbose)
+
+        // .check_output() TODO
+}

--- a/tools/multiqc/test/nextflow.config
+++ b/tools/multiqc/test/nextflow.config
@@ -1,0 +1,2 @@
+// docker.enabled = true
+params.outdir = './results'


### PR DESCRIPTION
This module uses the output of a simple ChIPseq pipeline, namely:
`FastQC`->`FastQ_Screen`->`Trim Galore`->`FastQC`->`Bowtie2`

The module accepts additional parameters in the usual way to customise the MultiQC experience (e.g.: `--multiqc_args="-o custom_output_dirname --title custom_report_title"`)

The files that are being fed to the MultiQC channel are:
```
test_R1_fastqc.zip
test_R2_fastqc.zip
test_R1.fastq.gz_trimming_report.txt
test_R2.fastq.gz_trimming_report.txt
test_R1_screen.txt
test_R1_val_1_fastqc.zip
test_R2_val_2_fastqc.zip
test_GRCm38_bowtie2_stats.txt
```
