### PR TITLE
Add custom/dumpsoftwareversions modules for nf-core pipeline template

### DIFF
--- a/modules/custom/dumpsoftwareversions/functions.nf
+++ b/modules/custom/dumpsoftwareversions/functions.nf
@@ -1,0 +1,78 @@
+//
+//  Utility functions used in nf-core DSL2 module files
+//
+
+//
+// Extract name of software tool from process name using $task.process
+//
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+//
+// Extract name of module from process name using $task.process
+//
+def getProcessName(task_process) {
+    return task_process.tokenize(':')[-1]
+}
+
+//
+// Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+//
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
+    return options
+}
+
+//
+// Tidy up and join elements of a list to return a path string
+//
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+//
+// Function to save/publish module results
+//
+def saveFiles(Map args) {
+    def ioptions  = initOptions(args.options)
+    def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+
+    // Do not publish versions.yml unless running from pytest workflow
+    if (args.filename.equals('versions.yml') && !System.getenv("NF_CORE_MODULES_TEST")) {
+        return null
+    }
+    if (ioptions.publish_by_meta) {
+        def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+        for (key in key_list) {
+            if (args.meta && key instanceof String) {
+                def path = key
+                if (args.meta.containsKey(key)) {
+                    path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                }
+                path = path instanceof String ? path : ''
+                path_list.add(path)
+            }
+        }
+    }
+    if (ioptions.publish_files instanceof Map) {
+        for (ext in ioptions.publish_files) {
+            if (args.filename.endsWith(ext.key)) {
+                def ext_list = path_list.collect()
+                ext_list.add(ext.value)
+                return "${getPathFromList(ext_list)}/$args.filename"
+            }
+        }
+    } else if (ioptions.publish_files == null) {
+        return "${getPathFromList(path_list)}/$args.filename"
+    }
+}

--- a/modules/custom/dumpsoftwareversions/main.nf
+++ b/modules/custom/dumpsoftwareversions/main.nf
@@ -1,0 +1,105 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName; getProcessName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process CUSTOM_DUMPSOFTWAREVERSIONS {
+    label 'process_low'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'pipeline_info', meta:[:], publish_by_meta:[]) }
+
+    // Requires `pyyaml` which does not have a dedicated container but is in the MultiQC container
+    conda (params.enable_conda ? "bioconda::multiqc=1.11" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/multiqc:1.11--pyhdfd78af_0"
+    } else {
+        container "quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0"
+    }
+
+    input:
+    path versions
+
+    output:
+    path 'software_versions.yml'    , emit: yml
+    path 'software_versions_mqc.yml', emit: mqc_yaml
+    path 'versions.yml'             , emit: versions
+
+    script:
+    """
+    #!/usr/bin/env python
+
+    import yaml
+    import platform
+    from textwrap import dedent
+
+    def _make_versions_html(versions):
+        html = [
+            dedent(
+                '''\\
+                <style>
+                #nf-core-versions tbody:nth-child(even) {
+                    background-color: #f2f2f2;
+                }
+                </style>
+                <table class="table" style="width:100%" id="nf-core-versions">
+                    <thead>
+                        <tr>
+                            <th> Process Name </th>
+                            <th> Software </th>
+                            <th> Version  </th>
+                        </tr>
+                    </thead>
+                '''
+            )
+        ]
+        for process, tmp_versions in sorted(versions.items()):
+            html.append("<tbody>")
+            for i, (tool, version) in enumerate(sorted(tmp_versions.items())):
+                html.append(
+                    dedent(
+                        f'''\\
+                        <tr>
+                            <td><samp>{process if (i == 0) else ''}</samp></td>
+                            <td><samp>{tool}</samp></td>
+                            <td><samp>{version}</samp></td>
+                        </tr>
+                        '''
+                    )
+                )
+            html.append("</tbody>")
+        html.append("</table>")
+        return "\\n".join(html)
+
+    with open("$versions") as f:
+        versions = yaml.safe_load(f)
+
+    versions["Workflow"] = {
+        "Nextflow": "$workflow.nextflow.version",
+        "$workflow.manifest.name": "$workflow.manifest.version"
+    }
+
+    versions_mqc = {
+        'id': 'software_versions',
+        'section_name': '${workflow.manifest.name} Software Versions',
+        'section_href': 'https://github.com/${workflow.manifest.name}',
+        'plot_type': 'html',
+        'description': 'are collected at run time from the software output.',
+        'data': _make_versions_html(versions)
+    }
+
+    with open("software_versions.yml", 'w') as f:
+        yaml.dump(versions, f, default_flow_style=False)
+    with open("software_versions_mqc.yml", 'w') as f:
+        yaml.dump(versions_mqc, f, default_flow_style=False)
+
+    yaml_version = {}
+    yaml_version["${getProcessName(task.process)}"] = {
+        'python': platform.python_version(),
+        'yaml': yaml.__version__
+    }
+    with open('versions.yml', 'w') as f:
+        yaml.dump(yaml_version, f, default_flow_style=False)
+    """
+}

