### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         nxf_version: ["21.04.0"]
-        tags: ${{ fromJson(needs.modules_changes.outputs.modules) }}
+        tags: ${{ fromJson(needs.module_changes.outputs.modules) }}
         profile: ["docker", "singularity", "conda"]
     env:
       NXF_ANSI_LOG: false


### PR DESCRIPTION
Correct the typo in `fromJson(needs.module_changes.outputs.modules)` and remove the superfluous quoted array part.