### PR TITLE
GATK4 SplitNCigarReads: fasta_fai_dict tuple is now split into separate input channels

### DIFF
--- a/modules/gatk4/splitncigarreads/main.nf
+++ b/modules/gatk4/splitncigarreads/main.nf
@@ -20,9 +20,9 @@ process GATK4_SPLITNCIGARREADS {
 
     input:
     tuple val(meta), path(bam)
-    path(fasta)
-    path(fai)
-    path(dict)
+    path  fasta
+    path  fai
+    path  dict
 
     output:
     tuple val(meta), path('*.bam'), emit: bam

--- a/modules/gatk4/splitncigarreads/main.nf
+++ b/modules/gatk4/splitncigarreads/main.nf
@@ -20,7 +20,9 @@ process GATK4_SPLITNCIGARREADS {
 
     input:
     tuple val(meta), path(bam)
-    tuple path(fasta), path(fai), path(dict)
+    path(fasta)
+    path(fai)
+    path(dict)
 
     output:
     tuple val(meta), path('*.bam'), emit: bam

--- a/modules/gatk4/splitncigarreads/meta.yml
+++ b/modules/gatk4/splitncigarreads/meta.yml
@@ -23,7 +23,7 @@ input:
       type: list
       description: BAM/SAM/CRAM file containing reads
       pattern: "*.{bam,sam,cram}"
-   - fasta:
+  - fasta:
       type: file
       description: The reference fasta file
       pattern: "*.fasta"

--- a/modules/gatk4/splitncigarreads/meta.yml
+++ b/modules/gatk4/splitncigarreads/meta.yml
@@ -23,11 +23,18 @@ input:
       type: list
       description: BAM/SAM/CRAM file containing reads
       pattern: "*.{bam,sam,cram}"
-  - fasta:
-      type: tuple of files
-      description: |
-        Tuple of fasta file (first), sequence dict (second) and fasta index (third)
-      pattern: ["*.fasta", "*.dict", "*.fai"]
+   - fasta:
+      type: file
+      description: The reference fasta file
+      pattern: "*.fasta"
+  - fai:
+      type: file
+      description: Index of reference fasta file
+      pattern: "fasta.fai"
+  - dict:
+      type: file
+      description: GATK sequence dictionary
+      pattern: "*.dict"
 output:
   - bam:
       type: file

--- a/modules/gatk4/splitncigarreads/meta.yml
+++ b/modules/gatk4/splitncigarreads/meta.yml
@@ -30,7 +30,7 @@ input:
   - fai:
       type: file
       description: Index of reference fasta file
-      pattern: "fasta.fai"
+      pattern: "*.fasta.fai"
   - dict:
       type: file
       description: GATK sequence dictionary

--- a/tests/modules/gatk4/splitncigarreads/main.nf
+++ b/tests/modules/gatk4/splitncigarreads/main.nf
@@ -8,10 +8,9 @@ workflow test_gatk4_splitncigarreads {
     input = [ [ id:'test' ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true) ] 
             ]
-    fasta = [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
-              file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true),
-              file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
-            ]
+    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fai = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
+    dict = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
 
-    GATK4_SPLITNCIGARREADS ( input, fasta )
+    GATK4_SPLITNCIGARREADS ( input, fasta, fai, dict )
 }


### PR DESCRIPTION
fasta_fai_dict tuple channel has now been split into separate input channels as followed in other modules. It could be convenient way to pass inputs to module when used. 

## PR checklist
- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
