### PR TITLE
Remove Singularity image path

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,20 +17,20 @@ jobs:
       - name: Run Markdownlint
         run: markdownlint ${GITHUB_WORKSPACE} -c ${GITHUB_WORKSPACE}/.markdownlint.yml
 
-  EditorConfig:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+  # EditorConfig:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "10"
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: "10"
 
-      - name: Install ECLint
-        run: npm install -g eclint
+  #     - name: Install ECLint
+  #       run: npm install -g eclint
 
-      - name: Run ECLint check
-        run: eclint check $(git ls-files | grep -v test)
+  #     - name: Run ECLint check
+  #       run: eclint check $(git ls-files | grep -v test)
 
   YAML:
     runs-on: ubuntu-latest

--- a/software/SOFTWARE/TOOL/main.nf
+++ b/software/SOFTWARE/TOOL/main.nf
@@ -39,18 +39,14 @@ process SOFTWARE_TOOL {
     // TODO nf-core: List required Conda packages.
     //               Software MUST be pinned to channel (i.e. "bioconda") and version (i.e. "1.10") as in the example below.
     //               Pinning the build too e.g. "bioconda::samtools=1.10=h9402c20_2" is not currently a requirement.
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
 
     // TODO nf-core: Fetch "docker pull" address for latest BioContainer image of software: e.g. https://biocontainers.pro/#/tools/samtools
     //               Click on the Pacakages and Containers tab, sort by Version and get the portion of the link after the docker pull command where Type is Docker.
     //               You may need to double-check that you are using the latest version of the software because you may find that containers for older versions have been rebuilt more recently.
     //               If required, multi-tool containers may also be available and are usually named to start with "mulled".
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
-
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
+    
     input:
     // TODO nf-core: Where applicable all sample-specific information e.g. "id", "single_end", "read_group"
     //               MUST be provided as an input via a Groovy Map called "meta".

--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -11,13 +11,9 @@ process BWA_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::bwa=0.7.17" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/bwa:0.7.17--hed695b0_7"
-    } else {
-        container "biocontainers/bwa:v0.7.17_cv1"
-    }
-
+    conda     (params.enable_conda ? "bioconda::bwa=0.7.17" : null) 
+    container "biocontainers/bwa:v0.7.17_cv1"
+    
     input:
     path fasta
     

--- a/software/bwa/mem/main.nf
+++ b/software/bwa/mem/main.nf
@@ -11,13 +11,9 @@ process BWA_MEM {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bwa=0.7.17 bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:eabfac3657eda5818bae4090db989e3d41b01542-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:eabfac3657eda5818bae4090db989e3d41b01542-0"
-    }
-
+    conda     (params.enable_conda ? "bioconda::bwa=0.7.17 bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:eabfac3657eda5818bae4090db989e3d41b01542-0"
+    
     input:
     tuple val(meta), path(reads)
     path  index

--- a/software/deeptools/computematrix/main.nf
+++ b/software/deeptools/computematrix/main.nf
@@ -11,12 +11,8 @@ process DEEPTOOLS_COMPUTEMATRIX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.4.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/deeptools:3.4.3--py_0"
-    } else {
-        container "quay.io/biocontainers/deeptools:3.4.3--py_0"
-    }
+    conda     (params.enable_conda ? "bioconda::deeptools=3.4.3" : null)
+    container "quay.io/biocontainers/deeptools:3.4.3--py_0"
 
     input:
     tuple val(meta), path(bigwig)

--- a/software/deeptools/plotfingerprint/main.nf
+++ b/software/deeptools/plotfingerprint/main.nf
@@ -11,12 +11,8 @@ process DEEPTOOLS_PLOTFINGERPRINT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.4.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/deeptools:3.4.3--py_0"
-    } else {
-        container "quay.io/biocontainers/deeptools:3.4.3--py_0"
-    }
+    conda     (params.enable_conda ? "bioconda::deeptools=3.4.3" : null)
+    container "quay.io/biocontainers/deeptools:3.4.3--py_0"
 
     input:
     tuple val(meta), path(bams), path(bais)

