### PR TITLE
Replace remaining task.ext.suffix with task.ext.prefix

### DIFF
--- a/modules/artic/minion/main.nf
+++ b/modules/artic/minion/main.nf
@@ -32,8 +32,8 @@ process ARTIC_MINION {
     path  "versions.yml"                                              , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     def version  = scheme_version.toString().toLowerCase().replaceAll('v','')
     def fast5    = fast5_dir ? "--fast5-directory $fast5_dir"             : ""
     def summary  = sequencing_summary ? "--sequencing-summary $sequencing_summary" : ""

--- a/modules/bakta/main.nf
+++ b/modules/bakta/main.nf
@@ -26,8 +26,8 @@ process BAKTA {
     path "versions.yml"                                 , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     def proteins_opt = proteins ? "--proteins ${proteins[0]}" : ""
     def prodigal_opt = prodigal_tf ? "--prodigal-tf ${prodigal_tf[0]}" : ""
     """
@@ -47,7 +47,7 @@ process BAKTA {
     """
 
     stub:
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.embl
     touch ${prefix}.faa

--- a/modules/bcftools/concat/main.nf
+++ b/modules/bcftools/concat/main.nf
@@ -15,8 +15,8 @@ process BCFTOOLS_CONCAT {
     path  "versions.yml"         , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     bcftools concat \\
         --output ${prefix}.vcf.gz \\

--- a/modules/bcftools/isec/main.nf
+++ b/modules/bcftools/isec/main.nf
@@ -15,8 +15,8 @@ process BCFTOOLS_ISEC {
     path  "versions.yml"              , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     bcftools isec  \\
         $args \\

--- a/modules/bcftools/merge/main.nf
+++ b/modules/bcftools/merge/main.nf
@@ -15,8 +15,8 @@ process BCFTOOLS_MERGE {
     path  "versions.yml"         , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     bcftools merge -Oz \\
         --output ${prefix}.vcf.gz \\

--- a/modules/bedtools/getfasta/main.nf
+++ b/modules/bedtools/getfasta/main.nf
@@ -16,8 +16,8 @@ process BEDTOOLS_GETFASTA {
     path "versions.yml" , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.suffix ? "${bed.baseName}${task.ext.suffix}" : "${bed.baseName}"
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${bed.baseName}"
     """
     bedtools \\
         getfasta \\

--- a/modules/checkm/lineagewf/main.nf
+++ b/modules/checkm/lineagewf/main.nf
@@ -17,8 +17,8 @@ process CHECKM_LINEAGEWF {
     path "versions.yml"                   , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     checkm \\
         lineage_wf \\

--- a/modules/csvtk/concat/main.nf
+++ b/modules/csvtk/concat/main.nf
@@ -17,8 +17,8 @@ process CSVTK_CONCAT {
     path "versions.yml"                                , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     def delimiter = in_format == "tsv" ? "\t" : (in_format == "csv" ? "," : in_format)
     def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
     out_extension = out_format == "tsv" ? 'tsv' : 'csv'

--- a/modules/damageprofiler/main.nf
+++ b/modules/damageprofiler/main.nf
@@ -18,8 +18,8 @@ process DAMAGEPROFILER {
     path  "versions.yml"              , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     def reference    = fasta ? "-r $fasta" : ""
     def species_list = specieslist ? "-sf $specieslist" : ""
     """

--- a/modules/dedup/main.nf
+++ b/modules/dedup/main.nf
@@ -18,8 +18,8 @@ process DEDUP {
     path "versions.yml"                 , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
 
     """
     dedup \\

--- a/modules/fargene/main.nf
+++ b/modules/fargene/main.nf
@@ -32,8 +32,8 @@ process FARGENE {
     path "versions.yml"                                                                          , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     fargene \\
         $args \\

--- a/modules/gatk4/genomicsdbimport/main.nf
+++ b/modules/gatk4/genomicsdbimport/main.nf
@@ -20,8 +20,8 @@ process GATK4_GENOMICSDBIMPORT {
     path "versions.yml"                                    , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
 
     // settings for running default create gendb mode
     inputs_command = input_map ? "--sample-name-map ${vcf[0]}" : "${'-V ' + vcf.join(' -V ')}"

--- a/modules/gffread/main.nf
+++ b/modules/gffread/main.nf
@@ -15,8 +15,8 @@ process GFFREAD {
     path "versions.yml" , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.suffix ? "${gff.baseName}${task.ext.suffix}" : "${gff.baseName}"
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${gff.baseName}"
     """
     gffread \\
         $gff \\

--- a/modules/leehom/main.nf
+++ b/modules/leehom/main.nf
@@ -24,8 +24,8 @@ process LEEHOM {
     path "versions.yml"                                             , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
 
     if (reads.toString().endsWith('.bam')) {
         """

--- a/modules/msisensor/msi/main.nf
+++ b/modules/msisensor/msi/main.nf
@@ -18,8 +18,8 @@ process MSISENSOR_MSI {
     path "versions.yml"                        , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     msisensor \\
         msi \\

--- a/modules/nextclade/main.nf
+++ b/modules/nextclade/main.nf
@@ -19,8 +19,8 @@ process NEXTCLADE {
     path "versions.yml"                          , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     nextclade \\
         $args \\

--- a/modules/optitype/main.nf
+++ b/modules/optitype/main.nf
@@ -15,9 +15,9 @@ process OPTITYPE {
     path "versions.yml"               , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args  = task.ext.args   ?: ''
+    def args2 = task.ext.args2  ?: ''
+    prefix    = task.ext.prefix ?: "${meta.id}"
 
     """
     # Create a config for OptiType on a per sample basis with task.ext.args2

--- a/modules/plasmidid/main.nf
+++ b/modules/plasmidid/main.nf
@@ -23,8 +23,8 @@ process PLASMIDID {
     path "versions.yml"                                   , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     plasmidID \\
         -d $fasta \\

--- a/modules/prodigal/main.nf
+++ b/modules/prodigal/main.nf
@@ -19,8 +19,8 @@ process PRODIGAL {
     path "versions.yml"           , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     """
     prodigal -i "${genome}" \\
         $args \\

--- a/modules/prokka/main.nf
+++ b/modules/prokka/main.nf
@@ -28,8 +28,8 @@ process PROKKA {
     path "versions.yml" , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     def proteins_opt = proteins ? "--proteins ${proteins[0]}" : ""
     def prodigal_opt = prodigal_tf ? "--prodigaltf ${prodigal_tf[0]}" : ""
     """

--- a/modules/qualimap/bamqc/main.nf
+++ b/modules/qualimap/bamqc/main.nf
@@ -17,8 +17,8 @@ process QUALIMAP_BAMQC {
     path  "versions.yml"              , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
 
     def collect_pairs = meta.single_end ? '' : '--collect-overlap-pairs'
     def memory     = task.memory.toGiga() + "G"

--- a/modules/qualimap/rnaseq/main.nf
+++ b/modules/qualimap/rnaseq/main.nf
@@ -16,8 +16,8 @@ process QUALIMAP_RNASEQ {
     path  "versions.yml"              , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     def paired_end = meta.single_end ? '' : '-pe'
     def memory     = task.memory.toGiga() + "G"
 

--- a/modules/quast/main.nf
+++ b/modules/quast/main.nf
@@ -19,8 +19,8 @@ process QUAST {
     path "versions.yml" , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ?: 'quast'
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: 'quast'
     def features  = use_gff ? "--features $gff" : ''
     def reference = use_fasta ? "-r $fasta" : ''
     """

--- a/modules/rsem/calculateexpression/main.nf
+++ b/modules/rsem/calculateexpression/main.nf
@@ -23,8 +23,8 @@ process RSEM_CALCULATEEXPRESSION {
     tuple val(meta), path("${prefix}.transcript.bam"), optional:true, emit: bam_transcript
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
 
     def strandedness = ''
     if (meta.strandedness == 'forward') {

--- a/modules/salmon/quant/main.nf
+++ b/modules/salmon/quant/main.nf
@@ -20,8 +20,8 @@ process SALMON_QUANT {
     path  "versions.yml"              , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
 
     def reference   = "--index $index"
     def input_reads = meta.single_end ? "-r $reads" : "-1 ${reads[0]} -2 ${reads[1]}"

--- a/modules/samtools/merge/main.nf
+++ b/modules/samtools/merge/main.nf
@@ -17,8 +17,8 @@ process SAMTOOLS_MERGE {
     path  "versions.yml"                                  , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     def file_type = input_files[0].getExtension()
     def reference = fasta ? "--reference ${fasta}" : ""
     """

--- a/modules/seqkit/split2/main.nf
+++ b/modules/seqkit/split2/main.nf
@@ -15,8 +15,8 @@ process SEQKIT_SPLIT2 {
     path "versions.yml"                     , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     if(meta.single_end){
         """
         seqkit \\

--- a/modules/seqtk/subseq/main.nf
+++ b/modules/seqtk/subseq/main.nf
@@ -16,8 +16,8 @@ process SEQTK_SUBSEQ {
     path "versions.yml" , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.suffix ?: ''
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: ''
     def ext = "fa"
     if ("$sequences" ==~ /.+\.fq|.+\.fq.gz|.+\.fastq|.+\.fastq.gz/) {
         ext = "fq"

--- a/modules/tbprofiler/profile/main.nf
+++ b/modules/tbprofiler/profile/main.nf
@@ -19,8 +19,8 @@ process TBPROFILER_PROFILE {
     path "versions.yml"                    , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
+    def args = task.ext.args   ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
     def input_reads = meta.single_end ? "--read1 $reads" : "--read1 ${reads[0]} --read2 ${reads[1]}"
     """
     tb-profiler \\

--- a/tests/modules/gffread/nextflow.config
+++ b/tests/modules/gffread/nextflow.config
@@ -3,7 +3,7 @@ process {
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
     withName: GFFREAD {
-        ext.prefix = { "${meta.id}.out" }
+        ext.prefix = { "${gff.baseName}.out" }
     }
 
 }

--- a/tests/modules/seqtk/subseq/nextflow.config
+++ b/tests/modules/seqtk/subseq/nextflow.config
@@ -3,7 +3,7 @@ process {
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
     withName: SEQTK_SUBSEQ {
-        ext.prefix = { "${meta.id}.filtered" }
+        ext.prefix = { ".filtered" }
     }
 
 }


### PR DESCRIPTION
Fixes remaining modules that still had `task.ext.suffix` to `task.ext.prefix`.