### PR TITLE
bwameth: fix container not matching conda version

### DIFF
--- a/software/bwameth/align/main.nf
+++ b/software/bwameth/align/main.nf
@@ -13,9 +13,9 @@ process BWAMETH_ALIGN {
 
     conda (params.enable_conda ? "bioconda::bwameth=0.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/bwameth:0.20--py35_0"
+        container "https://depot.galaxyproject.org/singularity/bwameth:0.2.2--py_1"
     } else {
-        container "quay.io/biocontainers/bwameth:0.20--py35_0"
+        container "quay.io/biocontainers/bwameth:0.2.2--py_1"
     }
 
     input:

--- a/software/bwameth/index/main.nf
+++ b/software/bwameth/index/main.nf
@@ -13,9 +13,9 @@ process BWAMETH_INDEX {
 
     conda (params.enable_conda ? "bioconda::bwameth=0.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/bwameth:0.20--py35_0"
+        container "https://depot.galaxyproject.org/singularity/bwameth:0.2.2--py_1"
     } else {
-        container "quay.io/biocontainers/bwameth:0.20--py35_0"
+        container "quay.io/biocontainers/bwameth:0.2.2--py_1"
     }
 
     input:


### PR DESCRIPTION
The container was not matching the latest conda package version, but used a rather old version of bwameth instead.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