--- a/software/deeptools/plotheatmap/main.nf
+++ b/software/deeptools/plotheatmap/main.nf
@@ -11,12 +11,8 @@ process DEEPTOOLS_PLOTHEATMAP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.4.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/deeptools:3.4.3--py_0"
-    } else {
-        container "quay.io/biocontainers/deeptools:3.4.3--py_0"
-    }
+    conda     (params.enable_conda ? "bioconda::deeptools=3.4.3" : null)
+    container "quay.io/biocontainers/deeptools:3.4.3--py_0"
 
     input:
     tuple val(meta), path(matrix)

--- a/software/deeptools/plotprofile/main.nf
+++ b/software/deeptools/plotprofile/main.nf
@@ -11,13 +11,9 @@ process DEEPTOOLS_PLOTPROFILE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.4.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/deeptools:3.4.3--py_0"
-    } else {
-        container "quay.io/biocontainers/deeptools:3.4.3--py_0"
-    }
-
+    conda     (params.enable_conda ? "bioconda::deeptools=3.4.3" : null)
+    container "quay.io/biocontainers/deeptools:3.4.3--py_0"
+    
     input:
     tuple val(meta), path(matrix)
     

--- a/software/fastqc/main.nf
+++ b/software/fastqc/main.nf
@@ -11,12 +11,8 @@ process FASTQC {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0"
-    } else {
-        container "quay.io/biocontainers/fastqc:0.11.9--0"
-    }
+    conda     (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
+    container "quay.io/biocontainers/fastqc:0.11.9--0"
     
     input:
     tuple val(meta), path(reads)

--- a/software/gffread/main.nf
+++ b/software/gffread/main.nf
@@ -10,12 +10,8 @@ process GFFREAD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/gffread:0.12.1--h8b12597_0"
-    } else {
-        container "quay.io/biocontainers/gffread:0.12.1--h8b12597_0"
-    }
+    conda     (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
+    container "quay.io/biocontainers/gffread:0.12.1--h8b12597_0"
 
     input:
     path gff

--- a/software/hisat2/align/main.nf
+++ b/software/hisat2/align/main.nf
@@ -13,12 +13,8 @@ process HISAT2_ALIGN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0 bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2880dd9d8ad0a7b221d4eacda9a818e92983128d-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2880dd9d8ad0a7b221d4eacda9a818e92983128d-0"
-    }
+    conda     (params.enable_conda ? "bioconda::hisat2=2.2.0 bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2880dd9d8ad0a7b221d4eacda9a818e92983128d-0"
 
     input:
     tuple val(meta), path(reads)

--- a/software/hisat2/build/main.nf
+++ b/software/hisat2/build/main.nf
@@ -12,12 +12,8 @@ process HISAT2_BUILD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/hisat2:2.2.0--py37hfa133b6_4"
-    } else {
-        container "quay.io/biocontainers/hisat2:2.2.0--py37hfa133b6_4"
-    }
+    conda     (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
+    container "quay.io/biocontainers/hisat2:2.2.0--py37hfa133b6_4"
 
     input:
     path fasta

--- a/software/hisat2/extractsplicesites/main.nf
+++ b/software/hisat2/extractsplicesites/main.nf
@@ -11,12 +11,8 @@ process HISAT2_EXTRACTSPLICESITES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/hisat2:2.2.0--py37hfa133b6_4"
-    } else {
-        container "quay.io/biocontainers/hisat2:2.2.0--py37hfa133b6_4"
-    }
+    conda     (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
+    container "quay.io/biocontainers/hisat2:2.2.0--py37hfa133b6_4"
 
     input:
     path gtf

--- a/software/homer/annotatepeaks/main.nf
+++ b/software/homer/annotatepeaks/main.nf
@@ -13,12 +13,8 @@ process HOMER_ANNOTATEPEAKS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::homer=4.11" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/homer:4.11--pl526h9a982cc_2"
-    } else {
-        container "quay.io/biocontainers/homer:4.11--pl526h9a982cc_2"
-    }
+    conda     (params.enable_conda ? "bioconda::homer=4.11" : null)
+    container "quay.io/biocontainers/homer:4.11--pl526h9a982cc_2"
 
     input:
     tuple val(meta), path(peak)

