### PR TITLE
Allow one single end or two paired end files in cat/fastq

### DIFF
--- a/modules/cat/fastq/main.nf
+++ b/modules/cat/fastq/main.nf
@@ -28,13 +28,13 @@ process CAT_FASTQ {
     def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def readList = reads.collect{ it.toString() }
     if (meta.single_end) {
-        if (readList.size > 1) {
+        if (readList.size >= 1) {
             """
             cat ${readList.sort().join(' ')} > ${prefix}.merged.fastq.gz
             """
         }
     } else {
-        if (readList.size > 2) {
+        if (readList.size >= 2) {
             def read1 = []
             def read2 = []
             readList.eachWithIndex{ v, ix -> ( ix & 1 ? read2 : read1 ) << v }

--- a/tests/modules/cat/fastq/main.nf
+++ b/tests/modules/cat/fastq/main.nf
@@ -4,7 +4,15 @@ nextflow.enable.dsl = 2
 
 include { CAT_FASTQ } from '../../../../modules/cat/fastq/main.nf' addParams( options: [:] )
 
-workflow test_cat_fastq_single_end {
+workflow test_cat_fastq_single_end_single_file {
+    input = [ [ id:'test', single_end:true ], // meta map
+              [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
+            ]
+
+    CAT_FASTQ ( input )
+}
+
+workflow test_cat_fastq_single_end_multiple_files {
     input = [ [ id:'test', single_end:true ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
                 file(params.test_data['sarscov2']['illumina']['test2_1_fastq_gz'], checkIfExists: true) ]
@@ -13,7 +21,16 @@ workflow test_cat_fastq_single_end {
     CAT_FASTQ ( input )
 }
 
-workflow test_cat_fastq_paired_end {
+workflow test_cat_fastq_paired_end_single_pair_files {
+    input = [ [ id:'test', single_end:false ], // meta map
+              [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
+            ]
+
+    CAT_FASTQ ( input )
+}
+
+workflow test_cat_fastq_paired_end_multiple_pair_files {
     input = [ [ id:'test', single_end:false ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
                 file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true),

--- a/tests/modules/cat/fastq/test.yml
+++ b/tests/modules/cat/fastq/test.yml
@@ -1,14 +1,34 @@
-- name: cat fastq single-end
-  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_single_end -c tests/config/nextflow.config
+- name: cat fastq single-end single file
+  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_single_end_single_file -c tests/config/nextflow.config
   tags:
     - cat
     - cat/fastq
   files:
-    - path: ./output/merged_fastq/test.merged.fastq.gz
+    - path: ./output/merged_fastq/test_single_end_single_file.merged.fastq.gz
+      md5sum: e325ef7deb4023447a1f074e285761af
+
+- name: cat fastq single-end multiple files
+  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_single_end_multiple_files -c tests/config/nextflow.config
+  tags:
+    - cat
+    - cat/fastq
+  files:
+    - path: ./output/merged_fastq/test_single_end_multiple_files.merged.fastq.gz
       md5sum: 59f6dbe193741bb40f498f254aeb2e99
 
-- name: cat fastq fastqc_paired_end
-  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_paired_end -c tests/config/nextflow.config
+- name: cat fastq fastqc_paired_end single pair files
+  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_paired_end_single_pair_file -c tests/config/nextflow.config
+  tags:
+    - cat
+    - cat/fastq
+  files:
+    - path: ./output/merged_fastq/test_2.merged.fastq.gz
+      md5sum: 22342ee8873e5bfa51b4707bb1d56ec6
+      - path: ./output/merged_fastq/test_1.merged.fastq.gz
+      md5sum: e325ef7deb4023447a1f074e285761af
+
+- name: cat fastq fastqc_paired_end multiple pair files
+  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_paired_end_multiple_pair_files -c tests/config/nextflow.config
   tags:
     - cat
     - cat/fastq

--- a/tests/modules/cat/fastq/test.yml
+++ b/tests/modules/cat/fastq/test.yml
@@ -24,7 +24,7 @@
   files:
     - path: ./output/merged_fastq/test_2.merged.fastq.gz
       md5sum: 22342ee8873e5bfa51b4707bb1d56ec6
-      - path: ./output/merged_fastq/test_1.merged.fastq.gz
+    - path: ./output/merged_fastq/test_1.merged.fastq.gz
       md5sum: e325ef7deb4023447a1f074e285761af
 
 - name: cat fastq fastqc_paired_end multiple pair files

--- a/tests/modules/cat/fastq/test.yml
+++ b/tests/modules/cat/fastq/test.yml
@@ -4,7 +4,7 @@
     - cat
     - cat/fastq
   files:
-    - path: ./output/merged_fastq/test_single_end_single_file.merged.fastq.gz
+    - path: ./output/merged_fastq/test.merged.fastq.gz
       md5sum: e325ef7deb4023447a1f074e285761af
 
 - name: cat fastq single-end multiple files
@@ -13,11 +13,11 @@
     - cat
     - cat/fastq
   files:
-    - path: ./output/merged_fastq/test_single_end_multiple_files.merged.fastq.gz
+    - path: ./output/merged_fastq/test.merged.fastq.gz
       md5sum: 59f6dbe193741bb40f498f254aeb2e99
 
 - name: cat fastq fastqc_paired_end single pair files
-  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_paired_end_single_pair_file -c tests/config/nextflow.config
+  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_paired_end_single_pair_files -c tests/config/nextflow.config
   tags:
     - cat
     - cat/fastq


### PR DESCRIPTION
While reviewing another issue, I noticed that attempting to cat one single end or two paired end files in `cat/fastq` would result in error, e.g.

```
$ PROFILE=docker nextflow run ./tests/modules/cat/fastq \
  -entry test_cat_fastq_paired_end_single_pair_files \
  -c tests/config/nextflow.config

N E X T F L O W  ~  version 21.04.1
Launching `./tests/modules/cat/fastq/main.nf` [chaotic_williams] - revision: a5ff39ccbb
executor >  local (1)
[8f/7b37c5] process > test_cat_fastq_paired_end_single_pair_files:CAT_FASTQ (test) [100%] 1 of 1, failed: 1 ✘
Error executing process > 'test_cat_fastq_paired_end_single_pair_files:CAT_FASTQ (test)'

Caused by:
  Process `test_cat_fastq_paired_end_single_pair_files:CAT_FASTQ (test)` terminated with an error exit status (127)

Command executed:

  null

Command exit status:
  127

Command output:
  (empty)

Command error:
  .command.sh: line 2: null: command not found
```

This pull request adds tests for those cases and fixes the errors.  I'm not sure if this helps though, perhaps this module was never intended to handle those cases.  There is still an issue if `input` were entirely empty, not sure what to do in that case.