### PR TITLE
Update pytest tag name for fastqc in README's examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,21 +362,21 @@ Please follow the steps below to run the tests locally:
 
         ```console
         cd /path/to/git/clone/of/nf-core/modules/
-        PROFILE=docker pytest --tag fastqc_single_end --symlink --keep-workflow-wd
+        PROFILE=docker pytest --tag fastqc --symlink --keep-workflow-wd
         ```
 
     - Typical command with Singularity:
 
         ```console
         cd /path/to/git/clone/of/nf-core/modules/
-        TMPDIR=~ PROFILE=singularity pytest --tag fastqc_single_end --symlink --keep-workflow-wd
+        TMPDIR=~ PROFILE=singularity pytest --tag fastqc --symlink --keep-workflow-wd
         ```
 
     - Typical command with Conda:
 
         ```console
         cd /path/to/git/clone/of/nf-core/modules/
-        PROFILE=conda pytest --tag fastqc_single_end --symlink --keep-workflow-wd
+        PROFILE=conda pytest --tag fastqc --symlink --keep-workflow-wd
         ```
 
     - See [docs on running pytest-workflow](https://pytest-workflow.readthedocs.io/en/stable/#running-pytest-workflow) for more info.


### PR DESCRIPTION
Running pytest with `--tag fastqc_single_end` does not work (it runs zero tests), as it appears that the tag name was changed to `fastqc` during the transition from underscores to slashes.
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
