### PR TITLE
New last/lastdb module to index sequences before alignment.

### DIFF
--- a/software/last/lastdb/functions.nf
+++ b/software/last/lastdb/functions.nf
@@ -1,0 +1,60 @@
+/*
+ * -----------------------------------------------------
+ *  Utility functions used in nf-core DSL2 module files
+ * -----------------------------------------------------
+ */
+
+/*
+ * Extract name of software tool from process name using $task.process
+ */
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+/*
+ * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+ */
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args          = args.args ?: ''
+    options.args2         = args.args2 ?: ''
+    options.args3         = args.args3 ?: ''
+    options.publish_by_id = args.publish_by_id ?: false
+    options.publish_dir   = args.publish_dir ?: ''
+    options.publish_files = args.publish_files
+    options.suffix        = args.suffix ?: ''
+    return options
+}
+
+/*
+ * Tidy up and join elements of a list to return a path string
+ */
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
+    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+/*
+ * Function to save/publish module results
+ */
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_id) {
+            path_list.add(args.publish_id)
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/software/last/lastdb/functions.nf
+++ b/software/last/lastdb/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/last/lastdb/main.nf
+++ b/software/last/lastdb/main.nf
@@ -9,7 +9,7 @@ process LAST_LASTDB {
     label 'process_medium'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::last=1219" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
@@ -27,14 +27,14 @@ process LAST_LASTDB {
 
     script:
     def software = getSoftwareName(task.process)
-
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     """
     mkdir lastdb
     lastdb \\
-        ${options.args} \\
-        -P ${task.cpus} \\
-        lastdb/${meta.id} \\
-        ${fastx}
+        $options.args \\
+        -P $task.cpus \\
+        lastdb/${prefix} \\
+        $fastx
 
     echo \$(lastdb --version 2>&1) | sed 's/lastdb //' > ${software}.version.txt
     """

--- a/software/last/lastdb/main.nf
+++ b/software/last/lastdb/main.nf
@@ -27,7 +27,7 @@ process LAST_LASTDB {
 
     script:
     def software = getSoftwareName(task.process)
-    
+
     """
     mkdir lastdb
     lastdb \\

--- a/software/last/lastdb/main.nf
+++ b/software/last/lastdb/main.nf
@@ -1,0 +1,41 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process LAST_LASTDB {
+    tag "$meta.id"
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+
+    conda (params.enable_conda ? "bioconda::last=1219" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/last:1219--h2e03b76_0"
+    } else {
+        container "quay.io/biocontainers/last:1219--h2e03b76_0"
+    }
+
+    input:
+    tuple val(meta), path(fastx)
+
+    output:
+    tuple val(meta), path("lastdb"), emit: index
+    path "*.version.txt"           , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    
+    """
+    mkdir lastdb
+    lastdb \\
+        ${options.args} \\
+        -P ${task.cpus} \\
+        lastdb/${meta.id} \\
+        ${fastx}
+
+    echo \$(lastdb --version 2>&1) | sed 's/lastdb //' > ${software}.version.txt
+    """
+}

--- a/software/last/lastdb/meta.yml
+++ b/software/last/lastdb/meta.yml
@@ -1,0 +1,41 @@
+name: last_lastdb
+description: Prepare sequences for subsequent alignment with lastal.
+keywords:
+  - LAST
+  - index
+  - fasta
+  - fastq
+tools:
+  - last:
+      description: LAST finds & aligns related regions of sequences.
+      homepage: https://gitlab.com/mcfrith/last
+      documentation: https://gitlab.com/mcfrith/last/-/blob/main/doc/lastdb.rst
+      tool_dev_url: https://gitlab.com/mcfrith/last
+      doi: ""
+      licence: ['GPL-3.0-or-later']
+
+input:
+  - meta:
+      type: map
+      description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+  - fastx:
+      type: file
+      description: >
+          Sequence file in FASTA or FASTQ format.
+          May be compressed with gzip.
+      pattern: "*.{fasta,fasta.gz,fastq,fastq.gz}"
+
+output:
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "*.{version.txt}"
+  - index:
+      type: directory
+      description: directory containing the files of the LAST index
+      pattern: "lastdb/"
+
+authors:
+  - "@charles-plessy"

--- a/tests/config/pytest_software.yml
+++ b/tests/config/pytest_software.yml
@@ -334,6 +334,10 @@ kraken2/run:
   - software/untar/**
   - tests/software/kraken2/run/**
 
+last_lastdb:
+  - software/last/lastdb/**
+  - tests/software/last/lastdb/**
+
 mash/sketch:
   - software/mash/sketch/**
   - tests/software/mash/sketch/**

--- a/tests/config/pytest_software.yml
+++ b/tests/config/pytest_software.yml
@@ -334,7 +334,7 @@ kraken2/run:
   - software/untar/**
   - tests/software/kraken2/run/**
 
-last_lastdb:
+last/lastdb:
   - software/last/lastdb/**
   - tests/software/last/lastdb/**
 

--- a/tests/software/last/lastdb/main.nf
+++ b/tests/software/last/lastdb/main.nf
@@ -1,0 +1,23 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { LAST_LASTDB } from '../../../../software/last/lastdb/main.nf' addParams( options: ['args': '-Q0'] )
+
+workflow test_last_lastdb {
+
+    input = [ [ id:'test' ], // meta map
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            ]
+
+    LAST_LASTDB ( input )
+}
+
+workflow test_last_lastdb_gzipped_input {
+
+    input = [ [ id:'test' ], // meta map
+              file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+            ]
+
+    LAST_LASTDB ( input )
+}

--- a/tests/software/last/lastdb/test.yml
+++ b/tests/software/last/lastdb/test.yml
@@ -22,9 +22,8 @@
 - name: last lastdb test_last_lastdb_gzipped_input
   command: nextflow run tests/software/last/lastdb -entry test_last_lastdb_gzipped_input -c tests/config/nextflow.config
   tags:
-    - last/lastdb
-    - last_lastdb_gzipped_input
     - last
+    - last/lastdb
   files:
     - path: output/last/lastdb/test.bck
       md5sum: 8692b1229b1fff1c2d39c4c610ff842b

--- a/tests/software/last/lastdb/test.yml
+++ b/tests/software/last/lastdb/test.yml
@@ -1,0 +1,42 @@
+- name: last lastdb test_last_lastdb
+  command: nextflow run tests/software/last/lastdb -entry test_last_lastdb -c tests/config/nextflow.config
+  tags:
+    - last
+    - last_lastdb
+  files:
+    - path: output/last/lastdb/test.bck
+      md5sum: 5519879b9b6c4d1fc508da7f17f88f2e
+    - path: output/last/lastdb/test.des
+      md5sum: 3a9ea6d336e113a74d7fdca5e7b623fc
+    - path: output/last/lastdb/test.prj
+      md5sum: 489715f14b0fea6273822696e72357f9
+    - path: output/last/lastdb/test.sds
+      md5sum: 2cd381f4f8a9c52cfcd323a2863eccb2
+    - path: output/last/lastdb/test.ssp
+      md5sum: 4137fb6fe9df2b3d78d5b960390aac7b
+    - path: output/last/lastdb/test.suf
+      md5sum: 1895efa8653e8e9bd3605cff0408ed33
+    - path: output/last/lastdb/test.tis
+      md5sum: b7c40f06b1309dc6f37849eeb86dfd22
+
+- name: last lastdb test_last_lastdb_gzipped_input
+  command: nextflow run tests/software/last/lastdb -entry test_last_lastdb_gzipped_input -c tests/config/nextflow.config
+  tags:
+    - last_lastdb
+    - last_lastdb_gzipped_input
+    - last
+  files:
+    - path: output/last/lastdb/test.bck
+      md5sum: 8692b1229b1fff1c2d39c4c610ff842b
+    - path: output/last/lastdb/test.des
+      md5sum: 26ab49015cc572172b9efa50fc5190bc
+    - path: output/last/lastdb/test.prj
+      md5sum: a302beb8b8b884d8450055ede61e973b
+    - path: output/last/lastdb/test.sds
+      md5sum: cad9927d4bd161257e98165ad755d8e4
+    - path: output/last/lastdb/test.ssp
+      md5sum: 574c8a080247c2af9b5c46ff70936186
+    - path: output/last/lastdb/test.suf
+      md5sum: 8c406111b398631e51ca79d99b0ee897
+    - path: output/last/lastdb/test.tis
+      md5sum: d57a3a5f7e3e036807356c15bd3aad97

--- a/tests/software/last/lastdb/test.yml
+++ b/tests/software/last/lastdb/test.yml
@@ -2,7 +2,7 @@
   command: nextflow run tests/software/last/lastdb -entry test_last_lastdb -c tests/config/nextflow.config
   tags:
     - last
-    - last_lastdb
+    - last/lastdb
   files:
     - path: output/last/lastdb/test.bck
       md5sum: 5519879b9b6c4d1fc508da7f17f88f2e
@@ -22,7 +22,7 @@
 - name: last lastdb test_last_lastdb_gzipped_input
   command: nextflow run tests/software/last/lastdb -entry test_last_lastdb_gzipped_input -c tests/config/nextflow.config
   tags:
-    - last_lastdb
+    - last/lastdb
     - last_lastdb_gzipped_input
     - last
   files:


### PR DESCRIPTION
The `lastdb` command creates a sequence index for the [LAST aligner](https://gitlab.com/mcfrith/last). Input can be in FASTA or FASTQ format, and compression is handled automagically.  DNA or protein sequences can be indexed.

The sequence index is a collection of files sharing the same basename. This module sets the basename to the sample identifier (`$meta.id`) and creates the index in a directory always called `lastdb`.  The module's output channel then conveys a copy of the metadata and the path to the `lastdb` directory.

Other modules will follow (see Issue #464).  The LAST aligner can align proteins to proteins, DNA to DNA and can translate DNA align to proteins.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
