### PR TITLE
FIx plasmidid tests for new contigs.fasta file

### DIFF
--- a/tests/software/plasmidid/test.yml
+++ b/tests/software/plasmidid/test.yml
@@ -8,31 +8,31 @@
     - path: output/plasmidid/test/data/test.coverage_adapted_clustered_ac
       md5sum: 3a9ea6d336e113a74d7fdca5e7b623fc
     - path: output/plasmidid/test/data/test.err
-      md5sum: 1eabbbcb19d8886182f78b86fc50884c
+      md5sum: 011108fd8b0bb4a4c0b5b2cf46452a90
     - path: output/plasmidid/test/data/test.fna
-      md5sum: 78328536870d04afc54a4dfaf103cac8
+      md5sum: 503a5e1d4654bb2df19420e211070db3
     - path: output/plasmidid/test/data/test.gbk
-      md5sum: acc40ebd7864b84fc14e5ad22e30f83f
+      md5sum: 7c8a56fa96601fc0ce3a9c3f773b8c0e
     - path: output/plasmidid/test/data/test.gff
-      md5sum: 0dd7015f77e2fc3ecaa978362f7334cb
+      md5sum: 3ed8912ee9b0712ca491fa78ff5f4da1
     - path: output/plasmidid/test/data/test.karyotype_individual.txt
       md5sum: aaf0f5bfe297fb9846ace761ff018d22
     - path: output/plasmidid/test/data/test.karyotype_summary.txt
       md5sum: aaf0f5bfe297fb9846ace761ff018d22
     - path: output/plasmidid/test/data/test.plasmids.blast
-      md5sum: b089b7a073f4e48fabf0949168581b4c
+      md5sum: 241045ea62156c1ca9bc1eb734ac9526
     - path: output/plasmidid/test/data/test.plasmids.blast.links
-      md5sum: 3528f4e0a046826a9b7f916838b086c6
+      md5sum: a44d6aa388b582da8ad53c5b49467b8f
     - path: output/plasmidid/test/data/test.plasmids.complete
-      md5sum: 8d30d205c471ee3c8151b4c3d90e753b
+      md5sum: fbc7235285dbb963b07561dd6972a883
     - path: output/plasmidid/test/database/test.fna
       md5sum: 6b843fe652b4369addb382f61952c3dd
     - path: output/plasmidid/test/database/test.gbk
-      md5sum: d2e24369b999bc6a0dae9b7612edb839
+      md5sum: 7de7416b848ef27cb69c33f803148be5
     - path: output/plasmidid/test/database/test.gff
       md5sum: 7e65da147d0a413020b0d92b7b03ffcd
     - path: output/plasmidid/test/fasta_files/MT192765.1_term.fasta
-      md5sum: 2387d7d9c861e6f6e7d9f9395f9bad5c
+      md5sum: 8a8537dd3b21e6905f9367b51c3b3074
     - path: output/plasmidid/test/images/test_individual.circos.conf
       md5sum: f74467ab77232e2b342e2bd408897b12
     - path: output/plasmidid/test/images/test_MT192765.1_individual.circos.conf
@@ -41,8 +41,6 @@
       md5sum: e59dc3b77ee610a48b79230da705aba0
     - path: output/plasmidid/test/images/test_MT192765.1.png
     - path: output/plasmidid/test/images/test_summary.png
-    - path: output/plasmidid/test/kmer/database.filtered_0.8_term.0.5.clusters.tab
-      md5sum: cf75e4418631796bb4675129b575915d
     - path: output/plasmidid/test/kmer/database.filtered_0.8_term.0.5.clusters.tab
       md5sum: cf75e4418631796bb4675129b575915d
     - path: output/plasmidid/test/kmer/database.filtered_0.8_term.0.5.representative.fasta

--- a/tests/software/plasmidid/test.yml
+++ b/tests/software/plasmidid/test.yml
@@ -12,7 +12,7 @@
     - path: output/plasmidid/test/data/test.fna
       md5sum: 503a5e1d4654bb2df19420e211070db3
     - path: output/plasmidid/test/data/test.gbk
-      md5sum: 7c8a56fa96601fc0ce3a9c3f773b8c0e
+      md5sum: b52331b77a1a8cc16d88807dba97ba6a
     - path: output/plasmidid/test/data/test.gff
       md5sum: 3ed8912ee9b0712ca491fa78ff5f4da1
     - path: output/plasmidid/test/data/test.karyotype_individual.txt
@@ -28,7 +28,7 @@
     - path: output/plasmidid/test/database/test.fna
       md5sum: 6b843fe652b4369addb382f61952c3dd
     - path: output/plasmidid/test/database/test.gbk
-      md5sum: 7de7416b848ef27cb69c33f803148be5
+      md5sum: a059ee355b0b72c5a116bd2a604fddda
     - path: output/plasmidid/test/database/test.gff
       md5sum: 7e65da147d0a413020b0d92b7b03ffcd
     - path: output/plasmidid/test/fasta_files/MT192765.1_term.fasta


### PR DESCRIPTION
After changing `contigs.fasta` files on this [PR](https://github.com/nf-core/test-datasets/pull/234) the md5sum checks need to be updated.
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #433 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x]] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
