### PR TITLE
Update Nextclade to output all files by default

### DIFF
--- a/modules/nextclade/main.nf
+++ b/modules/nextclade/main.nf
@@ -20,35 +20,28 @@ process NEXTCLADE {
 
     input:
     tuple val(meta), path(fasta)
-    val   output_format
 
     output:
-    tuple val(meta), path("${prefix}.csv")       , optional:true, emit: csv
-    tuple val(meta), path("${prefix}.json")      , optional:true, emit: json
-    tuple val(meta), path("${prefix}.tree.json") , optional:true, emit: json_tree
-    tuple val(meta), path("${prefix}.tsv")       , optional:true, emit: tsv
+    tuple val(meta), path("${prefix}.csv")       , emit: csv
+    tuple val(meta), path("${prefix}.json")      , emit: json
+    tuple val(meta), path("${prefix}.tree.json") , emit: json_tree
+    tuple val(meta), path("${prefix}.tsv")       , emit: tsv
     tuple val(meta), path("${prefix}.clades.tsv"), optional:true, emit: tsv_clades
     path "*.version.txt"                         , emit: version
 
     script:
     def software = getSoftwareName(task.process)
     prefix       = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
-    def format   = output_format
-    if (!(format in ['json', 'csv', 'tsv', 'tree', 'tsv-clades-only'])) {
-        format = 'json'
-    }
-    def extension = format
-    if (format in ['tsv-clades-only']) {
-        extension = '.clades.tsv'
-    } else if (format in ['tree']) {
-        extension = 'tree.json'
-    }
     """
     nextclade \\
         $options.args \\
         --jobs $task.cpus \\
         --input-fasta $fasta \\
-        --output-${format} ${prefix}.${extension}
+        --output-json ${prefix}.json \\
+        --output-csv ${prefix}.csv \\
+        --output-tsv ${prefix}.tsv \\
+        --output-tsv-clades-only ${prefix}.clades.tsv \\
+        --output-tree ${prefix}.tree.json
 
     echo \$(nextclade --version 2>&1) > ${software}.version.txt
     """

--- a/modules/nextclade/meta.yml
+++ b/modules/nextclade/meta.yml
@@ -11,7 +11,7 @@ tools:
       documentation: None
       tool_dev_url: https://github.com/nextstrain/nextclade
       doi: ""
-      licence: ['MIT']
+      licence: ["MIT"]
 
 input:
   - meta:
@@ -23,11 +23,6 @@ input:
       type: file
       description: FASTA file containing one or more consensus sequences
       pattern: "*.{fasta,fa}"
-  - output_format:
-      type: string
-      description: |
-        String for output format supported by nextclade
-        i.e one of 'json', 'csv', 'tsv', 'tree', 'tsv-clades-only'
 
 output:
   - meta:

--- a/tests/modules/nextclade/main.nf
+++ b/tests/modules/nextclade/main.nf
@@ -4,30 +4,11 @@ nextflow.enable.dsl = 2
 
 include { NEXTCLADE } from '../../../modules/nextclade/main.nf' addParams( options: [:] )
 
-workflow test_nextclade_json {
-    input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-            ]
-    NEXTCLADE ( input, 'json' )
-}
-
-workflow test_nextclade_csv {
-    input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-            ]
-    NEXTCLADE ( input, 'csv' )
-}
-
-workflow test_nextclade_tsv {
-    input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-            ]
-    NEXTCLADE ( input, 'tsv' )
-}
-
-workflow test_nextclade_tree {
-    input = [ [ id:'test', single_end:false ], // meta map
-              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-            ]
-    NEXTCLADE ( input, 'tree' )
+workflow test_nextclade {
+    input = [ 
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+    
+    NEXTCLADE ( input )
 }

--- a/tests/modules/nextclade/test.yml
+++ b/tests/modules/nextclade/test.yml
@@ -1,31 +1,13 @@
-- name: nextclade test_nextclade_json
-  command: nextflow run tests/modules/nextclade -entry test_nextclade_json -c tests/config/nextflow.config
+- name: nextclade test_nextclade
+  command: nextflow run tests/modules/nextclade -entry test_nextclade -c tests/config/nextflow.config
   tags:
     - nextclade
   files:
     - path: output/nextclade/test.json
       md5sum: cab92830c5cb66076e7d6c054ea98362
-
-- name: nextclade test_nextclade_csv
-  command: nextflow run tests/modules/nextclade -entry test_nextclade_csv -c tests/config/nextflow.config
-  tags:
-    - nextclade
-  files:
     - path: output/nextclade/test.csv
       md5sum: 4f7096df9be51f99a0d62a38653b29cf
-
-- name: nextclade test_nextclade_tsv
-  command: nextflow run tests/modules/nextclade -entry test_nextclade_tsv -c tests/config/nextflow.config
-  tags:
-    - nextclade
-  files:
     - path: output/nextclade/test.tsv
       md5sum: fe07dc4ffcd81742ca9bef93f88e8836
-
-- name: nextclade test_nextclade_tree
-  command: nextflow run tests/modules/nextclade -entry test_nextclade_tree -c tests/config/nextflow.config
-  tags:
-    - nextclade
-  files:
     - path: output/nextclade/test.tree.json
       md5sum: 5c57dd724bc2b5cfde8f42a17ff2865a


### PR DESCRIPTION
This PR will fix https://github.com/nf-core/viralrecon/issues/226. I have thought about this a little and it is going to be too much hassle adding logic to check for multiple output formats in the module / pipeline. We can simply just publish whichever files with `publish_files` in `modules.config` and leave it up to the user to amend that via a `custom.config` if required. The files will be tiny and the `work/` directory will most likely be deleted after the run anyway.