### PR TITLE
fix: update checksum or filename

### DIFF
--- a/tests/software/TOOL/SUBTOOL/test.yml
+++ b/tests/software/TOOL/SUBTOOL/test.yml
@@ -5,4 +5,4 @@
     - tool_subtool
   files:
     - path: output/tool/test.bam
-      md5sum: a41bfadacd2eeef1d31e05c135cc4f4e
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc

--- a/tests/software/bwa/mem/test.yml
+++ b/tests/software/bwa/mem/test.yml
@@ -6,7 +6,7 @@
     - bwa_mem_single_end
   files:
     - path: output/bwa/test.bam
-      md5sum: 52e81e5bd523d0b27fe533b21a0d80f5
+      md5sum: 2bea94a4458cd1216214874b11c2e394
 
 - name: bwa mem paired-end
   command: nextflow run ./tests/software/bwa/mem -entry test_bwa_mem_paired_end -c tests/config/nextflow.config
@@ -16,4 +16,4 @@
     - bwa_mem_paired_end
   files:
     - path: output/bwa/test.bam
-      md5sum: 86d82fdb68ed384c656cfc62a253052f
+      md5sum: 2d952be81c7d2856712391b5d8556039

--- a/tests/software/bwamem2/mem/test.yml
+++ b/tests/software/bwamem2/mem/test.yml
@@ -6,7 +6,7 @@
     - bwamem2_mem_single_end
   files:
     - path: output/bwamem2/test.bam
-      md5sum: 354acd3b7033a2d4ee69452df18c0a4d
+      md5sum: b8fceee111b3e23372c95ed765ac4401
 
 - name: bwamem2 mem paired-end
   command: nextflow run ./tests/software/bwamem2/mem -entry test_bwamem2_mem_paired_end -c tests/config/nextflow.config
@@ -16,4 +16,4 @@
     - bwamem2_mem_paired_end
   files:
     - path: output/bwamem2/test.bam
-      md5sum: 26187528a7bde13a2a9e9dd549b9bcd0
+      md5sum: 4b05c7e1b28e0835c647e890854897e4

--- a/tests/software/fastp/test.yml
+++ b/tests/software/fastp/test.yml
@@ -5,9 +5,9 @@
     - fastp_single_end
   files:
     - path: ./output/fastp/test.fastp.json
-      md5sum: b81d53bfa5c1553bed89f6475edcf437
+      md5sum: 8740a96898a850a3c2ce0081d9a259fb
     - path: ./output/fastp/test.trim.fastq.gz
-      md5sum: 2f5516df477b123e3f78adb67effa3bc
+      md5sum: 63fea84c6907d2716aeb53fe890b288d
     - path: ./output/fastp/test.fastp.log
     - path: ./output/fastp/test.fastp.html
 
@@ -19,7 +19,7 @@
   files:
     - path: ./output/fastp/test.fastp.html
     - path: ./output/fastp/test.fastp.json
-      md5sum: 40db7fcbed478b0a96a1c5c1bb5f737b
+      md5sum: 7afba66526b1dd4cd3b1012809ba0327
     - path: ./output/fastp/test.fastp.log
     - path: ./output/fastp/test_1.trim.fastq.gz
       md5sum: c8844c05194b50ae368e6825e997aa7f

--- a/tests/software/pangolin/test.yml
+++ b/tests/software/pangolin/test.yml
@@ -4,4 +4,4 @@
     - pangolin
   files:
     - path: ./output/pangolin/test.pangolin.csv
-      md5sum: 097669de1843e27f4529d6db8bbed97b
+      md5sum: 43edd267815f6408b66961a0abf9ddd6

--- a/tests/software/samtools/sort/test.yml
+++ b/tests/software/samtools/sort/test.yml
@@ -5,4 +5,4 @@
     - samtools_sort
   files:
     - path: output/samtools/test.bam
-      md5sum: a41bfadacd2eeef1d31e05c135cc4f4e
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc

--- a/tests/software/star/align/test.yml
+++ b/tests/software/star/align/test.yml
@@ -22,7 +22,7 @@
     - path: output/star/star/exonInfo.tab
       md5sum: 42eca6ebc2dc72d9d6e6b3acd3714343
     - path: output/star/star/genomeParameters.txt
-      md5sum: ed47b8b034cae2fefcdb39321aea47cd
+      md5sum: 05e1041cbfb7f81686e17bc80b3ddcea
     - path: output/star/star/sjdbInfo.txt
       md5sum: 1082ab459363b3f2f7aabcef0979c1ed
     - path: output/star/star/sjdbList.fromGTF.out.tab
