### PR TITLE
New last/dotplot module for pairwise similarity plots

### DIFF
--- a/software/last/dotplot/functions.nf
+++ b/software/last/dotplot/functions.nf
@@ -1,0 +1,70 @@
+/*
+ * -----------------------------------------------------
+ *  Utility functions used in nf-core DSL2 module files
+ * -----------------------------------------------------
+ */
+
+/*
+ * Extract name of software tool from process name using $task.process
+ */
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+/*
+ * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+ */
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
+    return options
+}
+
+/*
+ * Tidy up and join elements of a list to return a path string
+ */
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+/*
+ * Function to save/publish module results
+ */
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions  = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/software/last/dotplot/functions.nf
+++ b/software/last/dotplot/functions.nf
@@ -1,19 +1,17 @@
-/*
- * -----------------------------------------------------
- *  Utility functions used in nf-core DSL2 module files
- * -----------------------------------------------------
- */
+//
+//  Utility functions used in nf-core DSL2 module files
+//
 
-/*
- * Extract name of software tool from process name using $task.process
- */
+//
+// Extract name of software tool from process name using $task.process
+//
 def getSoftwareName(task_process) {
     return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
 }
 
-/*
- * Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
- */
+//
+// Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+//
 def initOptions(Map args) {
     def Map options = [:]
     options.args            = args.args ?: ''
@@ -26,18 +24,18 @@ def initOptions(Map args) {
     return options
 }
 
-/*
- * Tidy up and join elements of a list to return a path string
- */
+//
+// Tidy up and join elements of a list to return a path string
+//
 def getPathFromList(path_list) {
     def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
     paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
     return paths.join('/')
 }
 
-/*
- * Function to save/publish module results
- */
+//
+// Function to save/publish module results
+//
 def saveFiles(Map args) {
     if (!args.filename.endsWith('.version.txt')) {
         def ioptions  = initOptions(args.options)

--- a/software/last/dotplot/main.nf
+++ b/software/last/dotplot/main.nf
@@ -1,0 +1,41 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process LAST_DOTPLOT {
+    tag "$meta.id"
+    label 'process_low'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+
+    conda (params.enable_conda ? "bioconda::last=1219" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/last:1219--h2e03b76_0"
+    } else {
+        container "quay.io/biocontainers/last:1219--h2e03b76_0"
+    }
+
+    input:
+    tuple val(meta), path(maf)
+
+    output:
+    tuple val(meta), path("*.{png,gif}"), emit: plot
+    path "*.version.txt"                , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def format   = options.args2  ? options.args2                 : "png"
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    """
+    last-dotplot \\
+        $options.args \\
+        $maf \\
+        $prefix.$format
+
+    # last-dotplot has no --version option so let's use lastal from the same suite
+    lastal --version | sed 's/lastal //' > ${software}.version.txt
+    """
+}

--- a/software/last/dotplot/meta.yml
+++ b/software/last/dotplot/meta.yml
@@ -1,0 +1,40 @@
+name: last_dotplot
+description: Makes a dotplot (Oxford Grid) of pair-wise sequence alignments
+keywords:
+  - LAST
+  - plot
+  - pair
+  - alignment
+  - MAF
+tools:
+  - last:
+      description: LAST finds & aligns related regions of sequences.
+      homepage: https://gitlab.com/mcfrith/last
+      documentation: https://gitlab.com/mcfrith/last/-/blob/main/doc/last-dotplot.rst
+      tool_dev_url: https://gitlab.com/mcfrith/last
+      doi: ""
+      licence: ['GPL-3.0-or-later']
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - maf:
+      type: file
+      description: Multiple Aligment Format (MAF) file, compressed with gzip
+      pattern: "*.{maf.gz}"
+
+output:
+  - plot:
+      type: file
+      description: Pairwise alignment dot plot image, in PNG or other format.
+      pattern: "*.{gif,png}"
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "*.{version.txt}"
+
+authors:
+  - "@charles-plessy"

--- a/tests/config/pytest_software.yml
+++ b/tests/config/pytest_software.yml
@@ -378,6 +378,10 @@ kraken2/run:
   - software/untar/**
   - tests/software/kraken2/run/**
 
+last/dotplot:
+  - software/last/dotplot/**
+  - tests/software/last/dotplot/**
+
 last/lastal:
   - software/last/lastal/**
   - tests/software/last/lastal/**
@@ -455,13 +459,13 @@ optitype:
   - software/optitype/**
   - tests/software/optitype/**
 
-pairtools/flip:
-  - software/pairtools/flip/**
-  - tests/software/pairtools/flip/**
-
 pairtools/dedup:
   - software/pairtools/dedup/**
   - tests/software/pairtools/dedup/**
+
+pairtools/flip:
+  - software/pairtools/flip/**
+  - tests/software/pairtools/flip/**
 
 pairtools/parse:
   - software/pairtools/parse/**

--- a/tests/software/last/dotplot/main.nf
+++ b/tests/software/last/dotplot/main.nf
@@ -1,0 +1,23 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { LAST_DOTPLOT } from '../../../../software/last/dotplot/main.nf' addParams( options: [:] )
+
+workflow test_last_dotplot {
+
+    input = [ [ id:'test' ], // meta map
+              file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true) ]
+
+    LAST_DOTPLOT ( input )
+}
+
+include { LAST_DOTPLOT as LAST_DOTPLOT_GIF } from '../../../../software/last/dotplot/main.nf' addParams( options: [args2:'gif'] )
+
+workflow test_last_dotplot_gif {
+
+    input = [ [ id:'test' ], // meta map
+              file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true) ]
+
+    LAST_DOTPLOT_GIF ( input )
+}

--- a/tests/software/last/dotplot/test.yml
+++ b/tests/software/last/dotplot/test.yml
@@ -1,0 +1,17 @@
+- name: last dotplot test_last_dotplot
+  command: nextflow run tests/software/last/dotplot -entry test_last_dotplot -c tests/config/nextflow.config
+  tags:
+    - last
+    - last/dotplot
+  files:
+    - path: output/last/test.png
+      md5sum: 6189aaf96f522cdb664869724997bbcd
+
+- name: last dotplot test_last_dotplot_gif
+  command: nextflow run tests/software/last/dotplot -entry test_last_dotplot_gif -c tests/config/nextflow.config
+  tags:
+    - last
+    - last/dotplot
+  files:
+    - path: output/last/test.gif
+      md5sum: 1dd2c85fb5495ca0e85c4ef1dcfce220


### PR DESCRIPTION
The `last-dotplot` tool takes a pairwise alignment in [MAF](http://genome.ucsc.edu/FAQ/FAQformat.html#format5) format,
possibly compressed with gzip, or in a tabular format produced by the `maf-convert` tool, and produces a similarity dot-plot of the two sequences in one of the graphical formats supported by the Python Imaging Library.

A the tool guesses the output format by the file extension of the file, which is constructed by the module at run time, I have used the `args2` option to convey this information to the module.

This new module is part of the work described in Issue #464.  During this development, we fix the version of LAST to 1219 to ensure consistency (hence please ignore lint's version warning).

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
