### PR TITLE
Fix filtlong and its tests

### DIFF
--- a/modules/filtlong/main.nf
+++ b/modules/filtlong/main.nf
@@ -27,7 +27,8 @@ process FILTLONG {
 
     script:
     def prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
-    def short_reads = meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}"
+    def short_reads = '' // Start with empty value in case there are no short reads.
+    if (shortreads) short_reads = meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}"
     """
     filtlong \\
         $short_reads \\

--- a/modules/filtlong/main.nf
+++ b/modules/filtlong/main.nf
@@ -27,8 +27,7 @@ process FILTLONG {
 
     script:
     def prefix = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
-    def short_reads = '' // Start with empty value in case there are no short reads.
-    if (shortreads) short_reads = meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}"
+    def short_reads = shortreads ? ( meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}" ) : ""
     """
     filtlong \\
         $short_reads \\

--- a/tests/modules/filtlong/main.nf
+++ b/tests/modules/filtlong/main.nf
@@ -2,7 +2,7 @@
 
 nextflow.enable.dsl = 2
 
-include { FILTLONG } from '../../../modules/filtlong/main.nf' addParams( options: [:] )
+include { FILTLONG } from '../../../modules/filtlong/main.nf' addParams( options: [args: '--keep_percent 90'] )
 
 workflow test_filtlong {
     

--- a/tests/modules/filtlong/test.yml
+++ b/tests/modules/filtlong/test.yml
@@ -4,7 +4,7 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
+      md5sum: 809ab868cad1f8677ca852bd1daaeb59
 
 - name: filtlong test_filtlong_illumina_se
   command: nextflow run tests/modules/filtlong -entry test_filtlong_illumina_se -c tests/config/nextflow.config
@@ -12,7 +12,7 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
+      md5sum: ac8d36e8620bed992672731c24837349
 
 - name: filtlong test_filtlong_illumina_pe
   command: nextflow run tests/modules/filtlong -entry test_filtlong_illumina_pe -c tests/config/nextflow.config
@@ -20,4 +20,4 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
+      md5sum: fbbc93e410a73a8a3b4ec4126af7aab0


### PR DESCRIPTION
I found issues with the `filtlong` module, which produced compressed empty files, MD5 sum `7029066c27ac6f5ef18d660d5741979a`; see `printf '' | gzip -n | md5sum` for a reproducible example.

1. When no short-read data was given to the module, it generated command-line arguments using the filename `null`, causing an error.
2. In the tests, the command was always ending with an error because no threshold was given.

This is addressed in two separate commits; the third refreshes the tests.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