@@ -32,7 +32,7 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 8fbe69abbbef4f89da3854873984dbac
     - path: output/star/test.Aligned.out.bam
-      md5sum: d7f59c1728482e76a18e3f6eb9c66c25
+      md5sum: b7f113f12ff62e09d16fa0ace290d03e
     - path: output/star/test.SJ.out.tab
       md5sum: d41d8cd98f00b204e9800998ecf8427e
 
@@ -60,7 +60,7 @@
     - path: output/star/star/exonInfo.tab
       md5sum: 42eca6ebc2dc72d9d6e6b3acd3714343
     - path: output/star/star/genomeParameters.txt
-      md5sum: ed47b8b034cae2fefcdb39321aea47cd
+      md5sum: 05e1041cbfb7f81686e17bc80b3ddcea
     - path: output/star/star/sjdbInfo.txt
       md5sum: 1082ab459363b3f2f7aabcef0979c1ed
     - path: output/star/star/sjdbList.fromGTF.out.tab
@@ -70,6 +70,6 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 8fbe69abbbef4f89da3854873984dbac
     - path: output/star/test.Aligned.out.bam
-      md5sum: 5c52bcaa15e86914ad6b895638235166
+      md5sum: a1f92e8dbeb954b6b8d3d7cc6b9814fb
     - path: output/star/test.SJ.out.tab
       md5sum: d41d8cd98f00b204e9800998ecf8427e

--- a/tests/software/star/genomegenerate/test.yml
+++ b/tests/software/star/genomegenerate/test.yml
@@ -21,7 +21,7 @@
     - path: output/star/star/exonInfo.tab
       md5sum: 42eca6ebc2dc72d9d6e6b3acd3714343
     - path: output/star/star/genomeParameters.txt
-      md5sum: ed47b8b034cae2fefcdb39321aea47cd
+      md5sum: 05e1041cbfb7f81686e17bc80b3ddcea
     - path: output/star/star/sjdbInfo.txt
       md5sum: 1082ab459363b3f2f7aabcef0979c1ed
     - path: output/star/star/sjdbList.fromGTF.out.tab

--- a/tests/software/stringtie/test.yml
+++ b/tests/software/stringtie/test.yml
@@ -3,10 +3,10 @@
   tags:
     - stringtie
   files:
-    - path: output/test_stringtie_forward/test.gene_abundance.txt
+    - path: output/test_stringtie_forward/test.gene.abundance.txt
       md5sum: cea2e346f4e8137da13265b9b0a4c573
     - path: output/test_stringtie_forward/test.transcripts.gtf
-      md5sum: f1b5baa8d94f86e499556a4ec419a75a
+      md5sum: 80a4155b459a124eac64b52cde7e8ad1
     - path: output/test_stringtie_forward/test.coverage.gtf
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: output/test_stringtie_forward/test.ballgown/e_data.ctab
@@ -25,10 +25,10 @@
   tags:
     - stringtie
   files:
-    - path: output/test_stringtie_reverse/test.gene_abundance.txt
+    - path: output/test_stringtie_reverse/test.gene.abundance.txt
       md5sum: cea2e346f4e8137da13265b9b0a4c573
     - path: output/test_stringtie_reverse/test.transcripts.gtf
-      md5sum: cb0367e5f98f19fcc2043d248deb513c
+      md5sum: a69eabfc201112167f0844ffb80005c5
     - path: output/test_stringtie_reverse/test.coverage.gtf
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: output/test_stringtie_reverse/test.ballgown/e_data.ctab


### PR DESCRIPTION
follow up on #182

From @drpatelh 
> We need to fix all of the tests that are failing here for Docker / Singularity. It's fine to ignore the ones failing for Conda. Maybe the test files were generated relative to Conda and now that we have removed the pinned build the Docker / Singularity tests are failing? Don't know but I need to find a bed. Someone fancy fixing these in a follow up PR?
> 
> ```
> bcftools_filter
> bcftools_stats
> bwa_mem
> bwamem2_mem
> fastp
> pangolin
> salmon
> samtools_sort
> star_align
> star_genomegenerate
> stringtie
> tool_subtool
> ```

Managed to fix all tests, it was indeed just issue with `md5sum`, and some filename for `sringtie`
But couldn't find any issue for `bcftools_filter` and `bcftools_stats`