### PR TITLE
Increase conda build time

### DIFF
--- a/software/artic/minion/meta.yml
+++ b/software/artic/minion/meta.yml
@@ -1,5 +1,6 @@
 name: artic_minion
-description: write your description here
+description: |
+    Run the alignment/variant-call/consensus logic of the artic pipeline
 keywords:
   - artic
   - aggregate

--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -21,6 +21,9 @@ if ("$PROFILE" == "singularity") {
     docker.runOptions = '-u \$(id -u):\$(id -g)'
 }
 
+// Increase time available to build Conda environment
+conda { createTimeout = "120 min" }
+
 // Load test_data.config containing paths to test data
 includeConfig 'test_data.config'
 


### PR DESCRIPTION
The build time for `conda` build has been increased to `120 min`. The default time (20 min), see [here](https://www.nextflow.io/docs/latest/config.html#scope-conda), was not enough for many tools and the `conda` tests were repeatedly failing due to this reason.
Also, the description of the `meta.yml` file of the `artic/minion` module was missing. Updated.
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
