### PR TITLE
output constant sites as a val so it can be passed into iqtree

### DIFF
--- a/software/snpsites/main.nf
+++ b/software/snpsites/main.nf
@@ -24,7 +24,7 @@ process SNPSITES {
     path "*.fas"        , emit: fasta
     path "*.sites.txt"  , emit: constant_sites
     path "*.version.txt", emit: version
-    stdout                emit: constant_sites_string
+    env CONSTANT_SITES,   emit: constant_sites_string
 
     script:
     def software = getSoftwareName(task.process)
@@ -35,7 +35,7 @@ process SNPSITES {
 
     echo \$(snp-sites -C $alignment) > constant.sites.txt
 
-    cat constant.sites.txt
+    CONSTANT_SITES=\$(cat constant.sites.txt)
 
     echo \$(snp-sites -V 2>&1) | sed 's/snp-sites //' > ${software}.version.txt
     """

--- a/software/snpsites/main.nf
+++ b/software/snpsites/main.nf
@@ -24,7 +24,7 @@ process SNPSITES {
     path "*.fas"        , emit: fasta
     path "*.sites.txt"  , emit: constant_sites
     path "*.version.txt", emit: version
-    env CONSTANT_SITES,   emit: constant_sites_string
+    env   CONSTANT_SITES, emit: constant_sites_string
 
     script:
     def software = getSoftwareName(task.process)

--- a/software/snpsites/main.nf
+++ b/software/snpsites/main.nf
@@ -24,6 +24,7 @@ process SNPSITES {
     path "*.fas"        , emit: fasta
     path "*.sites.txt"  , emit: constant_sites
     path "*.version.txt", emit: version
+    stdout                emit: constant_sites_string
 
     script:
     def software = getSoftwareName(task.process)
@@ -33,6 +34,8 @@ process SNPSITES {
         > filtered_alignment.fas
 
     echo \$(snp-sites -C $alignment) > constant.sites.txt
+
+    cat constant.sites.txt
 
     echo \$(snp-sites -V 2>&1) | sed 's/snp-sites //' > ${software}.version.txt
     """


### PR DESCRIPTION
## PR checklist

Currently the constant sites are emitted as a file. It would be useful to pass onwards as a string also
- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
