### PR TITLE
Add default publish_dir for index processes

### DIFF
--- a/software/bowtie/build/main.nf
+++ b/software/bowtie/build/main.nf
@@ -9,7 +9,7 @@ process BOWTIE_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::bowtie=1.3.0' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bowtie2/build/main.nf
+++ b/software/bowtie2/build/main.nf
@@ -9,7 +9,7 @@ process BOWTIE2_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? 'bioconda::bowtie2=2.4.2' : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwa/index/main.nf
+++ b/software/bwa/index/main.nf
@@ -9,7 +9,7 @@ process BWA_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwa=0.7.17" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwamem2/index/main.nf
+++ b/software/bwamem2/index/main.nf
@@ -9,7 +9,7 @@ process BWAMEM2_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwa-mem2=2.2.1" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/bwameth/index/main.nf
+++ b/software/bwameth/index/main.nf
@@ -9,7 +9,7 @@ process BWAMETH_INDEX {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::bwameth=0.2.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/cat/fastq/main.nf
+++ b/software/cat/fastq/main.nf
@@ -9,7 +9,7 @@ process CAT_FASTQ {
     label 'process_low'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'merged_fastq', meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/hisat2/build/main.nf
+++ b/software/hisat2/build/main.nf
@@ -11,7 +11,7 @@ process HISAT2_BUILD {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/rsem/preparereference/main.nf
+++ b/software/rsem/preparereference/main.nf
@@ -9,7 +9,7 @@ process RSEM_PREPAREREFERENCE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/salmon/index/main.nf
+++ b/software/salmon/index/main.nf
@@ -9,7 +9,7 @@ process SALMON_INDEX {
     label "process_medium"
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::salmon=1.4.0" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/star/genomegenerate/main.nf
+++ b/software/star/genomegenerate/main.nf
@@ -9,7 +9,7 @@ process STAR_GENOMEGENERATE {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
     conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)

--- a/software/yara/index/main.nf
+++ b/software/yara/index/main.nf
@@ -9,7 +9,7 @@ process YARA_INDEX {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'index', meta:[:], publish_by_meta:[]) }
 
     conda (params.enable_conda ? "bioconda::yara=1.0.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {


### PR DESCRIPTION

This was missed on the auto-update script I wrote yesterday but I noticed it when testing after re-installing all  nf-core/modules for the viralrecon pipeline [here](https://github.com/nf-core/viralrecon/pull/172).