### PR TITLE
Remove runOptions from docker profile

### DIFF
--- a/.github/workflows/pytest-workflow-all.yml
+++ b/.github/workflows/pytest-workflow-all.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nxf_version: ['20.11.0-edge' '21.03.0-edge']
+        nxf_version: ['20.11.0-edge', '21.03.0-edge']
         profile: ['docker'] # , 'singularity', 'conda']
     env:
       NXF_ANSI_LOG: false

--- a/.github/workflows/pytest-workflow-all.yml
+++ b/.github/workflows/pytest-workflow-all.yml
@@ -11,8 +11,6 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     name: ${{ matrix.profile }} ${{ matrix.nxf_version }}
-    needs: changes
-    if: needs.changes.outputs.modules != '[]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pytest-workflow-all.yml
+++ b/.github/workflows/pytest-workflow-all.yml
@@ -1,0 +1,86 @@
+name: Pytest-workflow Everything
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    name: ${{ matrix.profile }} ${{ matrix.nxf_version }}
+    needs: changes
+    if: needs.changes.outputs.modules != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        nxf_version: ['20.11.0-edge' '21.03.0-edge']
+        profile: ['docker'] # , 'singularity', 'conda']
+    env:
+      NXF_ANSI_LOG: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - uses: actions/cache@v2
+        with:
+          path: /usr/local/bin/nextflow
+          key: ${{ runner.os }}-nextflow-${{ matrix.nxf_version }}
+          restore-keys: |
+            ${{ runner.os }}-nextflow-
+
+      - name: Install Nextflow
+        env:
+          NXF_VER: ${{ matrix.nxf_version }}
+        run: |
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip pytest-workflow
+
+      - name: Set up Singularity
+        if: matrix.profile == 'singularity'
+        uses: eWaterCycle/setup-singularity@v5
+        with:
+          singularity-version: 3.7.1
+
+      - name: Setup miniconda
+        if: matrix.profile == 'conda'
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          channels: conda-forge,bioconda,defaults
+          python-version: ${{ matrix.python-version }}
+      - name: Conda clean
+        if: matrix.profile == 'conda'
+        run: conda clean -a
+
+      # Test the module
+      - name: Run pytest-workflow
+        # only use one thread for pytest-workflow to avoid race condition on conda cache.
+        run: TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --symlink --kwdof
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-${{ matrix.profile }}-${{ matrix.nxf_version }}
+          path: |
+            /home/runner/pytest_workflow_*/*/.nextflow.log
+            /home/runner/pytest_workflow_*/*/log.out
+            /home/runner/pytest_workflow_*/*/log.err

--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -18,7 +18,6 @@ if ("$PROFILE" == "singularity") {
     params.enable_conda = true
 } else {
     docker.enabled = true
-    docker.runOptions = '-u \$(id -u):\$(id -g)'
 }
 
 manifest {


### PR DESCRIPTION
WIP, removing `runOptions` from the test docker profile to see what fails, if anything

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
