### PR TITLE
ci: Skip subworkflows

### DIFF
--- a/.github/workflows/nf-core-linting.yml
+++ b/.github/workflows/nf-core-linting.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Lint ${{ matrix.tags }}
         run: nf-core modules lint ${{ matrix.tags }}
-        # HACK
+        # HACK Skip subworkflows
         if: startsWith( matrix.tags, 'subworkflow' ) != true
 
       - uses: actions/cache@v2

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -92,6 +92,8 @@ jobs:
 
       # Test the module
       - name: Run pytest-workflow
+        # HACK Skip subworkflows
+        if: startsWith( matrix.tags, 'subworkflow' ) != true
         # only use one thread for pytest-workflow to avoid race condition on conda cache.
         run: NF_CORE_MODULES_TEST=1 TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --tag ${{ matrix.tags }} --symlink --kwdof
 


### PR DESCRIPTION
Punting for now on these. We can still accept PRs to start collecting them, but they'll all need to be cleaned up eventually with the new syntax.