### PR TITLE
add csvtk/concat module

### DIFF
--- a/modules/csvtk/concat/functions.nf
+++ b/modules/csvtk/concat/functions.nf
@@ -1,0 +1,78 @@
+//
+//  Utility functions used in nf-core DSL2 module files
+//
+
+//
+// Extract name of software tool from process name using $task.process
+//
+def getSoftwareName(task_process) {
+    return task_process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()
+}
+
+//
+// Extract name of module from process name using $task.process
+//
+def getProcessName(task_process) {
+    return task_process.tokenize(':')[-1]
+}
+
+//
+// Function to initialise default values and to generate a Groovy Map of available options for nf-core modules
+//
+def initOptions(Map args) {
+    def Map options = [:]
+    options.args            = args.args ?: ''
+    options.args2           = args.args2 ?: ''
+    options.args3           = args.args3 ?: ''
+    options.publish_by_meta = args.publish_by_meta ?: []
+    options.publish_dir     = args.publish_dir ?: ''
+    options.publish_files   = args.publish_files
+    options.suffix          = args.suffix ?: ''
+    return options
+}
+
+//
+// Tidy up and join elements of a list to return a path string
+//
+def getPathFromList(path_list) {
+    def paths = path_list.findAll { item -> !item?.trim().isEmpty() }      // Remove empty entries
+    paths     = paths.collect { it.trim().replaceAll("^[/]+|[/]+\$", "") } // Trim whitespace and trailing slashes
+    return paths.join('/')
+}
+
+//
+// Function to save/publish module results
+//
+def saveFiles(Map args) {
+    def ioptions  = initOptions(args.options)
+    def path_list = [ ioptions.publish_dir ?: args.publish_dir ]
+
+    // Do not publish versions.yml unless running from pytest workflow
+    if (args.filename.equals('versions.yml') && !System.getenv("NF_CORE_MODULES_TEST")) {
+        return null
+    }
+    if (ioptions.publish_by_meta) {
+        def key_list = ioptions.publish_by_meta instanceof List ? ioptions.publish_by_meta : args.publish_by_meta
+        for (key in key_list) {
+            if (args.meta && key instanceof String) {
+                def path = key
+                if (args.meta.containsKey(key)) {
+                    path = args.meta[key] instanceof Boolean ? "${key}_${args.meta[key]}".toString() : args.meta[key]
+                }
+                path = path instanceof String ? path : ''
+                path_list.add(path)
+            }
+        }
+    }
+    if (ioptions.publish_files instanceof Map) {
+        for (ext in ioptions.publish_files) {
+            if (args.filename.endsWith(ext.key)) {
+                def ext_list = path_list.collect()
+                ext_list.add(ext.value)
+                return "${getPathFromList(ext_list)}/$args.filename"
+            }
+        }
+    } else if (ioptions.publish_files == null) {
+        return "${getPathFromList(path_list)}/$args.filename"
+    }
+}

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -1,0 +1,49 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName; getProcessName } from './functions'
+params.options = [:]
+options        = initOptions(params.options)
+
+process CSVTK_CONCAT {
+    tag "$meta.id"
+    label 'process_low'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+
+    conda (params.enable_conda ? "bioconda::csvtk=0.23.0" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/csvtk:0.23.0--h9ee0642_0"
+    } else {
+        container "quay.io/biocontainers/csvtk:0.23.0--h9ee0642_0"
+    }
+
+    input:
+    tuple val(meta), path(csv)
+    val(in_format)
+    val(out_format)
+
+    output:
+    tuple val(meta), path("*.${out_format}"), emit: table
+    path "versions.yml"                     , emit: versions
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    def delimiter = in_format == "tsv" ? "\t" : ","
+    def out_delimiter = out_format == "tsv" ? "\t" : ","
+    """
+    csvtk \\
+        concat \\
+        $options.args \\
+        --num-cpus ${task.cpus} \\
+        --delimiter "${delimiter}" \\
+        --out-delimiter "${out_delimiter}" \\
+        --out-file ${prefix}.${out_format} \\
+        ${csv}
+
+    cat <<-END_VERSIONS > versions.yml
+    ${getProcessName(task.process)}:
+        csvtk: \$(echo \$( csvtk version | sed -e "s/csvtk v//g" ))
+    END_VERSIONS
+    """
+}

