### PR TITLE
fix: lofreq/call `test.yml` md5sum

### DIFF
--- a/tests/modules/lofreq/call/test.yml
+++ b/tests/modules/lofreq/call/test.yml
@@ -5,4 +5,4 @@
     - lofreq/call
   files:
     - path: output/lofreq/test.vcf.gz
-      md5sum: 421b407a172191e54d054018c8868cf7
+      contains: ['##INFO=<ID=CONSVAR,Number=0,Type=Flag,Description="Indicates that the variant is a consensus variant (as opposed to a low frequency variant).">']


### PR DESCRIPTION
Lofreq output VCF contains the current day date therefore automated tests containing md5sum will fail when the date changes.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
