### PR TITLE
Added cutadapt module

### DIFF
--- a/.github/workflows/cutadapt.yml
+++ b/.github/workflows/cutadapt.yml
@@ -1,0 +1,40 @@
+name: cutadapt
+on:
+  push:
+    paths:
+      - software/cutadapt/**
+      - .github/workflows/cutadapt.yml
+      - tests/software/cutadapt/**
+  pull_request:
+    paths:
+      - software/cutadapt/**
+      - .github/workflows/cutadapt.yml
+      - tests/software/cutadapt/**
+
+jobs:
+  ci_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nxf_version: [20.11.0-edge]
+    env:
+      NXF_ANSI_LOG: false
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Nextflow
+        env:
+          NXF_VER: ${{ matrix.nxf_version }}
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip pytest-workflow
+
+      # Test the module
+      - run: pytest --tag cutadapt --symlink --wt 2

--- a/software/cutadapt/functions.nf
+++ b/software/cutadapt/functions.nf
@@ -1,0 +1,59 @@
+/*
+ * -----------------------------------------------------
+ *  Utility functions used in nf-core DSL2 module files
+ * -----------------------------------------------------
+ */
+
+/*
+ * Extract name of software tool from process name using $task.process
+ */
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+/*
+ * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+ */
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args          = args.args ?: ''
+    options.args2         = args.args2 ?: ''
+    options.publish_by_id = args.publish_by_id ?: false
+    options.publish_dir   = args.publish_dir ?: ''
+    options.publish_files = args.publish_files
+    options.suffix        = args.suffix ?: ''
+    return options
+}
+
+/*
+ * Tidy up and join elements of a list to return a path string
+ */
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
+    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+/*
+ * Function to save/publish module results
+ */
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_id) {
+            path_list.add(args.publish_id)
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/software/cutadapt/main.nf
+++ b/software/cutadapt/main.nf
@@ -1,0 +1,42 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+def options    = initOptions(params.options)
+
+process CUTADAPT {
+    tag "$meta.id"
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+
+    conda (params.enable_conda ? 'bioconda::cutadapt:3.2' : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container 'https://depot.galaxyproject.org/singularity/cutadapt:3.2--py38h0213d0e_0'
+    } else {
+        container 'quay.io/biocontainers/cutadapt:3.2--py38h0213d0e_0'
+    }
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path('*.trim.fastq.gz'), emit: reads
+    tuple val(meta), path('*.log')          , emit: log
+    path '*.version.txt'                    , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    def trimmed  = meta.single_end ? "-o ${prefix}.trim.fastq.gz" : "-o ${prefix}_1.trim.fastq.gz -p ${prefix}_2.trim.fastq.gz"
+    """
+    cutadapt \\
+        --cores $task.cpus \\
+        $options.args \\
+        $trimmed \\
+        $reads \\
+        > ${prefix}.cutadapt.log
+    echo \$(cutadapt --version) > ${software}.version.txt
+    """
+}

--- a/software/cutadapt/meta.yml
+++ b/software/cutadapt/meta.yml
@@ -1,0 +1,66 @@
+name: cutadapt
+description: Perform adapter/quality trimming on sequencing reads
+keywords:
+  - trimming
+  - adapter trimming
+  - adapters
+  - quality trimming
+tools:
+  - cuatadapt:
+      description: |
+        Cutadapt finds and removes adapter sequences, primers, poly-A tails and other types of unwanted sequence from your high-throughput sequencing reads.
+      documentation: https://cutadapt.readthedocs.io/en/stable/index.html
+      doi: DOI:10.14806/ej.17.1.200
+params:
+  - outdir:
+      type: string
+      description: |
+        The pipeline's output directory. By default, the module will
+        output files into `$params.outdir/<SOFTWARE>`
+  - publish_dir_mode:
+      type: string
+      description: |
+        Value for the Nextflow `publishDir` mode parameter.
+        Available: symlink, rellink, link, copy, copyNoFollow, move.
+  - enable_conda:
+      type: boolean
+      description: |
+        Run the module with Conda using the software specified
+        via the `conda` directive
+  - singularity_pull_docker_container:
+      type: boolean
+      description: |
+        Instead of directly downloading Singularity images for use with Singularity,
+        force the workflow to pull and convert Docker containers instead.
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: The trimmed/modified fastq reads
+      pattern: "*fastq.gz"
+  - log:
+      type: file
+      description: cuatadapt log file
+      pattern: "*cutadapt.log"
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "*.{version.txt}"
+authors:
+  - "@drpatelh"
+  - "@kevinmenden"

--- a/tests/software/cutadapt/main.nf
+++ b/tests/software/cutadapt/main.nf
@@ -1,0 +1,30 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { CUTADAPT } from '../../../software/cutadapt/main.nf'  addParams( options: [ args:'-q 25' ] )
+
+/*
+ * Test with single-end data
+ */
+workflow test_cutadapt_se {
+    def input = []
+    input = [ [ id:'test', single_end:true ], // meta map
+              [ file("${launchDir}/tests/data/fastq/rna/test_single_end.fastq.gz", checkIfExists: true) ] ]
+
+    CUTADAPT( input )
+}
+
+/*
+ * Test with paired-end data
+ */
+
+workflow test_cutadapt_pe {
+    def input = []
+    input = [ [ id:'test', single_end:false ], // meta map
+              [ file("${launchDir}/tests/data/fastq/rna/test_R1.fastq.gz", checkIfExists: true),
+                file("${launchDir}/tests/data/fastq/rna/test_R2.fastq.gz", checkIfExists: true) ] ]
+
+    CUTADAPT( input )
+}
+

--- a/tests/software/cutadapt/test.yml
+++ b/tests/software/cutadapt/test.yml
@@ -1,0 +1,23 @@
+- name: Run cutadapt single-end test workflow
+  command: nextflow run ./tests/software/cutadapt -profile docker -entry test_cutadapt_se -c tests/config/nextflow.config
+  tags:
+    - cutadapt
+    - cutadapt_se
+  files:
+    - path: ./output/cutadapt/test.cutadapt.log
+      md5sum: 789eb0504edb85482b4ddbf5d74ea7d2
+    - path: ./output/cutadapt/test.trim.fastq.gz
+      md5sum: c972c96a5863f1dcf5d5a2ffcc1f99a5
+
+- name: Run cutadapt paired-end test workflow
+  command: nextflow run ./tests/software/cutadapt -profile docker -entry test_cutadapt_pe -c tests/config/nextflow.config
+  tags:
+    - cutadapt
+    - cutadapt_pe
+  files:
+    - path: ./output/cutadapt/test.cutadapt.log
+      md5sum: 695d9a7649bda71adb6b288a30e82143
+    - path: ./output/cutadapt/test_1.trim.fastq.gz
+      md5sum: dfb465f41075a792ae2c81c4835250a2
+    - path: ./output/cutadapt/test_2.trim.fastq.gz
+      md5sum: a3c5aa879d14ae7135807f85b957fb6c

--- a/tests/software/cutadapt/test.yml
+++ b/tests/software/cutadapt/test.yml
@@ -5,9 +5,7 @@
     - cutadapt_se
   files:
     - path: ./output/cutadapt/test.cutadapt.log
-      md5sum: 789eb0504edb85482b4ddbf5d74ea7d2
     - path: ./output/cutadapt/test.trim.fastq.gz
-      md5sum: c972c96a5863f1dcf5d5a2ffcc1f99a5
 
 - name: Run cutadapt paired-end test workflow
   command: nextflow run ./tests/software/cutadapt -profile docker -entry test_cutadapt_pe -c tests/config/nextflow.config
@@ -16,8 +14,5 @@
     - cutadapt_pe
   files:
     - path: ./output/cutadapt/test.cutadapt.log
-      md5sum: 695d9a7649bda71adb6b288a30e82143
     - path: ./output/cutadapt/test_1.trim.fastq.gz
-      md5sum: dfb465f41075a792ae2c81c4835250a2
     - path: ./output/cutadapt/test_2.trim.fastq.gz
-      md5sum: a3c5aa879d14ae7135807f85b957fb6c


### PR DESCRIPTION
This PR adds the cutadapt module, modified from https://github.com/drpatelh/nf-core-viralrecon/blob/dsl2/modules/local/cutadapt.nf

### cutadapt module
I have adapted the module to be more flexible, i.e. I have removed 
`def paired   = meta.single_end ? "-a file:adapters.sub.fa"   : "-a file:adapters.sub.fa -A file:adapters.sub.fa"`

and thus the possibility of handing over a channel with adapters to the process. Cutadapt is highly flexible and can do all kinds of different trimming options. The code above, for instance, only allows to trim the same 3'-adapters from both mates. So in this version, the user has to specify the adapter files in the `modules.config`

I think this is reasonable as the adapters shouldn't change for different samples in the same pipeline run and it goes along the nf-core/modules guidelines to have only input and output specified.

### cutadapt test
I have added tests - however no md5 sums. They change for the log files (speed information etc.) but surprisingly also for the fastq.gz output files. I have no idea why, I tried running on a single core but that wasn't the issue. Happy to hear some ideas on that one :-) 