--- a/modules/custom/dumpsoftwareversions/meta.yml
+++ b/modules/custom/dumpsoftwareversions/meta.yml
@@ -1,0 +1,33 @@
+name: custom_dumpsoftwareversions
+description: Custom module used to dump software versions within the nf-core pipeline template
+keywords:
+  - custom
+  - version
+tools:
+  - custom:
+      description: Custom module used to dump software versions within the nf-core pipeline template
+      homepage: https://github.com/nf-core/tools
+      documentation: https://github.com/nf-core/tools
+
+input:
+  - versions:
+      type: file
+      description: YML file containing software versions
+      pattern: "*.yml"
+
+output:
+  - yml:
+      type: file
+      description: Standard YML file containing software versions
+      pattern: "software_versions.yml"
+  - mqc_yml:
+      type: file
+      description: MultiQC custom content YML file containing software versions
+      pattern: "software_versions_mqc.yml"
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "versions.yml"
+
+authors:
+  - "@drpatelh"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -258,6 +258,10 @@ cooler/dump:
   - modules/cooler/dump/**
   - tests/modules/cooler/dump/**
 
+custom/dumpsoftwareversions:
+  - modules/custom/dumpsoftwareversions/**
+  - tests/modules/custom/dumpsoftwareversions/**
+
 cutadapt:
   - modules/cutadapt/**
   - tests/modules/cutadapt/**
@@ -286,13 +290,13 @@ delly/call:
   - modules/delly/call/**
   - tests/modules/delly/call/**
 
-diamond/blastx:
-  - modules/diamond/blastx/**
-  - tests/modules/diamond/blastx/**
-
 diamond/blastp:
   - modules/diamond/blastp/**
   - tests/modules/diamond/blastp/**
+
+diamond/blastx:
+  - modules/diamond/blastx/**
+  - tests/modules/diamond/blastx/**
 
 diamond/makedb:
   - modules/diamond/makedb/**

--- a/tests/modules/custom/dumpsoftwareversions/main.nf
+++ b/tests/modules/custom/dumpsoftwareversions/main.nf
@@ -1,0 +1,24 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { FASTQC                      } from '../../../../modules/fastqc/main.nf'                      addParams( options: [:]                    )
+include { MULTIQC                     } from '../../../../modules/multiqc/main.nf'                     addParams( options: [:]                    )
+include { CUSTOM_DUMPSOFTWAREVERSIONS } from '../../../../modules/custom/dumpsoftwareversions/main.nf' addParams( options: [publish_dir:'custom'] )
+
+workflow test_custom_dumpsoftwareversions {
+    input = [
+        [ id: 'test', single_end: false ],
+        [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
+    ]
+
+    FASTQC  ( input )
+    MULTIQC ( FASTQC.out.zip.collect { it[1] } )
+
+    ch_software_versions = Channel.empty()
+    ch_software_versions = ch_software_versions.mix(FASTQC.out.version)
+    ch_software_versions = ch_software_versions.mix(MULTIQC.out.version)
+
+    CUSTOM_DUMPSOFTWAREVERSIONS ( ch_software_versions.collectFile() )
+}

--- a/tests/modules/custom/dumpsoftwareversions/test.yml
+++ b/tests/modules/custom/dumpsoftwareversions/test.yml
@@ -1,0 +1,10 @@
+- name: custom dumpsoftwareversions
+  command: nextflow run ./tests/modules/custom/dumpsoftwareversions -entry test_custom_dumpsoftwareversions -c tests/config/nextflow.config
+  tags:
+    - custom
+    - custom/dumpsoftwareversions
+  files:
+    - path: output/custom/software_versions.yml
+      md5sum: 43b30e450c2ec438393284c0df55f785
+    - path: output/custom/software_versions_mqc.yml
+      md5sum: 80a90d05474c9fdd7b1aebe3a543e308

--- a/tests/modules/custom/dumpsoftwareversions/test.yml
+++ b/tests/modules/custom/dumpsoftwareversions/test.yml
@@ -5,6 +5,4 @@
     - custom/dumpsoftwareversions
   files:
     - path: output/custom/software_versions.yml
-      md5sum: 43b30e450c2ec438393284c0df55f785
     - path: output/custom/software_versions_mqc.yml
-      md5sum: 80a90d05474c9fdd7b1aebe3a543e308


### PR DESCRIPTION
* Updated version of (and closes) https://github.com/nf-core/modules/pull/368
* Since the Python code is self-contained within the module we don't have to worry about providing a separate executable for the module
* We can now install this module directly into the pipeline template
* Can't check for md5sums in the tests because the NF version outputted to the YAML will be subjective on where you run the tests
