### PR TITLE
update methyldackel version

### DIFF
--- a/software/methyldackel/extract/main.nf
+++ b/software/methyldackel/extract/main.nf
@@ -11,11 +11,11 @@ process METHYLDACKEL_EXTRACT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::methyldackel=0.5.0" : null)
+    conda (params.enable_conda ? "bioconda::methyldackel=0.5.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/methyldackel:0.5.0--hed50d52_0"
+        container "https://depot.galaxyproject.org/singularity/methyldackel:0.5.2--h7435645_0"
     } else {
-        container "quay.io/biocontainers/methyldackel:0.5.0--hed50d52_0"
+        container "quay.io/biocontainers/methyldackel:0.5.2--h7435645_0"
     }
 
     input:

--- a/software/methyldackel/mbias/main.nf
+++ b/software/methyldackel/mbias/main.nf
@@ -11,11 +11,11 @@ process METHYLDACKEL_MBIAS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::methyldackel=0.5.0" : null)
+    conda (params.enable_conda ? "bioconda::methyldackel=0.5.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/methyldackel:0.5.0--hed50d52_0"
+        container "https://depot.galaxyproject.org/singularity/methyldackel:0.5.2--h7435645_0"
     } else {
-        container "quay.io/biocontainers/methyldackel:0.5.0--hed50d52_0"
+        container "quay.io/biocontainers/methyldackel:0.5.2--h7435645_0"
     }
 
     input:


### PR DESCRIPTION
Previously,  MethylDackel was pinned to `0.5.0` because it had some `htslib` related issue that caused segfaults.
The issue is fixed in the latest version `0.5.2`, so let's use it.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
