### PR TITLE
Remove Conda build ids for all modules

### DIFF
--- a/software/TOOL/SUBTOOL/main.nf
+++ b/software/TOOL/SUBTOOL/main.nf
@@ -37,8 +37,9 @@ process TOOL_SUBTOOL {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
     // TODO nf-core: List required Conda packages.
-    //               Software MUST be pinned to channel (i.e. "bioconda"), version (i.e. "1.10") and build (i.e. "h9402c20_2") as in the example below.
-    conda (params.enable_conda ? "bioconda::samtools=1.10=h9402c20_2" : null)
+    //               Software MUST be pinned to channel (i.e. "bioconda"), version (i.e. "1.10").
+    //               For Conda, the build (i.e. "h9402c20_2") must be excluded to support installation on different OS.
+    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
 
     // TODO nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bandage/image/main.nf
+++ b/software/bandage/image/main.nf
@@ -11,7 +11,7 @@ process BANDAGE_IMAGE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? 'bioconda::bandage=0.8.1=hc9558a2_2' : null)
+    conda (params.enable_conda ? 'bioconda::bandage=0.8.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bandage:0.8.1--hc9558a2_2"
     } else {

--- a/software/bcftools/consensus/main.nf
+++ b/software/bcftools/consensus/main.nf
@@ -10,7 +10,7 @@ process BCFTOOLS_CONSENSUS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bcftools=1.11=h7c999a4_0" : null)
+    conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bcftools:1.11--h7c999a4_0"
     } else {

--- a/software/bcftools/filter/main.nf
+++ b/software/bcftools/filter/main.nf
@@ -10,7 +10,7 @@ process BCFTOOLS_FILTER {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bcftools=1.11=h7c999a4_0" : null)
+    conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bcftools:1.11--h7c999a4_0"
     } else {

--- a/software/bcftools/isec/main.nf
+++ b/software/bcftools/isec/main.nf
@@ -10,7 +10,7 @@ process BCFTOOLS_ISEC {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bcftools=1.11=h7c999a4_0" : null)
+    conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bcftools:1.11--h7c999a4_0"
     } else {

--- a/software/bcftools/merge/main.nf
+++ b/software/bcftools/merge/main.nf
@@ -10,7 +10,7 @@ process BCFTOOLS_MERGE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bcftools=1.11=h7c999a4_0" : null)
+    conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bcftools:1.11--h7c999a4_0"
     } else {

--- a/software/bcftools/stats/main.nf
+++ b/software/bcftools/stats/main.nf
@@ -10,7 +10,7 @@ process BCFTOOLS_STATS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bcftools=1.11=h7c999a4_0" : null)
+    conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bcftools:1.11--h7c999a4_0"
     } else {

--- a/software/bedtools/complement/main.nf
+++ b/software/bedtools/complement/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_COMPLEMENT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0"
     } else {

--- a/software/bedtools/genomecov/main.nf
+++ b/software/bedtools/genomecov/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_GENOMECOV {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0"
     } else {

--- a/software/bedtools/getfasta/main.nf
+++ b/software/bedtools/getfasta/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_GETFASTA {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0"
     } else {

--- a/software/bedtools/intersect/main.nf
+++ b/software/bedtools/intersect/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_INTERSECT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0"
     } else {

--- a/software/bedtools/maskfasta/main.nf
+++ b/software/bedtools/maskfasta/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_MASKFASTA {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0"
     } else {

--- a/software/bedtools/merge/main.nf
+++ b/software/bedtools/merge/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_MERGE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0"
     } else {

--- a/software/bedtools/slop/main.nf
+++ b/software/bedtools/slop/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_SLOP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0"
     } else {

--- a/software/bedtools/sort/main.nf
+++ b/software/bedtools/sort/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_SORT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.30.0=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0"
     } else {

--- a/software/blast/blastn/main.nf
+++ b/software/blast/blastn/main.nf
@@ -11,7 +11,7 @@ process BLAST_BLASTN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? 'bioconda::blast=2.10.1=pl526he19e7b1_3' : null)
+    conda (params.enable_conda ? 'bioconda::blast=2.10.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/blast:2.10.1--pl526he19e7b1_3'
     } else {

--- a/software/blast/makeblastdb/main.nf
+++ b/software/blast/makeblastdb/main.nf
@@ -11,7 +11,7 @@ process BLAST_MAKEBLASTDB {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? 'bioconda::blast=2.10.1=pl526he19e7b1_3' : null)
+    conda (params.enable_conda ? 'bioconda::blast=2.10.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/blast:2.10.1--pl526he19e7b1_3'
     } else {

--- a/software/bowtie/align/main.nf
+++ b/software/bowtie/align/main.nf
@@ -11,7 +11,7 @@ process BOWTIE_ALIGN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? 'bioconda::bowtie=1.3.0=py38hed8969a_1 bioconda::samtools=1.11=h6270b1f_0' : null)
+    conda (params.enable_conda ? 'bioconda::bowtie=1.3.0 bioconda::samtools=1.11' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:9e14e16c284d6860574cf5b624bbc44c793cb024-0'
     } else {

--- a/software/bowtie/build/main.nf
+++ b/software/bowtie/build/main.nf
@@ -11,7 +11,7 @@ process BOWTIE_BUILD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? 'bioconda::bowtie=1.3.0=py38hed8969a_1' : null)
+    conda (params.enable_conda ? 'bioconda::bowtie=1.3.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/bowtie:1.3.0--py38hed8969a_1'
     } else {

--- a/software/bowtie2/align/main.nf
+++ b/software/bowtie2/align/main.nf
@@ -11,7 +11,7 @@ process BOWTIE2_ALIGN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? 'bioconda::bowtie2=2.4.2=py38h1c8e9b9_1 bioconda::samtools=1.11=h6270b1f_0 conda-forge::pigz=2.3.4=hed695b0_1' : null)
+    conda (params.enable_conda ? 'bioconda::bowtie2=2.4.2 bioconda::samtools=1.11 conda-forge::pigz=2.3.4' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/mulled-v2-ac74a7f02cebcfcc07d8e8d1d750af9c83b4d45a:577a697be67b5ae9b16f637fd723b8263a3898b3-0"
     } else {

--- a/software/bowtie2/build/main.nf
+++ b/software/bowtie2/build/main.nf
@@ -11,7 +11,7 @@ process BOWTIE2_BUILD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? 'bioconda::bowtie2=2.4.2=py38h1c8e9b9_1' : null)
+    conda (params.enable_conda ? 'bioconda::bowtie2=2.4.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/bowtie2:2.4.2--py38h1c8e9b9_1'
     } else {

--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -11,7 +11,7 @@ process BWA_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::bwa=0.7.17=hed695b0_7" : null)
+    conda (params.enable_conda ? "bioconda::bwa=0.7.17" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bwa:0.7.17--hed695b0_7"
     } else {

--- a/software/bwa/mem/main.nf
+++ b/software/bwa/mem/main.nf
@@ -11,7 +11,7 @@ process BWA_MEM {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bwa=0.7.17=hed695b0_7 bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::bwa=0.7.17 bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:eabfac3657eda5818bae4090db989e3d41b01542-0"
     } else {

--- a/software/bwamem2/index/main.nf
+++ b/software/bwamem2/index/main.nf
@@ -11,7 +11,7 @@ process BWAMEM2_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::bwa-mem2=2.1=he513fc3_0" : null)
+    conda (params.enable_conda ? "bioconda::bwa-mem2=2.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/bwa-mem2:2.1--he513fc3_0"
     } else {

--- a/software/bwamem2/mem/main.nf
+++ b/software/bwamem2/mem/main.nf
@@ -11,7 +11,7 @@ process BWAMEM2_MEM {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bwa-mem2=2.1=he513fc3_0 bioconda::samtools=1.11=h6270b1f_0" : null)
+    conda (params.enable_conda ? "bioconda::bwa-mem2=2.1 bioconda::samtools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:e6f0d20c9d78572ddbbf00d8767ee6ff865edd4e-0"
     } else {

--- a/software/cat/fastq/main.nf
+++ b/software/cat/fastq/main.nf
@@ -10,7 +10,7 @@ process CAT_FASTQ {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'merged_fastq', publish_id:meta.id) }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7=h1bed415_1000" : null)
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
     } else {

--- a/software/cat/fastq/meta.yml
+++ b/software/cat/fastq/meta.yml
@@ -30,7 +30,6 @@ params:
             Instead of directly downloading Singularity images for use with Singularity,
             force the workflow to pull and convert Docker containers instead.
 input:
-    input:
     - meta:
         type: map
         description: |

--- a/software/cutadapt/main.nf
+++ b/software/cutadapt/main.nf
@@ -11,7 +11,7 @@ process CUTADAPT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? 'bioconda::cutadapt:3.2=py38h0213d0e_0' : null)
+    conda (params.enable_conda ? 'bioconda::cutadapt:3.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/cutadapt:3.2--py38h0213d0e_0'
     } else {

--- a/software/deeptools/computematrix/main.nf
+++ b/software/deeptools/computematrix/main.nf
@@ -11,7 +11,7 @@ process DEEPTOOLS_COMPUTEMATRIX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.5.0=py_0" : null)
+    conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/deeptools:3.5.0--py_0"
     } else {

--- a/software/deeptools/plotfingerprint/main.nf
+++ b/software/deeptools/plotfingerprint/main.nf
@@ -11,7 +11,7 @@ process DEEPTOOLS_PLOTFINGERPRINT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.5.0=py_0" : null)
+    conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/deeptools:3.5.0--py_0"
     } else {

--- a/software/deeptools/plotheatmap/main.nf
+++ b/software/deeptools/plotheatmap/main.nf
@@ -11,7 +11,7 @@ process DEEPTOOLS_PLOTHEATMAP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.5.0=py_0" : null)
+    conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/deeptools:3.5.0--py_0"
     } else {

--- a/software/deeptools/plotprofile/main.nf
+++ b/software/deeptools/plotprofile/main.nf
@@ -11,7 +11,7 @@ process DEEPTOOLS_PLOTPROFILE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.5.0=py_0" : null)
+    conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/deeptools:3.5.0--py_0"
     } else {

--- a/software/dsh/filterbed/main.nf
+++ b/software/dsh/filterbed/main.nf
@@ -11,7 +11,7 @@ process DSH_FILTERBED {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::dsh-bio=2.0=0" : null)
+    conda (params.enable_conda ? "bioconda::dsh-bio=2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/dsh-bio:2.0--0"
     } else {

--- a/software/dsh/splitbed/main.nf
+++ b/software/dsh/splitbed/main.nf
@@ -11,7 +11,7 @@ process DSH_SPLITBED {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::dsh-bio=2.0=0" : null)
+    conda (params.enable_conda ? "bioconda::dsh-bio=2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/dsh-bio:2.0--0"
     } else {

--- a/software/fastp/main.nf
+++ b/software/fastp/main.nf
@@ -11,7 +11,7 @@ process FASTP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? 'bioconda::fastp=0.20.1=h8b12597_0' : null)
+    conda (params.enable_conda ? 'bioconda::fastp=0.20.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/fastp:0.20.1--h8b12597_0'
     } else {

--- a/software/fastqc/main.nf
+++ b/software/fastqc/main.nf
@@ -11,7 +11,7 @@ process FASTQC {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::fastqc=0.11.9=0" : null)
+    conda (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0"
     } else {

--- a/software/gffread/main.nf
+++ b/software/gffread/main.nf
@@ -10,7 +10,7 @@ process GFFREAD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::gffread=0.12.1=h8b12597_0" : null)
+    conda (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/gffread:0.12.1--h8b12597_0"
     } else {

--- a/software/gunzip/main.nf
+++ b/software/gunzip/main.nf
@@ -10,7 +10,7 @@ process GUNZIP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7=h1bed415_1000" : null)
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
     } else {

--- a/software/hisat2/align/main.nf
+++ b/software/hisat2/align/main.nf
@@ -13,7 +13,7 @@ process HISAT2_ALIGN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0=py37h3340039_3 bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::hisat2=2.2.0 bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2880dd9d8ad0a7b221d4eacda9a818e92983128d-0"
     } else {

--- a/software/hisat2/build/main.nf
+++ b/software/hisat2/build/main.nf
@@ -12,7 +12,7 @@ process HISAT2_BUILD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0=py37hfa133b6_4" : null)
+    conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/hisat2:2.2.0--py37hfa133b6_4"
     } else {

--- a/software/hisat2/extractsplicesites/main.nf
+++ b/software/hisat2/extractsplicesites/main.nf
@@ -11,7 +11,7 @@ process HISAT2_EXTRACTSPLICESITES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0=py37hfa133b6_4" : null)
+    conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/hisat2:2.2.0--py37hfa133b6_4"
     } else {

--- a/software/homer/annotatepeaks/main.nf
+++ b/software/homer/annotatepeaks/main.nf
@@ -13,7 +13,7 @@ process HOMER_ANNOTATEPEAKS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::homer=4.11=pl526hc9558a2_3" : null)
+    conda (params.enable_conda ? "bioconda::homer=4.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/homer:4.11--pl526hc9558a2_3"
     } else {

--- a/software/macs2/callpeak/main.nf
+++ b/software/macs2/callpeak/main.nf
@@ -11,7 +11,7 @@ process MACS2_CALLPEAK {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::macs2=2.2.7.1=py38h0213d0e_1" : null)
+    conda (params.enable_conda ? "bioconda::macs2=2.2.7.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/macs2:2.2.7.1--py38h0213d0e_1"
     } else {

--- a/software/minimap2/align/main.nf
+++ b/software/minimap2/align/main.nf
@@ -11,7 +11,7 @@ process MINIMAP2_ALIGN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::minimap2=2.17=hed695b0_3" : null)
+    conda (params.enable_conda ? "bioconda::minimap2=2.17" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/minimap2:2.17--hed695b0_3"
     } else {

--- a/software/multiqc/main.nf
+++ b/software/multiqc/main.nf
@@ -10,7 +10,7 @@ process MULTIQC {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename: filename, options: params.options, publish_dir: getSoftwareName(task.process), publish_id: '') }
 
-    conda (params.enable_conda ? "bioconda::multiqc=1.9=pyh9f0ad1d_0" : null)
+    conda (params.enable_conda ? "bioconda::multiqc=1.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/multiqc:1.9--pyh9f0ad1d_0"
     } else {

--- a/software/pangolin/main.nf
+++ b/software/pangolin/main.nf
@@ -11,11 +11,11 @@ process PANGOLIN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? 'bioconda::pangolin=2.2.1=py_0 bioconda::pangolearn=2021.02.05=pyh3252c3a_0' : null)
+    conda (params.enable_conda ? 'bioconda::pangolin=2.2.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container 'https://depot.galaxyproject.org/singularity/pangolin:2.2.1--py_0'
+        container 'https://depot.galaxyproject.org/singularity/pangolin:2.2.2--py_0'
     } else {
-        container 'quay.io/biocontainers/pangolin:2.2.1--py_0'
+        container 'quay.io/biocontainers/pangolin:2.2.2--py_0'
     }
 
     input:

--- a/software/phantompeakqualtools/main.nf
+++ b/software/phantompeakqualtools/main.nf
@@ -13,7 +13,7 @@ process PHANTOMPEAKQUALTOOLS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::phantompeakqualtools=1.2.2=0" : null)
+    conda (params.enable_conda ? "bioconda::phantompeakqualtools=1.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/phantompeakqualtools:1.2.2--0"
     } else {

--- a/software/picard/collectmultiplemetrics/main.nf
+++ b/software/picard/collectmultiplemetrics/main.nf
@@ -11,7 +11,7 @@ process PICARD_COLLECTMULTIPLEMETRICS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::picard=2.23.9=0" : null)
+    conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/picard:2.23.9--0"
     } else {

--- a/software/picard/markduplicates/main.nf
+++ b/software/picard/markduplicates/main.nf
@@ -11,7 +11,7 @@ process PICARD_MARKDUPLICATES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::picard=2.23.9=0" : null)
+    conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/picard:2.23.9--0"
     } else {

--- a/software/picard/mergesamfiles/main.nf
+++ b/software/picard/mergesamfiles/main.nf
@@ -11,7 +11,7 @@ process PICARD_MERGESAMFILES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::picard=2.23.9=0" : null)
+    conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/picard:2.23.9--0"
     } else {

--- a/software/preseq/lcextrap/main.nf
+++ b/software/preseq/lcextrap/main.nf
@@ -12,7 +12,7 @@ process PRESEQ_LCEXTRAP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::preseq=2.0.3=hf53bd2b_3" : null)
+    conda (params.enable_conda ? "bioconda::preseq=2.0.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/preseq:2.0.3--hf53bd2b_3"
     } else {

--- a/software/qualimap/rnaseq/main.nf
+++ b/software/qualimap/rnaseq/main.nf
@@ -11,7 +11,7 @@ process QUALIMAP_RNASEQ {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::qualimap=2.2.2d=1" : null)
+    conda (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/qualimap:2.2.2d--1"
     } else {

--- a/software/quast/main.nf
+++ b/software/quast/main.nf
@@ -10,7 +10,7 @@ process QUAST {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? 'bioconda::quast=5.0.2=py37pl526hb5aa323_2' : null)
+    conda (params.enable_conda ? 'bioconda::quast=5.0.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/quast:5.0.2--py37pl526hb5aa323_2'
     } else {

--- a/software/rsem/calculateexpression/main.nf
+++ b/software/rsem/calculateexpression/main.nf
@@ -11,7 +11,7 @@ process RSEM_CALCULATEEXPRESSION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rsem=1.3.3=pl526hfbaaabd_1 bioconda::star=2.7.6a=0" : null)
+    conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
     } else {

--- a/software/rsem/preparereference/main.nf
+++ b/software/rsem/preparereference/main.nf
@@ -11,7 +11,7 @@ process RSEM_PREPAREREFERENCE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::rsem=1.3.3=pl526hfbaaabd_1 bioconda::star=2.7.6a=0" : null)
+    conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
     } else {

--- a/software/rseqc/bamstat/main.nf
+++ b/software/rseqc/bamstat/main.nf
@@ -11,7 +11,7 @@ process RSEQC_BAMSTAT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1=py37h516909a_1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/software/rseqc/inferexperiment/main.nf
+++ b/software/rseqc/inferexperiment/main.nf
@@ -11,7 +11,7 @@ process RSEQC_INFEREXPERIMENT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1=py37h516909a_1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/software/rseqc/innerdistance/main.nf
+++ b/software/rseqc/innerdistance/main.nf
@@ -11,7 +11,7 @@ process RSEQC_INNERDISTANCE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1=py37h516909a_1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/software/rseqc/junctionannotation/main.nf
+++ b/software/rseqc/junctionannotation/main.nf
@@ -11,7 +11,7 @@ process RSEQC_JUNCTIONANNOTATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1=py37h516909a_1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/software/rseqc/junctionsaturation/main.nf
+++ b/software/rseqc/junctionsaturation/main.nf
@@ -11,7 +11,7 @@ process RSEQC_JUNCTIONSATURATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1=py37h516909a_1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/software/rseqc/readdistribution/main.nf
+++ b/software/rseqc/readdistribution/main.nf
@@ -11,7 +11,7 @@ process RSEQC_READDISTRIBUTION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1=py37h516909a_1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/software/rseqc/readduplication/main.nf
+++ b/software/rseqc/readduplication/main.nf
@@ -11,7 +11,7 @@ process RSEQC_READDUPLICATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1=py37h516909a_1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/software/salmon/index/main.nf
+++ b/software/salmon/index/main.nf
@@ -11,7 +11,7 @@ process SALMON_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::salmon=1.4.0=hf69c8f4_0" : null)
+    conda (params.enable_conda ? "bioconda::salmon=1.4.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/salmon:1.4.0--hf69c8f4_0"
     } else {

--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -11,7 +11,7 @@ process SALMON_QUANT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::salmon=1.4.0=hf69c8f4_0" : null)
+    conda (params.enable_conda ? "bioconda::salmon=1.4.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/salmon:1.4.0--hf69c8f4_0"
     } else {

--- a/software/samtools/flagstat/main.nf
+++ b/software/samtools/flagstat/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_FLAGSTAT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
     } else {

--- a/software/samtools/idxstats/main.nf
+++ b/software/samtools/idxstats/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_IDXSTATS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
     } else {

--- a/software/samtools/index/main.nf
+++ b/software/samtools/index/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
     } else {

--- a/software/samtools/mpileup/main.nf
+++ b/software/samtools/mpileup/main.nf
@@ -11,7 +11,7 @@ process SAMTOOLS_MPILEUP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
     } else {

--- a/software/samtools/sort/main.nf
+++ b/software/samtools/sort/main.nf
@@ -11,7 +11,7 @@ process SAMTOOLS_SORT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
     } else {

--- a/software/samtools/stats/main.nf
+++ b/software/samtools/stats/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_STATS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
     } else {

--- a/software/samtools/view/main.nf
+++ b/software/samtools/view/main.nf
@@ -10,7 +10,7 @@ process SAMTOOLS_VIEW {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10=h9402c20_2" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
     } else {

--- a/software/seacr/callpeak/main.nf
+++ b/software/seacr/callpeak/main.nf
@@ -13,7 +13,7 @@ process SEACR_CALLPEAK {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::seacr=1.3=1 conda-forge::r-base=4.0.2=he766273_1 bioconda::bedtools=2.29.2=hc088bd4_0" : null)
+    conda (params.enable_conda ? "bioconda::seacr=1.3 conda-forge::r-base=4.0.2 bioconda::bedtools=2.29.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/mulled-v2-03bfeb32fe80910c231f630d4262b83677c8c0f4:5bb5ed4307a8187a7f34730b00431de93688fa59-0"
     } else {

--- a/software/sortmerna/main.nf
+++ b/software/sortmerna/main.nf
@@ -11,7 +11,7 @@ process SORTMERNA {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::sortmerna=4.2.0=0" : null)
+    conda (params.enable_conda ? "bioconda::sortmerna=4.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/sortmerna:4.2.0--0"
     } else {

--- a/software/star/align/main.nf
+++ b/software/star/align/main.nf
@@ -12,7 +12,7 @@ process STAR_ALIGN {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? 'bioconda::star=2.6.1d=0' : null)
+    conda (params.enable_conda ? 'bioconda::star=2.6.1d' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container 'https://depot.galaxyproject.org/singularity/star:2.6.1d--0'
     } else {

--- a/software/star/genomegenerate/main.nf
+++ b/software/star/genomegenerate/main.nf
@@ -12,7 +12,7 @@ process STAR_GENOMEGENERATE {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::star=2.6.1d=0" : null)
+    conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/star:2.6.1d--0"
     } else {

--- a/software/stringtie/main.nf
+++ b/software/stringtie/main.nf
@@ -11,7 +11,7 @@ process STRINGTIE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::stringtie=2.1.4=h7e0af3c_0" : null)
+    conda (params.enable_conda ? "bioconda::stringtie=2.1.4" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/stringtie:2.1.4--h7e0af3c_0"
     } else {

--- a/software/subread/featurecounts/main.nf
+++ b/software/subread/featurecounts/main.nf
@@ -11,7 +11,7 @@ process SUBREAD_FEATURECOUNTS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::subread=2.0.1=hed695b0_0" : null)
+    conda (params.enable_conda ? "bioconda::subread=2.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/subread:2.0.1--hed695b0_0"
     } else {

--- a/software/trimgalore/main.nf
+++ b/software/trimgalore/main.nf
@@ -11,7 +11,7 @@ process TRIMGALORE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::trim-galore=0.6.6=0" : null)
+    conda (params.enable_conda ? "bioconda::trim-galore=0.6.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/trim-galore:0.6.6--0"
     } else {

--- a/software/ucsc/bedgraphtobigwig/main.nf
+++ b/software/ucsc/bedgraphtobigwig/main.nf
@@ -13,7 +13,7 @@ process UCSC_BEDGRAPHTOBIGWIG {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::ucsc-bedgraphtobigwig=377=h446ed27_1" : null)
+    conda (params.enable_conda ? "bioconda::ucsc-bedgraphtobigwig=377" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/ucsc-bedgraphtobigwig:377--h446ed27_1"
     } else {

--- a/software/umitools/dedup/main.nf
+++ b/software/umitools/dedup/main.nf
@@ -11,7 +11,7 @@ process UMITOOLS_DEDUP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::umi_tools=1.1.1=py38h0213d0e_1" : null)
+    conda (params.enable_conda ? "bioconda::umi_tools=1.1.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/umi_tools:1.1.1--py38h0213d0e_1"
     } else {

--- a/software/umitools/extract/main.nf
+++ b/software/umitools/extract/main.nf
@@ -11,7 +11,7 @@ process UMITOOLS_EXTRACT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::umi_tools=1.1.1=py38h0213d0e_1" : null)
+    conda (params.enable_conda ? "bioconda::umi_tools=1.1.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/umi_tools:1.1.1--py38h0213d0e_1"
     } else {

--- a/software/untar/main.nf
+++ b/software/untar/main.nf
@@ -10,7 +10,7 @@ process UNTAR {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7=h1bed415_1000" : null)
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
     } else {


### PR DESCRIPTION
Removed build ids from the `conda` directive for all modules agaaaaaainnn. Conda can quite happily have different build ids on different OSs which means either we provide one build id per OS along with a bunch of custom code to deal with that or we don't touch that mess with a bargepole in favour of keeping things simple. 

Given that Conda isn't great for reproducibility we should anyway encourage the use of Docker / Singularity. One issue with removing the build info is that the md5sum checks may fail because it is now entirely possible that there will be a discrepancy between the build of the tool used in the Docker / Singularity container relative to the one installed by Conda. But we will have to find a workaround with the CI tests to deal with this as the modules will still be fully functional.
