### PR TITLE
Add samtools ampliconclip

### DIFF
--- a/modules/samtools/ampliconclip/functions.nf
+++ b/modules/samtools/ampliconclip/functions.nf
@@ -1,0 +1,68 @@
+//
+//  Utility functions used in nf-core DSL2 module files
+//
+
+//
+// Extract name of software tool from process name using $task.process
+//
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+//
+// Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+//
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
+    return options
+}
+
+//
+// Tidy up and join elements of a list to return a path string
+//
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+//
+// Function to save/publish module results
+//
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions  = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/modules/samtools/ampliconclip/main.nf
+++ b/modules/samtools/ampliconclip/main.nf
@@ -1,22 +1,6 @@
 // Import generic module functions
 include { initOptions; saveFiles; getSoftwareName } from './functions'
 
-// TODO nf-core: If in doubt look at other nf-core/modules to see how we are doing things! :)
-//               https://github.com/nf-core/modules/tree/master/software
-//               You can also ask for help via your pull request or on the #modules channel on the nf-core Slack workspace:
-//               https://nf-co.re/join
-
-// TODO nf-core: A module file SHOULD only define input and output files as command-line parameters.
-//               All other parameters MUST be provided as a string i.e. "options.args"
-//               where "params.options" is a Groovy Map that MUST be provided via the addParams section of the including workflow.
-//               Any parameters that need to be evaluated in the context of a particular sample
-//               e.g. single-end/paired-end data MUST also be defined and evaluated appropriately.
-// TODO nf-core: Software that can be piped together SHOULD be added to separate module files
-//               unless there is a run-time, storage advantage in implementing in this way
-//               e.g. it's ok to have a single module for bwa to output BAM instead of SAM:
-//                 bwa mem | samtools view -B -T ref.fasta
-// TODO nf-core: Optional inputs are not currently supported by Nextflow. However, "fake files" MAY be used to work around this issue.
-
 params.options = [:]
 options        = initOptions(params.options)
 
@@ -27,50 +11,37 @@ process SAMTOOLS_AMPLICONCLIP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    // TODO nf-core: List required Conda package(s).
-    //               Software MUST be pinned to channel (i.e. "bioconda"), version (i.e. "1.10").
-    //               For Conda, the build (i.e. "h9402c20_2") must be EXCLUDED to support installation on different operating systems.
-    // TODO nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
     conda (params.enable_conda ? "bioconda::samtools=1.13" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/https://depot.galaxyproject.org/singularity/samtools:1.13--h8c37831_0"
+        container "https://depot.galaxyproject.org/singularity/samtools:1.13--h8c37831_0"
     } else {
-        container "quay.io/biocontainers/quay.io/biocontainers/samtools:1.13--h8c37831_0"
+        container "quay.io/biocontainers/samtools:1.13--h8c37831_0"
     }
 
     input:
-    // TODO nf-core: Where applicable all sample-specific information e.g. "id", "single_end", "read_group"
-    //               MUST be provided as an input via a Groovy Map called "meta".
-    //               This information may not be required in some instances e.g. indexing reference genome files:
-    //               https://github.com/nf-core/modules/blob/master/software/bwa/index/main.nf
-    // TODO nf-core: Where applicable please provide/convert compressed files as input/output
-    //               e.g. "*.fastq.gz" and NOT "*.fastq", "*.bam" and NOT "*.sam" etc.
     tuple val(meta), path(bam)
+    path bed
 
     output:
-    // TODO nf-core: Named file extensions MUST be emitted for ALL output channels
-    tuple val(meta), path("*.bam"), emit: bam
-    // TODO nf-core: List additional required output channels/values here
-    path "*.version.txt"          , emit: version
+    tuple val(meta), path("*.bam")             , emit: bam
+    tuple val(meta), path("*.clipstats.txt")  , optional:true, emit: stats
+    tuple val(meta), path("*.cliprejects.bam"), optional:true, emit: rejects_bam
+    path "*.version.txt"                       , emit: version
 
     script:
-    def software = getSoftwareName(task.process)
-    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
-    // TODO nf-core: Where possible, a command MUST be provided to obtain the version number of the software e.g. 1.10
-    //               If the software is unable to output a version number on the command-line then it can be manually specified
-    //               e.g. https://github.com/nf-core/modules/blob/master/software/homer/annotatepeaks/main.nf
-    // TODO nf-core: It MUST be possible to pass additional parameters to the tool as a command-line string via the "$options.args" variable
-    // TODO nf-core: If the tool supports multi-threading then you MUST provide the appropriate parameter
-    //               using the Nextflow "task" variable e.g. "--threads $task.cpus"
-    // TODO nf-core: Please replace the example samtools command below with your module's command
-    // TODO nf-core: Please indent the command appropriately (4 spaces!!) to help with readability ;)
+    def software    = getSoftwareName(task.process)
+    def prefix      = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    def rejects     = params.save_cliprejects ? "--rejects-file ${prefix}.cliprejects.bam" : ""
+    def stats       = params.save_clipstats   ? "-f ${prefix}.clipstats.txt"               : ""
     """
     samtools \\
-        sort \\
+        ampliconclip \\
         $options.args \\
         -@ $task.cpus \\
+        $rejects \\
+        $stats \\
+        -b $bed \\
         -o ${prefix}.bam \\
-        -T $prefix \\
         $bam
 
     echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' > ${software}.version.txt

--- a/modules/samtools/ampliconclip/main.nf
+++ b/modules/samtools/ampliconclip/main.nf
@@ -25,16 +25,16 @@ process SAMTOOLS_AMPLICONCLIP {
     val save_clipstats
 
     output:
-    tuple val(meta), path("*.bam")             , emit: bam
-    tuple val(meta), path("*.clipstats.txt")   , optional:true, emit: stats
-    tuple val(meta), path("*.cliprejects.bam") , optional:true, emit: rejects_bam
-    path "*.version.txt"                       , emit: version
+    tuple val(meta), path("*.bam")            , emit: bam
+    tuple val(meta), path("*.clipstats.txt")  , optional:true, emit: stats
+    tuple val(meta), path("*.cliprejects.bam"), optional:true, emit: rejects_bam
+    path "*.version.txt"                      , emit: version
 
     script:
-    def software    = getSoftwareName(task.process)
-    def prefix      = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
-    def rejects     = save_cliprejects ? "--rejects-file ${prefix}.cliprejects.bam" : ""
-    def stats       = save_clipstats   ? "-f ${prefix}.clipstats.txt"               : ""
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    def rejects  = save_cliprejects ? "--rejects-file ${prefix}.cliprejects.bam" : ""
+    def stats    = save_clipstats   ? "-f ${prefix}.clipstats.txt"               : ""
     """
     samtools \\
         ampliconclip \\

