### PR TITLE
New module last/postmask to filter alignment files

### DIFF
--- a/software/last/postmask/functions.nf
+++ b/software/last/postmask/functions.nf
@@ -1,0 +1,70 @@
+/*
+ * -----------------------------------------------------
+ *  Utility functions used in nf-core DSL2 module files
+ * -----------------------------------------------------
+ */
+
+/*
+ * Extract name of software tool from process name using $task.process
+ */
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+/*
+ * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+ */
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
+    return options
+}
+
+/*
+ * Tidy up and join elements of a list to return a path string
+ */
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+/*
+ * Function to save/publish module results
+ */
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions  = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/software/last/postmask/main.nf
+++ b/software/last/postmask/main.nf
@@ -1,0 +1,38 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process LAST_POSTMASK {
+    tag "$meta.id"
+    label 'process_low'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+
+    conda (params.enable_conda ? "bioconda::last=1219" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/last:1219--h2e03b76_0"
+    } else {
+        container "quay.io/biocontainers/last:1219--h2e03b76_0"
+    }
+
+    input:
+    tuple val(meta), path(maf)
+
+    output:
+    tuple val(meta), path("*.maf.gz"), emit: maf
+    path "*.version.txt"             , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    if( "$maf" == "${prefix}.maf.gz" ) error "Input and output names are the same, use the suffix option to disambiguate"
+    """
+    zcat $maf | last-postmask $options.args | gzip --no-name > ${prefix}.maf.gz
+
+    # last-postmask does not have a --version option
+    echo \$(lastal --version 2>&1) | sed 's/lastal //' > ${software}.version.txt
+    """
+}

--- a/software/last/postmask/meta.yml
+++ b/software/last/postmask/meta.yml
@@ -1,0 +1,39 @@
+name: last_postmask
+description: Post-alignment masking
+keywords:
+  - LAST
+  - mask
+  - alignment
+  - MAF
+tools:
+  - last:
+      description: LAST finds & aligns related regions of sequences.
+      homepage: https://gitlab.com/mcfrith/last
+      documentation: https://gitlab.com/mcfrith/last/-/blob/main/doc/last-postmask.rst
+      tool_dev_url: https://gitlab.com/mcfrith/last
+      doi: "10.1371/journal.pone.0028819"
+      licence: ['GPL-3.0-or-later']
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - maf:
+      type: file
+      description: Multiple Aligment Format (MAF) file, compressed with gzip
+      pattern: "*.{maf.gz}"
+
+output:
+  - maf:
+      type: file
+      description: Multiple Aligment Format (MAF) file, compressed with gzip
+      pattern: "*.{maf.gz}"
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "*.{version.txt}"
+
+authors:
+  - "@charles-plessy"

--- a/tests/config/pytest_software.yml
+++ b/tests/config/pytest_software.yml
@@ -390,6 +390,10 @@ last/mafswap:
   - software/last/mafswap/**
   - tests/software/last/mafswap/**
 
+last/postmask:
+  - software/last/postmask/**
+  - tests/software/last/postmask/**
+
 last/split:
   - software/last/split/**
   - tests/software/last/split/**

--- a/tests/software/last/postmask/main.nf
+++ b/tests/software/last/postmask/main.nf
@@ -1,0 +1,13 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { LAST_POSTMASK } from '../../../../software/last/postmask/main.nf' addParams( options: [suffix:'.postmask'] )
+
+workflow test_last_postmask {
+
+    input = [ [ id:'contigs.genome' ], // meta map
+              file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true) ]
+
+    LAST_POSTMASK ( input )
+}

--- a/tests/software/last/postmask/test.yml
+++ b/tests/software/last/postmask/test.yml
@@ -1,0 +1,8 @@
+- name: last postmask test_last_postmask
+  command: nextflow run tests/software/last/postmask -entry test_last_postmask -c tests/config/nextflow.config
+  tags:
+    - last
+    - last/postmask
+  files:
+    - path: output/last/contigs.genome.postmask.maf.gz
+      md5sum: 3a0f42e76da9549748983ac4d7ff7473


### PR DESCRIPTION
The `last-postmask` tool distributed with [LAST](https://gitlab.com/mcfrith/last) filters alignments in a MAF file to remove those with too many masked (lower-case) positions compared with their score.

As other filter modules like `last/split`, its output file risks to overwrite its input file as their names are constructed from the sample
ID when multiple filters are chained in the pipeline.  Following our discussion on Slack, I added a check that gives a clearer error message in this case.  Please let me know what you think about; I can add this test to the existing LAST modules as well.

This new module is part of the work described in Issue #464. During this development, we fix the version of LAST to 1219 to ensure consistency. We will upgrade it later.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
