### PR TITLE
add mashtree module

### DIFF
--- a/modules/mashtree/functions.nf
+++ b/modules/mashtree/functions.nf
@@ -1,0 +1,78 @@
+//
+//  Utility functions used in nf-core DSL2 module files
+//
+
+//
+// Extract name of software tool from process name using $task.process
+//
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+//
+// Extract name of module from process name using $task.process
+//
+def getProcessName(task_process) {
+    return task_process.tokenize(':')[-1]
+}
+
+//
+// Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+//
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
+    return options
+}
+
+//
+// Tidy up and join elements of a list to return a path string
+//
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+//
+// Function to save/publish module results
+//
+def saveFiles(Map args) {
+    def ioptions  = initOptions(args.options)
+    def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+
+    // Do not publish versions.yml unless running from pytest workflow
+    if (args.filename.equals('versions.yml') && !System.getenv("NF_CORE_MODULES_TEST")) {
+        return null
+    }
+    if (ioptions.publish_by_meta) {
+        def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+        for (key in key_list) {
+            if (args.meta && key instanceof String) {
+                def path = key
+                if (args.meta.containsKey(key)) {
+                    path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                }
+                path = path instanceof String ? path : ''
+                path_list.add(path)
+            }
+        }
+    }
+    if (ioptions.publish_files instanceof Map) {
+        for (ext in ioptions.publish_files) {
+            if (args.filename.endsWith(ext.key)) {
+                def ext_list = path_list.collect()
+                ext_list.add(ext.value)
+                return "${getPathFromList(ext_list)}/$args.filename"
+            }
+        }
+    } else if (ioptions.publish_files == null) {
+        return "${getPathFromList(path_list)}/$args.filename"
+    }
+}

--- a/modules/mashtree/main.nf
+++ b/modules/mashtree/main.nf
@@ -1,0 +1,44 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName; getProcessName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process MASHTREE {
+    tag "$meta.id"
+    label 'process_medium'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+
+    conda (params.enable_conda ? "bioconda::mashtree=1.2.0" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/mashtree:1.2.0--pl526h516909a_0"
+    } else {
+        container "quay.io/biocontainers/mashtree:1.2.0--pl526h516909a_0"
+    }
+
+    input:
+    tuple val(meta), path(seqs)
+
+    output:
+    tuple val(meta), path("*.dnd"), emit: tree
+    tuple val(meta), path("*.tsv"), emit: matrix
+    path "versions.yml"          , emit: version
+
+    script:
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    """
+    mashtree \\
+        $options.args \\
+        --numcpus $task.cpus \\
+        --outmatrix ${prefix}.tsv \\
+        --outtree ${prefix}.dnd \\
+        $seqs
+
+    cat <<-END_VERSIONS > versions.yml
+    ${getProcessName(task.process)}:
+        mashtree: \$( echo \$( mashtree --version 2>&1 ) | sed 's/^.*Mashtree //' )
+    END_VERSIONS
+    """
+}

--- a/modules/mashtree/meta.yml
+++ b/modules/mashtree/meta.yml
@@ -1,0 +1,49 @@
+name: mashtree
+description: Quickly create a tree using Mash distances
+keywords:
+  - tree
+  - mash
+  - fasta
+  - fastq
+tools:
+  - mashtree:
+      description: Create a tree using Mash distances
+      homepage: https://github.com/lskatz/mashtree
+      documentation: https://github.com/lskatz/mashtree
+      tool_dev_url: https://github.com/lskatz/mashtree
+      doi: "https://doi.org/10.21105/joss.01762"
+      licence: ['GPL v3']
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - seqs:
+      type: file
+      description: FASTA, FASTQ, GenBank, or Mash sketch files
+      pattern: "*.{fna,fna.gz,fasta,fasta.gz,fa,fa.gz,gbk,gbk.gz,fastq.gz,msh}"
+
+## TODO nf-core: Add a description of all of the variables used as output
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - version:
+      type: file
+      description: File containing software version
+      pattern: "versions.yml"
+  - tree:
+      type: file
+      description: A Newick formatted tree file
+      pattern: "*.{dnd}"
+  - matrix:
+      type: file
+      description: A TSV matrix of pair-wise Mash distances
+      pattern: "*.{tsv}"
+
+authors:
+  - "@rpetit3"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -602,6 +602,10 @@ mash/sketch:
   - modules/mash/sketch/**
   - tests/modules/mash/sketch/**
 
+mashtree:
+  - modules/mashtree/**
+  - tests/modules/mashtree/**
+
 metaphlan3:
   - modules/metaphlan3/**
   - tests/modules/metaphlan3/**

--- a/tests/modules/mashtree/main.nf
+++ b/tests/modules/mashtree/main.nf
@@ -1,0 +1,16 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { MASHTREE } from '../../../modules/mashtree/main.nf' addParams( options: [:] )
+
+workflow test_mashtree {
+    
+    input = [ 
+        [ id:'test', single_end:false ], // meta map
+        [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
+          file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
+    ]
+
+    MASHTREE ( input )
+}

--- a/tests/modules/mashtree/test.yml
+++ b/tests/modules/mashtree/test.yml
@@ -1,0 +1,9 @@
+- name: mashtree test_mashtree
+  command: nextflow run tests/modules/mashtree -entry test_mashtree -c tests/config/nextflow.config
+  tags:
+    - mashtree
+  files:
+    - path: output/mashtree/test.dnd
+      md5sum: 007b3949a9f0c991624791d2fb076824
+    - path: output/mashtree/test.tsv
+      md5sum: 7bc66e2f87c4bfa93e20e296eed4270d


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes https://github.com/nf-core/modules/issues/766<!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`


This PR adds a module for mashtree. Mashtree allows different inputs (FASTA, FASTQ, Genbank, Mash sketches) so I just called them `seqs`. If there is a better variable name please let me know.

### Test outputs

#### `test.dnd`
```
(genome:0.18629,test_1:0.18629);
```

#### `test.tsv`
```
.       genome  test_1
genome  0       0.372583
test_1  0.372583        0
```

#### `versions.yml`
```
MASHTREE:
    mashtree: 1.2.0
```