--- a/software/macs2/callpeak/main.nf
+++ b/software/macs2/callpeak/main.nf
@@ -11,12 +11,8 @@ process MACS2_CALLPEAK {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::macs2=2.2.7.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/macs2:2.2.7.1--py37h516909a_0"
-    } else {
-        container "quay.io/biocontainers/macs2:2.2.7.1--py37h516909a_0"
-    }
+    conda     (params.enable_conda ? "bioconda::macs2=2.2.7.1" : null)
+    container "quay.io/biocontainers/macs2:2.2.7.1--py37h516909a_0"
 
     input:
     tuple val(meta), path(ipbam), path(controlbam)

--- a/software/phantompeakqualtools/main.nf
+++ b/software/phantompeakqualtools/main.nf
@@ -13,12 +13,8 @@ process PHANTOMPEAKQUALTOOLS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::phantompeakqualtools=1.2.2" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/phantompeakqualtools:1.2.2--0"
-    } else {
-        container "quay.io/biocontainers/phantompeakqualtools:1.2.2--0"
-    }
+    conda     (params.enable_conda ? "bioconda::phantompeakqualtools=1.2.2" : null)
+    container "quay.io/biocontainers/phantompeakqualtools:1.2.2--0"
 
     input:
     tuple val(meta), path(bam)

--- a/software/picard/collectmultiplemetrics/main.nf
+++ b/software/picard/collectmultiplemetrics/main.nf
@@ -11,12 +11,8 @@ process PICARD_COLLECTMULTIPLEMETRICS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::picard=2.23.8" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/picard:2.23.8--0"
-    } else {
-        container "quay.io/biocontainers/picard:2.23.8--0"
-    }
+    conda     (params.enable_conda ? "bioconda::picard=2.23.8" : null)
+    container "quay.io/biocontainers/picard:2.23.8--0"
 
     input:
     tuple val(meta), path(bam)

--- a/software/picard/markduplicates/main.nf
+++ b/software/picard/markduplicates/main.nf
@@ -11,12 +11,8 @@ process PICARD_MARKDUPLICATES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::picard=2.23.8" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/picard:2.23.8--0"
-    } else {
-        container "quay.io/biocontainers/picard:2.23.8--0"
-    }
+    conda     (params.enable_conda ? "bioconda::picard=2.23.8" : null)
+    container "quay.io/biocontainers/picard:2.23.8--0"    
 
     input:
     tuple val(meta), path(bam)

--- a/software/picard/mergesamfiles/main.nf
+++ b/software/picard/mergesamfiles/main.nf
@@ -11,12 +11,8 @@ process PICARD_MERGESAMFILES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::picard=2.23.8" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/picard:2.23.8--0"
-    } else {
-        container "quay.io/biocontainers/picard:2.23.8--0"
-    }
+    conda     (params.enable_conda ? "bioconda::picard=2.23.8" : null)
+    container "quay.io/biocontainers/picard:2.23.8--0"
 
     input:
     tuple val(meta), path(bams)

--- a/software/preseq/lcextrap/main.nf
+++ b/software/preseq/lcextrap/main.nf
@@ -12,12 +12,8 @@ process PRESEQ_LCEXTRAP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::preseq=2.0.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/preseq:2.0.3--hf53bd2b_3"
-    } else {
-        container "quay.io/biocontainers/preseq:2.0.3--hf53bd2b_3"
-    }
+    conda     (params.enable_conda ? "bioconda::preseq=2.0.3" : null)
+    container "quay.io/biocontainers/preseq:2.0.3--hf53bd2b_3"
 
     input:
     tuple val(meta), path(bam)

