### PR TITLE
Move assembly test files from genome to illumina

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -24,14 +24,10 @@ params {
                 kraken2                                   = "${test_data_dir}/genomics/sarscov2/genome/db/kraken2"
                 kraken2_tar_gz                            = "${test_data_dir}/genomics/sarscov2/genome/db/kraken2.tar.gz"
 
-                test_wig_gz                               = "${test_data_dir}/genomics/sarscov2/genome/gcwiggle/test.wig.gz"
+                test_wig_gz                               = "${test_data_dir}/genomics/sarscov2/illumina/wig/test.wig.gz"
 
                 all_sites_fas                             = "${test_data_dir}/genomics/sarscov2/genome/alignment/all_sites.fas"
                 informative_sites_fas                     = "${test_data_dir}/genomics/sarscov2/genome/alignment/informative_sites.fas"
-
-                contigs_fasta                             = "${test_data_dir}/genomics/sarscov2/genome/contigs.fasta"
-                scaffolds_fasta                           = "${test_data_dir}/genomics/sarscov2/genome/scaffolds.fasta"
-                assembly_gfa                              = "${test_data_dir}/genomics/sarscov2/genome/assembly.gfa"
             }
             'illumina' {
                 test_single_end_bam                       = "${test_data_dir}/genomics/sarscov2/illumina/bam/test_single_end.bam"
@@ -66,6 +62,10 @@ params {
                 test3_vcf                                 = "${test_data_dir}/genomics/sarscov2/illumina/vcf/test3.vcf"
                 test3_vcf_gz                              = "${test_data_dir}/genomics/sarscov2/illumina/vcf/test3.vcf.gz"
                 test3_vcf_gz_tbi                          = "${test_data_dir}/genomics/sarscov2/illumina/vcf/test3.vcf.gz.tbi"
+
+                contigs_fasta                             = "${test_data_dir}/genomics/sarscov2/illumina/fasta/contigs.fasta"
+                scaffolds_fasta                           = "${test_data_dir}/genomics/sarscov2/illumina/fasta/scaffolds.fasta"
+                assembly_gfa                              = "${test_data_dir}/genomics/sarscov2/illumina/gfa/assembly.gfa"
             }
             'nanopore' {
                 test_sorted_bam                           = "${test_data_dir}/genomics/sarscov2/nanopore/bam/test.sorted.bam"

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -24,8 +24,6 @@ params {
                 kraken2                                   = "${test_data_dir}/genomics/sarscov2/genome/db/kraken2"
                 kraken2_tar_gz                            = "${test_data_dir}/genomics/sarscov2/genome/db/kraken2.tar.gz"
 
-                test_wig_gz                               = "${test_data_dir}/genomics/sarscov2/illumina/wig/test.wig.gz"
-
                 all_sites_fas                             = "${test_data_dir}/genomics/sarscov2/genome/alignment/all_sites.fas"
                 informative_sites_fas                     = "${test_data_dir}/genomics/sarscov2/genome/alignment/informative_sites.fas"
             }

--- a/tests/software/abacas/main.nf
+++ b/tests/software/abacas/main.nf
@@ -7,7 +7,7 @@ include { ABACAS } from '../../../software/abacas/main.nf' addParams ( options: 
 workflow test_abacas {
 
     input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['illumina']['fasta']['scaffolds_fasta'], checkIfExists: true)
+              file(params.test_data['sarscov2']['illumina']['scaffolds_fasta'], checkIfExists: true)
             ]
 
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)

--- a/tests/software/abacas/main.nf
+++ b/tests/software/abacas/main.nf
@@ -7,7 +7,7 @@ include { ABACAS } from '../../../software/abacas/main.nf' addParams ( options: 
 workflow test_abacas {
 
     input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['genome']['scaffolds_fasta'], checkIfExists: true)
+              file(params.test_data['sarscov2']['illumina']['fasta']['scaffolds_fasta'], checkIfExists: true)
             ]
 
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)

--- a/tests/software/plasmidid/main.nf
+++ b/tests/software/plasmidid/main.nf
@@ -7,7 +7,7 @@ include { PLASMIDID } from '../../../software/plasmidid/main.nf' addParams ( opt
 workflow test_plasmidid {
 
     contigs = [ [ id:'test' ], // meta map
-                file(params.test_data['sarscov2']['illumina']['fasta']['contigs_fasta'], checkIfExists: true)
+                file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true)
               ]
 
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)

