### PR TITLE
Require r-base>=3.5 for RSeqC Conda envs

### DIFF
--- a/modules/rseqc/bamstat/main.nf
+++ b/modules/rseqc/bamstat/main.nf
@@ -11,7 +11,7 @@ process RSEQC_BAMSTAT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1 'conda-forge::r-base>=3.5'" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/modules/rseqc/inferexperiment/main.nf
+++ b/modules/rseqc/inferexperiment/main.nf
@@ -11,7 +11,7 @@ process RSEQC_INFEREXPERIMENT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1 'conda-forge::r-base>=3.5'" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/modules/rseqc/innerdistance/main.nf
+++ b/modules/rseqc/innerdistance/main.nf
@@ -11,7 +11,7 @@ process RSEQC_INNERDISTANCE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1 'conda-forge::r-base>=3.5'" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/modules/rseqc/junctionannotation/main.nf
+++ b/modules/rseqc/junctionannotation/main.nf
@@ -11,7 +11,7 @@ process RSEQC_JUNCTIONANNOTATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1 'conda-forge::r-base>=3.5'" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/modules/rseqc/junctionsaturation/main.nf
+++ b/modules/rseqc/junctionsaturation/main.nf
@@ -11,7 +11,7 @@ process RSEQC_JUNCTIONSATURATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1 'conda-forge::r-base>=3.5'" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/modules/rseqc/readdistribution/main.nf
+++ b/modules/rseqc/readdistribution/main.nf
@@ -11,7 +11,7 @@ process RSEQC_READDISTRIBUTION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1 'conda-forge::r-base>=3.5'" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {

--- a/modules/rseqc/readduplication/main.nf
+++ b/modules/rseqc/readduplication/main.nf
@@ -11,7 +11,7 @@ process RSEQC_READDUPLICATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    conda (params.enable_conda ? "bioconda::rseqc=3.0.1 'conda-forge::r-base>=3.5'" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
         container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
     } else {


### PR DESCRIPTION
## PR checklist

This is the prerequisite to close the following bug: nf-core/rnaseq#685 

This PR mainly enforces a working conda env with the appropriate R version needed by rseqc