### PR TITLE
Add cpus, memory and time requirements to limit resource consumption

### DIFF
--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -5,6 +5,12 @@ params {
     singularity_pull_docker_container = false
 }
 
+process {
+  cpus = 2
+  memory = 6.GB
+  time = 48.h
+}
+
 if ("$PROFILE" == "singularity") {
     singularity.enabled = true
     singularity.autoMounts = true


### PR DESCRIPTION
I think it's a good practice to have that especially to limit resources for our CI tests here with GitHub actions
cf #177 