### PR TITLE
fix: lofreq/callparallel missing arg (#562)

### DIFF
--- a/modules/lofreq/callparallel/main.nf
+++ b/modules/lofreq/callparallel/main.nf
@@ -20,12 +20,12 @@ process LOFREQ_CALLPARALLEL {
 
     input:
     tuple val(meta), path(bam), path(bai)
-    file fasta
-    file fai
+    path fasta
+    path fai
 
     output:
-    tuple val(meta), path("*.vcf"), emit: vcf
-    path "*.version.txt"          , emit: version
+    tuple val(meta), path("*.vcf.gz"), emit: vcf
+    path "*.version.txt"             , emit: version
 
     script:
     def software = getSoftwareName(task.process)
@@ -34,10 +34,11 @@ process LOFREQ_CALLPARALLEL {
     lofreq \\
         call-parallel \\
         --pp-threads $task.cpus \\
+        $options.args \\
         -f $fasta \\
-        -o ${prefix}.vcf \\
+        -o ${prefix}.vcf.gz \\
         $bam
 
-    echo \$(lofreq version 2>&1) | sed 's/^.*lofreq //; s/Using.*\$//' > ${software}.version.txt
+    echo \$(lofreq version 2>&1) | sed 's/^version: //; s/ *commit.*\$//' > ${software}.version.txt
     """
 }

--- a/modules/lofreq/callparallel/meta.yml
+++ b/modules/lofreq/callparallel/meta.yml
@@ -51,3 +51,4 @@ output:
 
 authors:
   - "@kaurravneet4123"
+  - "@bjohnnyd"

--- a/tests/modules/lofreq/callparallel/test.yml
+++ b/tests/modules/lofreq/callparallel/test.yml
@@ -1,7 +1,8 @@
-- name: lofreq callparallel
-  command: nextflow run ./tests/modules/lofreq/callparallel -entry test_lofreq_callparallel -c tests/config/nextflow.config
+- name: lofreq callparallel test_lofreq_callparallel
+  command: nextflow run tests/modules/lofreq/callparallel -entry test_lofreq_callparallel -c tests/config/nextflow.config
   tags:
-    - lofreq
     - lofreq/callparallel
+    - lofreq
   files:
-    - path: output/lofreq/test.vcf
+    - path: output/lofreq/test.vcf.gz
+      contains: ['##INFO=<ID=CONSVAR,Number=0,Type=Flag,Description="Indicates that the variant is a consensus variant (as opposed to a low frequency variant).">']


### PR DESCRIPTION
After using the `lofreq/callparallel` module I noticed that my arguments were not being passed to the process as it was missing `$options.args`.

In addition:

- changed the version file to only contain version number
- changed test to check if the output file contains a string
- as lofreq can output compressed based on suffix changed output to compressed vcf

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
