### PR TITLE
Fix bwa index failing to put outputs in correct dir

### DIFF
--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -22,14 +22,14 @@ process BWA_INDEX {
     path fasta
 
     output:
-    path "bwa"          , emit: index
+    path "index"          , emit: index
     path "*.version.txt", emit: version
 
     script:
     def software = getSoftwareName(task.process)
     """
-    mkdir bwa
-    bwa index $options.args $fasta -p bwa/${fasta.baseName}
+    mkdir index
+    bwa index $options.args -p index/${fasta.baseName} $fasta 
     echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//' > ${software}.version.txt
     """
 }

--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -29,7 +29,7 @@ process BWA_INDEX {
     def software = getSoftwareName(task.process)
     """
     mkdir index
-    bwa index $options.args -p index/${fasta.baseName} $fasta 
+    bwa index $options.args -p index/${fasta.baseName} $fasta
     echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//' > ${software}.version.txt
     """
 }

--- a/tests/software/bwa/index/test.yml
+++ b/tests/software/bwa/index/test.yml
@@ -4,13 +4,13 @@
     - bwa
     - bwa_index
   files:
-    - path: ./output/bwa/bwa/test_genome.bwt
+    - path: ./output/bwa/index/test_genome.bwt
       md5sum: 0469c30a1e239dd08f68afe66fde99da
-    - path: ./output/bwa/bwa/test_genome.amb
+    - path: ./output/bwa/index/test_genome.amb
       md5sum: 3a68b8b2287e07dd3f5f95f4344ba76e
-    - path: ./output/bwa/bwa/test_genome.sa
+    - path: ./output/bwa/index/test_genome.sa
       md5sum: ab3952cabf026b48cd3eb5bccbb636d1
-    - path: ./output/bwa/bwa/test_genome.pac
+    - path: ./output/bwa/index/test_genome.pac
       md5sum: 983e3d2cd6f36e2546e6d25a0da78d66
-    - path: ./output/bwa/bwa/test_genome.ann
+    - path: ./output/bwa/index/test_genome.ann
       md5sum: c32e11f6c859f166c7525a9c1d583567


### PR DESCRIPTION
## PR checklist
* The argument `-p bwa/${${fasta.baseName}` doesn't make the indicies in the `bwa` dir unless it comes before the fasta sequence
* If these are made in a directory called index then the publishDir will become `bwa/index`
- [x] This comment contains a description of changes (with reason).
