### PR TITLE
ci: Fix artifact path

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -88,6 +88,6 @@ jobs:
         with:
           name: logs-${{ matrix.tags }}-${{ matrix.profile }}-${{ matrix.nxf_version }}
           path: |
-            /tmp/pytest_workflow_*/*/.nextflow.log
-            /tmp/pytest_workflow_*/*/log.out
-            /tmp/pytest_workflow_*/*/log.err
+            /home/runner/pytest_workflow_*/*/.nextflow.log
+            /home/runner/pytest_workflow_*/*/log.out
+            /home/runner/pytest_workflow_*/*/log.err


### PR DESCRIPTION
Had to change tmp dir to ~ for singularity but didn't update where the log upload was looking for logs