### PR TITLE
Added HISAT2 module and test workflow

### DIFF
--- a/tools/bowtie2/main.nf
+++ b/tools/bowtie2/main.nf
@@ -1,0 +1,55 @@
+nextflow.preview.dsl=2
+params.genome = ''
+
+process BOWTIE2 {
+	// depending on the genome used one might want/need to adjust the memory settings.
+	// For the E. coli test data this is probably not required
+
+	// label 'bigMem' 
+	// label 'multiCore'
+		
+    input:
+	    tuple val(name), path(reads)
+		val (outdir)
+		val (bowtie2_args)
+		val (verbose)
+
+	output:
+	    path "*bam",  emit: bam
+		path "*stats.txt", emit: stats 
+
+	publishDir "$outdir/bowtie2",
+		mode: "copy", overwrite: true
+
+	script:
+		if (verbose){
+			println ("[MODULE] BOWTIE2 ARGS: " + bowtie2_args)
+		}
+
+		cores = 4
+
+		readString = ""
+
+		// Options we add are
+		bowtie2_options = bowtie2_args
+		bowtie2_options +=  " --no-unal "  // We don't need unaligned reads in the BAM file
+		
+		// single-end / paired-end distinction. Might also be handled via params.single_end 
+		if (reads instanceof List) {
+			readString = "-1 " + reads[0] + " -2 " + reads[1]
+		}
+		else {
+			readString = "-U " + reads
+		}
+		
+		index = params.genome["bowtie2"]
+		bowtie2_name = name + "_" + params.genome["name"]
+
+		println ("bowtie2 -x ${index} -p ${cores} ${bowtie2_options} ${readString}  2>${bowtie2_name}_bowtie2_stats.txt | samtools view -bS -F 4 -F 8 -F 256 -> ${bowtie2_name}_bowtie2.bam")
+		"""
+		module load bowtie2
+		module load samtools
+		bowtie2 -x ${index} -p ${cores} ${bowtie2_options} ${readString}  2>${bowtie2_name}_bowtie2_stats.txt | samtools view -bS -F 4 -F 8 -F 256 -> ${bowtie2_name}_bowtie2.bam
+		"""
+
+}

