### PR TITLE
Add log to output from bbmap/align

### DIFF
--- a/modules/bbmap/align/main.nf
+++ b/modules/bbmap/align/main.nf
@@ -24,6 +24,7 @@ process BBMAP_ALIGN {
 
     output:
     tuple val(meta), path("*.bam"), emit: bam
+    tuple val(meta), path("*.log"), emit: log
     path "versions.yml"           , emit: versions
 
     script:
@@ -51,7 +52,8 @@ process BBMAP_ALIGN {
         out=${prefix}.bam \\
         $options.args \\
         threads=$task.cpus \\
-        -Xmx${task.memory.toGiga()}g
+        -Xmx${task.memory.toGiga()}g \\
+        &> ${prefix}.bbmap.log
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:

--- a/tests/modules/bbmap/align/test.yml
+++ b/tests/modules/bbmap/align/test.yml
@@ -6,6 +6,7 @@
   files:
     - path: output/bbmap/test.bam
       md5sum: e0ec7f1eec537acf146fac1cbdd868d1
+    - path: output/bbmap/test.bbmap.log
 
 - name: bbmap align paired end index ref
   command: nextflow run ./tests/modules/bbmap/align -entry test_bbmap_align_paired_end_index_ref -c tests/config/nextflow.config
@@ -15,6 +16,7 @@
   files:
     - path: output/bbmap/test.bam
       md5sum: 345a72a0d58366d75dd263b107caa460
+    - path: output/bbmap/test.bbmap.log
 
 - name: bbmap align single end index ref
   command: nextflow run ./tests/modules/bbmap/align -entry test_bbmap_align_single_end_index_ref -c tests/config/nextflow.config
@@ -24,6 +26,7 @@
   files:
     - path: output/bbmap/test.bam
       md5sum: 95f690636581ce9b27cf8568c715ae4d
+    - path: output/bbmap/test.bbmap.log
 
 - name: bbmap align paired end index ref pigz
   command: nextflow run ./tests/modules/bbmap/align -entry test_bbmap_align_paired_end_index_ref_pigz -c tests/config/nextflow.config
@@ -33,3 +36,4 @@
   files:
     - path: output/bbmap/test.bam
       md5sum: 441c4f196b9a82c7b224903538064308
+    - path: output/bbmap/test.bbmap.log


### PR DESCRIPTION
## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`

Standard output from the command was not kept except in `.command.log`. I added this as an output channel.
MD5 sums from log files are not stable (probably because the time it took is recorded), so I didn't add them to `test.yml`.