### PR TITLE
Fix freebayes tests

### DIFF
--- a/tests/modules/freebayes/test.yml
+++ b/tests/modules/freebayes/test.yml
@@ -4,7 +4,6 @@
     - freebayes
   files:
     - path: output/freebayes/test.vcf.gz
-      md5sum: e8de5fe0025e331b939c2a849290f325
 
 - name: freebayes test_freebayes_bed
   command: nextflow run tests/modules/freebayes -entry test_freebayes_bed -c tests/config/nextflow.config
@@ -12,4 +11,4 @@
     - freebayes
   files:
     - path: output/freebayes/test.vcf.gz
-      md5sum: 1c41cbec0cfa15002ce91b869ce9d519
+


### PR DESCRIPTION
The `vcf` generated by `freebayes` includes a line like the one below:

```
##fileDate=YYYYMMDD
```

This line is variable and makes md5sum checks fail, as was detected [here](https://github.com/JoseEspinosa/nf-core-modules/runs/3961054430) after merging the current `master` with my fork.
I tried to find a way to get rid of the line but does not seem possible, see [this](https://github.com/freebayes/freebayes/issues/256) discussion. For this reason, the tests were updated to just check for the presence of the `vcf.gz`file
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).