### PR TITLE
raxml-ng is compute intensive - upgrade process label to high

### DIFF
--- a/software/raxmlng/main.nf
+++ b/software/raxmlng/main.nf
@@ -5,7 +5,7 @@ params.options = [:]
 options        = initOptions(params.options)
 
 process RAXMLNG {
-    label 'process_medium'
+    label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:[:], publish_by_meta:[]) }


### PR DESCRIPTION
## PR checklist

Just updating the process label to high

- [x] This comment contains a description of changes (with reason).

