### PR TITLE
New last/train module to train alignment parameters.

### DIFF
--- a/software/last/train/functions.nf
+++ b/software/last/train/functions.nf
@@ -1,0 +1,60 @@
+/*
+ * -----------------------------------------------------
+ *  Utility functions used in nf-core DSL2 module files
+ * -----------------------------------------------------
+ */
+
+/*
+ * Extract name of software tool from process name using $task.process
+ */
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+/*
+ * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+ */
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args          = args.args ?: ''
+    options.args2         = args.args2 ?: ''
+    options.args3         = args.args3 ?: ''
+    options.publish_by_id = args.publish_by_id ?: false
+    options.publish_dir   = args.publish_dir ?: ''
+    options.publish_files = args.publish_files
+    options.suffix        = args.suffix ?: ''
+    return options
+}
+
+/*
+ * Tidy up and join elements of a list to return a path string
+ */
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
+    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+/*
+ * Function to save/publish module results
+ */
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_id) {
+            path_list.add(args.publish_id)
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/software/last/train/functions.nf
+++ b/software/last/train/functions.nf
@@ -16,13 +16,13 @@ def getSoftwareName(task_process) {
  */
 def initOptions(Map args) {
     def Map options = [:]
-    options.args          = args.args ?: ''
-    options.args2         = args.args2 ?: ''
-    options.args3         = args.args3 ?: ''
-    options.publish_by_id = args.publish_by_id ?: false
-    options.publish_dir   = args.publish_dir ?: ''
-    options.publish_files = args.publish_files
-    options.suffix        = args.suffix ?: ''
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
     return options
 }
 
@@ -30,8 +30,8 @@ def initOptions(Map args) {
  * Tidy up and join elements of a list to return a path string
  */
 def getPathFromList(path_list) {
-    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }  // Remove empty entries
-    paths = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
@@ -40,10 +40,20 @@ def getPathFromList(path_list) {
  */
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
-        def ioptions = initOptions(args.options)
+        def ioptions  = initOptions(args.options)
         def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
-        if (ioptions.publish_by_id) {
-            path_list.add(args.publish_id)
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
         }
         if (ioptions.publish_files instanceof Map) {
             for (ext in ioptions.publish_files) {

--- a/software/last/train/main.nf
+++ b/software/last/train/main.nf
@@ -9,7 +9,7 @@ process LAST_TRAIN {
     label 'process_high'
     publishDir "${params.outdir}",
         mode: params.publish_dir_mode,
-        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "bioconda::last=1219" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {

--- a/software/last/train/main.nf
+++ b/software/last/train/main.nf
@@ -37,7 +37,7 @@ process LAST_TRAIN {
         -P $task.cpus \\
         ${index}/\$INDEX_NAME \\
         ${fastx} \\
-        > ${meta.id}_\$INDEX_NAME.par
+        > ${meta.id}__\$INDEX_NAME.par
 
     lastdb --version | sed 's/lastdb //' > ${software}.version.txt
     """

--- a/software/last/train/main.nf
+++ b/software/last/train/main.nf
@@ -37,7 +37,7 @@ process LAST_TRAIN {
         -P $task.cpus \\
         ${index}/\$INDEX_NAME \\
         ${fastx} \\
-        > ${meta.id}__\$INDEX_NAME.par
+        > ${prefix}.\$INDEX_NAME.par
 
     lastdb --version | sed 's/lastdb //' > ${software}.version.txt
     """

--- a/software/last/train/main.nf
+++ b/software/last/train/main.nf
@@ -19,8 +19,8 @@ process LAST_TRAIN {
     }
 
     input:
-    tuple val(meta_index), path(index)
-    tuple val(meta),       path(fastx)
+    tuple val(meta), path(fastx)
+    path  index
 
     output:
     tuple val(meta), path("*.par"), emit: param_file
@@ -30,12 +30,14 @@ process LAST_TRAIN {
     def software = getSoftwareName(task.process)
     def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     """
+    INDEX=`find -L ./ -name "*.rev.1.bt2" | sed 's/.rev.1.bt2//'`
+    
     last-train \\
         $options.args \\
         -P $task.cpus \\
-        ${index}/${meta_index.id} \\
+        ${index}/\$INDEX \\
         ${fastx} \\
-        > ${meta.id}__${meta_index.id}.par
+        > ${meta.id}_\$INDEX.par
 
     lastdb --version | sed 's/lastdb //' > ${software}.version.txt
     """

--- a/software/last/train/main.nf
+++ b/software/last/train/main.nf
@@ -30,14 +30,14 @@ process LAST_TRAIN {
     def software = getSoftwareName(task.process)
     def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     """
-    INDEX=`find -L ./ -name "*.rev.1.bt2" | sed 's/.rev.1.bt2//'`
+    INDEX_NAME=`find -L lastdb/ -name "*.bck" | sed 's/.bck//' | sed 's,lastdb/,,'`
     
     last-train \\
         $options.args \\
         -P $task.cpus \\
-        ${index}/\$INDEX \\
+        ${index}/\$INDEX_NAME \\
         ${fastx} \\
-        > ${meta.id}_\$INDEX.par
+        > ${meta.id}_\$INDEX_NAME.par
 
     lastdb --version | sed 's/lastdb //' > ${software}.version.txt
     """

--- a/software/last/train/main.nf
+++ b/software/last/train/main.nf
@@ -1,0 +1,42 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process LAST_TRAIN {
+    tag "$meta.id"
+    label 'process_high'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
+
+    conda (params.enable_conda ? "bioconda::last=1219" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/last:1219--h2e03b76_0"
+    } else {
+        container "quay.io/biocontainers/last:1219--h2e03b76_0"
+    }
+
+    input:
+    tuple val(meta_index), path(index)
+    tuple val(meta),       path(fastx)
+
+    output:
+    tuple val(meta), path("*.par"), emit: param_file
+    path "*.version.txt"          , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    """
+    last-train \\
+        $options.args \\
+        -P $task.cpus \\
+        ${index}/${meta_index.id} \\
+        ${fastx} \\
+        > ${meta.id}__${meta_index.id}.par
+
+    lastdb --version | sed 's/lastdb //' > ${software}.version.txt
+    """
+}

--- a/software/last/train/main.nf
+++ b/software/last/train/main.nf
@@ -36,7 +36,7 @@ process LAST_TRAIN {
         $options.args \\
         -P $task.cpus \\
         ${index}/\$INDEX_NAME \\
-        ${fastx} \\
+        $fastx \\
         > ${prefix}.\$INDEX_NAME.par
 
     lastdb --version | sed 's/lastdb //' > ${software}.version.txt

--- a/software/last/train/main.nf
+++ b/software/last/train/main.nf
@@ -31,7 +31,7 @@ process LAST_TRAIN {
     def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     """
     INDEX_NAME=`find -L lastdb/ -name "*.bck" | sed 's/.bck//' | sed 's,lastdb/,,'`
-    
+
     last-train \\
         $options.args \\
         -P $task.cpus \\

--- a/software/last/train/meta.yml
+++ b/software/last/train/meta.yml
@@ -1,0 +1,53 @@
+name: last_train
+description: Find suitable score parameters for sequence alignment
+keywords:
+  - LAST
+  - train
+  - fastq
+  - fasta
+tools:
+  - last:
+      description: LAST finds & aligns related regions of sequences.
+      homepage: https://gitlab.com/mcfrith/last
+      documentation: https://gitlab.com/mcfrith/last/-/blob/main/doc/last-train.rst
+      tool_dev_url: https://gitlab.com/mcfrith/last
+      doi: ""
+      licence: ['GPL v3-or-later']
+
+input:
+  - meta_index:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - index:
+      type: directory
+      description: Directory containing the files of the LAST index
+      pattern: "lastdb/"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fastx:
+      type: file
+      description: FASTA/FASTQ file
+      pattern: "*.{fasta,fastq}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "*.{version.txt}"
+  - param_file:
+      type: file
+      description: Trained parameter file
+      pattern: "*.par"
+
+authors:
+  - "@aleksandrabliznina"

--- a/software/last/train/meta.yml
+++ b/software/last/train/meta.yml
@@ -15,11 +15,6 @@ tools:
       licence: ['GPL v3-or-later']
 
 input:
-  - meta_index:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
   - index:
       type: directory
       description: Directory containing the files of the LAST index

--- a/tests/config/pytest_software.yml
+++ b/tests/config/pytest_software.yml
@@ -362,6 +362,10 @@ last/lastdb:
   - software/last/lastdb/**
   - tests/software/last/lastdb/**
 
+last_train:
+  - software/last/train/**
+  - tests/software/last/train/**
+
 mash/sketch:
   - software/mash/sketch/**
   - tests/software/mash/sketch/**

--- a/tests/config/pytest_software.yml
+++ b/tests/config/pytest_software.yml
@@ -362,7 +362,7 @@ last/lastdb:
   - software/last/lastdb/**
   - tests/software/last/lastdb/**
 
-last_train:
+last/train:
   - software/last/train/**
   - tests/software/last/train/**
 

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -26,6 +26,8 @@ params {
 
                 all_sites_fas                                  = "${test_data_dir}/genomics/sarscov2/genome/alignment/all_sites.fas"
                 informative_sites_fas                          = "${test_data_dir}/genomics/sarscov2/genome/alignment/informative_sites.fas"
+
+                lastdb_tar_gz                                  = "${test_data_dir}/genomics/sarscov2/genome/alignment/last/lastdb.tar.gz"
             }
             'illumina' {
                 test_single_end_bam                            = "${test_data_dir}/genomics/sarscov2/illumina/bam/test.single_end.bam"

--- a/tests/software/last/train/main.nf
+++ b/tests/software/last/train/main.nf
@@ -1,0 +1,17 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { UNTAR      } from '../../../../software/untar/main.nf'      addParams( options: [:] )
+include { LAST_TRAIN } from '../../../../software/last/train/main.nf' addParams( options: [:] )
+
+workflow test_last_train {
+
+    db =         [ file(params.test_data['sarscov2']['genome']['lastdb_tar_gz'], checkIfExists: true) ]
+    input =      [ [ id:'contigs' ], // meta map
+                   file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true) ]
+    UNTAR ( db )
+    // add meta map needed by LAST_TRAIN
+    ch_index = UNTAR.out.untar.map {row -> [ [ id : 'genome' ], row ] }
+    LAST_TRAIN ( ch_index, input )
+}

--- a/tests/software/last/train/main.nf
+++ b/tests/software/last/train/main.nf
@@ -11,7 +11,5 @@ workflow test_last_train {
     input =      [ [ id:'contigs' ], // meta map
                    file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true) ]
     UNTAR ( db )
-    // add meta map needed by LAST_TRAIN
-    ch_index = UNTAR.out.untar.map {row -> [ [ id : 'genome' ], row ] }
-    LAST_TRAIN ( ch_index, input )
+    LAST_TRAIN ( input, UNTAR.out.untar )
 }

--- a/tests/software/last/train/test.yml
+++ b/tests/software/last/train/test.yml
@@ -1,0 +1,22 @@
+- name: last train test_last_train
+  command: nextflow run tests/software/last/train -entry test_last_train -c tests/config/nextflow.config
+  tags:
+    - last_train
+    - last
+  files:
+    - path: output/last/contigs__genome.par
+      contains: 'score matrix'
+    - path: output/untar/lastdb/genome.bck
+      md5sum: 5519879b9b6c4d1fc508da7f17f88f2e
+    - path: output/untar/lastdb/genome.des
+      md5sum: 3a9ea6d336e113a74d7fdca5e7b623fc
+    - path: output/untar/lastdb/genome.prj
+      md5sum: 489715f14b0fea6273822696e72357f9
+    - path: output/untar/lastdb/genome.sds
+      md5sum: 2cd381f4f8a9c52cfcd323a2863eccb2
+    - path: output/untar/lastdb/genome.ssp
+      md5sum: 4137fb6fe9df2b3d78d5b960390aac7b
+    - path: output/untar/lastdb/genome.suf
+      md5sum: 1895efa8653e8e9bd3605cff0408ed33
+    - path: output/untar/lastdb/genome.tis
+      md5sum: b7c40f06b1309dc6f37849eeb86dfd22

--- a/tests/software/last/train/test.yml
+++ b/tests/software/last/train/test.yml
@@ -4,7 +4,7 @@
     - last/train
     - last
   files:
-    - path: output/last/contigs_genome.par
+    - path: output/last/contigs__genome.par
       contains: 'score matrix'
     - path: output/untar/lastdb/genome.bck
       md5sum: 5519879b9b6c4d1fc508da7f17f88f2e

--- a/tests/software/last/train/test.yml
+++ b/tests/software/last/train/test.yml
@@ -5,7 +5,8 @@
     - last
   files:
     - path: output/last/contigs__genome.par
-      contains: 'score matrix'
+      contains:
+        - "score matrix"
     - path: output/untar/lastdb/genome.bck
       md5sum: 5519879b9b6c4d1fc508da7f17f88f2e
     - path: output/untar/lastdb/genome.des

--- a/tests/software/last/train/test.yml
+++ b/tests/software/last/train/test.yml
@@ -4,7 +4,7 @@
     - last/train
     - last
   files:
-    - path: output/last/contigs__genome.par
+    - path: output/last/contigs_genome.par
       contains: 'score matrix'
     - path: output/untar/lastdb/genome.bck
       md5sum: 5519879b9b6c4d1fc508da7f17f88f2e

--- a/tests/software/last/train/test.yml
+++ b/tests/software/last/train/test.yml
@@ -4,7 +4,7 @@
     - last/train
     - last
   files:
-    - path: output/last/contigs__genome.par
+    - path: output/last/contigs.genome.par
       contains:
         - "score matrix"
     - path: output/untar/lastdb/genome.bck

--- a/tests/software/last/train/test.yml
+++ b/tests/software/last/train/test.yml
@@ -1,7 +1,7 @@
 - name: last train test_last_train
   command: nextflow run tests/software/last/train -entry test_last_train -c tests/config/nextflow.config
   tags:
-    - last_train
+    - last/train
     - last
   files:
     - path: output/last/contigs__genome.par


### PR DESCRIPTION
The last-train command creates a parameter file that will be used by last/lastal module for sequence alignment. It takes indexed sequences and query sequences as input and we use the metadata of both to create an id of the parameter output file.

Submission of the LAST modules is discussed in more details in the issue #464. For consistency, we use LAST version 1219 for this whole development and will upgrade later.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
