### PR TITLE
Replaced param with input val channel

### DIFF
--- a/modules/fastp/main.nf
+++ b/modules/fastp/main.nf
@@ -20,7 +20,7 @@ process FASTP {
 
     input:
     tuple val(meta), path(reads)
-    val save_trimmed_fail
+    val   save_trimmed_fail
 
     output:
     tuple val(meta), path('*.trim.fastq.gz'), emit: reads

--- a/modules/fastp/main.nf
+++ b/modules/fastp/main.nf
@@ -20,6 +20,7 @@ process FASTP {
 
     input:
     tuple val(meta), path(reads)
+    val save_trimmed_fail
 
     output:
     tuple val(meta), path('*.trim.fastq.gz'), emit: reads
@@ -34,7 +35,7 @@ process FASTP {
     def software = getSoftwareName(task.process)
     def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     if (meta.single_end) {
-        def fail_fastq = params.save_trimmed_fail ? "--failed_out ${prefix}.fail.fastq.gz" : ''
+        def fail_fastq = save_trimmed_fail ? "--failed_out ${prefix}.fail.fastq.gz" : ''
         """
         [ ! -f  ${prefix}.fastq.gz ] && ln -s $reads ${prefix}.fastq.gz
         fastp \\
@@ -49,7 +50,7 @@ process FASTP {
         echo \$(fastp --version 2>&1) | sed -e "s/fastp //g" > ${software}.version.txt
         """
     } else {
-        def fail_fastq = params.save_trimmed_fail ? "--unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
+        def fail_fastq = save_trimmed_fail ? "--unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
         """
         [ ! -f  ${prefix}_1.fastq.gz ] && ln -s ${reads[0]} ${prefix}_1.fastq.gz
         [ ! -f  ${prefix}_2.fastq.gz ] && ln -s ${reads[1]} ${prefix}_2.fastq.gz

--- a/tests/modules/fastp/main.nf
+++ b/tests/modules/fastp/main.nf
@@ -11,8 +11,9 @@ workflow test_fastp_single_end {
     input = [ [ id:'test', single_end:true ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
             ]
+    save_trimmed_fail = Channel.value(false)
 
-    FASTP ( input )
+    FASTP ( input, save_trimmed_fail )
 }
 
 //
@@ -23,7 +24,33 @@ workflow test_fastp_paired_end {
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
                 file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
             ]
+    save_trimmed_fail = Channel.value(false)
 
-    FASTP ( input )
+    FASTP ( input, save_trimmed_fail )
+}
+
+//
+// Test with single-end data with saving trimming fails
+//
+workflow test_fastp_single_end_trimfail {
+    input = [ [ id:'test', single_end:true ], // meta map
+              [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
+            ]
+    save_trimmed_fail = Channel.value(true)
+
+    FASTP ( input, save_trimmed_fail )
+}
+
+//
+// Test with paired-end data with saving trimming fails
+//
+workflow test_fastp_paired_end_trimfail {
+    input = [ [ id:'test', single_end:false ], // meta map
+              [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
+            ]
+    save_trimmed_fail = Channel.value(true)
+
+    FASTP ( input, save_trimmed_fail )
 }
 

--- a/tests/modules/fastp/main.nf
+++ b/tests/modules/fastp/main.nf
@@ -11,7 +11,7 @@ workflow test_fastp_single_end {
     input = [ [ id:'test', single_end:true ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
             ]
-    save_trimmed_fail = Channel.value(false)
+    save_trimmed_fail = false
 
     FASTP ( input, save_trimmed_fail )
 }
@@ -24,7 +24,7 @@ workflow test_fastp_paired_end {
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
                 file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
             ]
-    save_trimmed_fail = Channel.value(false)
+    save_trimmed_fail = false
 
     FASTP ( input, save_trimmed_fail )
 }
@@ -32,7 +32,7 @@ workflow test_fastp_paired_end {
 //
 // Test with single-end data with saving trimming fails
 //
-workflow test_fastp_single_end_trimfail {
+workflow test_fastp_single_end_trim_fail {
     input = [ [ id:'test', single_end:true ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
             ]
@@ -44,7 +44,7 @@ workflow test_fastp_single_end_trimfail {
 //
 // Test with paired-end data with saving trimming fails
 //
-workflow test_fastp_paired_end_trimfail {
+workflow test_fastp_paired_end_trim_fail {
     input = [ [ id:'test', single_end:false ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
                 file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
@@ -53,4 +53,3 @@ workflow test_fastp_paired_end_trimfail {
 
     FASTP ( input, save_trimmed_fail )
 }
-

--- a/tests/modules/fastp/main.nf
+++ b/tests/modules/fastp/main.nf
@@ -49,7 +49,7 @@ workflow test_fastp_paired_end_trim_fail {
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
                 file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
             ]
-    save_trimmed_fail = Channel.value(true)
+    save_trimmed_fail = true
 
     FASTP ( input, save_trimmed_fail )
 }

--- a/tests/modules/fastp/main.nf
+++ b/tests/modules/fastp/main.nf
@@ -36,7 +36,7 @@ workflow test_fastp_single_end_trim_fail {
     input = [ [ id:'test', single_end:true ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
             ]
-    save_trimmed_fail = Channel.value(true)
+    save_trimmed_fail = true
 
     FASTP ( input, save_trimmed_fail )
 }

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -36,3 +36,48 @@
       md5sum: e2257263668dc8a75d95475099fb472d
     - path: output/fastp/test_2.trim.fastq.gz
       md5sum: 9eff7203596580cc5e42aceab4a469df
+
+- name: fastp test_fastp_single_end_trimfail
+  command: nextflow run tests/modules/fastp -entry test_fastp_single_end_trimfail -c tests/config/nextflow.config
+  tags:
+    - fastp
+  files:
+    - path: output/fastp/test.fastp.html
+      contains:
+        - "Q20 bases:</td><td class='col2'>12.922000 K (92.984097%)"
+        - "single end (151 cycles)"
+    - path: output/fastp/test.fastp.log
+      contains:
+        - "Q20 bases: 12922(92.9841%)"
+        - "reads passed filter: 99"
+    - path: output/fastp/test.trim.fastq.gz
+      md5sum: e2257263668dc8a75d95475099fb472d
+    - path: output/fastp/test.fastp.json
+      md5sum: ee65a46d6e59fa556f112727b8a902ce
+    - path: output/fastp/test.fail.fastq.gz
+      md5sum: de315d397c994d8e66bafc7a8dc11070
+
+- name: fastp test_fastp_paired_end_trimfail
+  command: nextflow run tests/modules/fastp -entry test_fastp_paired_end_trimfail -c tests/config/nextflow.config
+  tags:
+    - fastp
+  files:
+    - path: output/fastp/test.fastp.html
+      contains:
+        - "Q20 bases:</td><td class='col2'>25.719000 K (93.033098%)"
+        - "The input has little adapter percentage (~0.000000%), probably it's trimmed before."
+    - path: output/fastp/test.fastp.log
+      contains:
+        - "No adapter detected for read1"
+        - "Q30 bases: 12281(88.3716%)"
+    - path: output/fastp/test.fastp.json
+      contains:
+        - '"passed_filter_reads": 198'
+    - path: output/fastp/test_1.trim.fastq.gz
+      md5sum: e2257263668dc8a75d95475099fb472d
+    - path: output/fastp/test_2.trim.fastq.gz
+      md5sum: 9eff7203596580cc5e42aceab4a469df
+    - path: output/fastp/test_1.fail.fastq.gz
+      md5sum: e62ff0123a74adfc6903d59a449cbdb0
+    - path: output/fastp/test_2.fail.fastq.gz
+      md5sum: f52309b35a7c15cbd56a9c3906ef98a5

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -37,8 +37,8 @@
     - path: output/fastp/test_2.trim.fastq.gz
       md5sum: 9eff7203596580cc5e42aceab4a469df
 
-- name: fastp test_fastp_single_end_trimfail
-  command: nextflow run tests/modules/fastp -entry test_fastp_single_end_trimfail -c tests/config/nextflow.config
+- name: fastp test_fastp_single_end_trim_fail
+command: nextflow run tests/modules/fastp -entry test_fastp_single_end_trim_fail -c tests/config/nextflow.config
   tags:
     - fastp
   files:
@@ -57,8 +57,8 @@
     - path: output/fastp/test.fail.fastq.gz
       md5sum: de315d397c994d8e66bafc7a8dc11070
 
-- name: fastp test_fastp_paired_end_trimfail
-  command: nextflow run tests/modules/fastp -entry test_fastp_paired_end_trimfail -c tests/config/nextflow.config
+- name: fastp test_fastp_paired_end_trim_fail
+  command: nextflow run tests/modules/fastp -entry test_fastp_paired_end_trim_fail -c tests/config/nextflow.config
   tags:
     - fastp
   files:

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -38,7 +38,7 @@
       md5sum: 9eff7203596580cc5e42aceab4a469df
 
 - name: fastp test_fastp_single_end_trim_fail
-command: nextflow run tests/modules/fastp -entry test_fastp_single_end_trim_fail -c tests/config/nextflow.config
+  command: nextflow run tests/modules/fastp -entry test_fastp_single_end_trim_fail -c tests/config/nextflow.config
   tags:
     - fastp
   files:


### PR DESCRIPTION
## PR checklist

Current `fastp` module includes a `params` option which isn't allowed according to the nf-core module guidelines. This replaces the `params.save_trimmed_fail` with a input `value` channel

Note: I'm not sure if this is the most optimal implementation here, as it means it adds a _required_ input channel , and I'm not 100% of this parameter can be considered to be 'required as it requires the explicit creation of an extra channel for a parameter maybe irrelevant for some cases of `fastp`.

Closes #594 

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
