### PR TITLE
fix: reduce number of required input files for damage profiler

### DIFF
--- a/modules/damageprofiler/main.nf
+++ b/modules/damageprofiler/main.nf
@@ -30,15 +30,25 @@ process DAMAGEPROFILER {
     script:
     def software   = getSoftwareName(task.process)
     prefix         = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    println("Myfasta " + fasta)
+    if ( fasta ) {
+        """
+        damageprofiler \\
+            -i $bam \\
+            -r $fasta \\
+            -o $prefix/ \\
+            $options.args
 
-    """
-    damageprofiler \\
-        -i $bam \\
-        -r $fasta \\
-        -o $prefix/ \\
-        $options.args
+        echo \$(damageprofiler -v) | sed 's/^DamageProfiler v//' > ${software}.version.txt
+        """
+    } else {
+        """
+        damageprofiler \\
+            -i $bam \\
+            -o $prefix/ \\
+            $options.args
 
-
-    echo \$(damageprofiler -v) | sed 's/^DamageProfiler v//' > ${software}.version.txt
-    """
+        echo \$(damageprofiler -v) | sed 's/^DamageProfiler v//' > ${software}.version.txt
+        """
+    }
 }

--- a/modules/damageprofiler/meta.yml
+++ b/modules/damageprofiler/meta.yml
@@ -32,11 +32,11 @@ input:
       pattern: "*.{bam,cram,sam}"
   - fasta:
       type: file
-      description: FASTA reference file
+      description: OPTIONAL FASTA reference file
       pattern: "*.{fasta,fna,fa}"
   - fai:
       type: file
-      description: FASTA index file from samtools faidx
+      description: OPTIONAL FASTA index file from samtools faidx
       pattern: "*.{fai}"
 
 output:

--- a/tests/modules/damageprofiler/main.nf
+++ b/tests/modules/damageprofiler/main.nf
@@ -8,6 +8,14 @@ workflow test_damageprofiler {
 
     input = [ [ id:'test', single_end:false ], // meta map
               [ file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ] ]
+
+    DAMAGEPROFILER ( input, [], [] )
+}
+
+workflow test_damageprofiler_reference {
+
+    input = [ [ id:'test', single_end:false ], // meta map
+              [ file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ] ]
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
 

--- a/tests/modules/damageprofiler/test.yml
+++ b/tests/modules/damageprofiler/test.yml
@@ -34,3 +34,40 @@
       md5sum: c5d029bf3a92b613310ee23f47d94981
     - path: output/damageprofiler/test/misincorporation.txt
       md5sum: 3aa6dd749010a492d92a815a83c196a8
+
+- name: damageprofiler_reference
+  command: nextflow run ./tests/modules/damageprofiler -entry test_damageprofiler_reference -c tests/config/nextflow.config -dump-channels
+  tags:
+    - damageprofiler
+  files:
+    - path: output/damageprofiler/test/3p_freq_misincorporations.txt
+      md5sum: da4cac90c78899a7cb6d72d415392b49
+    - path: output/damageprofiler/test/3pGtoA_freq.txt
+      md5sum: 8dab75d51a4b943b501d0995169c767f
+    - path: output/damageprofiler/test/5pCtoT_freq.txt
+      md5sum: fcc48ee5f72edff930d627c8bfdd8a5b
+    - path: output/damageprofiler/test/5p_freq_misincorporations.txt
+      md5sum: 54665474f5ef17dcc268567e5eaa7d86
+    - path: output/damageprofiler/test/DamagePlot_five_prime.svg
+    - path: output/damageprofiler/test/DamagePlot.pdf
+    - path: output/damageprofiler/test/DamagePlot_three_prime.svg
+    - path: output/damageprofiler/test/DamageProfiler.log
+      contains:
+        - "FINISHED SUCCESSFULLY"
+    - path: output/damageprofiler/test/dmgprof.json
+      md5sum: 98499024c7e937896e481f2d3cfbdd3e
+    - path: output/damageprofiler/test/DNA_comp_genome.txt
+      md5sum: f91e70760d91a1193a27e360aaddf2fd
+    - path: output/damageprofiler/test/DNA_composition_sample.txt
+      md5sum: 1257eb3eb42484647bfba2151f9ef04f
+    - path: output/damageprofiler/test/edit_distance.pdf
+    - path: output/damageprofiler/test/edit_distance.svg
+    - path: output/damageprofiler/test/editDistance.txt
+      md5sum: af2d2f4a99058ec56eae88ec27779e38
+    - path: output/damageprofiler/test/Length_plot_combined_data.svg
+    - path: output/damageprofiler/test/Length_plot_forward_reverse_separated.svg
+    - path: output/damageprofiler/test/Length_plot.pdf
+    - path: output/damageprofiler/test/lgdistribution.txt
+      md5sum: c5d029bf3a92b613310ee23f47d94981
+    - path: output/damageprofiler/test/misincorporation.txt
+      md5sum: 3aa6dd749010a492d92a815a83c196a8


### PR DESCRIPTION
## PR checklist

I just realised that damageprofiler doesn't _actually_ require a FASTA file (just for certain output files). This removes FASTA input as being _required_.

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