--- a/modules/csvtk/concat/meta.yml
+++ b/modules/csvtk/concat/meta.yml
@@ -1,0 +1,51 @@
+name: csvtk_concat
+description: Concatenate two or more CSV (or TSV) tables into a single table
+keywords:
+  - concatenate
+  - tsv
+  - csv
+tools:
+  - csvtk:
+      description: A cross-platform, efficient, practical CSV/TSV toolkit
+      homepage: http://bioinf.shenwei.me/csvtk
+      documentation: http://bioinf.shenwei.me/csvtk
+      tool_dev_url: https://github.com/shenwei356/csvtk
+      doi: ""
+      licence: ['MIT']
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - csv:
+      type: file
+      description: CSV/TSV formatted files
+      pattern: "*.{csv,tsv}"
+  - in_format:
+      type: string
+      description: Input format (csv, tab, or a delimiting character)
+      pattern: "*"
+  - out_format:
+      type: string
+      description: Output format (csv, tab, or a delimiting character)
+      pattern: "*"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "version.yml"
+  - csv:
+      type: file
+      description: Concatenated CSV/TSV file
+      pattern: "*.{csv,tsv}"
+
+authors:
+  - "@rpetit3"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -266,6 +266,10 @@ cooler/dump:
   - modules/cooler/dump/**
   - tests/modules/cooler/dump/**
 
+csvtk/concat:
+  - modules/csvtk/concat/**
+  - tests/modules/csvtk/concat/**
+
 custom/dumpsoftwareversions:
   - modules/custom/dumpsoftwareversions/**
   - tests/modules/custom/dumpsoftwareversions/**

--- a/tests/modules/csvtk/concat/main.nf
+++ b/tests/modules/csvtk/concat/main.nf
@@ -1,0 +1,20 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { CSVTK_CONCAT } from '../../../../modules/csvtk/concat/main.nf' addParams( options: [:] )
+
+workflow test_csvtk_concat {
+
+    input = [ 
+        [ id:'test' ], // meta map
+        [ file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_hybrid.csv", checkIfExists: true),
+          file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_long.csv", checkIfExists: true),
+          file("https://github.com/nf-core/test-datasets/raw/bacass/bacass_short.csv", checkIfExists: true) ]
+    ]
+
+    in_format = "tsv"
+    out_format = "csv"
+
+    CSVTK_CONCAT ( input, in_format, out_format )
+}

--- a/tests/modules/csvtk/concat/test.yml
+++ b/tests/modules/csvtk/concat/test.yml
@@ -1,0 +1,8 @@
+- name: csvtk concat
+  command: nextflow run ./tests/modules/csvtk/concat -entry test_csvtk_concat -c tests/config/nextflow.config
+  tags:
+    - csvtk
+    - csvtk/concat
+  files:
+    - path: output/csvtk/test.csv
+      md5sum: 917fe5d857f04b58e0f49c384d167cec


### PR DESCRIPTION
I goofed and reworked, which broke my ability to edit this PR https://github.com/nf-core/modules/pull/751

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes https://github.com/nf-core/modules/issues/747 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`


So a few things

1. I used TSVs from the bacass test-data.

2. Should I even do the "extension guessing" or just always make it `.csv`? Currently it will give `.tsv` to TSV files

3. CSVTK, allows you to use any input or output delimiter (e.g. `;`, `,`, `\t`, `-`, etc...). I need guidance on how we approach this (allow all our only `,` (csv) and `\t` (tsv). 

This PR will probably be the framework for additional CSVTK sub-commands, so I'm OK with making changes.  Thank you very much for you help!