### PR TITLE
Add link to issue in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,8 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modu
 
 ## PR checklist
 
+Closes #XXX <!-- If this PR fixes an issue, please link it here! --> 
+
 - [ ] This comment contains a description of changes (with reason).
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modu
 
 ## PR checklist
 
-Closes #XXX <!-- If this PR fixes an issue, please link it here! --> 
+Closes #XXX <!-- If this PR fixes an issue, please link it here! -->
 
 - [ ] This comment contains a description of changes (with reason).
 - [ ] If you've fixed a bug or added code that should be tested, add tests!


### PR DESCRIPTION
Encourages PR submitters to link the corresponding issue - and trigger closing it automatically when the PR is merged. 