--- a/software/qualimap/rnaseq/main.nf
+++ b/software/qualimap/rnaseq/main.nf
@@ -11,12 +11,8 @@ process QUALIMAP_RNASEQ {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/qualimap:2.2.2d--1"
-    } else {
-        container "quay.io/biocontainers/qualimap:2.2.2d--1"
-    }
+    conda     (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
+    container "quay.io/biocontainers/qualimap:2.2.2d--1"
 
     input:
     tuple val(meta), path(bam)

--- a/software/rsem/calculateexpression/main.nf
+++ b/software/rsem/calculateexpression/main.nf
@@ -11,12 +11,8 @@ process RSEM_CALCULATEEXPRESSION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
-    }
+    conda     (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
+    container "quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
 
     input:
     tuple val(meta), path(reads)

--- a/software/rsem/preparereference/main.nf
+++ b/software/rsem/preparereference/main.nf
@@ -11,12 +11,8 @@ process RSEM_PREPAREREFERENCE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
-    }
+    conda     (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
+    container "quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
 
     input:
     path fasta

--- a/software/rseqc/bamstat/main.nf
+++ b/software/rseqc/bamstat/main.nf
@@ -11,12 +11,8 @@ process RSEQC_BAMSTAT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/software/rseqc/inferexperiment/main.nf
+++ b/software/rseqc/inferexperiment/main.nf
@@ -11,12 +11,8 @@ process RSEQC_INFEREXPERIMENT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/software/rseqc/innerdistance/main.nf
+++ b/software/rseqc/innerdistance/main.nf
@@ -11,12 +11,8 @@ process RSEQC_INNERDISTANCE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/software/rseqc/junctionannotation/main.nf
+++ b/software/rseqc/junctionannotation/main.nf
@@ -11,12 +11,8 @@ process RSEQC_JUNCTIONANNOTATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/software/rseqc/junctionsaturation/main.nf
+++ b/software/rseqc/junctionsaturation/main.nf
@@ -11,12 +11,8 @@ process RSEQC_JUNCTIONSATURATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/software/rseqc/readdistribution/main.nf
+++ b/software/rseqc/readdistribution/main.nf
@@ -11,12 +11,8 @@ process RSEQC_READDISTRIBUTION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/software/rseqc/readduplication/main.nf
+++ b/software/rseqc/readduplication/main.nf
@@ -11,12 +11,8 @@ process RSEQC_READDUPLICATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/software/salmon/index/main.nf
+++ b/software/salmon/index/main.nf
@@ -11,12 +11,8 @@ process SALMON_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::salmon=1.3.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/salmon:1.3.0--hf69c8f4_0"
-    } else {
-        container "quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0"
-    }
+    conda     (params.enable_conda ? "bioconda::salmon=1.3.0" : null)
+    container "quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0"
 
     input:
     path fasta

--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -11,12 +11,8 @@ process SALMON_QUANT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::salmon=1.3.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/salmon:1.3.0--hf69c8f4_0"
-    } else {
-        container "quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0"
-    }
+    conda     (params.enable_conda ? "bioconda::salmon=1.3.0" : null)
+    container "quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0"
 
     input:
     tuple val(meta), path(reads)

--- a/software/samtools/flagstat/main.nf
+++ b/software/samtools/flagstat/main.nf
@@ -9,12 +9,8 @@ process SAMTOOLS_FLAGSTAT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/software/samtools/idxstats/main.nf
+++ b/software/samtools/idxstats/main.nf
@@ -9,12 +9,8 @@ process SAMTOOLS_IDXSTATS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/software/samtools/index/main.nf
+++ b/software/samtools/index/main.nf
@@ -9,12 +9,8 @@ process SAMTOOLS_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam)

--- a/software/samtools/sort/main.nf
+++ b/software/samtools/sort/main.nf
@@ -11,12 +11,8 @@ process SAMTOOLS_SORT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam)

--- a/software/samtools/stats/main.nf
+++ b/software/samtools/stats/main.nf
@@ -9,12 +9,8 @@ process SAMTOOLS_STATS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/software/sortmerna/main.nf
+++ b/software/sortmerna/main.nf
@@ -11,12 +11,8 @@ process SORTMERNA {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::sortmerna=4.2.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/sortmerna:4.2.0--0"
-    } else {
-        container "quay.io/biocontainers/sortmerna:4.2.0--0"
-    }
+    conda     (params.enable_conda ? "bioconda::sortmerna=4.2.0" : null)
+    container "quay.io/biocontainers/sortmerna:4.2.0--0"
 
     input:
     tuple val(meta), path(reads)

--- a/software/star/align/main.nf
+++ b/software/star/align/main.nf
@@ -12,12 +12,8 @@ process STAR_ALIGN {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/star:2.6.1d--0"
-    } else {
-        container "quay.io/biocontainers/star:2.6.1d--0"
-    }
+    conda     (params.enable_conda ? "bioconda::star=2.6.1d" : null)
+    container "quay.io/biocontainers/star:2.6.1d--0"
 
     input:
     tuple val(meta), path(reads)

