### PR TITLE
remove cpu restrictions for piped commands

### DIFF
--- a/modules/bowtie/align/main.nf
+++ b/modules/bowtie/align/main.nf
@@ -29,7 +29,6 @@ process BOWTIE_ALIGN {
     tuple val(meta), path('*fastq.gz'), optional:true, emit: fastq
 
     script:
-    def split_cpus = Math.floor(task.cpus/2)
     def software  = getSoftwareName(task.process)
     def prefix    = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def unaligned = params.save_unaligned ? "--un ${prefix}.unmapped.fastq" : ''
@@ -37,7 +36,7 @@ process BOWTIE_ALIGN {
     """
     INDEX=`find -L ./ -name "*.3.ebwt" | sed 's/.3.ebwt//'`
     bowtie \\
-        --threads ${split_cpus} \\
+        --threads $task.cpus \\
         --sam \\
         -x \$INDEX \\
         -q \\
@@ -45,7 +44,7 @@ process BOWTIE_ALIGN {
         $options.args \\
         $endedness \\
         2> ${prefix}.out \\
-        | samtools view $options.args2 -@ ${split_cpus} -bS -o ${prefix}.bam -
+        | samtools view $options.args2 -@ $task.cpus -bS -o ${prefix}.bam -
 
     if [ -f ${prefix}.unmapped.fastq ]; then
         gzip ${prefix}.unmapped.fastq

--- a/modules/bowtie2/align/main.nf
+++ b/modules/bowtie2/align/main.nf
@@ -29,7 +29,6 @@ process BOWTIE2_ALIGN {
     tuple val(meta), path('*fastq.gz'), optional:true, emit: fastq
 
     script:
-    def split_cpus = Math.floor(task.cpus/2)
     def software   = getSoftwareName(task.process)
     def prefix     = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     if (meta.single_end) {
@@ -39,11 +38,11 @@ process BOWTIE2_ALIGN {
         bowtie2 \\
             -x \$INDEX \\
             -U $reads \\
-            --threads $split_cpus \\
+            --threads $task.cpus \\
             $unaligned \\
             $options.args \\
             2> ${prefix}.bowtie2.log \\
-            | samtools view -@ ${split_cpus} $options.args2 -bhS -o ${prefix}.bam -
+            | samtools view -@ $task.cpus $options.args2 -bhS -o ${prefix}.bam -
 
         cat <<-END_VERSIONS > versions.yml
         ${getProcessName(task.process)}:
@@ -60,11 +59,11 @@ process BOWTIE2_ALIGN {
             -x \$INDEX \\
             -1 ${reads[0]} \\
             -2 ${reads[1]} \\
-            --threads $split_cpus \\
+            --threads $task.cpus \\
             $unaligned \\
             $options.args \\
             2> ${prefix}.bowtie2.log \\
-            | samtools view -@ ${split_cpus} $options.args2 -bhS -o ${prefix}.bam -
+            | samtools view -@ $task.cpus $options.args2 -bhS -o ${prefix}.bam -
 
         if [ -f ${prefix}.unmapped.fastq.1.gz ]; then
             mv ${prefix}.unmapped.fastq.1.gz ${prefix}.unmapped_1.fastq.gz

--- a/modules/bwa/mem/main.nf
+++ b/modules/bwa/mem/main.nf
@@ -27,7 +27,6 @@ process BWA_MEM {
     path  "versions.yml"          , emit: version
 
     script:
-    def split_cpus = Math.floor(task.cpus/2)
     def software   = getSoftwareName(task.process)
     def prefix     = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def read_group = meta.read_group ? "-R ${meta.read_group}" : ""
@@ -37,10 +36,10 @@ process BWA_MEM {
     bwa mem \\
         $options.args \\
         $read_group \\
-        -t $split_cpus \\
+        -t $task.cpus \\
         \$INDEX \\
         $reads \\
-        | samtools view $options.args2 -@ ${split_cpus} -bhS -o ${prefix}.bam -
+        | samtools view $options.args2 -@ $task.cpus -bhS -o ${prefix}.bam -
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:

--- a/modules/bwamem2/mem/main.nf
+++ b/modules/bwamem2/mem/main.nf
@@ -27,7 +27,6 @@ process BWAMEM2_MEM {
     path  "versions.yml"          , emit: version
 
     script:
-    def split_cpus = Math.floor(task.cpus/2)
     def software   = getSoftwareName(task.process)
     def prefix     = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def read_group = meta.read_group ? "-R ${meta.read_group}" : ""
@@ -38,10 +37,10 @@ process BWAMEM2_MEM {
         mem \\
         $options.args \\
         $read_group \\
-        -t $split_cpus \\
+        -t $task.cpus \\
         \$INDEX \\
         $reads \\
-        | samtools view $options.args2 -@ ${split_cpus} -bhS -o ${prefix}.bam -
+        | samtools view $options.args2 -@ $task.cpus -bhS -o ${prefix}.bam -
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:

--- a/modules/bwameth/align/main.nf
+++ b/modules/bwameth/align/main.nf
@@ -27,7 +27,6 @@ process BWAMETH_ALIGN {
     path  "versions.yml"          , emit: version
 
     script:
-    def split_cpus = Math.floor(task.cpus/2)
     def software   = getSoftwareName(task.process)
     def prefix     = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def read_group = meta.read_group ? "-R ${meta.read_group}" : ""
@@ -37,10 +36,10 @@ process BWAMETH_ALIGN {
     bwameth.py \\
         $options.args \\
         $read_group \\
-        -t ${split_cpus} \\
+        -t $task.cpus \\
         --reference \$INDEX \\
         $reads \\
-        | samtools view $options.args2 -@ ${split_cpus} -bhS -o ${prefix}.bam -
+        | samtools view $options.args2 -@ $task.cpus -bhS -o ${prefix}.bam -
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:


### PR DESCRIPTION
In case of modules with piped commands, currently, we are splitting the number of cpus assigned for that process equally between the two softwares. This is good idea in general, but when we have a combination of aligner and samtools (for converting the resulting output to bam), I think it is very inefficient to assign half the number of cpus to samtools when the rate limiting step here is the alignment.

These are the affected modules.
-  bowtie/align
-  bowtie2/align
-  bwa/mem
-  bwamem2/mem
-  bwameth/align

Based on the comments and discussion in the nf-core slack channel [here](https://nfcore.slack.com/archives/CJRH30T6V/p1632822976224200), [here](https://nfcore.slack.com/archives/CJRH30T6V/p1632822291214200), and [here](https://nfcore.slack.com/archives/CJRH30T6V/p1632822851221500), I am getting rid of these restrictions in this PR. The rationale being that these manual restrictions hurt most users, and almost all schedulers in use today should be able to handle resource allocation efficiently on their own. 

Should anyone face any issues due to changes in this PR there are other workarounds (like, taskset) that they can adopt to fix those issues. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
