### PR TITLE
Check for minimum NF version

### DIFF
--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -20,3 +20,7 @@ if ("$PROFILE" == "singularity") {
     docker.enabled = true
     docker.runOptions = '-u \$(id -u):\$(id -g)'
 }
+
+manifest {
+  nextflowVersion = '!>=20.11.0-edge'
+}


### PR DESCRIPTION
This exits nicely if you are running any module tests with `nf-core modules create-test-yml` and are running with an older version of Nextflow.