### PR TITLE
Minor style improvements

### DIFF
--- a/software/bowtie2/main.nf
+++ b/software/bowtie2/main.nf
@@ -8,6 +8,9 @@ process BOWTIE2 {
     // label 'bigMem'
     // label 'multiCore'
 
+    publishDir "$outdir/bowtie2",
+        mode: "copy", overwrite: true
+
     input:
         tuple val(name), path(reads)
         val (outdir)
@@ -17,9 +20,6 @@ process BOWTIE2 {
     output:
         path "*bam",  emit: bam
         path "*stats.txt", emit: stats
-
-    publishDir "$outdir/bowtie2",
-        mode: "copy", overwrite: true
 
     script:
         if (verbose){

--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -1,13 +1,13 @@
 process bwa_index {
-    tag {fasta}
+    tag "$fasta"
 
     container 'quay.io/biocontainers/bwa:0.7.17--hed695b0_7'
 
     input:
-        path(fasta)
+        path fasta
 
     output:
-        path("${fasta}.*")
+        path "${fasta}.*"
 
     script:
     """

--- a/software/bwa/mem/main.nf
+++ b/software/bwa/mem/main.nf
@@ -2,7 +2,7 @@ params.bwa_options = "-M -B 2"
 params.sequencer = "ILLUMINA"
 
 process bwa_mem {
-    tag {id}
+    tag "$id"
 
     publishDir "${params.outdir}/bwa_mem", mode: 'copy'
 

--- a/software/cutadapt/main.nf
+++ b/software/cutadapt/main.nf
@@ -4,10 +4,10 @@ process cutadapt {
     container 'quay.io/biocontainers/cutadapt:1.16--py27_1'
 
     input:
-    tuple val(sample_id), file(reads)
+    tuple val(sample_id), path(reads)
 
     output:
-    tuple sample_id, file("trimmed_*.fastq")
+    tuple sample_id, path("trimmed_*.fastq")
 
     script:
     forward_fq = "trimmed_1.fastq"

--- a/software/fastq_screen/main.nf
+++ b/software/fastq_screen/main.nf
@@ -2,25 +2,25 @@ nextflow.preview.dsl=2
 
 process FASTQ_SCREEN {
 
+    publishDir "$outputdir",
+        mode: "link", overwrite: true
+
     // depending on the number of genomes and the type of genome (e.g. plants!), memory needs to be ample!
     // label 'bigMem'
     // label 'multiCore'
 
     input:
         tuple val(name), path(reads)
-        val (outputdir)
+        val outputdir
         // fastq_screen_args are best passed in to the workflow in the following manner:
         // --fastq_screen_args="--subset 200000 --force"
-        val (fastq_screen_args)
-        val (verbose)
+        val fastq_screen_args
+        val verbose
 
     output:
         path "*png",  emit: png
         path "*html", emit: html
         path "*txt",  emit: report
-
-    publishDir "$outputdir",
-        mode: "link", overwrite: true
 
     script:
         println(name)

--- a/software/gatk/dict/main.nf
+++ b/software/gatk/dict/main.nf
@@ -4,14 +4,14 @@ process gatk_dict {
     container 'quay.io/biocontainers/gatk4-spark:4.1.4.1--1'
 
     input:
-        path(fasta)
+        path fasta
 
     output:
-        path("${fasta.baseName}.dict")
+        path "${fasta.baseName}.dict"
 
     script:
     """
-    gatk --java-options "-Xmx${task.memory.toGiga()}g" \
+    gatk --java-options "-Xmx${task.memory.giga}g" \
         CreateSequenceDictionary \
         --REFERENCE ${fasta} \
         --OUTPUT ${fasta.baseName}.dict

--- a/software/hisat2/main.nf
+++ b/software/hisat2/main.nf
@@ -7,18 +7,18 @@ process HISAT2 {
     // label 'bigMem'
     // label 'multiCore'
 
+    publishDir "$outdir/hisat2",
+        mode: "copy", overwrite: true
+
     input:
         tuple val(name), path(reads)
-        val (outdir)
-        val (hisat2_args)
-        val (verbose)
+        val outdir
+        val hisat2_args
+        val verbose
 
     output:
         path "*bam",       emit: bam
         path "*stats.txt", emit: stats
-
-    publishDir "$outdir/hisat2",
-        mode: "copy", overwrite: true
 
     script:
 

--- a/software/htslib/tabix/main.nf
+++ b/software/htslib/tabix/main.nf
@@ -1,13 +1,13 @@
 process htslib_tabix {
-    tag {vcf}
+    tag "$vcf"
 
     container 'quay.io/biocontainers/tabix:0.2.6--ha92aebf_0'
 
     input:
-        path(vcf)
+        path vcf
 
     output:
-        path("${vcf}.tbi")
+        path "${vcf}.tbi"
 
     script:
     """

--- a/software/multiqc/main.nf
+++ b/software/multiqc/main.nf
@@ -4,19 +4,19 @@ process MULTIQC {
 
     // tag "FastQC - $sample_id"
 
+    publishDir "${outdir}/multiqc",
+        mode: "copy", overwrite: true
+
     input:
-        path (file)
-        val (outdir)
-        val (multiqc_args)
+        path file
+        val outdir
+        val multiqc_args
         // multiqc_args are best passed into the workflow in the following manner:
         // --multiqc_args="--exlude STAR --title custom_report_title"
-        val (verbose)
+        val verbose
 
     output:
         path "*html",       emit: html
-
-    publishDir "${outdir}/multiqc",
-        mode: "copy", overwrite: true
 
     script:
 

--- a/software/samtools/faidx/main.nf
+++ b/software/samtools/faidx/main.nf
@@ -1,13 +1,13 @@
 process samtools_faidx {
-    tag {fasta}
+    tag "$fasta"
 
     container 'quay.io/biocontainers/samtools:1.9--h10a08f8_12'
 
     input:
-        path(fasta)
+        path fasta
 
     output:
-        path("${fasta}.fai")
+        path "${fasta}.fai"
 
     script:
     """

--- a/software/samtools/index/main.nf
+++ b/software/samtools/index/main.nf
@@ -4,7 +4,7 @@ process samtools_index {
     container 'quay.io/biocontainers/samtools:1.9--h10a08f8_12'
 
     input:
-    path(bam)
+    path bam
 
     output:
     path "*.bai"

--- a/software/samtools/sort/main.nf
+++ b/software/samtools/sort/main.nf
@@ -4,7 +4,7 @@ process samtools_index {
     container 'quay.io/biocontainers/samtools:1.9--h10a08f8_12'
 
     input:
-    path(bam)
+    path bam
 
     output:
     path "*.bam.bai"

--- a/software/shovill/main.nf
+++ b/software/shovill/main.nf
@@ -1,16 +1,16 @@
 process shovill {
 
-    tag { shovill }
+    tag "$shovill"
 
     publishDir "${params.outdir}", pattern: '*.fasta', mode: 'copy'
 
     container "quay.io/biocontainers/shovill:1.0.9--0"
 
     input:
-    tuple(sample_id, path(forward), path(reverse))
+    tuple val(sample_id), path(forward), path(reverse)
 
     output:
-    path("${sample_id}.fasta")
+    path "${sample_id}.fasta"
 
     script:
     """

--- a/software/tcoffee/main.nf
+++ b/software/tcoffee/main.nf
@@ -1,13 +1,13 @@
 process tcoffee {
-    tag {fasta}
+    tag "$fasta"
     publishDir "${params.outdir}/tcoffee"
     container 'quay.io/biocontainers/t_coffee:11.0.8--py27pl5.22.0_5'
 
     input:
-    path(fasta)
+    path "$fasta"
 
     output:
-    path("${fasta}.aln")
+    path "${fasta}.aln"
 
     script:
     """

--- a/software/trim_galore/main.nf
+++ b/software/trim_galore/main.nf
@@ -18,24 +18,26 @@ process TRIM_GALORE {
     // container 'quay.io/biocontainers/trim-galore:0.6.5--0' // maybe later
     // tag "$sample_id"
 
+
+    // Trimming reports are not generated for e.g. --hardtrim5, --clock etc
+    // saveAs: {filename ->
+    //   else if (filename.indexOf("trimming_report.txt") > 0) "logs/$filename"
+    //   else filename
+    // }
+
+    publishDir "${outdir}/trim_galore",
+        mode: "copy", overwrite: true
+
     input:
-        tuple val (name), path (reads)
-        val (outdir)
-        val (trim_galore_args)
-        val (verbose)
+        tuple val(name), path(reads)
+        val outdir
+        val trim_galore_args
+        val verbose
 
     output:
         tuple val(name), path ("*fq.gz"),             emit: reads
         path "*trimming_report.txt", optional: true,  emit: report
 
-        // Trimming reports are not generated for e.g. --hardtrim5, --clock etc
-        // saveAs: {filename ->
-        //   else if (filename.indexOf("trimming_report.txt") > 0) "logs/$filename"
-        //   else filename
-        // }
-
-    publishDir "${outdir}/trim_galore",
-        mode: "copy", overwrite: true
 
     script:
         if (verbose){


### PR DESCRIPTION
This commit provides a minor refactoring with som
Nextflow code style improvments:
- Replaces `.toGiga()` with `.giga`
- Replaces `tag { foo }` with `tag "$foo"`
- Move publishDir before input declarations. Directives should be
  before the first input. Tho this is not enforced, it may be in
  future versions.
- Replaces input `file` with `path`
- Remove unnecessary parentheses