### PR TITLE
patch output extension in csvtk/concat

### DIFF
--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -24,11 +24,11 @@ process CSVTK_CONCAT {
     val out_format
 
     output:
-    tuple val(meta), path("*.{tsv,csv}"), emit: csv
-    path "versions.yml"                 , emit: versions
+    tuple val(meta), path("${prefix}.{tsv,csv}"), emit: csv
+    path "versions.yml"                         , emit: versions
 
     script:
-    def prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def delimiter = in_format == "tsv" ? "\t" : (in_format == "csv" ? "," : in_format)
     def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
     def out_extension = out_format == "tsv" ? 'tsv' : 'csv'

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -24,14 +24,14 @@ process CSVTK_CONCAT {
     val out_format
 
     output:
-    tuple val(meta), path("${prefix}.{tsv,csv}"), emit: csv
+    tuple val(meta), path("${prefix}.${out_extension}"), emit: csv
     path "versions.yml"                         , emit: versions
 
     script:
     prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def delimiter = in_format == "tsv" ? "\t" : (in_format == "csv" ? "," : in_format)
     def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
-    def out_extension = out_format == "tsv" ? 'tsv' : 'csv'
+    out_extension = out_format == "tsv" ? 'tsv' : 'csv'
     """
     csvtk \\
         concat \\

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -25,7 +25,7 @@ process CSVTK_CONCAT {
 
     output:
     tuple val(meta), path("*.{tsv,csv}"), emit: csv
-    path "versions.yml"                  , emit: versions
+    path "versions.yml"                 , emit: versions
 
     script:
     def prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -39,7 +39,7 @@ process CSVTK_CONCAT {
         --num-cpus $task.cpus \\
         --delimiter "${delimiter}" \\
         --out-delimiter "${out_delimiter}" \\
-        --out-file ${prefix}.${out_format} \\
+        --out-file ${prefix}.${out_extension} \\
         $csv
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -25,7 +25,7 @@ process CSVTK_CONCAT {
 
     output:
     tuple val(meta), path("${prefix}.${out_extension}"), emit: csv
-    path "versions.yml"                         , emit: versions
+    path "versions.yml"                                , emit: versions
 
     script:
     prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -24,7 +24,7 @@ process CSVTK_CONCAT {
     val out_format
 
     output:
-    tuple val(meta), path("*.${tsv,csv}"), emit: csv
+    tuple val(meta), path("*.{tsv,csv}"), emit: csv
     path "versions.yml"                  , emit: versions
 
     script:

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -24,8 +24,8 @@ process CSVTK_CONCAT {
     val out_format
 
     output:
-    tuple val(meta), path("*.${out_extension}"), emit: csv
-    path "versions.yml"                        , emit: versions
+    tuple val(meta), path("*.${tsv,csv}"), emit: csv
+    path "versions.yml"                  , emit: versions
 
     script:
     def prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -24,13 +24,14 @@ process CSVTK_CONCAT {
     val out_format
 
     output:
-    tuple val(meta), path("*.${out_format}"), emit: csv
-    path "versions.yml"                     , emit: versions
+    tuple val(meta), path("*.${out_extension}"), emit: csv
+    path "versions.yml"                        , emit: versions
 
     script:
     def prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def delimiter = in_format == "tsv" ? "\t" : (in_format == "csv" ? "," : in_format)
     def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
+    def out_extension = out_format == "tsv" ? 'tsv' : 'csv'
     """
     csvtk \\
         concat \\


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`

@drpatelh haha as soon as you merged, I thought of something.

In the current implementation, you could theoretically get output files with random delimiter characters (e.g. if `out_format = '-'` the output file would be named `*.-` and thats an issue.

I think should make it either `tsv` or default to `csv`