--- a/tools/bowtie2/main.nf
+++ b/tools/bowtie2/main.nf
@@ -45,10 +45,7 @@ process BOWTIE2 {
 		index = params.genome["bowtie2"]
 		bowtie2_name = name + "_" + params.genome["name"]
 
-		println ("bowtie2 -x ${index} -p ${cores} ${bowtie2_options} ${readString}  2>${bowtie2_name}_bowtie2_stats.txt | samtools view -bS -F 4 -F 8 -F 256 -> ${bowtie2_name}_bowtie2.bam")
 		"""
-		module load bowtie2
-		module load samtools
 		bowtie2 -x ${index} -p ${cores} ${bowtie2_options} ${readString}  2>${bowtie2_name}_bowtie2_stats.txt | samtools view -bS -F 4 -F 8 -F 256 -> ${bowtie2_name}_bowtie2.bam
 		"""
 

--- a/tools/bowtie2/meta.yml
+++ b/tools/bowtie2/meta.yml
@@ -1,0 +1,37 @@
+name: Bowtie 2 
+description: Ultrafast alignment to reference genome
+keywords:
+    - Alignment
+    - Short reads
+    - FM Index
+tools:
+    - fastqc:
+        description: |
+            Bowtie 2 is an ultrafast and memory-efficient tool for aligning sequencing reads
+            to long reference sequences. It is particularly good at aligning reads of about
+            50 up to 100s or 1,000s of characters, and particularly good at aligning to relatively
+            long (e.g. mammalian) genomes. Bowtie 2 indexes the genome with an FM Index to keep
+            its memory footprint small: for the human genome, its memory footprint is typically
+            around 3.2 GB. Bowtie 2 supports gapped, local, and paired-end alignment modes.
+        homepage: http://bowtie-bio.sourceforge.net/bowtie2/index.shtml
+        documentation: http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml
+input:
+    -
+        - sample_id:
+            type: string
+            description: Sample identifier
+        - reads:
+            type: file
+            description: Input FastQ file, or pair of files
+output:
+    -
+        - report:
+            type: file
+            description: mapping statistics report
+            pattern: *bowtie2_stats.txt
+        - alignment:
+            type: file
+            description: alignment file in BAM format
+            pattern: *bowtie2.bam
+authors:
+    - @FelixKrueger

--- a/tools/bowtie2/test/main.nf
+++ b/tools/bowtie2/test/main.nf
@@ -1,0 +1,31 @@
+#!/usr/bin/env nextflow
+nextflow.preview.dsl=2
+
+params.outdir = "."
+params.genome = ""
+params.bowtie2_args = ''
+// Bowtie2 arguments should be supplied in the following format to work:
+// --bowtie2_args="--score-min L,0,-0.8"
+
+params.verbose = false
+
+if (params.verbose){
+    println ("[WORKFLOW] BOWTIE2 ARGS: "      + params.bowtie2_args)
+}
+
+// for other genomes this needs to be handled somehow to return all possible genomes
+genomeValues = ["name" : params.genome]
+genomeValues["bowtie2"] = "/bi/home/fkrueger/VersionControl/nf-core-modules/test-datasets/indices/bowtie2/E_coli/${params.genome}";
+
+include '../main.nf'   params(genome: genomeValues)
+
+ch_read_files = Channel
+  .fromFilePairs('../../../test-datasets/Ecoli*{1,2}.fastq.gz',size:-1)
+  // .view()  // to check whether the input channel works
+
+workflow {
+
+    main:
+        BOWTIE2(ch_read_files, params.outdir, params.bowtie2_args, params.verbose)
+    
+}

--- a/tools/bowtie2/test/nextflow.config
+++ b/tools/bowtie2/test/nextflow.config
@@ -1,0 +1,2 @@
+docker.enabled = true
+params.outdir = './results'

--- a/tools/hisat2/main.nf
+++ b/tools/hisat2/main.nf
@@ -52,8 +52,6 @@ process HISAT2 {
         hisat_name = name + "_" + params.genome["name"]
 
         """
-        module load hisat2
-        module load samtools
         hisat2 -p ${cores} ${hisat_options} -x ${index} ${splices} ${readString}  2>${hisat_name}_hisat2_stats.txt | samtools view -bS -F 4 -F 8 -F 256 -> ${hisat_name}_hisat2.bam
         """
 

--- a/tools/hisat2/main.nf
+++ b/tools/hisat2/main.nf
@@ -1,0 +1,60 @@
+nextflow.preview.dsl=2
+params.genome = ''
+
+process HISAT2 {
+    // depending on the genome used one might want/need to adjust the memory settings.
+    // For the E. coli test data this is probably not required
+    // label 'bigMem'
+    // label 'multiCore'
+
+    input:
+        tuple val(name), path(reads)
+        val (outdir)
+        val (hisat2_args)
+        val (verbose)
+
+    output:
+        path "*bam",       emit: bam
+        path "*stats.txt", emit: stats 
+
+    publishDir "$outdir/hisat2",
+        mode: "copy", overwrite: true
+
+    script:
+    
+        if (verbose){
+            println ("[MODULE] HISAT2 ARGS: " + hisat2_args)
+        }
+    
+        cores = 4
+        readString = ""
+        hisat_options = hisat2_args
+
+        // Options we add are
+        hisat_options = hisat_options + " --no-unal --no-softclip "
+
+        if (reads instanceof List) {
+            readString = "-1 "+reads[0]+" -2 "+reads[1]
+            hisat_options = hisat_options + " --no-mixed --no-discordant"
+        }
+        else {
+            readString = "-U "+reads
+        }
+        index = params.genome["hisat2"]
+        
+        splices = ''
+        if (params.genome.containsKey("hisat2_splices")){
+            splices = " --known-splicesite-infile " + params.genome["hisat2_splices"]
+        }
+        else{
+            println ("No key 'hisat2_splices' was supplied. Skipping...")
+        }
+        hisat_name = name + "_" + params.genome["name"]
+
+        """
+        module load hisat2
+        module load samtools
+        hisat2 -p ${cores} ${hisat_options} -x ${index} ${splices} ${readString}  2>${hisat_name}_hisat2_stats.txt | samtools view -bS -F 4 -F 8 -F 256 -> ${hisat_name}_hisat2.bam
+        """
+
+}

--- a/tools/hisat2/meta.yml
+++ b/tools/hisat2/meta.yml
@@ -1,0 +1,37 @@
+name: HISAT2 
+description: Graph-based alignment of next generation sequencing reads to a population of genomes
+keywords:
+    - Alignment
+    - Short reads
+    - graph FM Index (GFM)
+    - RNA-seq
+tools:
+    - fastqc:
+        description: |
+            HISAT2 is a fast and sensitive alignment program for mapping next-generation
+            sequencing reads (whole-genome, transcriptome, and exome sequencing data)
+            against the general human population (as well as against a single reference genome).
+            Based on GCSA (an extension of BWT for a graph) it is designed and implemented as a
+            graph FM index (GFM).
+        homepage: http://daehwankimlab.github.io/hisat2/
+        documentation: https://ccb.jhu.edu/software/hisat2/manual.shtml
+input:
+    -
+        - sample_id:
+            type: string
+            description: Sample identifier
+        - reads:
+            type: file
+            description: Input FastQ file, or pair of files
+output:
+    -
+        - report:
+            type: file
+            description: mapping statistics report
+            pattern: *hisat2_stats.txt
+        - alignment:
+            type: file
+            description: alignment file in BAM format
+            pattern: *hisat2.bam
+authors:
+    - @FelixKrueger

--- a/tools/hisat2/test/main.nf
+++ b/tools/hisat2/test/main.nf
@@ -1,0 +1,34 @@
+#!/usr/bin/env nextflow
+nextflow.preview.dsl=2
+
+params.outdir = "."
+params.genome = ""
+params.hisat2_args = ''
+// HISAT2 arguments should be supplied in the following format to work:
+// --hisat2_args="--score-min L,0,-0.8"
+
+params.verbose = false
+
+if (params.verbose){
+    println ("[WORKFLOW] HISAT2 ARGS ARE: "       + params.hisat2_args)
+}
+// for other genomes this needs to be handled somehow to return all possible genomes
+genomeValues = ["name" : params.genome]
+genomeValues["hisat2"] = "/bi/home/fkrueger/VersionControl/nf-core-modules/test-datasets/indices/hisat2/E_coli/${params.genome}";
+
+include '../main.nf'   params(genome: genomeValues)
+
+ch_read_files = Channel
+  .fromFilePairs('../../../test-datasets/Ecoli*{1,2}.fastq.gz',size:-1)
+  // .view()  // to check whether the input channel works
+
+workflow {
+
+    main:
+        HISAT2(ch_read_files, params.outdir, params.hisat2_args, params.verbose)
+}
+
+
+
+
+

--- a/tools/hisat2/test/nextflow.config
+++ b/tools/hisat2/test/nextflow.config
@@ -1,0 +1,2 @@
+// docker.enabled = true
+params.outdir = './results'


### PR DESCRIPTION
Input data is the same E. coli test DNA data which is also used for Bowtie2. 

E. coli has to my knowledge no splice sites file, but the module handles `--known_splice_sites <file>` if this is supplied. 

Another comment: the output file is getting piped to `samtools view`. Not exactly sure whether this is an acceptable dependency, or how we are supposed to handle that. I suppose it is alright, as other tools also have dependencies...