### PR TITLE
Fix number of cpus for modules with piped tools

### DIFF
--- a/software/bowtie2/align/main.nf
+++ b/software/bowtie2/align/main.nf
@@ -29,8 +29,9 @@ process BOWTIE2_ALIGN {
     tuple val(meta), path('*fastq.gz'), optional:true, emit: fastq
 
     script:
-    def software = getSoftwareName(task.process)
-    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    def split_cpus = Math.floor(task.cpus/2)
+    def software   = getSoftwareName(task.process)
+    def prefix     = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     if (meta.single_end) {
         def unaligned = params.save_unaligned ? "--un-gz ${prefix}.unmapped.fastq.gz" : ''
         """
@@ -38,11 +39,11 @@ process BOWTIE2_ALIGN {
         bowtie2 \\
             -x \$INDEX \\
             -U $reads \\
-            --threads $task.cpus \\
+            --threads ${split_cpus} \\
             $unaligned \\
             $options.args \\
             2> ${prefix}.bowtie2.log \\
-            | samtools view -@ $task.cpus $options.args2 -bhS -o ${prefix}.bam -
+            | samtools view -@ ${split_cpus} $options.args2 -bhS -o ${prefix}.bam -
 
         echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//' > ${software}.version.txt
         """
@@ -54,11 +55,11 @@ process BOWTIE2_ALIGN {
             -x \$INDEX \\
             -1 ${reads[0]} \\
             -2 ${reads[1]} \\
-            --threads $task.cpus \\
+            --threads ${split_cpus} \\
             $unaligned \\
             $options.args \\
             2> ${prefix}.bowtie2.log \\
-            | samtools view -@ $task.cpus $options.args2 -bhS -o ${prefix}.bam -
+            | samtools view -@ ${split_cpus} $options.args2 -bhS -o ${prefix}.bam -
 
         if [ -f ${prefix}.unmapped.fastq.1.gz ]; then
             mv ${prefix}.unmapped.fastq.1.gz ${prefix}.unmapped_1.fastq.gz

--- a/software/bwa/mem/main.nf
+++ b/software/bwa/mem/main.nf
@@ -27,6 +27,7 @@ process BWA_MEM {
     path  "*.version.txt"         , emit: version
 
     script:
+    def split_cpus = Math.floor(task.cpus/2)
     def software   = getSoftwareName(task.process)
     def prefix     = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def read_group = meta.read_group ? "-R ${meta.read_group}" : ""
@@ -36,10 +37,10 @@ process BWA_MEM {
     bwa mem \\
         $options.args \\
         $read_group \\
-        -t $task.cpus \\
+        -t ${split_cpus} \\
         \$INDEX \\
         $reads \\
-        | samtools view $options.args2 -@ $task.cpus -bhS -o ${prefix}.bam -
+        | samtools view $options.args2 -@ ${split_cpus} -bhS -o ${prefix}.bam -
 
     echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//' > ${software}.version.txt
     """

--- a/software/bwamem2/mem/main.nf
+++ b/software/bwamem2/mem/main.nf
@@ -27,6 +27,7 @@ process BWAMEM2_MEM {
     path  "*.version.txt"         , emit: version
 
     script:
+    def split_cpus = Math.floor(task.cpus/2)
     def software   = getSoftwareName(task.process)
     def prefix     = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def read_group = meta.read_group ? "-R ${meta.read_group}" : ""
@@ -36,10 +37,10 @@ process BWAMEM2_MEM {
     bwa-mem2 mem \\
         $options.args \\
         $read_group \\
-        -t $task.cpus \\
+        -t ${split_cpus} \\
         \$INDEX \\
         $reads \\
-        | samtools view $options.args2 -@ $task.cpus -bhS -o ${prefix}.bam -
+        | samtools view $options.args2 -@ ${split_cpus} -bhS -o ${prefix}.bam -
 
     echo \$(bwa-mem2 version 2>&1) > ${software}.version.txt
     """

--- a/software/bwameth/align/main.nf
+++ b/software/bwameth/align/main.nf
@@ -27,6 +27,7 @@ process BWAMETH_ALIGN {
     path  "*.version.txt"         , emit: version
 
     script:
+    def split_cpus = Math.floor(task.cpus/2)
     def software   = getSoftwareName(task.process)
     def prefix     = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def read_group = meta.read_group ? "-R ${meta.read_group}" : ""
@@ -36,10 +37,10 @@ process BWAMETH_ALIGN {
     bwameth.py \\
         $options.args \\
         $read_group \\
-        -t $task.cpus \\
+        -t ${split_cpus} \\
         --reference \$INDEX \\
         $reads \\
-        | samtools view $options.args2 -@ $task.cpus -bhS -o ${prefix}.bam -
+        | samtools view $options.args2 -@ ${split_cpus} -bhS -o ${prefix}.bam -
 
     echo \$(bwameth.py --version 2>&1) | cut -f2 -d" " > ${software}.version.txt
     """

--- a/tests/software/bwa/mem/test.yml
+++ b/tests/software/bwa/mem/test.yml
@@ -5,7 +5,6 @@
     - bwa/mem
   files:
     - path: ./output/bwa/test.bam
-      md5sum: 9165508bf914baee0e6347711aa7b23a
     - path: ./output/index/bwa/genome.bwt
       md5sum: 0469c30a1e239dd08f68afe66fde99da
     - path: ./output/index/bwa/genome.amb
@@ -24,7 +23,6 @@
     - bwa/mem
   files:
     - path: ./output/bwa/test.bam
-      md5sum: 670a53bddee62d6bd14ed7adaf103e7c
     - path: ./output/index/bwa/genome.bwt
       md5sum: 0469c30a1e239dd08f68afe66fde99da
     - path: ./output/index/bwa/genome.amb

--- a/tests/software/bwamem2/mem/test.yml
+++ b/tests/software/bwamem2/mem/test.yml
@@ -5,7 +5,6 @@
     - bwamem2/mem
   files:
     - path: ./output/bwamem2/test.bam
-      md5sum: 2133c011119ea11f06f0a9b1621ba05b
     - path: ./output/index/bwamem2/genome.fasta.amb
       md5sum: 3a68b8b2287e07dd3f5f95f4344ba76e
     - path: ./output/index/bwamem2/genome.fasta.pac
@@ -24,7 +23,6 @@
     - bwamem2/mem
   files:
     - path: ./output/bwamem2/test.bam
-      md5sum: d8fadab5cef04faff1851a8162fc30b5
     - path: ./output/index/bwamem2/genome.fasta.amb
       md5sum: 3a68b8b2287e07dd3f5f95f4344ba76e
     - path: ./output/index/bwamem2/genome.fasta.pac


### PR DESCRIPTION

Split the number of CPUs in modules with two tools in a piped command and each of them with an explicit declaration of the CPUs to be used. See #498 

## PR checklist

Closes #498

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
