### PR TITLE
Only use one thread for pytest-workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,6 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modu
 - [ ] Add a resource `label`
 - [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
 - Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
-    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --wt 2 --keep-workflow-wd`
-    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --wt 2 --keep-workflow-wd`
-    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --wt 2 --keep-workflow-wd`
+    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
+    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
+    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -80,7 +80,8 @@ jobs:
 
       # Test the module
       - name: Run pytest-workflow
-        run: TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --tag ${{ matrix.tags }} --symlink --wt 2 --kwdof
+        # only use one thread for pytest-workflow to avoid race condition on conda cache. 
+        run: TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --tag ${{ matrix.tags }} --symlink --wt 1 --kwdof
 
       - name: Upload logs on failure
         if: failure()

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -81,7 +81,7 @@ jobs:
       # Test the module
       - name: Run pytest-workflow
         # only use one thread for pytest-workflow to avoid race condition on conda cache. 
-        run: TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --tag ${{ matrix.tags }} --symlink --wt 1 --kwdof
+        run: TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --tag ${{ matrix.tags }} --symlink --kwdof
 
       - name: Upload logs on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -275,21 +275,21 @@ In order to test that each module added to `nf-core/modules` is actually working
 
         ```console
         cd /path/to/git/clone/of/nf-core/modules/
-        PROFILE=docker pytest --tag bowtie --symlink --wt 2 --keep-workflow-wd
+        PROFILE=docker pytest --tag bowtie --symlink --keep-workflow-wd
         ```
 
     - Typical command with Singularity:
 
         ```console
         cd /path/to/git/clone/of/nf-core/modules/
-        TMPDIR=~ PROFILE=singularity pytest --tag bowtie --symlink --wt 2 --keep-workflow-wd
+        TMPDIR=~ PROFILE=singularity pytest --tag bowtie --symlink --keep-workflow-wd
         ```
 
     - Typical command with Conda:
 
         ```console
         cd /path/to/git/clone/of/nf-core/modules/
-        PROFILE=conda pytest --tag bowtie --symlink --wt 2 --keep-workflow-wd
+        PROFILE=conda pytest --tag bowtie --symlink --keep-workflow-wd
         ```
 
     - See [docs on running pytest-workflow](https://pytest-workflow.readthedocs.io/en/stable/#running-pytest-workflow) for more info.


### PR DESCRIPTION
This avoids a race condition on the conda cache.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --wt 2 --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --wt 2 --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --wt 2 --keep-workflow-wd`
