### PR TITLE
Fix picard markduplicates

### DIFF
--- a/modules/picard/markduplicates/main.nf
+++ b/modules/picard/markduplicates/main.nf
@@ -40,9 +40,9 @@ process PICARD_MARKDUPLICATES {
         -Xmx${avail_mem}g \\
         MarkDuplicates \\
         $options.args \\
-        -I $bam \\
-        -O ${prefix}.bam \\
-        -M ${prefix}.MarkDuplicates.metrics.txt
+        I=$bam \\
+        O=${prefix}.bam \\
+        M=${prefix}.MarkDuplicates.metrics.txt
 
     cat <<-END_VERSIONS > versions.yml
     ${getProcessName(task.process)}:

--- a/tests/modules/picard/markduplicates/main.nf
+++ b/tests/modules/picard/markduplicates/main.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl = 2
 
 include { PICARD_MARKDUPLICATES } from '../../../../modules/picard/markduplicates/main.nf' addParams( options: [:] )
-include { PICARD_MARKDUPLICATES as PICARD_MARKDUPLICATES_UNSORTED}  from '../../../../modules/picard/markduplicates/main.nf' addParams( options: [args : '--ASSUME_SORT_ORDER queryname'  ]   )
+include { PICARD_MARKDUPLICATES as PICARD_MARKDUPLICATES_UNSORTED}  from '../../../../modules/picard/markduplicates/main.nf' addParams( options: [args : 'ASSUME_SORT_ORDER=queryname'  ]   )
 
 workflow test_picard_markduplicates_sorted_bam  {
     input = [ [ id:'test', single_end:false ], // meta map

--- a/tests/modules/picard/markduplicates/test.yml
+++ b/tests/modules/picard/markduplicates/test.yml
@@ -5,8 +5,9 @@
     - picard/markduplicates
   files:
     - path: ./output/picard/test.MarkDuplicates.metrics.txt
+      contains:
+        - "1.0	97	97"
     - path: ./output/picard/test.bam
-      md5sum: 3270bb142039e86aaf2ab83c540225d5
 - name: picard markduplicates unsorted bam
   command: nextflow run ./tests/modules/picard/markduplicates -entry test_picard_markduplicates_unsorted_bam -c tests/config/nextflow.config
   tags:
@@ -14,6 +15,7 @@
     - picard/markduplicates
   files:
     - path: ./output/picard/test.MarkDuplicates.metrics.txt
+      contains:
+        - "1.0	97	97"
     - path: ./output/picard/test.bam
-      md5sum: 849a097b267b207bb185e199148f7888
 

--- a/tests/modules/picard/markduplicates/test.yml
+++ b/tests/modules/picard/markduplicates/test.yml
@@ -6,7 +6,7 @@
   files:
     - path: ./output/picard/test.MarkDuplicates.metrics.txt
     - path: ./output/picard/test.bam
-      md5sum: b520ccdc3a9edf3c6a314983752881f2
+      md5sum: 3270bb142039e86aaf2ab83c540225d5
 - name: picard markduplicates unsorted bam
   command: nextflow run ./tests/modules/picard/markduplicates -entry test_picard_markduplicates_unsorted_bam -c tests/config/nextflow.config
   tags:
@@ -15,5 +15,5 @@
   files:
     - path: ./output/picard/test.MarkDuplicates.metrics.txt
     - path: ./output/picard/test.bam
-      md5sum: 46a6fc76048ba801d328f869ac9db020
+      md5sum: 849a097b267b207bb185e199148f7888
 


### PR DESCRIPTION
The way options are set has in the script section has been updated to fit the new syntax `I= or INPUT=` instead of `-I`
Also, `test.yml` has been updated not to check md5sum and the `metrics.txt` is now checked for containing a given string. 


## PR checklist

Closes #1071

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