--- a/tests/software/plasmidid/main.nf
+++ b/tests/software/plasmidid/main.nf
@@ -7,7 +7,7 @@ include { PLASMIDID } from '../../../software/plasmidid/main.nf' addParams ( opt
 workflow test_plasmidid {
 
     contigs = [ [ id:'test' ], // meta map
-                file(params.test_data['sarscov2']['genome']['contigs_fasta'], checkIfExists: true)
+                file(params.test_data['sarscov2']['illumina']['fasta']['contigs_fasta'], checkIfExists: true)
               ]
 
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)

--- a/tests/software/plasmidid/test.yml
+++ b/tests/software/plasmidid/test.yml
@@ -8,31 +8,31 @@
     - path: output/plasmidid/test/data/test.coverage_adapted_clustered_ac
       md5sum: 3a9ea6d336e113a74d7fdca5e7b623fc
     - path: output/plasmidid/test/data/test.err
-      md5sum: 1eabbbcb19d8886182f78b86fc50884c
+      md5sum: 011108fd8b0bb4a4c0b5b2cf46452a90
     - path: output/plasmidid/test/data/test.fna
-      md5sum: 78328536870d04afc54a4dfaf103cac8
+      md5sum: 503a5e1d4654bb2df19420e211070db3
     - path: output/plasmidid/test/data/test.gbk
-      md5sum: acc40ebd7864b84fc14e5ad22e30f83f
+      md5sum: 7c8a56fa96601fc0ce3a9c3f773b8c0e
     - path: output/plasmidid/test/data/test.gff
-      md5sum: 0dd7015f77e2fc3ecaa978362f7334cb
+      md5sum: 3ed8912ee9b0712ca491fa78ff5f4da1
     - path: output/plasmidid/test/data/test.karyotype_individual.txt
       md5sum: aaf0f5bfe297fb9846ace761ff018d22
     - path: output/plasmidid/test/data/test.karyotype_summary.txt
       md5sum: aaf0f5bfe297fb9846ace761ff018d22
     - path: output/plasmidid/test/data/test.plasmids.blast
-      md5sum: b089b7a073f4e48fabf0949168581b4c
+      md5sum: 241045ea62156c1ca9bc1eb734ac9526
     - path: output/plasmidid/test/data/test.plasmids.blast.links
-      md5sum: 3528f4e0a046826a9b7f916838b086c6
+      md5sum: a44d6aa388b582da8ad53c5b49467b8f
     - path: output/plasmidid/test/data/test.plasmids.complete
-      md5sum: 8d30d205c471ee3c8151b4c3d90e753b
+      md5sum: fbc7235285dbb963b07561dd6972a883
     - path: output/plasmidid/test/database/test.fna
       md5sum: 6b843fe652b4369addb382f61952c3dd
     - path: output/plasmidid/test/database/test.gbk
-      md5sum: d2e24369b999bc6a0dae9b7612edb839
+      md5sum: 7de7416b848ef27cb69c33f803148be5
     - path: output/plasmidid/test/database/test.gff
       md5sum: 7e65da147d0a413020b0d92b7b03ffcd
     - path: output/plasmidid/test/fasta_files/MT192765.1_term.fasta
-      md5sum: 2387d7d9c861e6f6e7d9f9395f9bad5c
+      md5sum: 8a8537dd3b21e6905f9367b51c3b3074
     - path: output/plasmidid/test/images/test_individual.circos.conf
       md5sum: f74467ab77232e2b342e2bd408897b12
     - path: output/plasmidid/test/images/test_MT192765.1_individual.circos.conf
@@ -41,8 +41,6 @@
       md5sum: e59dc3b77ee610a48b79230da705aba0
     - path: output/plasmidid/test/images/test_MT192765.1.png
     - path: output/plasmidid/test/images/test_summary.png
-    - path: output/plasmidid/test/kmer/database.filtered_0.8_term.0.5.clusters.tab
-      md5sum: cf75e4418631796bb4675129b575915d
     - path: output/plasmidid/test/kmer/database.filtered_0.8_term.0.5.clusters.tab
       md5sum: cf75e4418631796bb4675129b575915d
     - path: output/plasmidid/test/kmer/database.filtered_0.8_term.0.5.representative.fasta

--- a/tests/software/plasmidid/test.yml
+++ b/tests/software/plasmidid/test.yml
@@ -12,7 +12,7 @@
     - path: output/plasmidid/test/data/test.fna
       md5sum: 503a5e1d4654bb2df19420e211070db3
     - path: output/plasmidid/test/data/test.gbk
-      md5sum: 7c8a56fa96601fc0ce3a9c3f773b8c0e
+      md5sum: b52331b77a1a8cc16d88807dba97ba6a
     - path: output/plasmidid/test/data/test.gff
       md5sum: 3ed8912ee9b0712ca491fa78ff5f4da1
     - path: output/plasmidid/test/data/test.karyotype_individual.txt
@@ -28,7 +28,7 @@
     - path: output/plasmidid/test/database/test.fna
       md5sum: 6b843fe652b4369addb382f61952c3dd
     - path: output/plasmidid/test/database/test.gbk
-      md5sum: 7de7416b848ef27cb69c33f803148be5
+      md5sum: a059ee355b0b72c5a116bd2a604fddda
     - path: output/plasmidid/test/database/test.gff
       md5sum: 7e65da147d0a413020b0d92b7b03ffcd
     - path: output/plasmidid/test/fasta_files/MT192765.1_term.fasta


### PR DESCRIPTION
Assembly files from sarscov2 are generated from Illumina reads and thus, it was somehow misleading to place them under `genome` folder. They were moved on [test-datasets](https://github.com/nf-core/test-datasets/pull/236).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Follow the naming conventions.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
