### PR TITLE
Testing `bump-versions` on bcftools

### DIFF
--- a/software/bcftools/filter/main.nf
+++ b/software/bcftools/filter/main.nf
@@ -11,11 +11,11 @@ process BCFTOOLS_FILTER {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::bcftools=1.11" : null)
+    conda (params.enable_conda ? bioconda::bcftools=1.12 : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/bcftools:1.11--h7c999a4_0"
+        container "https://depot.galaxyproject.org/singularity/bcftools:1.12--h45bccc9_1
     } else {
-        container "quay.io/biocontainers/bcftools:1.11--h7c999a4_0"
+        container "quay.io/biocontainers/bcftools:1.12--h45bccc9_1
     }
 
     input:


### PR DESCRIPTION
Updated `bcftools/filter` using the new `nf-core modules bump-versions` command.