### PR TITLE
Update salmon/quant to provide '--libType A' option

### DIFF
--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -41,11 +41,16 @@ process SALMON_QUANT {
         input_reads = "-a $reads"
     }
 
-    def strandedness =  ''
-    if (lib_type) {
+    def strandedness_opts = [
+        'A', 'U', 'SF', 'SR',
+        'IS', 'IU' , 'ISF', 'ISR',
+        'OS', 'OU' , 'OSF', 'OSR',
+        'MS', 'MU' , 'MSF', 'MSR' 
+    ]
+    def strandedness =  'A'
+    if (strandedness_opts.contains(lib_type)) {
         strandedness = "${lib_type}"
-    }
-    else {
+    } else {
         strandedness = meta.single_end ? 'U' : 'IU'
         if (meta.strandedness == 'forward') {
             strandedness = meta.single_end ? 'SF' : 'ISF'
@@ -53,7 +58,6 @@ process SALMON_QUANT {
             strandedness = meta.single_end ? 'SR' : 'ISR'
         }
     }
-
 
     """
     salmon quant \\

--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -45,7 +45,7 @@ process SALMON_QUANT {
         'A', 'U', 'SF', 'SR',
         'IS', 'IU' , 'ISF', 'ISR',
         'OS', 'OU' , 'OSF', 'OSR',
-        'MS', 'MU' , 'MSF', 'MSR' 
+        'MS', 'MU' , 'MSF', 'MSR'
     ]
     def strandedness =  'A'
     if (strandedness_opts.contains(lib_type)) {

--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -24,6 +24,7 @@ process SALMON_QUANT {
     path  gtf
     path  transcript_fasta
     val   alignment_mode
+    val   lib_type
 
     output:
     tuple val(meta), path("${prefix}"), emit: results
@@ -40,12 +41,20 @@ process SALMON_QUANT {
         input_reads = "-a $reads"
     }
 
-    def strandedness = meta.single_end ? 'U' : 'IU'
-    if (meta.strandedness == 'forward') {
-        strandedness = meta.single_end ? 'SF' : 'ISF'
-    } else if (meta.strandedness == 'reverse') {
-        strandedness = meta.single_end ? 'SR' : 'ISR'
+    def strandedness =  ''
+    if (lib_type) {
+        strandedness = 'A'
     }
+    else {
+        strandedness = meta.single_end ? 'U' : 'IU'
+        if (meta.strandedness == 'forward') {
+            strandedness = meta.single_end ? 'SF' : 'ISF'
+        } else if (meta.strandedness == 'reverse') {
+            strandedness = meta.single_end ? 'SR' : 'ISR'
+        }
+    }
+
+
     """
     salmon quant \\
         --geneMap $gtf \\

--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -48,8 +48,12 @@ process SALMON_QUANT {
         'MS', 'MU' , 'MSF', 'MSR'
     ]
     def strandedness =  'A'
-    if (strandedness_opts.contains(lib_type)) {
-        strandedness = "${lib_type}"
+    if (lib_type) {
+        if (strandedness_opts.contains(lib_type)) {
+            strandedness = lib_type
+        } else {
+            log.info "[Salmon Quant] Invalid library type specified '--libType=${lib_type}', defaulting to auto-detection with '--libType=A'."
+        }
     } else {
         strandedness = meta.single_end ? 'U' : 'IU'
         if (meta.strandedness == 'forward') {
@@ -58,7 +62,6 @@ process SALMON_QUANT {
             strandedness = meta.single_end ? 'SR' : 'ISR'
         }
     }
-
     """
     salmon quant \\
         --geneMap $gtf \\

--- a/software/salmon/quant/main.nf
+++ b/software/salmon/quant/main.nf
@@ -43,7 +43,7 @@ process SALMON_QUANT {
 
     def strandedness =  ''
     if (lib_type) {
-        strandedness = 'A'
+        strandedness = "${lib_type}"
     }
     else {
         strandedness = meta.single_end ? 'U' : 'IU'

--- a/software/salmon/quant/meta.yml
+++ b/software/salmon/quant/meta.yml
@@ -36,9 +36,9 @@ input:
     type: boolean
     description: whether to run salmon in alignment mode
   - lib_type:
-    type: boolean
+    type: string
     description: |
-      Whether to enable salmon option to automatically infer the library type
+      Override library type inferred based on strandedness defined in meta object
 
 output:
   - sample_output:

--- a/software/salmon/quant/meta.yml
+++ b/software/salmon/quant/meta.yml
@@ -35,6 +35,10 @@ input:
   - alignment_mode:
     type: boolean
     description: whether to run salmon in alignment mode
+  - lib_type:
+    type: boolean
+    description: |
+      Whether to enable salmon option to automatically infer the library type
 
 output:
   - sample_output:

--- a/tests/software/salmon/quant/main.nf
+++ b/tests/software/salmon/quant/main.nf
@@ -15,7 +15,7 @@ workflow test_salmon_quant_single_end {
     gtf              = file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
 
     SALMON_INDEX ( genome_fasta, transcript_fasta )
-    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, false )
+    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, '' )
 
 }
 
@@ -30,7 +30,7 @@ workflow test_salmon_quant_paired_end {
     gtf              = file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
 
     SALMON_INDEX ( genome_fasta, transcript_fasta )
-    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, false )
+    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, '' )
 
 }
 
@@ -44,7 +44,7 @@ workflow test_salmon_quant_single_end_lib_type_A {
     gtf              = file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
 
     SALMON_INDEX ( genome_fasta, transcript_fasta )
-    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, true )
+    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, 'A' )
 
 }
 

--- a/tests/software/salmon/quant/main.nf
+++ b/tests/software/salmon/quant/main.nf
@@ -8,14 +8,14 @@ include { SALMON_QUANT } from '../../../../software/salmon/quant/main.nf' addPar
 workflow test_salmon_quant_single_end {
 
     input = [ [ id:'test', single_end:true ], // meta map
-                file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) 
+                file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
             ]
     genome_fasta     = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     transcript_fasta = file(params.test_data['sarscov2']['genome']['transcriptome_fasta'], checkIfExists: true)
     gtf              = file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
 
     SALMON_INDEX ( genome_fasta, transcript_fasta )
-    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false )
+    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, false )
 
 }
 
@@ -30,6 +30,21 @@ workflow test_salmon_quant_paired_end {
     gtf              = file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
 
     SALMON_INDEX ( genome_fasta, transcript_fasta )
-    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false )
+    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, false )
 
 }
+
+workflow test_salmon_quant_single_end_lib_type_A {
+
+    input = [ [ id:'test', single_end:true ], // meta map
+                file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+            ]
+    genome_fasta     = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    transcript_fasta = file(params.test_data['sarscov2']['genome']['transcriptome_fasta'], checkIfExists: true)
+    gtf              = file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+
+    SALMON_INDEX ( genome_fasta, transcript_fasta )
+    SALMON_QUANT ( input, SALMON_INDEX.out.index, gtf, transcript_fasta, false, true )
+
+}
+

--- a/tests/software/salmon/quant/test.yml
+++ b/tests/software/salmon/quant/test.yml
@@ -95,7 +95,57 @@
       md5sum: 8d1970505b2b08ca0eb5ff7722b48cde
     - path: ./output/index/salmon/ctg_offsets.bin
       md5sum: 27a76542337df436436e66017f66dd25
+
     - path: ./output/index/salmon/rank.bin
+      md5sum: 3f34dca1ec26cdf89a6d19b1d1c07e71
+    - path: ./output/index/salmon/pos.bin
+    - path: ./output/index/salmon/seq.bin
+
+- name: salmon quant test_salmon_quant_single_end_lib_type_A
+  command: nextflow run tests/software/salmon/quant -entry test_salmon_quant_single_end_lib_type_A -c tests/config/nextflow.config
+  tags:
+    - salmon/quant
+    - salmon
+  files:
+    - path: ./output/salmon/test/cmd_info.json
+    - path: output/salmon/test/quant.sf
+      md5sum: 687368b9963874c1797d210310b38516
+    - path: ./output/salmon/test/lib_format_counts.json
+    - path: ./output/salmon/test/quant.genes.sf
+      md5sum: ad4d31437f06db49b2436abeec29c78e
+    - path: ./output/salmon/test/logs/salmon_quant.log
+    - path: output/salmon/test/aux_info/expected_bias.gz
+      md5sum: 24ee10af39b41ecf4f4e08faaaf537ee
+    - path: output/salmon/test/aux_info/observed_bias_3p.gz
+      md5sum: ef13c06a538e9c34ca9f84212c82f44e
+    - path: ./output/salmon/test/aux_info/meta_info.json
+    - path: ./output/salmon/test/aux_info/fld.gz
+    - path: output/salmon/test/aux_info/ambig_info.tsv
+      md5sum: 2ee3dc3080ad7222e0687481e7a1ee03
+    - path: ./output/salmon/test/aux_info/observed_bias.gz
+      md5sum: ef13c06a538e9c34ca9f84212c82f44e
+    - path: output/salmon/test/libParams/flenDist.txt
+      md5sum: 2de170bdc9f6fd237d286429b292bb28
+    - path: ./output/index/salmon/ref_indexing.log
+    - path: output/index/salmon/refseq.bin
+      md5sum: 79c4ddf34be3a98d5a7b9d153629a6f7
+    - path: output/index/salmon/versionInfo.json
+      md5sum: 204865f645102587c4953fccb256797c
+    - path: output/index/salmon/complete_ref_lens.bin
+      md5sum: f57562f1fca3ae7b133f895ae13c3d08
+    - path: output/index/salmon/mphf.bin
+      md5sum: 53669a47610e33e031faafd32703b714
+    - path: output/index/salmon/duplicate_clusters.tsv
+      md5sum: 51b5292e3a874119c0e1aa566e95d70c
+    - path: output/index/salmon/reflengths.bin
+      md5sum: f57562f1fca3ae7b133f895ae13c3d08
+    - path: output/index/salmon/info.json
+      md5sum: 61ff4d3471134c280668355ddd39e99f
+    - path: output/index/salmon/refAccumLengths.bin
+      md5sum: 8d1970505b2b08ca0eb5ff7722b48cde
+    - path: output/index/salmon/ctg_offsets.bin
+      md5sum: 27a76542337df436436e66017f66dd25
+    - path: output/index/salmon/rank.bin
       md5sum: 3f34dca1ec26cdf89a6d19b1d1c07e71
     - path: ./output/index/salmon/pos.bin
     - path: ./output/index/salmon/seq.bin


### PR DESCRIPTION
An input `val` has been included in `salmon/quant` which enables to set the `--libType A option`. This option allows Salmon to automatically infer the library type.

Closes #535

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfill software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`