### PR TITLE
add spatyper

### DIFF
--- a/modules/spatyper/functions.nf
+++ b/modules/spatyper/functions.nf
@@ -1,0 +1,68 @@
+//
+//  Utility functions used in nf-core DSL2 module files
+//
+
+//
+// Extract name of software tool from process name using $task.process
+//
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+//
+// Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+//
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
+    return options
+}
+
+//
+// Tidy up and join elements of a list to return a path string
+//
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+//
+// Function to save/publish module results
+//
+def saveFiles(Map args) {
+    if (!args.filename.endsWith('.version.txt')) {
+        def ioptions  = initOptions(args.options)
+        def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+        if (ioptions.publish_by_meta) {
+            def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+            for (key in key_list) {
+                if (args.meta && key instanceof String) {
+                    def path = key
+                    if (args.meta.containsKey(key)) {
+                        path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                    }
+                    path = path instanceof String ? path : ''
+                    path_list.add(path)
+                }
+            }
+        }
+        if (ioptions.publish_files instanceof Map) {
+            for (ext in ioptions.publish_files) {
+                if (args.filename.endsWith(ext.key)) {
+                    def ext_list = path_list.collect()
+                    ext_list.add(ext.value)
+                    return "${getPathFromList(ext_list)}/$args.filename"
+                }
+            }
+        } else if (ioptions.publish_files == null) {
+            return "${getPathFromList(path_list)}/$args.filename"
+        }
+    }
+}

--- a/modules/spatyper/main.nf
+++ b/modules/spatyper/main.nf
@@ -1,0 +1,36 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process SPATYPER {
+    tag "$meta.id"
+    label 'process_low'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+
+    conda (params.enable_conda ? "bioconda::spatyper=0.3.3" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/spatyper:0.3.3--py_1"
+    } else {
+        container "quay.io/biocontainers/spatyper:0.3.3--py_1"
+    }
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("*.tsv"), emit: tsv
+    path "*.version.txt"          , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    """
+    spaTyper --fasta $fasta --output ${prefix}.tsv $options.args
+
+    echo \$(spaTyper --version 2>&1) | sed 's/^.*spaTyper //' > ${software}.version.txt
+    """
+}

--- a/modules/spatyper/meta.yml
+++ b/modules/spatyper/meta.yml
@@ -1,0 +1,42 @@
+name: spatyper
+description: Computational method for finding spa types.
+keywords:
+  - fasta
+  - spatype
+tools:
+  - spatyper:
+      description: Computational method for finding spa types.
+      homepage: https://github.com/HCGB-IGTP/spaTyper
+      documentation: https://github.com/HCGB-IGTP/spaTyper
+      tool_dev_url: https://github.com/HCGB-IGTP/spaTyper
+      doi: https://doi.org/10.5281/zenodo.4063625
+      licence: ['LGPL v3']
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: FASTA assembly file
+      pattern: "*.{fasta,fasta.gz,fa,fa.gz,fna,fna.gz}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "*.{version.txt}"
+  - tsv:
+      type: file
+      description: Tab-delimited results
+      pattern: "*.{tsv}"
+
+authors:
+  - "@rpetit3"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -831,6 +831,10 @@ spades:
   - modules/spades/**
   - tests/modules/spades/**
 
+spatyper:
+  - modules/spatyper/**
+  - tests/modules/spatyper/**
+
 star/align:
   - modules/star/align/**
   - tests/modules/star/align/**

--- a/tests/modules/spatyper/main.nf
+++ b/tests/modules/spatyper/main.nf
@@ -1,0 +1,20 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { SPATYPER } from '../../../modules/spatyper/main.nf' addParams( options: [:] )
+include { SPATYPER as SPATYPER_ENRICH } from '../../../modules/spatyper/main.nf' addParams( options: [args: '--do_enrich'] )
+
+workflow test_spatyper {
+    input = [ [ id:'test' ],
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+
+    SPATYPER ( input )
+}
+
+workflow test_spatyper_enrich {
+    input = [ [ id:'test' ],
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+
+    SPATYPER_ENRICH ( input )
+}

--- a/tests/modules/spatyper/test.yml
+++ b/tests/modules/spatyper/test.yml
@@ -1,0 +1,15 @@
+- name: spatyper test_spatyper
+  command: nextflow run tests/modules/spatyper -entry test_spatyper -c tests/config/nextflow.config
+  tags:
+    - spatyper
+  files:
+    - path: output/spatyper/test.tsv
+      md5sum: a698352823875171696e5e7ed7015c13
+
+- name: spatyper test_spatyper_enrich
+  command: nextflow run tests/modules/spatyper -entry test_spatyper_enrich -c tests/config/nextflow.config
+  tags:
+    - spatyper
+  files:
+    - path: output/spatyper/test.tsv
+      md5sum: a698352823875171696e5e7ed7015c13


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes https://github.com/nf-core/modules/issues/703<!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`


__NOTE:__ I think there is an issue with the Docker/Singularity containers. It passes with Conda.

Singularity
```
WARNING: Skipping mount /usr/local/var/singularity/mnt/session/etc/resolv.conf [files]: /etc/resolv.conf doesn't exist in container
  FATAL:   container creation failed: mount /tmp/pytest_workflow_5psgjkj7/spatyper_test_spatyper_enrich/work->/tmp/pytest_workflow_5psgjkj7/spatyper_test_spatyper_enrich/work error: while mounting /tmp/pytest_workflow_5psgjkj7/spatyper_test_spatyper_enrich/work: destination /tmp/pytest_workflow_5psgjkj7/spatyper_test_spatyper_enrich/work doesn't exist in container
```

Docker
```

Command output:
  Start the identification of repeats in Spa protein:
  + Check or download repeats fasta file in folder:  /usr/local/bin

Command error:
  WARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.
  Traceback (most recent call last):
    File "/usr/local/bin/spaTyper", line 92, in <module>
      args.repeat_file = spaTyper.utils.download_file_repeats(args.folder, args.debug)
    File "/usr/local/lib/python3.9/site-packages/spaTyper/utils.py", line 134, in download_file_repeats
      print_time_stamp(filename_stamp)
    File "/usr/local/lib/python3.9/site-packages/spaTyper/utils.py", line 192, in print_time_stamp
      timefile = open(out, 'w')
  PermissionError: [Errno 13] Permission denied: '/usr/local/bin/.success'
```