### PR TITLE
New module to use hmmalign from HMMER to align sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ test_output/
 output/
 .DS_Store
 *.code-workspace
+.screenrc
+.*.sw?

--- a/software/hmmer/hmmalign/functions.nf
+++ b/software/hmmer/hmmalign/functions.nf
@@ -1,0 +1,60 @@
+/*
+ * -----------------------------------------------------
+ *  Utility functions used in nf-core DSL2 module files
+ * -----------------------------------------------------
+ */
+
+/*
+ * Extract name of software tool from process name using $task.process
+ */
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+/*
+ * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+ */
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args          = args.args ?: ''
+    options.args2         = args.args2 ?: ''
+    options.args3         = args.args3 ?: ''
+    options.publish_by_id = args.publish_by_id ?: false
+    options.publish_dir   = args.publish_dir ?: ''
+    options.publish_files = args.publish_files
+    options.suffix        = args.suffix ?: ''
+    return options
+}
+
+/*
+ * Tidy up and join elements of a list to return a path string
+ */
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
+    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+/*
+ * Function to save/publish module results
+ */
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_id) {
+            path_list.add(args.publish_id)
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/software/hmmer/hmmalign/functions.nf
+++ b/software/hmmer/hmmalign/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/hmmer/hmmalign/main.nf
+++ b/software/hmmer/hmmalign/main.nf
@@ -40,5 +40,3 @@ process HMMER_HMMALIGN {
     echo \$(hmmalign -h | grep -o '^# HMMER [0-9.]*') | sed 's/^# HMMER *//' > ${software}.version.txt
     """
 }
-
-// vim:sw=4

--- a/software/hmmer/hmmalign/main.nf
+++ b/software/hmmer/hmmalign/main.nf
@@ -19,8 +19,8 @@ process HMMER_HMMALIGN {
     }
 
     input:
-    tuple val(meta), path(fasta) // Gzipped fasta file
-    path hmm                     // Profile hmm to align to
+    tuple val(meta), path(fasta)
+    path hmm
 
     output:
     tuple val(meta), path("*.sthlm.gz"), emit: sthlm

--- a/software/hmmer/hmmalign/main.nf
+++ b/software/hmmer/hmmalign/main.nf
@@ -9,7 +9,7 @@ process HMMER_HMMALIGN {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::hmmer=3.3.2" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/hmmer/hmmalign/main.nf
+++ b/software/hmmer/hmmalign/main.nf
@@ -1,0 +1,44 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process HMMER_HMMALIGN {
+    tag "$meta.id"
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+
+    conda (params.enable_conda ? "bioconda::hmmer=3.3.2" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/hmmer:3.3.2--h1b792b2_1"
+    } else {
+        container "quay.io/biocontainers/hmmer:3.3.2--h1b792b2_1"
+    }
+
+    input:
+    tuple val(meta), path(fasta) // Gzipped fasta file
+    path hmm                     // Profile hmm to align to
+
+    output:
+    tuple val(meta), path("*.sthlm.gz"), emit: sthlm
+    path "*.version.txt"               , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    def fastacmd = fasta.getExtension() == 'gz' ? "gunzip -c $fasta" : "cat $fasta"
+    """
+    $fastacmd | \\
+        hmmalign \\
+        $options.args \\
+        $hmm \\
+        - | gzip -c > ${meta.id}.sthlm.gz
+
+    echo \$(hmmalign -h | grep -o '^# HMMER [0-9.]*') | sed 's/^# HMMER *//' > ${software}.version.txt
+    """
+}
+
+// vim:sw=4

--- a/software/hmmer/hmmalign/meta.yml
+++ b/software/hmmer/hmmalign/meta.yml
@@ -43,5 +43,3 @@ output:
 
 authors:
   - "@erikrikarddaniel"
-
-# vim:sw=4

--- a/software/hmmer/hmmalign/meta.yml
+++ b/software/hmmer/hmmalign/meta.yml
@@ -1,0 +1,47 @@
+name: hmmer_hmmalign
+description: hmmalign from the HMMER suite aligns a number of sequences to an HMM profile
+keywords:
+  - alignment
+tools:
+  - hmmer:
+      description: Biosequence analysis using profile hidden Markov models
+      homepage: http://hmmer.org/
+      documentation: http://hmmer.org/documentation.html
+      tool_dev_url: None
+      doi: "http://dx.doi.org/10.1371/journal.pcbi.1002195"
+      licence: ['BSD']
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - fasta:
+      type: file
+      description: Amino acid or nucleotide fasta file, gzipped or not
+      pattern: "*.{fna,fna.gz,faa,faa.gz,fasta,fasta.gz,fa,fa.gz}"
+  - hmm:
+      type: file
+      description: HMM file
+      pattern: "*.hmm"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "*.{version.txt}"
+  - sthlm:
+      type: file
+      description: Multiple alignment in gzipped Stockholm format
+      pattern: "*.sthlm.gz"
+
+authors:
+  - "@erikrikarddaniel"
+
+# vim:sw=4

--- a/tests/config/pytest_software.yml
+++ b/tests/config/pytest_software.yml
@@ -293,6 +293,10 @@ hisat2/extractsplicesites:
   - software/hisat2/extractsplicesites/**
   - tests/software/hisat2/extractsplicesites/**
 
+hmmer_hmmalign:
+  - software/hmmer/hmmalign/**
+  - tests/software/hmmer/hmmalign/**
+
 homer/annotatepeaks:
   - software/homer/annotatepeaks/**
   - tests/software/homer/annotatepeaks/**

--- a/tests/config/pytest_software.yml
+++ b/tests/config/pytest_software.yml
@@ -293,7 +293,7 @@ hisat2/extractsplicesites:
   - software/hisat2/extractsplicesites/**
   - tests/software/hisat2/extractsplicesites/**
 
-hmmer_hmmalign:
+hmmer/hmmalign:
   - software/hmmer/hmmalign/**
   - tests/software/hmmer/hmmalign/**
 

--- a/tests/software/hmmer/hmmalign/main.nf
+++ b/tests/software/hmmer/hmmalign/main.nf
@@ -15,5 +15,3 @@ workflow test_hmmer_hmmalign {
 
     HMMER_HMMALIGN ( input, hmm )
 }
-
-// vim:sw=4

--- a/tests/software/hmmer/hmmalign/main.nf
+++ b/tests/software/hmmer/hmmalign/main.nf
@@ -1,0 +1,22 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { HMMER_HMMALIGN } from '../../../../software/hmmer/hmmalign/main.nf' addParams( options: [:] )
+
+workflow test_hmmer_hmmalign {
+    
+//    input = [ [ id:'test' ], // meta map
+//              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
+
+    input = [
+        [ id:'test' ], // meta map
+        file('https://raw.githubusercontent.com/erikrikarddaniel/test-datasets/modules/data/delete_me/e_coli_k12_16s.fna')
+    ]
+
+    hmm   = file('https://raw.githubusercontent.com/erikrikarddaniel/test-datasets/modules/data/delete_me/bac.16S_rRNA.hmm')
+
+    HMMER_HMMALIGN ( input, hmm )
+}
+
+// vim:sw=4

--- a/tests/software/hmmer/hmmalign/main.nf
+++ b/tests/software/hmmer/hmmalign/main.nf
@@ -5,9 +5,6 @@ nextflow.enable.dsl = 2
 include { HMMER_HMMALIGN } from '../../../../software/hmmer/hmmalign/main.nf' addParams( options: [:] )
 
 workflow test_hmmer_hmmalign {
-    
-//    input = [ [ id:'test' ], // meta map
-//              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
 
     input = [
         [ id:'test' ], // meta map

--- a/tests/software/hmmer/hmmalign/main.nf
+++ b/tests/software/hmmer/hmmalign/main.nf
@@ -11,7 +11,7 @@ workflow test_hmmer_hmmalign {
 
     input = [
         [ id:'test' ], // meta map
-        file('https://raw.githubusercontent.com/erikrikarddaniel/test-datasets/modules/data/delete_me/e_coli_k12_16s.fna')
+        file('https://raw.githubusercontent.com/erikrikarddaniel/test-datasets/modules/data/delete_me/e_coli_k12_16s.fna')      // Change to params.test_data syntax after the data is included in tests/config/test_data.config
     ]
 
     hmm   = file('https://raw.githubusercontent.com/erikrikarddaniel/test-datasets/modules/data/delete_me/bac.16S_rRNA.hmm')

--- a/tests/software/hmmer/hmmalign/test.yml
+++ b/tests/software/hmmer/hmmalign/test.yml
@@ -2,7 +2,7 @@
   command: nextflow run tests/software/hmmer/hmmalign -entry test_hmmer_hmmalign -c tests/config/nextflow.config
   tags:
     - hmmer
-    - hmmer_hmmalign
+    - hmmer/hmmalign
   files:
     - path: output/hmmer/test.sthlm.gz
       md5sum: ddaa8b96291edf4e1a929a224329161b

--- a/tests/software/hmmer/hmmalign/test.yml
+++ b/tests/software/hmmer/hmmalign/test.yml
@@ -1,10 +1,8 @@
-## TODO nf-core: Please run the following command to build this file:
-#                nf-core modules create-test-yml hmmer/hmmalign
-- name: hmmer hmmalign
-  command: nextflow run ./tests/software/hmmer/hmmalign -entry test_hmmer_hmmalign -c tests/config/nextflow.config
+- name: hmmer hmmalign test_hmmer_hmmalign
+  command: nextflow run tests/software/hmmer/hmmalign -entry test_hmmer_hmmalign -c tests/config/nextflow.config
   tags:
     - hmmer
     - hmmer_hmmalign
   files:
-    - path: output/hmmer/test.bam
-      md5sum: e667c7caad0bc4b7ac383fd023c654fc
+    - path: output/hmmer/test.sthlm.gz
+      md5sum: ddaa8b96291edf4e1a929a224329161b

--- a/tests/software/hmmer/hmmalign/test.yml
+++ b/tests/software/hmmer/hmmalign/test.yml
@@ -1,0 +1,10 @@
+## TODO nf-core: Please run the following command to build this file:
+#                nf-core modules create-test-yml hmmer/hmmalign
+- name: hmmer hmmalign
+  command: nextflow run ./tests/software/hmmer/hmmalign -entry test_hmmer_hmmalign -c tests/config/nextflow.config
+  tags:
+    - hmmer
+    - hmmer_hmmalign
+  files:
+    - path: output/hmmer/test.bam
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This PR adds a module, `hmmer/hmmalign`, that contains a function that calls `hmmalign` from the [HMMER](http://hmmer.org) package to make a multiple alignment of sequences from a fasta file to an hmm profile.

Tests pass with Docker using Nextflow 21.04.0-edge, haven't tried Singularity nor Conda.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
