### PR TITLE
Run CI only on pull-requests and on the master-branch.

### DIFF
--- a/.github/workflows/code-linting.yml
+++ b/.github/workflows/code-linting.yml
@@ -1,5 +1,10 @@
 name: Code Linting
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
 
 jobs:
   Markdown:

--- a/.github/workflows/nf-core-linting.yml
+++ b/.github/workflows/nf-core-linting.yml
@@ -1,7 +1,12 @@
 name: nf-core linting
 # This workflow is triggered on pushes and PRs to the repository.
 # It runs the `nf-core lint` tests to ensure that the module code meets the nf-core guidelines
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
 
 jobs:
   changes:

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -1,5 +1,9 @@
 name: Pytest-workflow
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   changes:


### PR DESCRIPTION
Currently the CI runs twice unless the PR comes from a forked repository, see for instance #739

![image](https://user-images.githubusercontent.com/7051479/134776897-273b4cd2-502c-42f2-8e46-8355b07142d3.png)

The suggested change makes the CI only run on pull requests, and if the changes actually get merged into the master branch. 