### PR TITLE
Added an optional output junction channel in STAR

### DIFF
--- a/modules/star/align/main.nf
+++ b/modules/star/align/main.nf
@@ -36,6 +36,7 @@ process STAR_ALIGN {
     tuple val(meta), path('*Aligned.unsort.out.bam') , optional:true, emit: bam_unsorted
     tuple val(meta), path('*fastq.gz')               , optional:true, emit: fastq
     tuple val(meta), path('*.tab')                   , optional:true, emit: tab
+    tuple val(meta), path('*.out.junction')          , optional:true, emit: junction
 
     script:
     def software   = getSoftwareName(task.process)

--- a/modules/star/align/meta.yml
+++ b/modules/star/align/meta.yml
@@ -69,7 +69,7 @@ output:
       type: file
       description: STAR output tab file(s) (optional)
       pattern: "*.tab"
-  - tab:
+  - junction:
       type: file
       description: STAR chimeric junction output file (optional)
       pattern: "*.out.junction"

--- a/modules/star/align/meta.yml
+++ b/modules/star/align/meta.yml
@@ -69,7 +69,12 @@ output:
       type: file
       description: STAR output tab file(s) (optional)
       pattern: "*.tab"
+  - tab:
+      type: file
+      description: STAR chimeric junction output file (optional)
+      pattern: "*.out.junction"
 
 authors:
   - "@kevinmenden"
   - "@drpatelh"
+  - "@praveenraj2018"

--- a/tests/modules/star/align/main.nf
+++ b/tests/modules/star/align/main.nf
@@ -5,7 +5,7 @@ nextflow.enable.dsl = 2
 include { STAR_GENOMEGENERATE              } from '../../../../modules/star/genomegenerate/main.nf' addParams( options: [args: '--genomeSAindexNbases 9'] )
 include { STAR_ALIGN                       } from '../../../../modules/star/align/main.nf'          addParams( options: [args: '--readFilesCommand zcat'] )
 include { STAR_ALIGN as STAR_FOR_ARRIBA    } from '../../../../modules/star/align/main.nf'          addParams( options: [args: '--readFilesCommand zcat --outSAMtype BAM Unsorted --outSAMunmapped Within --outBAMcompression 0 --outFilterMultimapNmax 50 --peOverlapNbasesMin 10 --alignSplicedMateMapLminOverLmate 0.5 --alignSJstitchMismatchNmax 5 -1 5 5 --chimSegmentMin 10 --chimOutType WithinBAM HardClip --chimJunctionOverhangMin 10 --chimScoreDropMax 30 --chimScoreJunctionNonGTAG 0 --chimScoreSeparation 1 --chimSegmentReadGapMax 3 --chimMultimapNmax 50'] )
-
+include { STAR_ALIGN as STAR_FOR_STARFUSION } from '../../../../modules/star/align/main.nf'          addParams( options: [args: '--readFilesCommand zcat --outSAMtype BAM Unsorted --outReadsUnmapped None --twopassMode Basic --outSAMstrandField intronMotif --outSAMunmapped Within --chimSegmentMin 12 --chimJunctionOverhangMin 8 --chimOutJunctionFormat 1 --alignSJDBoverhangMin 10 --alignMatesGapMax 100000 --alignIntronMax 100000 --alignSJstitchMismatchNmax 5 -1 5 5 --chimMultimapScoreRange 3 --chimScoreJunctionNonGTAG -4 --chimMultimapNmax 20 --chimNonchimScoreDropMin 10 --peOverlapNbasesMin 12 --peOverlapMMp 0.1 --alignInsertionFlush Right --alignSplicedMateMapLminOverLmate 0 --alignSplicedMateMapLmin 30'] )
 
 workflow test_star_alignment_single_end {
     input = [ [ id:'test', single_end:true ], // meta map
@@ -41,4 +41,16 @@ workflow test_star_alignment_paired_end_for_fusion {
 
     STAR_GENOMEGENERATE ( fasta, gtf )
     STAR_FOR_ARRIBA ( input, STAR_GENOMEGENERATE.out.index, gtf )
+}
+
+workflow test_star_alignment_paired_end_for_starfusion {
+    input = [ [ id:'test', single_end:false ], // meta map
+              [ file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_1_fastq_gz'], checkIfExists: true),
+                file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_2_fastq_gz'], checkIfExists: true) ]
+            ]
+    fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+    gtf   = file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
+
+    STAR_GENOMEGENERATE ( fasta, gtf )
+    STAR_FOR_STARFUSION ( input, STAR_GENOMEGENERATE.out.index, gtf )
 }

--- a/tests/modules/star/align/main.nf
+++ b/tests/modules/star/align/main.nf
@@ -2,9 +2,9 @@
 
 nextflow.enable.dsl = 2
 
-include { STAR_GENOMEGENERATE              } from '../../../../modules/star/genomegenerate/main.nf' addParams( options: [args: '--genomeSAindexNbases 9'] )
-include { STAR_ALIGN                       } from '../../../../modules/star/align/main.nf'          addParams( options: [args: '--readFilesCommand zcat'] )
-include { STAR_ALIGN as STAR_FOR_ARRIBA    } from '../../../../modules/star/align/main.nf'          addParams( options: [args: '--readFilesCommand zcat --outSAMtype BAM Unsorted --outSAMunmapped Within --outBAMcompression 0 --outFilterMultimapNmax 50 --peOverlapNbasesMin 10 --alignSplicedMateMapLminOverLmate 0.5 --alignSJstitchMismatchNmax 5 -1 5 5 --chimSegmentMin 10 --chimOutType WithinBAM HardClip --chimJunctionOverhangMin 10 --chimScoreDropMax 30 --chimScoreJunctionNonGTAG 0 --chimScoreSeparation 1 --chimSegmentReadGapMax 3 --chimMultimapNmax 50'] )
+include { STAR_GENOMEGENERATE               } from '../../../../modules/star/genomegenerate/main.nf' addParams( options: [args: '--genomeSAindexNbases 9'] )
+include { STAR_ALIGN                        } from '../../../../modules/star/align/main.nf'          addParams( options: [args: '--readFilesCommand zcat'] )
+include { STAR_ALIGN as STAR_FOR_ARRIBA     } from '../../../../modules/star/align/main.nf'          addParams( options: [args: '--readFilesCommand zcat --outSAMtype BAM Unsorted --outSAMunmapped Within --outBAMcompression 0 --outFilterMultimapNmax 50 --peOverlapNbasesMin 10 --alignSplicedMateMapLminOverLmate 0.5 --alignSJstitchMismatchNmax 5 -1 5 5 --chimSegmentMin 10 --chimOutType WithinBAM HardClip --chimJunctionOverhangMin 10 --chimScoreDropMax 30 --chimScoreJunctionNonGTAG 0 --chimScoreSeparation 1 --chimSegmentReadGapMax 3 --chimMultimapNmax 50'] )
 include { STAR_ALIGN as STAR_FOR_STARFUSION } from '../../../../modules/star/align/main.nf'          addParams( options: [args: '--readFilesCommand zcat --outSAMtype BAM Unsorted --outReadsUnmapped None --twopassMode Basic --outSAMstrandField intronMotif --outSAMunmapped Within --chimSegmentMin 12 --chimJunctionOverhangMin 8 --chimOutJunctionFormat 1 --alignSJDBoverhangMin 10 --alignMatesGapMax 100000 --alignIntronMax 100000 --alignSJstitchMismatchNmax 5 -1 5 5 --chimMultimapScoreRange 3 --chimScoreJunctionNonGTAG -4 --chimMultimapNmax 20 --chimNonchimScoreDropMin 10 --peOverlapNbasesMin 12 --peOverlapMMp 0.1 --alignInsertionFlush Right --alignSplicedMateMapLminOverLmate 0 --alignSplicedMateMapLmin 30'] )
 
 workflow test_star_alignment_single_end {

--- a/tests/modules/star/align/test.yml
+++ b/tests/modules/star/align/test.yml
@@ -40,7 +40,9 @@
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
+      md5sum: b2bd061d6cbaaf3d6d3b1fed547f69b8
     - path: output/star/test.SJ.out.tab
+      md5sum: 75a516ab950fb958f40b29996474949c
 
 - name: star align test_star_alignment_paired_end
   command: nextflow run tests/modules/star/align -entry test_star_alignment_paired_end -c tests/config/nextflow.config
@@ -84,7 +86,9 @@
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
+      md5sum: b2bd061d6cbaaf3d6d3b1fed547f69b8
     - path: output/star/test.SJ.out.tab
+      md5sum: 844af19ab0fc8cd9a3f75228445aca0d
 
 - name: star align test_star_alignment_paired_end_for_fusion
   command: nextflow run tests/modules/star/align -entry test_star_alignment_paired_end_for_fusion -c tests/config/nextflow.config
@@ -130,3 +134,50 @@
     - path: output/star/test.Log.progress.out
     - path: output/star/test.SJ.out.tab
       md5sum: 5155c9fd1f787ad6d7d80987fb06219c
+
+- name: star align test_star_alignment_paired_end_for_starfusion
+  command: nextflow run tests/modules/star/align -entry test_star_alignment_paired_end_for_starfusion -c tests/config/nextflow.config
+  tags:
+    - star
+    - star/align
+  files:
+    - path: output/index/star/Genome
+      md5sum: a654229fbca6071dcb6b01ce7df704da
+    - path: output/index/star/Log.out
+    - path: output/index/star/SA
+      md5sum: 8c3edc46697b72c9e92440d4cf43506c
+    - path: output/index/star/SAindex
+      md5sum: 2a0c675d8b91d8e5e8c1826d3500482e
+    - path: output/index/star/chrLength.txt
+      md5sum: c81f40f27e72606d7d07097c1d56a5b5
+    - path: output/index/star/chrName.txt
+      md5sum: 5ae68a67b70976ee95342a7451cb5af1
+    - path: output/index/star/chrNameLength.txt
+      md5sum: b190587cae0531f3cf25552d8aa674db
+    - path: output/index/star/chrStart.txt
+      md5sum: 8d3291e6bcdbe9902fbd7c887494173f
+    - path: output/index/star/exonGeTrInfo.tab
+      md5sum: d04497f69d6ef889efd4d34fe63edcc4
+    - path: output/index/star/exonInfo.tab
+      md5sum: 0d560290fab688b7268d88d5494bf9fe
+    - path: output/index/star/geneInfo.tab
+      md5sum: 8b608537307443ffaee4927d2b428805
+    - path: output/index/star/genomeParameters.txt
+      md5sum: 3097677f4d8b2cb66770b9e55d343a7f
+    - path: output/index/star/sjdbInfo.txt
+      md5sum: 5690ea9d9f09f7ff85b7fd47bd234903
+    - path: output/index/star/sjdbList.fromGTF.out.tab
+      md5sum: 8760c33e966dad0b39f440301ebbdee4
+    - path: output/index/star/sjdbList.out.tab
+      md5sum: 9e4f991abbbfeb3935a2bb21b9e258f1
+    - path: output/index/star/transcriptInfo.tab
+      md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
+    - path: output/star/test.Aligned.out.bam
+      md5sum: a1bd1b40950a58ea2776908076160052
+    - path: output/star/test.Chimeric.out.junction
+      md5sum: 327629eb54032212f29e1c32cbac6975
+    - path: output/star/test.Log.final.out
+    - path: output/star/test.Log.out
+    - path: output/star/test.Log.progress.out
+    - path: output/star/test.SJ.out.tab
+      md5sum: 19c3faa1bfa9a0cc5e4c45f17065b53a

--- a/tests/modules/star/align/test.yml
+++ b/tests/modules/star/align/test.yml
@@ -40,9 +40,7 @@
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
-      md5sum: b2bd061d6cbaaf3d6d3b1fed547f69b8
     - path: output/star/test.SJ.out.tab
-      md5sum: 75a516ab950fb958f40b29996474949c
 
 - name: star align test_star_alignment_paired_end
   command: nextflow run tests/modules/star/align -entry test_star_alignment_paired_end -c tests/config/nextflow.config
@@ -86,9 +84,7 @@
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
-      md5sum: b2bd061d6cbaaf3d6d3b1fed547f69b8
     - path: output/star/test.SJ.out.tab
-      md5sum: 844af19ab0fc8cd9a3f75228445aca0d
 
 - name: star align test_star_alignment_paired_end_for_fusion
   command: nextflow run tests/modules/star/align -entry test_star_alignment_paired_end_for_fusion -c tests/config/nextflow.config
@@ -133,7 +129,6 @@
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
     - path: output/star/test.SJ.out.tab
-      md5sum: 5155c9fd1f787ad6d7d80987fb06219c
 
 - name: star align test_star_alignment_paired_end_for_starfusion
   command: nextflow run tests/modules/star/align -entry test_star_alignment_paired_end_for_starfusion -c tests/config/nextflow.config
@@ -180,4 +175,3 @@
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
     - path: output/star/test.SJ.out.tab
-      md5sum: 19c3faa1bfa9a0cc5e4c45f17065b53a


### PR DESCRIPTION
Added an optional output channel for getting chimeric junctions from STAR/align. This is required for the downstream analysis for fusion calling with STAR-fusion.