### PR TITLE
Input a triple (id, fasta, params) to last/lastal

### DIFF
--- a/software/last/lastal/main.nf
+++ b/software/last/lastal/main.nf
@@ -19,9 +19,8 @@ process LAST_LASTAL {
     }
 
     input:
-    tuple val(meta), path(fastx)
+    tuple val(meta), path(fastx), path (param_file)
     path index
-    path param_file
 
     output:
     tuple val(meta), path("*.maf.gz"), emit: maf

--- a/tests/software/last/lastal/main.nf
+++ b/tests/software/last/lastal/main.nf
@@ -8,20 +8,21 @@ include { LAST_LASTAL } from '../../../../software/last/lastal/main.nf' addParam
 workflow test_last_lastal_with_dummy_param_file {
 
     input = [ [ id:'contigs', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true) ]
+              file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true),
+              [] ]
     db    = [ file(params.test_data['sarscov2']['genome']['lastdb_tar_gz'], checkIfExists: true) ]
 
     UNTAR ( db )
-    LAST_LASTAL ( input, UNTAR.out.untar,  [] )
+    LAST_LASTAL ( input, UNTAR.out.untar)
 }
 
 workflow test_last_lastal_with_real_param_file {
 
     input      = [ [ id:'contigs', single_end:false ], // meta map
-                   file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true) ]
+                   file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true),
+                   file(params.test_data['sarscov2']['genome']['contigs_genome_par'], checkIfExists: true) ]
     db         = [ file(params.test_data['sarscov2']['genome']['lastdb_tar_gz'], checkIfExists: true) ]
-    param_file = [ file(params.test_data['sarscov2']['genome']['contigs_genome_par'], checkIfExists: true) ]
 
     UNTAR ( db )
-    LAST_LASTAL ( input, UNTAR.out.untar,  param_file )
+    LAST_LASTAL ( input, UNTAR.out.untar)
 }


### PR DESCRIPTION
The `last/lastal` submodule aligns query sequences to  a target index, and optionally takes one set of alignment parameters (including a score matrix) computed by the `last/train` module for each of the sequences.

In the previous implementation the sequences and the alignment parameters were provided in different channels, but this was causing them to be sometimes desynchronised.

In the patched implementation, `last/lastal` takes a 3-tuple as input to ensure synchronicity.  To produce this tuple in a pipeline,
one can use the `join` command as in the following example.

     LAST_TRAIN  ( query,
                   target )
     LAST_LASTAL ( query.join(LAST_TRAIN.out.param_file),
                   target )

In case no parameter file is computed one can pass a dummy file to the module as follows:

     LAST_LASTAL ( query.map { row -> [ row[0], row[1], [] ] },
                   target )

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `<SOFTWARE>.version.txt` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
