### PR TITLE
Changed options.publish_files definition in functions.nf/initOptions

### DIFF
--- a/software/SOFTWARE/TOOL/functions.nf
+++ b/software/SOFTWARE/TOOL/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/bwa/index/functions.nf
+++ b/software/bwa/index/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/bwa/mem/functions.nf
+++ b/software/bwa/mem/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/deeptools/computematrix/functions.nf
+++ b/software/deeptools/computematrix/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/deeptools/plotfingerprint/functions.nf
+++ b/software/deeptools/plotfingerprint/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/deeptools/plotheatmap/functions.nf
+++ b/software/deeptools/plotheatmap/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/deeptools/plotprofile/functions.nf
+++ b/software/deeptools/plotprofile/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/fastqc/functions.nf
+++ b/software/fastqc/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/homer/annotatepeaks/functions.nf
+++ b/software/homer/annotatepeaks/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/lib/functions.nf
+++ b/software/lib/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/macs2/callpeak/functions.nf
+++ b/software/macs2/callpeak/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/phantompeakqualtools/functions.nf
+++ b/software/phantompeakqualtools/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/picard/collectmultiplemetrics/functions.nf
+++ b/software/picard/collectmultiplemetrics/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/picard/markduplicates/functions.nf
+++ b/software/picard/markduplicates/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/picard/mergesamfiles/functions.nf
+++ b/software/picard/mergesamfiles/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/preseq/lcextrap/functions.nf
+++ b/software/preseq/lcextrap/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/samtools/flagstat/functions.nf
+++ b/software/samtools/flagstat/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/samtools/idxstats/functions.nf
+++ b/software/samtools/idxstats/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/samtools/index/functions.nf
+++ b/software/samtools/index/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/samtools/sort/functions.nf
+++ b/software/samtools/sort/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/samtools/stats/functions.nf
+++ b/software/samtools/stats/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/subread/featurecounts/functions.nf
+++ b/software/subread/featurecounts/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/trimgalore/functions.nf
+++ b/software/trimgalore/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }

--- a/software/ucsc/bedgraphtobigwig/functions.nf
+++ b/software/ucsc/bedgraphtobigwig/functions.nf
@@ -20,7 +20,7 @@ def initOptions(Map args) {
     options.args2         = args.args2 ?: ''
     options.publish_by_id = args.publish_by_id ?: false
     options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files ?: null
+    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
     options.suffix        = args.suffix ?: ''
     return options
 }


### PR DESCRIPTION
In the original code, if `args.publish_files = [:]` , then `args.publish_files?` is negative, and `options.publish_files=null`. The desired behavior is for `options.publish_files=[:]`, which should result in no files being published, rather than all of them. This is done by keeping `options.publish_files = args.publish_files` whenever `args.publish_files` is a Map.