### PR TITLE
few version and test data config fixes

### DIFF
--- a/modules/chromap/chromap/main.nf
+++ b/modules/chromap/chromap/main.nf
@@ -41,9 +41,7 @@ process CHROMAP_CHROMAP {
     def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def args     = options.args.tokenize()
 
-    def file_extension = options.args.contains("--SAM")? 'sam' :
-                        options.args.contains("--TagAlign")? 'tagAlign' :
-                        options.args.contains("--pairs")? 'pairs' : 'bed'
+    def file_extension = options.args.contains("--SAM") ? 'sam' : options.args.contains("--TagAlign")? 'tagAlign' : options.args.contains("--pairs")? 'pairs' : 'bed'
     if (barcodes) {
         args << "-b ${barcodes.join(',')}"
         if (whitelist) {
@@ -56,9 +54,8 @@ process CHROMAP_CHROMAP {
     if (pairs_chr_order){
         args << "--pairs-natural-chr-order $pairs_chr_order"
     }
-    def compression_cmds = """
-    gzip ${prefix}.${file_extension}
-    """
+    def final_args = args.join(' ')
+    def compression_cmds = "gzip ${prefix}.${file_extension}"
     if (options.args.contains("--SAM")) {
         compression_cmds = """
         samtools view $options.args2 -@ ${task.cpus} -bh \\
@@ -68,7 +65,7 @@ process CHROMAP_CHROMAP {
     }
     if (meta.single_end) {
         """
-        chromap ${args.join(' ')} \\
+        chromap ${final_args} \\
             -t $task.cpus \\
             -x $index \\
             -r $fasta \\
@@ -84,7 +81,7 @@ process CHROMAP_CHROMAP {
         """
     } else {
         """
-        chromap ${args.join(' ')} \\
+        chromap ${final_args} \\
             -t $task.cpus \\
             -x $index \\
             -r $fasta \\

--- a/modules/delly/call/main.nf
+++ b/modules/delly/call/main.nf
@@ -41,7 +41,7 @@ process DELLY_CALL {
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$(delly --version 2>&1 | sed 's/^.*Delly //; s/Using.*\$//')
+        ${getSoftwareName(task.process)}: \$( echo \$(delly --version 2>&1) | sed 's/^.*Delly version: v//; s/ using.*\$//')
     END_VERSIONS
     """
 }

--- a/modules/ensemblvep/main.nf
+++ b/modules/ensemblvep/main.nf
@@ -59,7 +59,7 @@ process ENSEMBLVEP {
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$(vep --help 2>&1)
+        ${getSoftwareName(task.process)}: \$( echo \$(vep --help 2>&1) | sed 's/^.*Versions:.*ensembl-vep : //;s/ .*\$//')
     END_VERSIONS
     """
 }

--- a/modules/expansionhunter/main.nf
+++ b/modules/expansionhunter/main.nf
@@ -42,7 +42,7 @@ process EXPANSIONHUNTER {
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$(ExpansionHunter --version 2>&1 | sed 's/^.*ExpansionHunter //')
+        ${getSoftwareName(task.process)}: \$( echo \$(ExpansionHunter --version 2>&1) | sed 's/^.*ExpansionHunter v//')
     END_VERSIONS
     """
 }

--- a/modules/fgbio/callmolecularconsensusreads/main.nf
+++ b/modules/fgbio/callmolecularconsensusreads/main.nf
@@ -33,9 +33,10 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
         -i $bam \\
         $options.args \\
         -o ${prefix}.bam
+
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$(fgbio --version | sed -e "s/fgbio v//g")
+        ${getSoftwareName(task.process)}: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
     END_VERSIONS
     """
 }

--- a/modules/fgbio/sortbam/main.nf
+++ b/modules/fgbio/sortbam/main.nf
@@ -35,7 +35,7 @@ process FGBIO_SORTBAM {
         -o ${prefix}.bam
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$(fgbio --version | sed -e "s/fgbio v//g")
+        ${getSoftwareName(task.process)}: \$( echo \$(fgbio --version 2>&1 | tr -d '[:cntrl:]' ) | sed -e 's/^.*Version: //;s/\\[.*\$//')
     END_VERSIONS
     """
 }

--- a/modules/glnexus/main.nf
+++ b/modules/glnexus/main.nf
@@ -44,9 +44,10 @@ process GLNEXUS {
         $options.args \\
         ${input.join(' ')} \\
         > ${prefix}.bcf
+
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$(glnexus_cli 2>&1 | head -n 1 | sed 's/^.*release //; s/ .*\$//')
+        ${getSoftwareName(task.process)}: \$( echo \$(glnexus_cli 2>&1) | head -n 1 | sed 's/^.*release v//; s/ .*\$//')
     END_VERSIONS
     """
 }

--- a/modules/kleborate/main.nf
+++ b/modules/kleborate/main.nf
@@ -36,7 +36,7 @@ process KLEBORATE {
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$( echo \$(kleborate --version 2>&1 | sed 's/Kleborate v//;'))
+        ${getSoftwareName(task.process)}: \$( echo \$(kleborate --version | sed 's/Kleborate v//;'))
     END_VERSIONS
     """
 }

--- a/modules/kleborate/main.nf
+++ b/modules/kleborate/main.nf
@@ -36,7 +36,7 @@ process KLEBORATE {
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$(kleborate -v 2>&1 | sed 's/kleborate //;')
+        ${getSoftwareName(task.process)}: \$( echo \$(kleborate --version 2>&1 | sed 's/Kleborate v//;'))
     END_VERSIONS
     """
 }

--- a/modules/minia/main.nf
+++ b/modules/minia/main.nf
@@ -30,8 +30,9 @@ process MINIA {
     script:
     def software = getSoftwareName(task.process)
     def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    def read_list = reads.join(",")
     """
-    echo "${reads.join("\n")}" > input_files.txt
+    echo "${read_list}" | sed 's/,/\\n/g' > input_files.txt
     minia \\
         $options.args \\
         -nb-cores $task.cpus \\
@@ -40,7 +41,7 @@ process MINIA {
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:
-        ${getSoftwareName(task.process)}: \$(echo \$(minia --version 2>&1) | sed 's/^.*Minia version //; s/ .*\$//')
+        ${getSoftwareName(task.process)}: \$(echo \$(minia --version 2>&1 | grep Minia) | sed 's/^.*Minia version //;')
     END_VERSIONS
     """
 }

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -180,6 +180,7 @@ params {
                 ccs_fq                                        = "${test_data_dir}/genomics/homo_sapiens/pacbio/fastq/alz.ccs.fastq"
                 ccs_fq_gz                                     = "${test_data_dir}/genomics/homo_sapiens/pacbio/fastq/alz.ccs.fastq.gz"
                 ccs_xml                                       = "${test_data_dir}/genomics/homo_sapiens/pacbio/xml/alz.ccs.consensusreadset.xml"
+                hifi                                          = "${test_data_dir}/genomics/homo_sapiens/pacbio/fastq/test_hifi.fastq.gz"
                 lima                                          = "${test_data_dir}/genomics/homo_sapiens/pacbio/bam/alz.ccs.fl.NEB_5p--NEB_Clontech_3p.bam"
                 refine                                        = "${test_data_dir}/genomics/homo_sapiens/pacbio/bam/alz.ccs.fl.NEB_5p--NEB_Clontech_3p.flnc.bam"
                 cluster                                       = "${test_data_dir}/genomics/homo_sapiens/pacbio/bam/alz.ccs.fl.NEB_5p--NEB_Clontech_3p.flnc.clustered.bam"

--- a/tests/modules/delly/call/test.yml
+++ b/tests/modules/delly/call/test.yml
@@ -5,6 +5,6 @@
     - delly/call
   files:
     - path: output/delly/test.bcf
-      md5sum: b20df3b9086faccd6bfd2641d97712c8
+      md5sum: 360c1bf6867f33bd2a868ddfb4d957fc
     - path: output/delly/test.bcf.csi
       md5sum: 19e0cdf06c415f4942f6d4dbd5fb7271

--- a/tests/modules/hifiasm/main.nf
+++ b/tests/modules/hifiasm/main.nf
@@ -10,7 +10,7 @@ include { HIFIASM } from '../../../modules/hifiasm/main.nf' addParams( options: 
 workflow test_hifiasm_hifi_only {
     input = [
         [ id:'test' ], // meta map
-        [ file(params.test_data['homo_sapiens']['pacbio']['test_hifi_fastq_gz'], checkIfExists: true) ]
+        [ file(params.test_data['homo_sapiens']['pacbio']['hifi'], checkIfExists: true) ]
     ]
 
     HIFIASM ( input, [], [], false )
@@ -22,7 +22,7 @@ workflow test_hifiasm_hifi_only {
 workflow test_hifiasm_with_parental_reads {
     input = [
         [ id:'test' ], // meta map
-        [ file(params.test_data['homo_sapiens']['pacbio']['test_hifi_fastq_gz'], checkIfExists: true) ]
+        [ file(params.test_data['homo_sapiens']['pacbio']['hifi'], checkIfExists: true) ]
     ]
     paternal_kmer_dump = file(params.test_data['homo_sapiens']['illumina']['test_yak'], checkIfExists: true)
     maternal_kmer_dump = file(params.test_data['homo_sapiens']['illumina']['test2_yak'], checkIfExists: true)


### PR DESCRIPTION
- Fixes `chromap/chromap`, `delly/call`, `ensemblevep`, `expansionhunter`, `fgbio/callmolecularconsensusreads`, `fgbio/sortbam`, `glnexus`, `kleborate`, `minia`
    - For `minia` I changed how the input list is created due changes in indentation created by previous method
        - had to do something similar with  `chromap`  
    - `fgbio` had color codes in the version that had to be removed
- Added `hifi` to test_data.config to make `hifiasm` work again
