### PR TITLE
Update functions.nf to be more flexible for publishing by meta keys

### DIFF
--- a/software/adapterremoval/functions.nf
+++ b/software/adapterremoval/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/adapterremoval/main.nf
+++ b/software/adapterremoval/main.nf
@@ -8,7 +8,7 @@ process ADAPTERREMOVAL {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::adapterremoval=2.3.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/adapterremoval/main.nf
+++ b/software/adapterremoval/main.nf
@@ -8,7 +8,7 @@ process ADAPTERREMOVAL {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::adapterremoval=2.3.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/allelecounter/functions.nf
+++ b/software/allelecounter/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/allelecounter/main.nf
+++ b/software/allelecounter/main.nf
@@ -9,7 +9,7 @@ process ALLELECOUNTER {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::cancerit-allelecount=4.2.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/allelecounter/main.nf
+++ b/software/allelecounter/main.nf
@@ -9,7 +9,7 @@ process ALLELECOUNTER {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::cancerit-allelecount=4.2.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bandage/image/functions.nf
+++ b/software/bandage/image/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bandage/image/main.nf
+++ b/software/bandage/image/main.nf
@@ -9,7 +9,7 @@ process BANDAGE_IMAGE {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::bandage=0.8.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bandage/image/main.nf
+++ b/software/bandage/image/main.nf
@@ -9,7 +9,7 @@ process BANDAGE_IMAGE {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::bandage=0.8.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/consensus/functions.nf
+++ b/software/bcftools/consensus/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bcftools/consensus/main.nf
+++ b/software/bcftools/consensus/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_CONSENSUS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::bcftools=1.11' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/consensus/main.nf
+++ b/software/bcftools/consensus/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_CONSENSUS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::bcftools=1.11' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/filter/functions.nf
+++ b/software/bcftools/filter/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bcftools/filter/main.nf
+++ b/software/bcftools/filter/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_FILTER {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/filter/main.nf
+++ b/software/bcftools/filter/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_FILTER {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/isec/functions.nf
+++ b/software/bcftools/isec/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bcftools/isec/main.nf
+++ b/software/bcftools/isec/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_ISEC {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/isec/main.nf
+++ b/software/bcftools/isec/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_ISEC {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/merge/functions.nf
+++ b/software/bcftools/merge/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bcftools/merge/main.nf
+++ b/software/bcftools/merge/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_MERGE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/merge/main.nf
+++ b/software/bcftools/merge/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_MERGE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/mpileup/functions.nf
+++ b/software/bcftools/mpileup/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -31,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -41,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bcftools/mpileup/main.nf
+++ b/software/bcftools/mpileup/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_MPILEUP {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/mpileup/main.nf
+++ b/software/bcftools/mpileup/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_MPILEUP {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/stats/functions.nf
+++ b/software/bcftools/stats/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bcftools/stats/main.nf
+++ b/software/bcftools/stats/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_STATS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bcftools/stats/main.nf
+++ b/software/bcftools/stats/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_STATS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/complement/functions.nf
+++ b/software/bedtools/complement/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bedtools/complement/main.nf
+++ b/software/bedtools/complement/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_COMPLEMENT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/complement/main.nf
+++ b/software/bedtools/complement/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_COMPLEMENT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/genomecov/functions.nf
+++ b/software/bedtools/genomecov/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bedtools/genomecov/main.nf
+++ b/software/bedtools/genomecov/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_GENOMECOV {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/genomecov/main.nf
+++ b/software/bedtools/genomecov/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_GENOMECOV {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/getfasta/functions.nf
+++ b/software/bedtools/getfasta/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bedtools/getfasta/main.nf
+++ b/software/bedtools/getfasta/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_GETFASTA {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/getfasta/main.nf
+++ b/software/bedtools/getfasta/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_GETFASTA {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/intersect/functions.nf
+++ b/software/bedtools/intersect/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bedtools/intersect/main.nf
+++ b/software/bedtools/intersect/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_INTERSECT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/intersect/main.nf
+++ b/software/bedtools/intersect/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_INTERSECT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/maskfasta/functions.nf
+++ b/software/bedtools/maskfasta/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bedtools/maskfasta/main.nf
+++ b/software/bedtools/maskfasta/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_MASKFASTA {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/maskfasta/main.nf
+++ b/software/bedtools/maskfasta/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_MASKFASTA {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/merge/functions.nf
+++ b/software/bedtools/merge/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bedtools/merge/main.nf
+++ b/software/bedtools/merge/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_MERGE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/merge/main.nf
+++ b/software/bedtools/merge/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_MERGE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/slop/functions.nf
+++ b/software/bedtools/slop/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bedtools/slop/main.nf
+++ b/software/bedtools/slop/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_SLOP {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/slop/main.nf
+++ b/software/bedtools/slop/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_SLOP {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/sort/functions.nf
+++ b/software/bedtools/sort/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bedtools/sort/main.nf
+++ b/software/bedtools/sort/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_SORT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bedtools/sort/main.nf
+++ b/software/bedtools/sort/main.nf
@@ -9,7 +9,7 @@ process BEDTOOLS_SORT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bedtools=2.30.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/align/functions.nf
+++ b/software/bismark/align/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bismark/align/main.nf
+++ b/software/bismark/align/main.nf
@@ -9,7 +9,7 @@ process BISMARK_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/align/main.nf
+++ b/software/bismark/align/main.nf
@@ -9,7 +9,7 @@ process BISMARK_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/deduplicate/functions.nf
+++ b/software/bismark/deduplicate/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bismark/deduplicate/main.nf
+++ b/software/bismark/deduplicate/main.nf
@@ -9,7 +9,7 @@ process BISMARK_DEDUPLICATE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/deduplicate/main.nf
+++ b/software/bismark/deduplicate/main.nf
@@ -9,7 +9,7 @@ process BISMARK_DEDUPLICATE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/genomepreparation/functions.nf
+++ b/software/bismark/genomepreparation/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bismark/genomepreparation/main.nf
+++ b/software/bismark/genomepreparation/main.nf
@@ -9,7 +9,7 @@ process BISMARK_GENOMEPREPARATION {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/genomepreparation/main.nf
+++ b/software/bismark/genomepreparation/main.nf
@@ -9,7 +9,7 @@ process BISMARK_GENOMEPREPARATION {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/methylationextractor/functions.nf
+++ b/software/bismark/methylationextractor/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bismark/methylationextractor/main.nf
+++ b/software/bismark/methylationextractor/main.nf
@@ -9,7 +9,7 @@ process BISMARK_METHYLATIONEXTRACTOR {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/methylationextractor/main.nf
+++ b/software/bismark/methylationextractor/main.nf
@@ -9,7 +9,7 @@ process BISMARK_METHYLATIONEXTRACTOR {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/report/functions.nf
+++ b/software/bismark/report/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bismark/report/main.nf
+++ b/software/bismark/report/main.nf
@@ -9,7 +9,7 @@ process BISMARK_REPORT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/report/main.nf
+++ b/software/bismark/report/main.nf
@@ -9,7 +9,7 @@ process BISMARK_REPORT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/summary/functions.nf
+++ b/software/bismark/summary/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bismark/summary/main.nf
+++ b/software/bismark/summary/main.nf
@@ -8,7 +8,7 @@ process BISMARK_SUMMARY {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bismark/summary/main.nf
+++ b/software/bismark/summary/main.nf
@@ -8,7 +8,7 @@ process BISMARK_SUMMARY {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bismark=0.23.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/blast/blastn/functions.nf
+++ b/software/blast/blastn/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/blast/blastn/main.nf
+++ b/software/blast/blastn/main.nf
@@ -9,7 +9,7 @@ process BLAST_BLASTN {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::blast=2.10.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/blast/blastn/main.nf
+++ b/software/blast/blastn/main.nf
@@ -9,7 +9,7 @@ process BLAST_BLASTN {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::blast=2.10.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/blast/makeblastdb/functions.nf
+++ b/software/blast/makeblastdb/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/blast/makeblastdb/main.nf
+++ b/software/blast/makeblastdb/main.nf
@@ -9,7 +9,7 @@ process BLAST_MAKEBLASTDB {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::blast=2.10.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/blast/makeblastdb/main.nf
+++ b/software/blast/makeblastdb/main.nf
@@ -9,7 +9,7 @@ process BLAST_MAKEBLASTDB {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::blast=2.10.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bowtie/align/functions.nf
+++ b/software/bowtie/align/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bowtie/align/main.nf
+++ b/software/bowtie/align/main.nf
@@ -9,7 +9,7 @@ process BOWTIE_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::bowtie=1.3.0 bioconda::samtools=1.11' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bowtie/align/main.nf
+++ b/software/bowtie/align/main.nf
@@ -9,7 +9,7 @@ process BOWTIE_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::bowtie=1.3.0 bioconda::samtools=1.11' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bowtie/build/functions.nf
+++ b/software/bowtie/build/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bowtie/build/main.nf
+++ b/software/bowtie/build/main.nf
@@ -9,7 +9,7 @@ process BOWTIE_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::bowtie=1.3.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bowtie/build/main.nf
+++ b/software/bowtie/build/main.nf
@@ -9,7 +9,7 @@ process BOWTIE_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::bowtie=1.3.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bowtie2/align/functions.nf
+++ b/software/bowtie2/align/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bowtie2/align/main.nf
+++ b/software/bowtie2/align/main.nf
@@ -9,7 +9,7 @@ process BOWTIE2_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::bowtie2=2.4.2 bioconda::samtools=1.11 conda-forge::pigz=2.3.4' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bowtie2/build/functions.nf
+++ b/software/bowtie2/build/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bowtie2/build/main.nf
+++ b/software/bowtie2/build/main.nf
@@ -9,7 +9,7 @@ process BOWTIE2_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::bowtie2=2.4.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bowtie2/build/main.nf
+++ b/software/bowtie2/build/main.nf
@@ -9,7 +9,7 @@ process BOWTIE2_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::bowtie2=2.4.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwa/index/functions.nf
+++ b/software/bwa/index/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -9,7 +9,7 @@ process BWA_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwa=0.7.17" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -9,7 +9,7 @@ process BWA_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwa=0.7.17" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwa/mem/functions.nf
+++ b/software/bwa/mem/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bwa/mem/main.nf
+++ b/software/bwa/mem/main.nf
@@ -9,7 +9,7 @@ process BWA_MEM {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bwa=0.7.17 bioconda::samtools=1.12" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwa/mem/main.nf
+++ b/software/bwa/mem/main.nf
@@ -9,7 +9,7 @@ process BWA_MEM {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bwa=0.7.17 bioconda::samtools=1.12" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwamem2/index/functions.nf
+++ b/software/bwamem2/index/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bwamem2/index/main.nf
+++ b/software/bwamem2/index/main.nf
@@ -9,7 +9,7 @@ process BWAMEM2_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwa-mem2=2.2.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwamem2/index/main.nf
+++ b/software/bwamem2/index/main.nf
@@ -9,7 +9,7 @@ process BWAMEM2_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwa-mem2=2.2.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwamem2/mem/functions.nf
+++ b/software/bwamem2/mem/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bwamem2/mem/main.nf
+++ b/software/bwamem2/mem/main.nf
@@ -9,7 +9,7 @@ process BWAMEM2_MEM {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bwa-mem2=2.2.1 bioconda::samtools=1.12" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwamem2/mem/main.nf
+++ b/software/bwamem2/mem/main.nf
@@ -9,7 +9,7 @@ process BWAMEM2_MEM {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bwa-mem2=2.2.1 bioconda::samtools=1.12" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwameth/align/functions.nf
+++ b/software/bwameth/align/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bwameth/align/main.nf
+++ b/software/bwameth/align/main.nf
@@ -9,7 +9,7 @@ process BWAMETH_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bwameth=0.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwameth/align/main.nf
+++ b/software/bwameth/align/main.nf
@@ -9,7 +9,7 @@ process BWAMETH_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::bwameth=0.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwameth/index/functions.nf
+++ b/software/bwameth/index/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/bwameth/index/main.nf
+++ b/software/bwameth/index/main.nf
@@ -9,7 +9,7 @@ process BWAMETH_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwameth=0.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwameth/index/main.nf
+++ b/software/bwameth/index/main.nf
@@ -9,7 +9,7 @@ process BWAMETH_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwameth=0.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/cat/fastq/functions.nf
+++ b/software/cat/fastq/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/cat/fastq/main.nf
+++ b/software/cat/fastq/main.nf
@@ -9,7 +9,7 @@ process CAT_FASTQ {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'merged_fastq', publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/cat/fastq/main.nf
+++ b/software/cat/fastq/main.nf
@@ -9,7 +9,7 @@ process CAT_FASTQ {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/cnvkit/functions.nf
+++ b/software/cnvkit/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/cnvkit/main.nf
+++ b/software/cnvkit/main.nf
@@ -9,7 +9,7 @@ process CNVKIT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::cnvkit=0.9.8" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/cnvkit/main.nf
+++ b/software/cnvkit/main.nf
@@ -9,7 +9,7 @@ process CNVKIT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::cnvkit=0.9.8" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/cutadapt/functions.nf
+++ b/software/cutadapt/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/cutadapt/main.nf
+++ b/software/cutadapt/main.nf
@@ -9,7 +9,7 @@ process CUTADAPT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::cutadapt=3.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/cutadapt/main.nf
+++ b/software/cutadapt/main.nf
@@ -9,7 +9,7 @@ process CUTADAPT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::cutadapt=3.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/deeptools/computematrix/functions.nf
+++ b/software/deeptools/computematrix/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/deeptools/computematrix/main.nf
+++ b/software/deeptools/computematrix/main.nf
@@ -9,7 +9,7 @@ process DEEPTOOLS_COMPUTEMATRIX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/deeptools/computematrix/main.nf
+++ b/software/deeptools/computematrix/main.nf
@@ -9,7 +9,7 @@ process DEEPTOOLS_COMPUTEMATRIX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/deeptools/plotfingerprint/functions.nf
+++ b/software/deeptools/plotfingerprint/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/deeptools/plotfingerprint/main.nf
+++ b/software/deeptools/plotfingerprint/main.nf
@@ -9,7 +9,7 @@ process DEEPTOOLS_PLOTFINGERPRINT {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/deeptools/plotfingerprint/main.nf
+++ b/software/deeptools/plotfingerprint/main.nf
@@ -9,7 +9,7 @@ process DEEPTOOLS_PLOTFINGERPRINT {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/deeptools/plotheatmap/functions.nf
+++ b/software/deeptools/plotheatmap/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/deeptools/plotheatmap/main.nf
+++ b/software/deeptools/plotheatmap/main.nf
@@ -9,7 +9,7 @@ process DEEPTOOLS_PLOTHEATMAP {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/deeptools/plotheatmap/main.nf
+++ b/software/deeptools/plotheatmap/main.nf
@@ -9,7 +9,7 @@ process DEEPTOOLS_PLOTHEATMAP {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/deeptools/plotprofile/functions.nf
+++ b/software/deeptools/plotprofile/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/deeptools/plotprofile/main.nf
+++ b/software/deeptools/plotprofile/main.nf
@@ -9,7 +9,7 @@ process DEEPTOOLS_PLOTPROFILE {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/deeptools/plotprofile/main.nf
+++ b/software/deeptools/plotprofile/main.nf
@@ -9,7 +9,7 @@ process DEEPTOOLS_PLOTPROFILE {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::deeptools=3.5.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/dsh/filterbed/functions.nf
+++ b/software/dsh/filterbed/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/dsh/filterbed/main.nf
+++ b/software/dsh/filterbed/main.nf
@@ -9,7 +9,7 @@ process DSH_FILTERBED {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::dsh-bio=2.0.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/dsh/filterbed/main.nf
+++ b/software/dsh/filterbed/main.nf
@@ -9,7 +9,7 @@ process DSH_FILTERBED {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::dsh-bio=2.0.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/dsh/splitbed/functions.nf
+++ b/software/dsh/splitbed/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/dsh/splitbed/main.nf
+++ b/software/dsh/splitbed/main.nf
@@ -9,7 +9,7 @@ process DSH_SPLITBED {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::dsh-bio=2.0.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/dsh/splitbed/main.nf
+++ b/software/dsh/splitbed/main.nf
@@ -9,7 +9,7 @@ process DSH_SPLITBED {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::dsh-bio=2.0.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fastp/functions.nf
+++ b/software/fastp/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/fastp/main.nf
+++ b/software/fastp/main.nf
@@ -9,7 +9,7 @@ process FASTP {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::fastp=0.20.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fastp/main.nf
+++ b/software/fastp/main.nf
@@ -9,7 +9,7 @@ process FASTP {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::fastp=0.20.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fastqc/functions.nf
+++ b/software/fastqc/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/fastqc/main.nf
+++ b/software/fastqc/main.nf
@@ -9,7 +9,7 @@ process FASTQC {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fastqc/main.nf
+++ b/software/fastqc/main.nf
@@ -9,7 +9,7 @@ process FASTQC {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fasttree/functions.nf
+++ b/software/fasttree/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/fasttree/main.nf
+++ b/software/fasttree/main.nf
@@ -8,7 +8,7 @@ process FASTTREE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::fasttree=2.1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fasttree/main.nf
+++ b/software/fasttree/main.nf
@@ -8,7 +8,7 @@ process FASTTREE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::fasttree=2.1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fgbio/callmolecularconsensusreads/functions.nf
+++ b/software/fgbio/callmolecularconsensusreads/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/fgbio/callmolecularconsensusreads/main.nf
+++ b/software/fgbio/callmolecularconsensusreads/main.nf
@@ -8,7 +8,7 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::fgbio=1.3.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fgbio/callmolecularconsensusreads/main.nf
+++ b/software/fgbio/callmolecularconsensusreads/main.nf
@@ -8,7 +8,7 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::fgbio=1.3.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fgbio/sortbam/functions.nf
+++ b/software/fgbio/sortbam/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/fgbio/sortbam/main.nf
+++ b/software/fgbio/sortbam/main.nf
@@ -8,7 +8,7 @@ process FGBIO_SORTBAM {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::fgbio=1.3.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/fgbio/sortbam/main.nf
+++ b/software/fgbio/sortbam/main.nf
@@ -8,7 +8,7 @@ process FGBIO_SORTBAM {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::fgbio=1.3.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/flash/functions.nf
+++ b/software/flash/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -31,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -41,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/flash/main.nf
+++ b/software/flash/main.nf
@@ -9,7 +9,7 @@ process FLASH {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }    conda (params.enable_conda ? "bioconda::flash=1.2.11" : null)
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }    conda (params.enable_conda ? "bioconda::flash=1.2.11" : null)
 
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/flash:1.2.11--hed695b0_5"

--- a/software/flash/main.nf
+++ b/software/flash/main.nf
@@ -9,8 +9,8 @@ process FLASH {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
-    conda (params.enable_conda ? "bioconda::flash=1.2.11" : null)
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }    conda (params.enable_conda ? "bioconda::flash=1.2.11" : null)
+
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/flash:1.2.11--hed695b0_5"
     } else {

--- a/software/gatk4/applybqsr/functions.nf
+++ b/software/gatk4/applybqsr/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/applybqsr/main.nf
+++ b/software/gatk4/applybqsr/main.nf
@@ -9,7 +9,7 @@ process GATK4_APPLYBQSR {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/applybqsr/main.nf
+++ b/software/gatk4/applybqsr/main.nf
@@ -9,7 +9,7 @@ process GATK4_APPLYBQSR {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/baserecalibrator/functions.nf
+++ b/software/gatk4/baserecalibrator/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/baserecalibrator/main.nf
+++ b/software/gatk4/baserecalibrator/main.nf
@@ -9,7 +9,7 @@ process GATK4_BASERECALIBRATOR {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/baserecalibrator/main.nf
+++ b/software/gatk4/baserecalibrator/main.nf
@@ -9,7 +9,7 @@ process GATK4_BASERECALIBRATOR {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/bedtointervallist/functions.nf
+++ b/software/gatk4/bedtointervallist/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/bedtointervallist/main.nf
+++ b/software/gatk4/bedtointervallist/main.nf
@@ -9,7 +9,7 @@ process GATK4_BEDTOINTERVALLIST {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/bedtointervallist/main.nf
+++ b/software/gatk4/bedtointervallist/main.nf
@@ -9,7 +9,7 @@ process GATK4_BEDTOINTERVALLIST {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/createsequencedictionary/functions.nf
+++ b/software/gatk4/createsequencedictionary/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/createsequencedictionary/main.nf
+++ b/software/gatk4/createsequencedictionary/main.nf
@@ -9,7 +9,7 @@ process GATK4_CREATESEQUENCEDICTIONARY {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.1.9.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/createsequencedictionary/main.nf
+++ b/software/gatk4/createsequencedictionary/main.nf
@@ -9,7 +9,7 @@ process GATK4_CREATESEQUENCEDICTIONARY {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.1.9.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/fastqtosam/functions.nf
+++ b/software/gatk4/fastqtosam/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/fastqtosam/main.nf
+++ b/software/gatk4/fastqtosam/main.nf
@@ -9,7 +9,7 @@ process GATK4_FASTQTOSAM {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/fastqtosam/main.nf
+++ b/software/gatk4/fastqtosam/main.nf
@@ -9,7 +9,7 @@ process GATK4_FASTQTOSAM {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/haplotypecaller/functions.nf
+++ b/software/gatk4/haplotypecaller/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/haplotypecaller/main.nf
+++ b/software/gatk4/haplotypecaller/main.nf
@@ -9,7 +9,7 @@ process GATK4_HAPLOTYPECALLER {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/haplotypecaller/main.nf
+++ b/software/gatk4/haplotypecaller/main.nf
@@ -9,7 +9,7 @@ process GATK4_HAPLOTYPECALLER {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/markduplicates/functions.nf
+++ b/software/gatk4/markduplicates/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/markduplicates/main.nf
+++ b/software/gatk4/markduplicates/main.nf
@@ -9,7 +9,7 @@ process GATK4_MARKDUPLICATES {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/markduplicates/main.nf
+++ b/software/gatk4/markduplicates/main.nf
@@ -9,7 +9,7 @@ process GATK4_MARKDUPLICATES {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/mergebamalignment/functions.nf
+++ b/software/gatk4/mergebamalignment/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/mergebamalignment/main.nf
+++ b/software/gatk4/mergebamalignment/main.nf
@@ -9,7 +9,7 @@ process GATK4_MERGEBAMALIGNMENT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/mergebamalignment/main.nf
+++ b/software/gatk4/mergebamalignment/main.nf
@@ -9,7 +9,7 @@ process GATK4_MERGEBAMALIGNMENT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/mergevcfs/functions.nf
+++ b/software/gatk4/mergevcfs/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/mergevcfs/main.nf
+++ b/software/gatk4/mergevcfs/main.nf
@@ -9,7 +9,7 @@ process GATK4_MERGEVCFS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/mergevcfs/main.nf
+++ b/software/gatk4/mergevcfs/main.nf
@@ -9,7 +9,7 @@ process GATK4_MERGEVCFS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/revertsam/functions.nf
+++ b/software/gatk4/revertsam/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/revertsam/main.nf
+++ b/software/gatk4/revertsam/main.nf
@@ -9,7 +9,7 @@ process GATK4_REVERTSAM {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/revertsam/main.nf
+++ b/software/gatk4/revertsam/main.nf
@@ -9,7 +9,7 @@ process GATK4_REVERTSAM {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/samtofastq/functions.nf
+++ b/software/gatk4/samtofastq/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/samtofastq/main.nf
+++ b/software/gatk4/samtofastq/main.nf
@@ -9,7 +9,7 @@ process GATK4_SAMTOFASTQ {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/samtofastq/main.nf
+++ b/software/gatk4/samtofastq/main.nf
@@ -9,7 +9,7 @@ process GATK4_SAMTOFASTQ {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/splitncigarreads/functions.nf
+++ b/software/gatk4/splitncigarreads/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/splitncigarreads/main.nf
+++ b/software/gatk4/splitncigarreads/main.nf
@@ -9,7 +9,7 @@ process GATK4_SPLITNCIGARREADS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/splitncigarreads/main.nf
+++ b/software/gatk4/splitncigarreads/main.nf
@@ -9,7 +9,7 @@ process GATK4_SPLITNCIGARREADS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::gatk4=4.1.9.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/variantfiltration/functions.nf
+++ b/software/gatk4/variantfiltration/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gatk4/variantfiltration/main.nf
+++ b/software/gatk4/variantfiltration/main.nf
@@ -9,7 +9,7 @@ process GATK4_VARIANTFILTRATION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gatk4/variantfiltration/main.nf
+++ b/software/gatk4/variantfiltration/main.nf
@@ -9,7 +9,7 @@ process GATK4_VARIANTFILTRATION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::gatk4=4.2.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gffread/functions.nf
+++ b/software/gffread/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gffread/main.nf
+++ b/software/gffread/main.nf
@@ -9,7 +9,7 @@ process GFFREAD {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gffread/main.nf
+++ b/software/gffread/main.nf
@@ -9,7 +9,7 @@ process GFFREAD {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gubbins/functions.nf
+++ b/software/gubbins/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gubbins/main.nf
+++ b/software/gubbins/main.nf
@@ -8,7 +8,7 @@ process GUBBINS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::gubbins=2.4.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gubbins/main.nf
+++ b/software/gubbins/main.nf
@@ -8,7 +8,7 @@ process GUBBINS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::gubbins=2.4.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gunzip/functions.nf
+++ b/software/gunzip/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/gunzip/main.nf
+++ b/software/gunzip/main.nf
@@ -9,7 +9,7 @@ process GUNZIP {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/gunzip/main.nf
+++ b/software/gunzip/main.nf
@@ -9,7 +9,7 @@ process GUNZIP {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/hisat2/align/functions.nf
+++ b/software/hisat2/align/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/hisat2/align/main.nf
+++ b/software/hisat2/align/main.nf
@@ -11,7 +11,7 @@ process HISAT2_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::hisat2=2.2.0 bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/hisat2/align/main.nf
+++ b/software/hisat2/align/main.nf
@@ -11,7 +11,7 @@ process HISAT2_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::hisat2=2.2.0 bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/hisat2/build/functions.nf
+++ b/software/hisat2/build/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/hisat2/build/main.nf
+++ b/software/hisat2/build/main.nf
@@ -11,7 +11,7 @@ process HISAT2_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/hisat2/build/main.nf
+++ b/software/hisat2/build/main.nf
@@ -11,7 +11,7 @@ process HISAT2_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/hisat2/extractsplicesites/functions.nf
+++ b/software/hisat2/extractsplicesites/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/hisat2/extractsplicesites/main.nf
+++ b/software/hisat2/extractsplicesites/main.nf
@@ -11,7 +11,7 @@ process HISAT2_EXTRACTSPLICESITES {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/hisat2/extractsplicesites/main.nf
+++ b/software/hisat2/extractsplicesites/main.nf
@@ -11,7 +11,7 @@ process HISAT2_EXTRACTSPLICESITES {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/homer/annotatepeaks/functions.nf
+++ b/software/homer/annotatepeaks/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/homer/annotatepeaks/main.nf
+++ b/software/homer/annotatepeaks/main.nf
@@ -11,7 +11,7 @@ process HOMER_ANNOTATEPEAKS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::homer=4.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/homer/annotatepeaks/main.nf
+++ b/software/homer/annotatepeaks/main.nf
@@ -11,7 +11,7 @@ process HOMER_ANNOTATEPEAKS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::homer=4.11" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ivar/consensus/functions.nf
+++ b/software/ivar/consensus/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/ivar/consensus/main.nf
+++ b/software/ivar/consensus/main.nf
@@ -9,7 +9,7 @@ process IVAR_CONSENSUS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ivar=1.3.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ivar/consensus/main.nf
+++ b/software/ivar/consensus/main.nf
@@ -9,7 +9,7 @@ process IVAR_CONSENSUS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ivar=1.3.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ivar/trim/functions.nf
+++ b/software/ivar/trim/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/ivar/trim/main.nf
+++ b/software/ivar/trim/main.nf
@@ -9,7 +9,7 @@ process IVAR_TRIM {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ivar=1.3.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ivar/trim/main.nf
+++ b/software/ivar/trim/main.nf
@@ -9,7 +9,7 @@ process IVAR_TRIM {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ivar=1.3.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ivar/variants/functions.nf
+++ b/software/ivar/variants/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/ivar/variants/main.nf
+++ b/software/ivar/variants/main.nf
@@ -9,7 +9,7 @@ process IVAR_VARIANTS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ivar=1.3.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ivar/variants/main.nf
+++ b/software/ivar/variants/main.nf
@@ -9,7 +9,7 @@ process IVAR_VARIANTS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ivar=1.3.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/kallisto/index/functions.nf
+++ b/software/kallisto/index/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/kallisto/index/main.nf
+++ b/software/kallisto/index/main.nf
@@ -9,7 +9,7 @@ process KALLISTO_INDEX {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::kallisto=0.46.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/kallisto/index/main.nf
+++ b/software/kallisto/index/main.nf
@@ -9,7 +9,7 @@ process KALLISTO_INDEX {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::kallisto=0.46.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/kallistobustools/ref/functions.nf
+++ b/software/kallistobustools/ref/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/kallistobustools/ref/main.nf
+++ b/software/kallistobustools/ref/main.nf
@@ -9,7 +9,7 @@ process KALLISTOBUSTOOLS_REF {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::kb-python=0.25.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/kallistobustools/ref/main.nf
+++ b/software/kallistobustools/ref/main.nf
@@ -9,7 +9,7 @@ process KALLISTOBUSTOOLS_REF {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::kb-python=0.25.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/kraken2/run/functions.nf
+++ b/software/kraken2/run/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/kraken2/run/main.nf
+++ b/software/kraken2/run/main.nf
@@ -9,7 +9,7 @@ process KRAKEN2_RUN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::kraken2=2.1.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/kraken2/run/main.nf
+++ b/software/kraken2/run/main.nf
@@ -9,7 +9,7 @@ process KRAKEN2_RUN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::kraken2=2.1.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/lib/functions.nf
+++ b/software/lib/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/macs2/callpeak/functions.nf
+++ b/software/macs2/callpeak/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = (args.publish_files instanceof Map) ? args.publish_files : null
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {
@@ -52,7 +63,7 @@ def saveFiles(Map args) {
                     return "${getPathFromList(ext_list)}/$args.filename"
                 }
             }
-        } else {
+        } else if (ioptions.publish_files == null) {
             return "${getPathFromList(path_list)}/$args.filename"
         }
     }

--- a/software/macs2/callpeak/main.nf
+++ b/software/macs2/callpeak/main.nf
@@ -9,7 +9,7 @@ process MACS2_CALLPEAK {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::macs2=2.2.7.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/macs2/callpeak/main.nf
+++ b/software/macs2/callpeak/main.nf
@@ -9,7 +9,7 @@ process MACS2_CALLPEAK {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::macs2=2.2.7.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/methyldackel/extract/functions.nf
+++ b/software/methyldackel/extract/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/methyldackel/extract/main.nf
+++ b/software/methyldackel/extract/main.nf
@@ -9,7 +9,7 @@ process METHYLDACKEL_EXTRACT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::methyldackel=0.5.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/methyldackel/extract/main.nf
+++ b/software/methyldackel/extract/main.nf
@@ -9,7 +9,7 @@ process METHYLDACKEL_EXTRACT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::methyldackel=0.5.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/methyldackel/mbias/functions.nf
+++ b/software/methyldackel/mbias/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/methyldackel/mbias/main.nf
+++ b/software/methyldackel/mbias/main.nf
@@ -9,7 +9,7 @@ process METHYLDACKEL_MBIAS {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::methyldackel=0.5.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/methyldackel/mbias/main.nf
+++ b/software/methyldackel/mbias/main.nf
@@ -9,7 +9,7 @@ process METHYLDACKEL_MBIAS {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::methyldackel=0.5.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/minia/functions.nf
+++ b/software/minia/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/minia/main.nf
+++ b/software/minia/main.nf
@@ -8,7 +8,7 @@ process MINIA {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::minia=3.2.4" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/minia/main.nf
+++ b/software/minia/main.nf
@@ -8,7 +8,7 @@ process MINIA {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::minia=3.2.4" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/minimap2/align/functions.nf
+++ b/software/minimap2/align/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/minimap2/align/main.nf
+++ b/software/minimap2/align/main.nf
@@ -9,7 +9,7 @@ process MINIMAP2_ALIGN {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::minimap2=2.17" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/minimap2/align/main.nf
+++ b/software/minimap2/align/main.nf
@@ -9,7 +9,7 @@ process MINIMAP2_ALIGN {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::minimap2=2.17" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/mosdepth/functions.nf
+++ b/software/mosdepth/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/mosdepth/main.nf
+++ b/software/mosdepth/main.nf
@@ -9,7 +9,7 @@ process MOSDEPTH {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::mosdepth=0.3.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/mosdepth/main.nf
+++ b/software/mosdepth/main.nf
@@ -9,7 +9,7 @@ process MOSDEPTH {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::mosdepth=0.3.1' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/msisensor/msi/functions.nf
+++ b/software/msisensor/msi/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/msisensor/msi/main.nf
+++ b/software/msisensor/msi/main.nf
@@ -9,7 +9,7 @@ process MSISENSOR_MSI {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::msisensor=0.5" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/msisensor/msi/main.nf
+++ b/software/msisensor/msi/main.nf
@@ -9,7 +9,7 @@ process MSISENSOR_MSI {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::msisensor=0.5" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/msisensor/scan/functions.nf
+++ b/software/msisensor/scan/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/msisensor/scan/main.nf
+++ b/software/msisensor/scan/main.nf
@@ -9,7 +9,7 @@ process MSISENSOR_SCAN {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::msisensor=0.5" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/msisensor/scan/main.nf
+++ b/software/msisensor/scan/main.nf
@@ -9,7 +9,7 @@ process MSISENSOR_SCAN {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::msisensor=0.5" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/multiqc/functions.nf
+++ b/software/multiqc/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/multiqc/main.nf
+++ b/software/multiqc/main.nf
@@ -8,7 +8,7 @@ process MULTIQC {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename: filename, options: params.options, publish_dir: getSoftwareName(task.process), publish_id: '') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::multiqc=1.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/multiqc/main.nf
+++ b/software/multiqc/main.nf
@@ -8,7 +8,7 @@ process MULTIQC {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::multiqc=1.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/nanoplot/functions.nf
+++ b/software/nanoplot/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/nanoplot/main.nf
+++ b/software/nanoplot/main.nf
@@ -9,7 +9,7 @@ process NANOPLOT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::nanoplot=1.32.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/nanoplot/main.nf
+++ b/software/nanoplot/main.nf
@@ -9,7 +9,7 @@ process NANOPLOT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::nanoplot=1.32.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/optitype/functions.nf
+++ b/software/optitype/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/optitype/main.nf
+++ b/software/optitype/main.nf
@@ -9,7 +9,7 @@ process OPTITYPE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::optitype=1.3.5" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/optitype/main.nf
+++ b/software/optitype/main.nf
@@ -9,7 +9,7 @@ process OPTITYPE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::optitype=1.3.5" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/pangolin/functions.nf
+++ b/software/pangolin/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/pangolin/main.nf
+++ b/software/pangolin/main.nf
@@ -9,7 +9,7 @@ process PANGOLIN {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::pangolin=2.3.8' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/pangolin/main.nf
+++ b/software/pangolin/main.nf
@@ -9,7 +9,7 @@ process PANGOLIN {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::pangolin=2.3.8' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/phantompeakqualtools/functions.nf
+++ b/software/phantompeakqualtools/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/phantompeakqualtools/main.nf
+++ b/software/phantompeakqualtools/main.nf
@@ -11,7 +11,7 @@ process PHANTOMPEAKQUALTOOLS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::phantompeakqualtools=1.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/phantompeakqualtools/main.nf
+++ b/software/phantompeakqualtools/main.nf
@@ -11,7 +11,7 @@ process PHANTOMPEAKQUALTOOLS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::phantompeakqualtools=1.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/picard/collectmultiplemetrics/functions.nf
+++ b/software/picard/collectmultiplemetrics/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/picard/collectmultiplemetrics/main.nf
+++ b/software/picard/collectmultiplemetrics/main.nf
@@ -9,7 +9,7 @@ process PICARD_COLLECTMULTIPLEMETRICS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/picard/collectmultiplemetrics/main.nf
+++ b/software/picard/collectmultiplemetrics/main.nf
@@ -9,7 +9,7 @@ process PICARD_COLLECTMULTIPLEMETRICS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/picard/collectwgsmetrics/functions.nf
+++ b/software/picard/collectwgsmetrics/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/picard/collectwgsmetrics/main.nf
+++ b/software/picard/collectwgsmetrics/main.nf
@@ -9,7 +9,7 @@ process PICARD_COLLECTWGSMETRICS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::picard=2.25.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/picard/collectwgsmetrics/main.nf
+++ b/software/picard/collectwgsmetrics/main.nf
@@ -9,7 +9,7 @@ process PICARD_COLLECTWGSMETRICS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::picard=2.25.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/picard/markduplicates/functions.nf
+++ b/software/picard/markduplicates/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/picard/markduplicates/main.nf
+++ b/software/picard/markduplicates/main.nf
@@ -9,7 +9,7 @@ process PICARD_MARKDUPLICATES {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/picard/markduplicates/main.nf
+++ b/software/picard/markduplicates/main.nf
@@ -9,7 +9,7 @@ process PICARD_MARKDUPLICATES {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/picard/mergesamfiles/functions.nf
+++ b/software/picard/mergesamfiles/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/picard/mergesamfiles/main.nf
+++ b/software/picard/mergesamfiles/main.nf
@@ -9,7 +9,7 @@ process PICARD_MERGESAMFILES {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/picard/mergesamfiles/main.nf
+++ b/software/picard/mergesamfiles/main.nf
@@ -9,7 +9,7 @@ process PICARD_MERGESAMFILES {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::picard=2.23.9" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/plasmidid/functions.nf
+++ b/software/plasmidid/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/plasmidid/main.nf
+++ b/software/plasmidid/main.nf
@@ -9,7 +9,7 @@ process PLASMIDID {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::plasmidid=1.6.4' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/plasmidid/main.nf
+++ b/software/plasmidid/main.nf
@@ -9,7 +9,7 @@ process PLASMIDID {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::plasmidid=1.6.4' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/preseq/lcextrap/functions.nf
+++ b/software/preseq/lcextrap/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/preseq/lcextrap/main.nf
+++ b/software/preseq/lcextrap/main.nf
@@ -10,7 +10,7 @@ process PRESEQ_LCEXTRAP {
     label 'error_ignore'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::preseq=2.0.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/preseq/lcextrap/main.nf
+++ b/software/preseq/lcextrap/main.nf
@@ -10,7 +10,7 @@ process PRESEQ_LCEXTRAP {
     label 'error_ignore'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::preseq=2.0.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/prodigal/functions.nf
+++ b/software/prodigal/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/prodigal/main.nf
+++ b/software/prodigal/main.nf
@@ -9,7 +9,7 @@ process PRODIGAL {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::prodigal=2.6.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/prodigal/main.nf
+++ b/software/prodigal/main.nf
@@ -9,7 +9,7 @@ process PRODIGAL {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::prodigal=2.6.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/prokka/functions.nf
+++ b/software/prokka/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/prokka/main.nf
+++ b/software/prokka/main.nf
@@ -8,7 +8,7 @@ process PROKKA {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::prokka=1.14.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/prokka/main.nf
+++ b/software/prokka/main.nf
@@ -8,7 +8,7 @@ process PROKKA {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::prokka=1.14.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/qualimap/bamqc/functions.nf
+++ b/software/qualimap/bamqc/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/qualimap/bamqc/main.nf
+++ b/software/qualimap/bamqc/main.nf
@@ -9,7 +9,7 @@ process QUALIMAP_BAMQC {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/qualimap/bamqc/main.nf
+++ b/software/qualimap/bamqc/main.nf
@@ -9,7 +9,7 @@ process QUALIMAP_BAMQC {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/qualimap/rnaseq/functions.nf
+++ b/software/qualimap/rnaseq/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/qualimap/rnaseq/main.nf
+++ b/software/qualimap/rnaseq/main.nf
@@ -9,7 +9,7 @@ process QUALIMAP_RNASEQ {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/qualimap/rnaseq/main.nf
+++ b/software/qualimap/rnaseq/main.nf
@@ -9,7 +9,7 @@ process QUALIMAP_RNASEQ {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/quast/functions.nf
+++ b/software/quast/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/quast/main.nf
+++ b/software/quast/main.nf
@@ -8,7 +8,7 @@ process QUAST {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::quast=5.0.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/quast/main.nf
+++ b/software/quast/main.nf
@@ -8,7 +8,7 @@ process QUAST {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::quast=5.0.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rapidnj/functions.nf
+++ b/software/rapidnj/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rapidnj/main.nf
+++ b/software/rapidnj/main.nf
@@ -8,7 +8,7 @@ process RAPIDNJ {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::rapidnj=2.3.2 conda-forge::biopython=1.78" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rapidnj/main.nf
+++ b/software/rapidnj/main.nf
@@ -8,7 +8,7 @@ process RAPIDNJ {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::rapidnj=2.3.2 conda-forge::biopython=1.78" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rasusa/functions.nf
+++ b/software/rasusa/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rasusa/main.nf
+++ b/software/rasusa/main.nf
@@ -9,7 +9,7 @@ process RASUSA {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rasusa=0.3.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rasusa/main.nf
+++ b/software/rasusa/main.nf
@@ -9,7 +9,7 @@ process RASUSA {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rasusa=0.3.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rsem/calculateexpression/functions.nf
+++ b/software/rsem/calculateexpression/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rsem/calculateexpression/main.nf
+++ b/software/rsem/calculateexpression/main.nf
@@ -9,7 +9,7 @@ process RSEM_CALCULATEEXPRESSION {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rsem/calculateexpression/main.nf
+++ b/software/rsem/calculateexpression/main.nf
@@ -9,7 +9,7 @@ process RSEM_CALCULATEEXPRESSION {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rsem/preparereference/functions.nf
+++ b/software/rsem/preparereference/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rsem/preparereference/main.nf
+++ b/software/rsem/preparereference/main.nf
@@ -9,7 +9,7 @@ process RSEM_PREPAREREFERENCE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rsem/preparereference/main.nf
+++ b/software/rsem/preparereference/main.nf
@@ -9,7 +9,7 @@ process RSEM_PREPAREREFERENCE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/bamstat/functions.nf
+++ b/software/rseqc/bamstat/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rseqc/bamstat/main.nf
+++ b/software/rseqc/bamstat/main.nf
@@ -9,7 +9,7 @@ process RSEQC_BAMSTAT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/bamstat/main.nf
+++ b/software/rseqc/bamstat/main.nf
@@ -9,7 +9,7 @@ process RSEQC_BAMSTAT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/inferexperiment/functions.nf
+++ b/software/rseqc/inferexperiment/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rseqc/inferexperiment/main.nf
+++ b/software/rseqc/inferexperiment/main.nf
@@ -9,7 +9,7 @@ process RSEQC_INFEREXPERIMENT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/inferexperiment/main.nf
+++ b/software/rseqc/inferexperiment/main.nf
@@ -9,7 +9,7 @@ process RSEQC_INFEREXPERIMENT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/innerdistance/functions.nf
+++ b/software/rseqc/innerdistance/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rseqc/innerdistance/main.nf
+++ b/software/rseqc/innerdistance/main.nf
@@ -9,7 +9,7 @@ process RSEQC_INNERDISTANCE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/innerdistance/main.nf
+++ b/software/rseqc/innerdistance/main.nf
@@ -9,7 +9,7 @@ process RSEQC_INNERDISTANCE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/junctionannotation/functions.nf
+++ b/software/rseqc/junctionannotation/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rseqc/junctionannotation/main.nf
+++ b/software/rseqc/junctionannotation/main.nf
@@ -9,7 +9,7 @@ process RSEQC_JUNCTIONANNOTATION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/junctionannotation/main.nf
+++ b/software/rseqc/junctionannotation/main.nf
@@ -9,7 +9,7 @@ process RSEQC_JUNCTIONANNOTATION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/junctionsaturation/functions.nf
+++ b/software/rseqc/junctionsaturation/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rseqc/junctionsaturation/main.nf
+++ b/software/rseqc/junctionsaturation/main.nf
@@ -9,7 +9,7 @@ process RSEQC_JUNCTIONSATURATION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/junctionsaturation/main.nf
+++ b/software/rseqc/junctionsaturation/main.nf
@@ -9,7 +9,7 @@ process RSEQC_JUNCTIONSATURATION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/readdistribution/functions.nf
+++ b/software/rseqc/readdistribution/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rseqc/readdistribution/main.nf
+++ b/software/rseqc/readdistribution/main.nf
@@ -9,7 +9,7 @@ process RSEQC_READDISTRIBUTION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/readdistribution/main.nf
+++ b/software/rseqc/readdistribution/main.nf
@@ -9,7 +9,7 @@ process RSEQC_READDISTRIBUTION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/readduplication/functions.nf
+++ b/software/rseqc/readduplication/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/rseqc/readduplication/main.nf
+++ b/software/rseqc/readduplication/main.nf
@@ -9,7 +9,7 @@ process RSEQC_READDUPLICATION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rseqc/readduplication/main.nf
+++ b/software/rseqc/readduplication/main.nf
@@ -9,7 +9,7 @@ process RSEQC_READDUPLICATION {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/salmon/index/functions.nf
+++ b/software/salmon/index/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/salmon/index/main.nf
+++ b/software/salmon/index/main.nf
@@ -9,7 +9,7 @@ process SALMON_INDEX {
     label "process_medium"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::salmon=1.4.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/salmon/index/main.nf
+++ b/software/salmon/index/main.nf
@@ -9,7 +9,7 @@ process SALMON_INDEX {
     label "process_medium"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::salmon=1.4.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/salmon/quant/functions.nf
+++ b/software/salmon/quant/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -9,7 +9,7 @@ process SALMON_QUANT {
     label "process_medium"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::salmon=1.4.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -9,7 +9,7 @@ process SALMON_QUANT {
     label "process_medium"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::salmon=1.4.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/faidx/functions.nf
+++ b/software/samtools/faidx/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/faidx/main.nf
+++ b/software/samtools/faidx/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_FAIDX {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/faidx/main.nf
+++ b/software/samtools/faidx/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_FAIDX {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/fastq/functions.nf
+++ b/software/samtools/fastq/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/fastq/main.nf
+++ b/software/samtools/fastq/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_FASTQ {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.12" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/fastq/main.nf
+++ b/software/samtools/fastq/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_FASTQ {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.12" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/flagstat/functions.nf
+++ b/software/samtools/flagstat/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/flagstat/main.nf
+++ b/software/samtools/flagstat/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_FLAGSTAT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/flagstat/main.nf
+++ b/software/samtools/flagstat/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_FLAGSTAT {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/idxstats/functions.nf
+++ b/software/samtools/idxstats/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/idxstats/main.nf
+++ b/software/samtools/idxstats/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_IDXSTATS {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/idxstats/main.nf
+++ b/software/samtools/idxstats/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_IDXSTATS {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/index/functions.nf
+++ b/software/samtools/index/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/index/main.nf
+++ b/software/samtools/index/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_INDEX {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/index/main.nf
+++ b/software/samtools/index/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_INDEX {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/merge/functions.nf
+++ b/software/samtools/merge/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/merge/main.nf
+++ b/software/samtools/merge/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_MERGE {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/merge/main.nf
+++ b/software/samtools/merge/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_MERGE {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/mpileup/functions.nf
+++ b/software/samtools/mpileup/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/mpileup/main.nf
+++ b/software/samtools/mpileup/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_MPILEUP {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/mpileup/main.nf
+++ b/software/samtools/mpileup/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_MPILEUP {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/sort/functions.nf
+++ b/software/samtools/sort/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/sort/main.nf
+++ b/software/samtools/sort/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_SORT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/sort/main.nf
+++ b/software/samtools/sort/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_SORT {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/stats/functions.nf
+++ b/software/samtools/stats/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/stats/main.nf
+++ b/software/samtools/stats/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_STATS {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/stats/main.nf
+++ b/software/samtools/stats/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_STATS {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/view/functions.nf
+++ b/software/samtools/view/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/samtools/view/main.nf
+++ b/software/samtools/view/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_VIEW {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/samtools/view/main.nf
+++ b/software/samtools/view/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_VIEW {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/seacr/callpeak/functions.nf
+++ b/software/seacr/callpeak/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/seacr/callpeak/main.nf
+++ b/software/seacr/callpeak/main.nf
@@ -11,7 +11,7 @@ process SEACR_CALLPEAK {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::seacr=1.3 conda-forge::r-base=4.0.2 bioconda::bedtools=2.29.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/seacr/callpeak/main.nf
+++ b/software/seacr/callpeak/main.nf
@@ -11,7 +11,7 @@ process SEACR_CALLPEAK {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::seacr=1.3 conda-forge::r-base=4.0.2 bioconda::bedtools=2.29.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/seqkit/split2/functions.nf
+++ b/software/seqkit/split2/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/seqkit/split2/main.nf
+++ b/software/seqkit/split2/main.nf
@@ -10,7 +10,7 @@ process SEQKIT_SPLIT2 {
 
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::seqkit=0.15.0" : null)
 

--- a/software/seqkit/split2/main.nf
+++ b/software/seqkit/split2/main.nf
@@ -10,7 +10,7 @@ process SEQKIT_SPLIT2 {
 
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::seqkit=0.15.0" : null)
 

--- a/software/sequenzautils/bam2seqz/functions.nf
+++ b/software/sequenzautils/bam2seqz/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/sequenzautils/bam2seqz/main.nf
+++ b/software/sequenzautils/bam2seqz/main.nf
@@ -9,7 +9,7 @@ process SEQUENZAUTILS_BAM2SEQZ {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::sequenza-utils=3.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/sequenzautils/bam2seqz/main.nf
+++ b/software/sequenzautils/bam2seqz/main.nf
@@ -9,7 +9,7 @@ process SEQUENZAUTILS_BAM2SEQZ {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::sequenza-utils=3.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/sequenzautils/gcwiggle/functions.nf
+++ b/software/sequenzautils/gcwiggle/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/sequenzautils/gcwiggle/main.nf
+++ b/software/sequenzautils/gcwiggle/main.nf
@@ -9,7 +9,7 @@ process SEQUENZAUTILS_GCWIGGLE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::sequenza-utils=3.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/sequenzautils/gcwiggle/main.nf
+++ b/software/sequenzautils/gcwiggle/main.nf
@@ -9,7 +9,7 @@ process SEQUENZAUTILS_GCWIGGLE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::sequenza-utils=3.0.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/seqwish/induce/functions.nf
+++ b/software/seqwish/induce/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/seqwish/induce/main.nf
+++ b/software/seqwish/induce/main.nf
@@ -10,7 +10,7 @@ process SEQWISH_INDUCE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::seqwish=0.4.1" : null)
 

--- a/software/seqwish/induce/main.nf
+++ b/software/seqwish/induce/main.nf
@@ -10,7 +10,7 @@ process SEQWISH_INDUCE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::seqwish=0.4.1" : null)
 

--- a/software/shovill/functions.nf
+++ b/software/shovill/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/shovill/main.nf
+++ b/software/shovill/main.nf
@@ -9,7 +9,7 @@ process SHOVILL {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::shovill=1.1.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/shovill/main.nf
+++ b/software/shovill/main.nf
@@ -9,7 +9,7 @@ process SHOVILL {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::shovill=1.1.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/snpsites/functions.nf
+++ b/software/snpsites/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/snpsites/main.nf
+++ b/software/snpsites/main.nf
@@ -8,7 +8,7 @@ process SNPSITES {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::snp-sites=2.5.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/snpsites/main.nf
+++ b/software/snpsites/main.nf
@@ -8,7 +8,7 @@ process SNPSITES {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::snp-sites=2.5.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/sortmerna/functions.nf
+++ b/software/sortmerna/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/sortmerna/main.nf
+++ b/software/sortmerna/main.nf
@@ -9,7 +9,7 @@ process SORTMERNA {
     label "process_high"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::sortmerna=4.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/sortmerna/main.nf
+++ b/software/sortmerna/main.nf
@@ -9,7 +9,7 @@ process SORTMERNA {
     label "process_high"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::sortmerna=4.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/spades/functions.nf
+++ b/software/spades/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/spades/main.nf
+++ b/software/spades/main.nf
@@ -9,7 +9,7 @@ process SPADES {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::spades=3.15.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/spades/main.nf
+++ b/software/spades/main.nf
@@ -9,7 +9,7 @@ process SPADES {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::spades=3.15.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/star/align/functions.nf
+++ b/software/star/align/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/star/align/main.nf
+++ b/software/star/align/main.nf
@@ -9,7 +9,7 @@ process STAR_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? 'bioconda::star=2.6.1d' : null)

--- a/software/star/align/main.nf
+++ b/software/star/align/main.nf
@@ -9,7 +9,7 @@ process STAR_ALIGN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? 'bioconda::star=2.6.1d' : null)

--- a/software/star/genomegenerate/functions.nf
+++ b/software/star/genomegenerate/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/star/genomegenerate/main.nf
+++ b/software/star/genomegenerate/main.nf
@@ -9,7 +9,7 @@ process STAR_GENOMEGENERATE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)

--- a/software/star/genomegenerate/main.nf
+++ b/software/star/genomegenerate/main.nf
@@ -9,7 +9,7 @@ process STAR_GENOMEGENERATE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)

--- a/software/strelka/germline/functions.nf
+++ b/software/strelka/germline/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -31,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -41,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/strelka/germline/main.nf
+++ b/software/strelka/germline/main.nf
@@ -9,7 +9,7 @@ process STRELKA_GERMLINE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::strelka=2.9.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/strelka/germline/main.nf
+++ b/software/strelka/germline/main.nf
@@ -9,7 +9,7 @@ process STRELKA_GERMLINE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::strelka=2.9.10" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/stringtie/functions.nf
+++ b/software/stringtie/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/stringtie/main.nf
+++ b/software/stringtie/main.nf
@@ -9,7 +9,7 @@ process STRINGTIE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::stringtie=2.1.4" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/stringtie/main.nf
+++ b/software/stringtie/main.nf
@@ -9,7 +9,7 @@ process STRINGTIE {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::stringtie=2.1.4" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/subread/featurecounts/functions.nf
+++ b/software/subread/featurecounts/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/subread/featurecounts/main.nf
+++ b/software/subread/featurecounts/main.nf
@@ -9,7 +9,7 @@ process SUBREAD_FEATURECOUNTS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::subread=2.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/subread/featurecounts/main.nf
+++ b/software/subread/featurecounts/main.nf
@@ -9,7 +9,7 @@ process SUBREAD_FEATURECOUNTS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::subread=2.0.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/tabix/bgzip/functions.nf
+++ b/software/tabix/bgzip/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", '') } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/tabix/bgzip/main.nf
+++ b/software/tabix/bgzip/main.nf
@@ -9,7 +9,7 @@ process TABIX_BGZIP {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::tabix=0.2.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/tabix/bgzip/main.nf
+++ b/software/tabix/bgzip/main.nf
@@ -9,7 +9,7 @@ process TABIX_BGZIP {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::tabix=0.2.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/tabix/tabix/functions.nf
+++ b/software/tabix/tabix/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/tabix/tabix/main.nf
+++ b/software/tabix/tabix/main.nf
@@ -9,7 +9,7 @@ process TABIX_TABIX {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::tabix=0.2.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/tabix/tabix/main.nf
+++ b/software/tabix/tabix/main.nf
@@ -9,7 +9,7 @@ process TABIX_TABIX {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::tabix=0.2.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/tiddit/sv/functions.nf
+++ b/software/tiddit/sv/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/tiddit/sv/main.nf
+++ b/software/tiddit/sv/main.nf
@@ -9,7 +9,7 @@ process TIDDIT_SV {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::tiddit=2.12.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/tiddit/sv/main.nf
+++ b/software/tiddit/sv/main.nf
@@ -9,7 +9,7 @@ process TIDDIT_SV {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::tiddit=2.12.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/trimgalore/functions.nf
+++ b/software/trimgalore/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/trimgalore/main.nf
+++ b/software/trimgalore/main.nf
@@ -9,7 +9,7 @@ process TRIMGALORE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::trim-galore=0.6.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/trimgalore/main.nf
+++ b/software/trimgalore/main.nf
@@ -9,7 +9,7 @@ process TRIMGALORE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::trim-galore=0.6.6" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ucsc/bed12tobigbed/functions.nf
+++ b/software/ucsc/bed12tobigbed/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/ucsc/bed12tobigbed/main.nf
+++ b/software/ucsc/bed12tobigbed/main.nf
@@ -11,7 +11,7 @@ process UCSC_BED12TOBIGBED {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ucsc-bedtobigbed=377" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ucsc/bed12tobigbed/main.nf
+++ b/software/ucsc/bed12tobigbed/main.nf
@@ -11,7 +11,7 @@ process UCSC_BED12TOBIGBED {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ucsc-bedtobigbed=377" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ucsc/bedgraphtobigwig/functions.nf
+++ b/software/ucsc/bedgraphtobigwig/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/ucsc/bedgraphtobigwig/main.nf
+++ b/software/ucsc/bedgraphtobigwig/main.nf
@@ -11,7 +11,7 @@ process UCSC_BEDGRAPHTOBIGWIG {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ucsc-bedgraphtobigwig=377" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/ucsc/bedgraphtobigwig/main.nf
+++ b/software/ucsc/bedgraphtobigwig/main.nf
@@ -11,7 +11,7 @@ process UCSC_BEDGRAPHTOBIGWIG {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::ucsc-bedgraphtobigwig=377" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/umitools/dedup/functions.nf
+++ b/software/umitools/dedup/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/umitools/dedup/main.nf
+++ b/software/umitools/dedup/main.nf
@@ -9,7 +9,7 @@ process UMITOOLS_DEDUP {
     label "process_medium"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::umi_tools=1.1.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/umitools/dedup/main.nf
+++ b/software/umitools/dedup/main.nf
@@ -9,7 +9,7 @@ process UMITOOLS_DEDUP {
     label "process_medium"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::umi_tools=1.1.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/umitools/extract/functions.nf
+++ b/software/umitools/extract/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/umitools/extract/main.nf
+++ b/software/umitools/extract/main.nf
@@ -9,7 +9,7 @@ process UMITOOLS_EXTRACT {
     label "process_low"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::umi_tools=1.1.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/umitools/extract/main.nf
+++ b/software/umitools/extract/main.nf
@@ -9,7 +9,7 @@ process UMITOOLS_EXTRACT {
     label "process_low"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::umi_tools=1.1.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/unicycler/functions.nf
+++ b/software/unicycler/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/unicycler/main.nf
+++ b/software/unicycler/main.nf
@@ -9,7 +9,7 @@ process UNICYCLER {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::unicycler=0.4.8' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/unicycler/main.nf
+++ b/software/unicycler/main.nf
@@ -9,7 +9,7 @@ process UNICYCLER {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? 'bioconda::unicycler=0.4.8' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/untar/functions.nf
+++ b/software/untar/functions.nf
@@ -16,12 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -29,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -39,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/untar/main.nf
+++ b/software/untar/main.nf
@@ -9,7 +9,7 @@ process UNTAR {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/untar/main.nf
+++ b/software/untar/main.nf
@@ -9,7 +9,7 @@ process UNTAR {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/vcftools/functions.nf
+++ b/software/vcftools/functions.nf
@@ -1,4 +1,3 @@
-
 /*
  * -----------------------------------------------------
  *  Utility functions used in nf-core DSL2 module files
@@ -17,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -31,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -41,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/vcftools/main.nf
+++ b/software/vcftools/main.nf
@@ -9,7 +9,7 @@ process VCFTOOLS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::vcftools=0.1.16" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/vcftools/main.nf
+++ b/software/vcftools/main.nf
@@ -9,7 +9,7 @@ process VCFTOOLS {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::vcftools=0.1.16" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/yara/index/functions.nf
+++ b/software/yara/index/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/yara/index/main.nf
+++ b/software/yara/index/main.nf
@@ -9,7 +9,7 @@ process YARA_INDEX {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', publish_id:'') }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::yara=1.0.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/yara/index/main.nf
+++ b/software/yara/index/main.nf
@@ -9,7 +9,7 @@ process YARA_INDEX {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::yara=1.0.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/yara/mapper/functions.nf
+++ b/software/yara/mapper/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/yara/mapper/main.nf
+++ b/software/yara/mapper/main.nf
@@ -9,7 +9,7 @@ process YARA_MAPPER {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::yara=1.0.2 bioconda::samtools=1.12" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/yara/mapper/main.nf
+++ b/software/yara/mapper/main.nf
@@ -9,7 +9,7 @@ process YARA_MAPPER {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+	saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::yara=1.0.2 bioconda::samtools=1.12" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {


### PR DESCRIPTION
Copied from Slack:

Started playing with changing the `publish_by_id` functionality we discussed a couple of weeks back. Soon realised I would have to sit down and test this all properly in a real-pipeline context. I now have something together relative to the #rnaseq pipeline [here](https://github.com/nf-core/rnaseq/pull/590)

I have renamed `publish_by_id` -> `publish_by_meta` and it now can either accept:
* A boolean `true` value in `modules.config` which is the same as the old behaviour i.e. `${publish_dir}/${meta.id}/`
* A list of keys available in `meta` that will be concatenated together to get the final directory path

e.g. as defined in modules.config :

```console
'fastqc' {
    args          = "--quiet"
    publish_by_meta = [ 'id', 'single_end', 'mytestfolder', 'strandedness']
    // If meta = [id:WT_REP1, single_end:false, strandedness:reverse]
    // Output folder: results/fastqc/WT_REP1/single_end_false/mytestfolder/reverse/
}
```

```console
'fastqc' {
    args          = "--quiet"
    publish_by_meta = true
    // If meta = [id:WT_REP1, single_end:false, strandedness:reverse]
    // Output folder: results/fastqc/WT_REP1/ i.e. ${meta[id]} by default
}
```

If an entry in `publish_by_meta` isn't present in the `meta` map then it will still be appended on to give developers even more control to customise the paths if they so wish e.g. `mytestfolder` in the above example.

If an entry in `publish_by_meta` has a boolean value in the meta map then the id is appended to the boolean value e.g. `single_end_false` in the above example.