### PR TITLE
Correct parsing versions with trailing zeros

### DIFF
--- a/modules/custom/dumpsoftwareversions/main.nf
+++ b/modules/custom/dumpsoftwareversions/main.nf
@@ -24,7 +24,7 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     output:
     path "software_versions.yml"    , emit: yml
     path "software_versions_mqc.yml", emit: mqc_yml
-    path "versions.yml"             , emit: versions
+    path "versions.out.yml"         , emit: versions
 
     script:
     """
@@ -79,7 +79,7 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     }
 
     with open("$versions") as f:
-        workflow_versions = yaml.safe_load(f) | module_versions
+        workflow_versions =  yaml.load(f, Loader=yaml.BaseLoader) | module_versions
 
     workflow_versions["Workflow"] = {
         "Nextflow": "$workflow.nextflow.version",
@@ -100,7 +100,7 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     with open("software_versions_mqc.yml", 'w') as f:
         yaml.dump(versions_mqc, f, default_flow_style=False)
 
-    with open('versions.yml', 'w') as f:
+    with open('versions.out.yml', 'w') as f:
         yaml.dump(module_versions, f, default_flow_style=False)
     """
 }


### PR DESCRIPTION
Versions such as `samtools 1.10` were not correctly reported due to trailing zeros. This PR fixes it.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