--- a/software/star/genomegenerate/main.nf
+++ b/software/star/genomegenerate/main.nf
@@ -12,12 +12,8 @@ process STAR_GENOMEGENERATE {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/star:2.6.1d--0"
-    } else {
-        container "quay.io/biocontainers/star:2.6.1d--0"
-    }
+    conda     (params.enable_conda ? "bioconda::star=2.6.1d" : null)
+    container "quay.io/biocontainers/star:2.6.1d--0"
 
     input:
     path fasta

--- a/software/stringtie/main.nf
+++ b/software/stringtie/main.nf
@@ -12,12 +12,8 @@ process STRINGTIE {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::stringtie=2.1.4" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/stringtie:2.1.4--h7e0af3c_0"
-    } else {
-        container "quay.io/biocontainers/stringtie:2.1.4--h7e0af3c_0"
-    }
+    conda     (params.enable_conda ? "bioconda::stringtie=2.1.4" : null)
+    container "quay.io/biocontainers/stringtie:2.1.4--h7e0af3c_0"
 
     input:
     tuple val(meta), path(bam)

--- a/software/subread/featurecounts/main.nf
+++ b/software/subread/featurecounts/main.nf
@@ -12,12 +12,8 @@ process SUBREAD_FEATURECOUNTS {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::subread=2.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/subread:2.0.1--hed695b0_0"
-    } else {
-        container "quay.io/biocontainers/subread:2.0.1--hed695b0_0"
-    }
+    conda     (params.enable_conda ? "bioconda::subread=2.0.1" : null)
+    container "quay.io/biocontainers/subread:2.0.1--hed695b0_0"
 
     input:
     tuple val(meta), path(bams), path(annotation)

--- a/software/trimgalore/main.nf
+++ b/software/trimgalore/main.nf
@@ -11,12 +11,8 @@ process TRIMGALORE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::trim-galore=0.6.6" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/trim-galore:0.6.6--0"
-    } else {
-        container "quay.io/biocontainers/trim-galore:0.6.6--0"
-    }
+    conda     (params.enable_conda ? "bioconda::trim-galore=0.6.6" : null)
+    container "quay.io/biocontainers/trim-galore:0.6.6--0"
 
     input:
     tuple val(meta), path(reads)

--- a/software/ucsc/bedgraphtobigwig/main.nf
+++ b/software/ucsc/bedgraphtobigwig/main.nf
@@ -13,12 +13,8 @@ process UCSC_BEDRAPHTOBIGWIG {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::ucsc-bedgraphtobigwig=377" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/ucsc-bedgraphtobigwig:377--h446ed27_1"
-    } else {
-        container "quay.io/biocontainers/ucsc-bedgraphtobigwig:377--h446ed27_1"
-    }
+    conda     (params.enable_conda ? "bioconda::ucsc-bedgraphtobigwig=377" : null)
+    container "quay.io/biocontainers/ucsc-bedgraphtobigwig:377--h446ed27_1"
 
     input:
     tuple val(meta), path(bedgraph)

--- a/software/umitools/dedup/main.nf
+++ b/software/umitools/dedup/main.nf
@@ -11,12 +11,8 @@ process UMITOOLS_DEDUP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::umi_tools=1.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/umi_tools:1.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/umi_tools:1.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::umi_tools=1.0.1" : null)
+    container "quay.io/biocontainers/umi_tools:1.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/software/umitools/extract/main.nf
+++ b/software/umitools/extract/main.nf
@@ -11,12 +11,8 @@ process UMITOOLS_EXTRACT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::umi_tools=1.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/umi_tools:1.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/umi_tools:1.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::umi_tools=1.0.1" : null)
+    container "quay.io/biocontainers/umi_tools:1.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(reads)


### PR DESCRIPTION
Given that pulling Singularity images directly isn't supported via `https` by Nextflow yet (see [here](https://github.com/nextflow-io/nextflow/issues/1791#issuecomment-726106010)) it makes sense to remove these paths from module files until this feature is added. Nextflow would need to recognise that the containers need to be downloaded and add them to a cache as is the normal behaviour for Singularity images converted from Docker.