### PR TITLE
Update for mutect2: add output channel for stats file

### DIFF
--- a/modules/gatk4/mutect2/main.nf
+++ b/modules/gatk4/mutect2/main.nf
@@ -33,6 +33,7 @@ process GATK4_MUTECT2 {
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf
     tuple val(meta), path("*.tbi")   , emit: tbi
+    tuple val(meta), path("*.stats")   , emit: stats
     tuple val(meta), path("*.f1r2.tar.gz"), optional:true, emit: f1r2
     path "*.version.txt"          , emit: version
 

--- a/modules/gatk4/mutect2/main.nf
+++ b/modules/gatk4/mutect2/main.nf
@@ -31,11 +31,11 @@ process GATK4_MUTECT2 {
     path panel_of_normals_idx
 
     output:
-    tuple val(meta), path("*.vcf.gz"), emit: vcf
-    tuple val(meta), path("*.tbi")   , emit: tbi
-    tuple val(meta), path("*.stats")   , emit: stats
+    tuple val(meta), path("*.vcf.gz")     , emit: vcf
+    tuple val(meta), path("*.tbi")        , emit: tbi
+    tuple val(meta), path("*.stats")      , emit: stats
     tuple val(meta), path("*.f1r2.tar.gz"), optional:true, emit: f1r2
-    path "*.version.txt"          , emit: version
+    path "*.version.txt"                  , emit: version
 
     script:
     def software = getSoftwareName(task.process)

--- a/modules/gatk4/mutect2/meta.yml
+++ b/modules/gatk4/mutect2/meta.yml
@@ -76,6 +76,10 @@ output:
       type: file
       description: Index of vcf file
       pattern: "*vcf.gz.tbi"
+  - stats:
+      type: file
+      description: Stats file that pairs with output vcf file
+      pattern: "*vcf.gz.stats"
   - f1r2:
       type: file
       description: file containing information to be passed to LearnReadOrientationModel (only outputted when tumor_normal_pair mode is run)

--- a/tests/modules/gatk4/mutect2/test.yml
+++ b/tests/modules/gatk4/mutect2/test.yml
@@ -6,6 +6,8 @@
   files:
     - path: output/gatk4/test.f1r2.tar.gz
     - path: output/gatk4/test.vcf.gz
+    - path: output/gatk4/test.vcf.gz.stats
+      md5sum: 6ecb874e6a95aa48233587b876c2a7a9
     - path: output/gatk4/test.vcf.gz.tbi
 
 - name: gatk4 mutect2 test_gatk4_mutect2_tumor_single
@@ -15,6 +17,8 @@
     - gatk4/mutect2
   files:
     - path: output/gatk4/test.vcf.gz
+    - path: output/gatk4/test.vcf.gz.stats
+      md5sum: e7ef613f7d158b8a0adf44abe5db2029
     - path: output/gatk4/test.vcf.gz.tbi
 
 - name: gatk4 mutect2 test_gatk4_mutect2_generate_pon
@@ -24,4 +28,6 @@
     - gatk4/mutect2
   files:
     - path: output/gatk4/test.vcf.gz
+    - path: output/gatk4/test.vcf.gz.stats
+      md5sum: 4f77301a125913170b8e9e7828b4ca3f
     - path: output/gatk4/test.vcf.gz.tbi


### PR DESCRIPTION

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This pull request adds an output channel for the stats file generated by mutect2. File is necessary when running filtermutectcalls. Meta yml file updated to include new output. Tests.yml updated to expect the stats file as an output during testing.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Remove all TODO statements.
- [x] Emit the `<SOFTWARE>.version.txt` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
