### PR TITLE
Add cram support to Allelecounter module

### DIFF
--- a/modules/allelecounter/main.nf
+++ b/modules/allelecounter/main.nf
@@ -21,6 +21,7 @@ process ALLELECOUNTER {
     input:
     tuple val(meta), path(bam), path(bai)
     path loci
+    path fasta
 
     output:
     tuple val(meta), path("*.alleleCount"), emit: allelecount
@@ -28,11 +29,14 @@ process ALLELECOUNTER {
 
     script:
     def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    def reference_options = fasta ? "-r $fasta": ""
+
     """
     alleleCounter \\
         $options.args \\
         -l $loci \\
         -b $bam \\
+        $reference_options \\
         -o ${prefix}.alleleCount
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/allelecounter/main.nf
+++ b/modules/allelecounter/main.nf
@@ -19,7 +19,7 @@ process ALLELECOUNTER {
     }
 
     input:
-    tuple val(meta), path(bam), path(bai)
+    tuple val(meta), path(input), path(input_index)
     path loci
     path fasta
 

--- a/modules/allelecounter/main.nf
+++ b/modules/allelecounter/main.nf
@@ -35,7 +35,7 @@ process ALLELECOUNTER {
     alleleCounter \\
         $options.args \\
         -l $loci \\
-        -b $bam \\
+        -b $input \\
         $reference_options \\
         -o ${prefix}.alleleCount
 

--- a/modules/allelecounter/meta.yml
+++ b/modules/allelecounter/meta.yml
@@ -31,7 +31,9 @@ input:
       type: file
       description: loci file <CHR><tab><POS1>
       pattern: "*.{tsv}"
-
+  - fasta:
+    type: file
+    description: Input genome fasta file. Required when passing CRAM files.
 
 output:
   - meta:
@@ -50,3 +52,4 @@ output:
 
 authors:
   - "@fullama"
+  - "@fbdtemme"

--- a/modules/allelecounter/meta.yml
+++ b/modules/allelecounter/meta.yml
@@ -19,11 +19,11 @@ input:
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  - bam:
+  - input:
       type: file
       description: BAM/CRAM/SAM file
       pattern: "*.{bam,cram,sam}"
-  - bai:
+  - input_index:
       type: file
       description: BAM/CRAM/SAM index file
       pattern: "*.{bai,crai,sai}"

--- a/tests/modules/allelecounter/main.nf
+++ b/tests/modules/allelecounter/main.nf
@@ -3,12 +3,24 @@ nextflow.enable.dsl = 2
 
 include { ALLELECOUNTER } from '../../../modules/allelecounter/main.nf' addParams( options: [:] )
 
-workflow test_allelecounter {
+workflow test_allelecounter_bam {
     input = [ [ id:'test', single_end:false ], // meta map
               file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
               file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true)
             ]
     positions = [ file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true) ]
 
-    ALLELECOUNTER ( input, positions )
+    ALLELECOUNTER ( input, positions, [] )
+}
+
+
+workflow test_allelecounter_cram {
+    input = [ [ id:'test', single_end:false ], // meta map
+              file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
+              file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true)
+            ]
+    positions = [ file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true) ]
+    fasta = [ file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true) ]
+
+    ALLELECOUNTER ( input, positions, fasta )
 }

--- a/tests/modules/allelecounter/test.yml
+++ b/tests/modules/allelecounter/test.yml
@@ -1,7 +1,15 @@
-- name: allelecounter test_allelecounter
-  command: nextflow run tests/modules/allelecounter -entry test_allelecounter -c tests/config/nextflow.config
+- name: allelecounter test_allelecounter_bam
+  command: nextflow run tests/modules/allelecounter -entry test_allelecounter_bam -c tests/config/nextflow.config
   tags:
     - allelecounter
   files:
     - path: output/allelecounter/test.alleleCount
       md5sum: 2bbe9d7331b78bdac30fe30dbc5fdaf3
+
+- name: allelecounter test_allelecounter_cram
+  command: nextflow run tests/modules/allelecounter -entry test_allelecounter_cram -c tests/config/nextflow.config
+  tags:
+    - allelecounter
+  files:
+    - path: output/allelecounter/test.alleleCount
+      md5sum: 2f83352a185168c7c98e9e42550b2856


### PR DESCRIPTION
## PR checklist

Closes #1012

This PR adds support for CRAM files to the allelecounter module by adding an optional fasta input parameter

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