--- a/modules/samtools/ampliconclip/main.nf
+++ b/modules/samtools/ampliconclip/main.nf
@@ -24,8 +24,8 @@ process SAMTOOLS_AMPLICONCLIP {
 
     output:
     tuple val(meta), path("*.bam")             , emit: bam
-    tuple val(meta), path("*.clipstats.txt")  , optional:true, emit: stats
-    tuple val(meta), path("*.cliprejects.bam"), optional:true, emit: rejects_bam
+    tuple val(meta), path("*.clipstats.txt")   , optional:true, emit: stats
+    tuple val(meta), path("*.cliprejects.bam") , optional:true, emit: rejects_bam
     path "*.version.txt"                       , emit: version
 
     script:

--- a/modules/samtools/ampliconclip/main.nf
+++ b/modules/samtools/ampliconclip/main.nf
@@ -21,6 +21,8 @@ process SAMTOOLS_AMPLICONCLIP {
     input:
     tuple val(meta), path(bam)
     path bed
+    val save_cliprejects
+    val save_clipstats
 
     output:
     tuple val(meta), path("*.bam")             , emit: bam
@@ -31,8 +33,8 @@ process SAMTOOLS_AMPLICONCLIP {
     script:
     def software    = getSoftwareName(task.process)
     def prefix      = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
-    def rejects     = params.save_cliprejects ? "--rejects-file ${prefix}.cliprejects.bam" : ""
-    def stats       = params.save_clipstats   ? "-f ${prefix}.clipstats.txt"               : ""
+    def rejects     = save_cliprejects ? "--rejects-file ${prefix}.cliprejects.bam" : ""
+    def stats       = save_clipstats   ? "-f ${prefix}.clipstats.txt"               : ""
     """
     samtools \\
         ampliconclip \\

--- a/modules/samtools/ampliconclip/main.nf
+++ b/modules/samtools/ampliconclip/main.nf
@@ -1,0 +1,78 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+// TODO nf-core: If in doubt look at other nf-core/modules to see how we are doing things! :)
+//               https://github.com/nf-core/modules/tree/master/software
+//               You can also ask for help via your pull request or on the #modules channel on the nf-core Slack workspace:
+//               https://nf-co.re/join
+
+// TODO nf-core: A module file SHOULD only define input and output files as command-line parameters.
+//               All other parameters MUST be provided as a string i.e. "options.args"
+//               where "params.options" is a Groovy Map that MUST be provided via the addParams section of the including workflow.
+//               Any parameters that need to be evaluated in the context of a particular sample
+//               e.g. single-end/paired-end data MUST also be defined and evaluated appropriately.
+// TODO nf-core: Software that can be piped together SHOULD be added to separate module files
+//               unless there is a run-time, storage advantage in implementing in this way
+//               e.g. it's ok to have a single module for bwa to output BAM instead of SAM:
+//                 bwa mem | samtools view -B -T ref.fasta
+// TODO nf-core: Optional inputs are not currently supported by Nextflow. However, "fake files" MAY be used to work around this issue.
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process SAMTOOLS_AMPLICONCLIP {
+    tag "$meta.id"
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+
+    // TODO nf-core: List required Conda package(s).
+    //               Software MUST be pinned to channel (i.e. "bioconda"), version (i.e. "1.10").
+    //               For Conda, the build (i.e. "h9402c20_2") must be EXCLUDED to support installation on different operating systems.
+    // TODO nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
+    conda (params.enable_conda ? "bioconda::samtools=1.13" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/https://depot.galaxyproject.org/singularity/samtools:1.13--h8c37831_0"
+    } else {
+        container "quay.io/biocontainers/quay.io/biocontainers/samtools:1.13--h8c37831_0"
+    }
+
+    input:
+    // TODO nf-core: Where applicable all sample-specific information e.g. "id", "single_end", "read_group"
+    //               MUST be provided as an input via a Groovy Map called "meta".
+    //               This information may not be required in some instances e.g. indexing reference genome files:
+    //               https://github.com/nf-core/modules/blob/master/software/bwa/index/main.nf
+    // TODO nf-core: Where applicable please provide/convert compressed files as input/output
+    //               e.g. "*.fastq.gz" and NOT "*.fastq", "*.bam" and NOT "*.sam" etc.
+    tuple val(meta), path(bam)
+
+    output:
+    // TODO nf-core: Named file extensions MUST be emitted for ALL output channels
+    tuple val(meta), path("*.bam"), emit: bam
+    // TODO nf-core: List additional required output channels/values here
+    path "*.version.txt"          , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    // TODO nf-core: Where possible, a command MUST be provided to obtain the version number of the software e.g. 1.10
+    //               If the software is unable to output a version number on the command-line then it can be manually specified
+    //               e.g. https://github.com/nf-core/modules/blob/master/software/homer/annotatepeaks/main.nf
+    // TODO nf-core: It MUST be possible to pass additional parameters to the tool as a command-line string via the "$options.args" variable
+    // TODO nf-core: If the tool supports multi-threading then you MUST provide the appropriate parameter
+    //               using the Nextflow "task" variable e.g. "--threads $task.cpus"
+    // TODO nf-core: Please replace the example samtools command below with your module's command
+    // TODO nf-core: Please indent the command appropriately (4 spaces!!) to help with readability ;)
+    """
+    samtools \\
+        sort \\
+        $options.args \\
+        -@ $task.cpus \\
+        -o ${prefix}.bam \\
+        -T $prefix \\
+        $bam
+
+    echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' > ${software}.version.txt
+    """
+}

--- a/modules/samtools/ampliconclip/meta.yml
+++ b/modules/samtools/ampliconclip/meta.yml
@@ -1,5 +1,4 @@
 name: samtools_ampliconclip
-## TODO nf-core: Add a description of the module and list keywords
 description: write your description here
 keywords:
   - amplicon
@@ -17,14 +16,12 @@ tools:
         documentation: hhttp://www.htslib.org/doc/samtools.html
         doi: 10.1093/bioinformatics/btp352
 
-## TODO nf-core: Add a description of all of the variables used as input
 input:
   - meta:
       type: map
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  ## TODO nf-core: Delete / customise this example input
   - bam:
       type: file
       description: BAM/CRAM/SAM file
@@ -34,7 +31,6 @@ input:
       description: BED file of regions to be removed (e.g. amplicon primers)
       pattern: "*.{bed}"
 
-## TODO nf-core: Add a description of all of the variables used as output
 output:
   - meta:
       type: map

--- a/modules/samtools/ampliconclip/meta.yml
+++ b/modules/samtools/ampliconclip/meta.yml
@@ -2,16 +2,20 @@ name: samtools_ampliconclip
 ## TODO nf-core: Add a description of the module and list keywords
 description: write your description here
 keywords:
-  - sort
+  - amplicon
+  - clipping
+  - ampliconclip
+  - samtools ampliconclip
+  - samtools
 tools:
-  - samtools:
-      ## TODO nf-core: Add a description and other details for the software below
-      description: Tools for dealing with SAM, BAM and CRAM files
-      homepage: None
-      documentation: None
-      tool_dev_url: None
-      doi: ""
-      licence: ['MIT']
+    - samtools:
+        description: |
+            SAMtools is a set of utilities for interacting with and post-processing
+            short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+            These files are generated as output by short read aligners like BWA.
+        homepage: http://www.htslib.org/
+        documentation: hhttp://www.htslib.org/doc/samtools.html
+        doi: 10.1093/bioinformatics/btp352
 
 ## TODO nf-core: Add a description of all of the variables used as input
 input:
@@ -25,6 +29,10 @@ input:
       type: file
       description: BAM/CRAM/SAM file
       pattern: "*.{bam,cram,sam}"
+  - bed:
+      type: file
+      description: BED file of regions to be removed (e.g. amplicon primers)
+      pattern: "*.{bed}"
 
 ## TODO nf-core: Add a description of all of the variables used as output
 output:
@@ -37,11 +45,18 @@ output:
       type: file
       description: File containing software version
       pattern: "*.{version.txt}"
-  ## TODO nf-core: Delete / customise this example output
   - bam:
       type: file
-      description: Sorted BAM/CRAM/SAM file
-      pattern: "*.{bam,cram,sam}"
+      description: Clipped reads BAM file
+      pattern: "*.{bam}"
+  - stats:
+      type: file
+      description: Clipping statistics text file
+      pattern: "*.{clipstats.txt}"
+  - rejects_bam:
+      type: file
+      description: Filtered reads BAM file
+      pattern: "*.{cliprejects.bam}"
 
 authors:
   - "@bjohnnyd"

--- a/modules/samtools/ampliconclip/meta.yml
+++ b/modules/samtools/ampliconclip/meta.yml
@@ -33,7 +33,7 @@ input:
   - save_cliprejects:
       type: value
       description: Save  filtered reads to a file
-  - save_clistats:
+  - save_clipstats:
       type: value
       description: Save clipping stats to a file
 

--- a/modules/samtools/ampliconclip/meta.yml
+++ b/modules/samtools/ampliconclip/meta.yml
@@ -32,7 +32,7 @@ input:
       pattern: "*.{bed}"
   - save_cliprejects:
       type: value
-      description: Save  filtered reads to a file
+      description: Save filtered reads to a file
   - save_clipstats:
       type: value
       description: Save clipping stats to a file

--- a/modules/samtools/ampliconclip/meta.yml
+++ b/modules/samtools/ampliconclip/meta.yml
@@ -30,6 +30,12 @@ input:
       type: file
       description: BED file of regions to be removed (e.g. amplicon primers)
       pattern: "*.{bed}"
+  - save_cliprejects:
+      type: value
+      description: Save  filtered reads to a file
+  - save_clistats:
+      type: value
+      description: Save clipping stats to a file
 
 output:
   - meta:

--- a/modules/samtools/ampliconclip/meta.yml
+++ b/modules/samtools/ampliconclip/meta.yml
@@ -1,0 +1,47 @@
+name: samtools_ampliconclip
+## TODO nf-core: Add a description of the module and list keywords
+description: write your description here
+keywords:
+  - sort
+tools:
+  - samtools:
+      ## TODO nf-core: Add a description and other details for the software below
+      description: Tools for dealing with SAM, BAM and CRAM files
+      homepage: None
+      documentation: None
+      tool_dev_url: None
+      doi: ""
+      licence: ['MIT']
+
+## TODO nf-core: Add a description of all of the variables used as input
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  ## TODO nf-core: Delete / customise this example input
+  - bam:
+      type: file
+      description: BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+
+## TODO nf-core: Add a description of all of the variables used as output
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "*.{version.txt}"
+  ## TODO nf-core: Delete / customise this example output
+  - bam:
+      type: file
+      description: Sorted BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+
+authors:
+  - "@bjohnnyd"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -651,6 +651,10 @@ salmon/quant:
   - modules/salmon/quant/**
   - tests/modules/salmon/quant/**
 
+samtools/ampliconclip:
+  - modules/samtools/ampliconclip/**
+  - tests/modules/samtools/ampliconclip/**
+
 samtools/faidx:
   - modules/samtools/faidx/**
   - tests/modules/samtools/faidx/**

--- a/tests/modules/samtools/ampliconclip/main.nf
+++ b/tests/modules/samtools/ampliconclip/main.nf
@@ -5,37 +5,40 @@ nextflow.enable.dsl = 2
 include { SAMTOOLS_AMPLICONCLIP } from '../../../../modules/samtools/ampliconclip/main.nf' addParams([:])
 
 workflow test_samtools_ampliconclip_no_stats_no_rejects {
-    params.save_cliprejects = false
-    params.save_clipstats   = false
 
     input = [ [ id:'test', single_end:false ],
               file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
             ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+    save_cliprejects = false
+    save_clipstats   = false
 
-    SAMTOOLS_AMPLICONCLIP ( input, bed )
+
+    SAMTOOLS_AMPLICONCLIP ( input, bed, save_cliprejects, save_clipstats )
 }
 
 workflow test_samtools_ampliconclip_no_stats_with_rejects {
-    params.save_cliprejects = true
-    params.save_clipstats   = false
 
     input = [ [ id:'test', single_end:false ],
               file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
             ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+    save_cliprejects = true
+    save_clipstats   = false
 
-    SAMTOOLS_AMPLICONCLIP ( input, bed )
+
+    SAMTOOLS_AMPLICONCLIP ( input, bed, save_cliprejects, save_clipstats )
 }
 
 workflow test_samtools_ampliconclip_with_stats_with_rejects {
-    params.save_cliprejects = true
-    params.save_clipstats   = true
 
     input = [ [ id:'test', single_end:false ],
               file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
             ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+    save_cliprejects = true
+    save_clipstats   = true
 
-    SAMTOOLS_AMPLICONCLIP ( input, bed )
+
+    SAMTOOLS_AMPLICONCLIP ( input, bed, save_cliprejects, save_clipstats )
 }

--- a/tests/modules/samtools/ampliconclip/main.nf
+++ b/tests/modules/samtools/ampliconclip/main.nf
@@ -4,10 +4,38 @@ nextflow.enable.dsl = 2
 
 include { SAMTOOLS_AMPLICONCLIP } from '../../../../modules/samtools/ampliconclip/main.nf' addParams( options: [:] )
 
-workflow test_samtools_ampliconclip {
-    
+workflow test_samtools_ampliconclip_no_stats_no_rejects {
+    params.save_cliprejects = false
+    params.save_clipstats   = false
+
     input = [ [ id:'test', single_end:false ], // meta map
               file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
 
-    SAMTOOLS_AMPLICONCLIP ( input )
+    bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+
+    SAMTOOLS_AMPLICONCLIP ( input, bed )
+}
+
+workflow test_samtools_ampliconclip_no_stats_with_rejects {
+    params.save_cliprejects = true
+    params.save_clipstats   = false
+
+    input = [ [ id:'test', single_end:false ], // meta map
+              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
+
+    bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+
+    SAMTOOLS_AMPLICONCLIP ( input, bed )
+}
+
+workflow test_samtools_ampliconclip_with_stats_with_rejects {
+    params.save_cliprejects = true
+    params.save_clipstats   = true
+
+    input = [ [ id:'test', single_end:false ], // meta map
+              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
+
+    bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+
+    SAMTOOLS_AMPLICONCLIP ( input, bed )
 }

--- a/tests/modules/samtools/ampliconclip/main.nf
+++ b/tests/modules/samtools/ampliconclip/main.nf
@@ -1,0 +1,13 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { SAMTOOLS_AMPLICONCLIP } from '../../../../modules/samtools/ampliconclip/main.nf' addParams( options: [:] )
+
+workflow test_samtools_ampliconclip {
+    
+    input = [ [ id:'test', single_end:false ], // meta map
+              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
+
+    SAMTOOLS_AMPLICONCLIP ( input )
+}

--- a/tests/modules/samtools/ampliconclip/main.nf
+++ b/tests/modules/samtools/ampliconclip/main.nf
@@ -2,15 +2,15 @@
 
 nextflow.enable.dsl = 2
 
-include { SAMTOOLS_AMPLICONCLIP } from '../../../../modules/samtools/ampliconclip/main.nf' addParams( options: [:] )
+include { SAMTOOLS_AMPLICONCLIP } from '../../../../modules/samtools/ampliconclip/main.nf' addParams([:])
 
 workflow test_samtools_ampliconclip_no_stats_no_rejects {
     params.save_cliprejects = false
     params.save_clipstats   = false
 
-    input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
-
+    input = [ [ id:'test', single_end:false ],
+              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+            ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
 
     SAMTOOLS_AMPLICONCLIP ( input, bed )
@@ -20,9 +20,9 @@ workflow test_samtools_ampliconclip_no_stats_with_rejects {
     params.save_cliprejects = true
     params.save_clipstats   = false
 
-    input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
-
+    input = [ [ id:'test', single_end:false ],
+              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+            ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
 
     SAMTOOLS_AMPLICONCLIP ( input, bed )
@@ -32,9 +32,9 @@ workflow test_samtools_ampliconclip_with_stats_with_rejects {
     params.save_cliprejects = true
     params.save_clipstats   = true
 
-    input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ]
-
+    input = [ [ id:'test', single_end:false ],
+              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+            ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
 
     SAMTOOLS_AMPLICONCLIP ( input, bed )

--- a/tests/modules/samtools/ampliconclip/main.nf
+++ b/tests/modules/samtools/ampliconclip/main.nf
@@ -6,39 +6,39 @@ include { SAMTOOLS_AMPLICONCLIP } from '../../../../modules/samtools/ampliconcli
 
 workflow test_samtools_ampliconclip_no_stats_no_rejects {
 
-    input = [ [ id:'test', single_end:false ],
-              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
-            ]
+    input = [ 
+        [ id:'test', single_end:false ],
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
     save_cliprejects = false
     save_clipstats   = false
-
 
     SAMTOOLS_AMPLICONCLIP ( input, bed, save_cliprejects, save_clipstats )
 }
 
 workflow test_samtools_ampliconclip_no_stats_with_rejects {
 
-    input = [ [ id:'test', single_end:false ],
-              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
-            ]
+    input = [ 
+        [ id:'test', single_end:false ],
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
     save_cliprejects = true
     save_clipstats   = false
-
 
     SAMTOOLS_AMPLICONCLIP ( input, bed, save_cliprejects, save_clipstats )
 }
 
 workflow test_samtools_ampliconclip_with_stats_with_rejects {
 
-    input = [ [ id:'test', single_end:false ],
-              file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
-            ]
+    input = [ 
+        [ id:'test', single_end:false ],
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
     bed = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
     save_cliprejects = true
     save_clipstats   = true
-
 
     SAMTOOLS_AMPLICONCLIP ( input, bed, save_cliprejects, save_clipstats )
 }

--- a/tests/modules/samtools/ampliconclip/test.yml
+++ b/tests/modules/samtools/ampliconclip/test.yml
@@ -1,10 +1,34 @@
 ## TODO nf-core: Please run the following command to build this file:
 #                nf-core modules create-test-yml samtools/ampliconclip
-- name: samtools ampliconclip
-  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip -c tests/config/nextflow.config
+- name: samtools ampliconclip no stats no rejects
+  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_no_stats_no_rejects -c tests/config/nextflow.config
   tags:
     - samtools
     - samtools/ampliconclip
   files:
     - path: output/samtools/test.bam
-      md5sum: e667c7caad0bc4b7ac383fd023c654fc
+      md5sum: 1c705ebe39f68f1dac164733ae99c9d2
+
+- name: samtools ampliconclip no stats with rejects
+  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_no_stats_with_rejects -c tests/config/nextflow.config --save_cliprejects
+  tags:
+    - samtools
+    - samtools/ampliconclip
+  files:
+    - path: output/samtools/test.bam
+      md5sum: 86c7bfb5378d57b16855c5b399000b2a
+    - path: output/samtools/test.cliprejects.bam
+      md5sum: 8e2eea2c0005b4d4e77c0eb549599133
+
+- name: samtools ampliconclip with stats with rejects
+  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_with_stats_with_rejects -c tests/config/nextflow.config --save_cliprejects --save_clipstats
+  tags:
+    - samtools
+    - samtools/ampliconclip
+  files:
+    - path: output/samtools/test.bam
+      md5sum: d96f5eebef0ff4635e68090e89756d4a
+    - path: output/samtools/test.cliprejects.bam
+      md5sum: ad83a523d6ff1c58caade4ddafbaaed7
+    - path: output/samtools/test.clipstats.txt
+      md5sum: 6fbde83d658cd2813b79900d33800d1d

--- a/tests/modules/samtools/ampliconclip/test.yml
+++ b/tests/modules/samtools/ampliconclip/test.yml
@@ -10,7 +10,7 @@
       md5sum: 1c705ebe39f68f1dac164733ae99c9d2
 
 - name: samtools ampliconclip no stats with rejects
-  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_no_stats_with_rejects -c tests/config/nextflow.config --save_cliprejects
+  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_no_stats_with_rejects -c tests/config/nextflow.config
   tags:
     - samtools
     - samtools/ampliconclip
@@ -21,7 +21,7 @@
       md5sum: 8e2eea2c0005b4d4e77c0eb549599133
 
 - name: samtools ampliconclip with stats with rejects
-  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_with_stats_with_rejects -c tests/config/nextflow.config --save_cliprejects --save_clipstats
+  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_with_stats_with_rejects -c tests/config/nextflow.config
   tags:
     - samtools
     - samtools/ampliconclip

--- a/tests/modules/samtools/ampliconclip/test.yml
+++ b/tests/modules/samtools/ampliconclip/test.yml
@@ -1,0 +1,10 @@
+## TODO nf-core: Please run the following command to build this file:
+#                nf-core modules create-test-yml samtools/ampliconclip
+- name: samtools ampliconclip
+  command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip -c tests/config/nextflow.config
+  tags:
+    - samtools
+    - samtools/ampliconclip
+  files:
+    - path: output/samtools/test.bam
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc


### PR DESCRIPTION
I have added the module with some optional outputs that are passed as params similar as it is implemented currently in `ivar/variants`:

https://github.com/nf-core/modules/blob/0b40798d1b59a28bd86aa5b558a0793614be1efa/modules/ivar/variants/main.nf#L34-L35

I have also included the `param` value setting in the `test.yml` files, again as it is currently implemented in `ivar/variants`:

https://github.com/nf-core/modules/blob/0b40798d1b59a28bd86aa5b558a0793614be1efa/tests/modules/ivar/variants/main.nf#L7-L10

@drpatelh, following the explanation from you on slack let me know if you would prefer me to move it from `params` to `input` and remove the assignments to `params.save_cliprejects` and `params.save_clipstats`.   

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
