### PR TITLE
add task.cpus to pangolin

### DIFF
--- a/software/pangolin/main.nf
+++ b/software/pangolin/main.nf
@@ -32,6 +32,7 @@ process PANGOLIN {
     pangolin \\
         $fasta\\
         --outfile ${prefix}.pangolin.csv \\
+        --threads $task.cpus \\
         $options.args
 
     pangolin --version | sed "s/pangolin //g" > ${software}.version.txt


### PR DESCRIPTION
Just adding `$task.cpus` to pangolin which has been forgotten in the original PR.