### PR TITLE
bismark/report: allow missing input data

### DIFF
--- a/software/bismark/report/main.nf
+++ b/software/bismark/report/main.nf
@@ -22,17 +22,13 @@ process BISMARK_REPORT {
     tuple val(meta), path(align_report), path(dedup_report), path(splitting_report), path(mbias)
 
     output:
-    tuple val(meta), path("*{html,txt}"), emit: report
-    path  "*.version.txt"               , emit: version
+    tuple val(meta), path("*report.{html,txt}"), emit: report
+    path  "*.version.txt"                      , emit: version
 
     script:
     def software = getSoftwareName(task.process)
     """
-    bismark2report \\
-        --alignment_report $align_report \\
-        --dedup_report $dedup_report \\
-        --splitting_report $splitting_report \\
-        --mbias_report $mbias
+    bismark2report $options.args
 
     echo \$(bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*\$//' > ${software}.version.txt
     """

--- a/software/bismark/summary/main.nf
+++ b/software/bismark/summary/main.nf
@@ -25,8 +25,8 @@ process BISMARK_SUMMARY {
     path(mbias)
 
     output:
-    path("*{html,txt}")  , emit: summary
-    path  "*.version.txt", emit: version
+    path  "*report.{html,txt}", emit: summary
+    path  "*.version.txt"     , emit: version
 
     script:
     def software = getSoftwareName(task.process)


### PR DESCRIPTION
bismark2report does some autodetection of input data based on filenames if no explicit arguments are given.
This change makes the process more lenient if input data is partially missing by relying on this autodetection (explicit arguments can still be passed via `options.args`)

Additionally, the output channel glob no longer matches the .version.txt output which was leading to input filename collisions when used in downstream processes.


<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
