### PR TITLE
fix: exclude conda/singularity images from pytest workflow output

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -103,3 +103,5 @@ jobs:
             /home/runner/pytest_workflow_*/*/log.out
             /home/runner/pytest_workflow_*/*/log.err
             /home/runner/pytest_workflow_*/*/work
+            !/home/runner/pytest_workflow_*/*/work/conda
+            !/home/runner/pytest_workflow_*/*/work/singularity


### PR DESCRIPTION
Currently adding entire `work` directory of CI tests to artifacts includes entire singularity images or ocnda environments which take a long time to upload and subsequently download when trying debug modules.

This excludes those specific folders to make the whole process faster, but also reduce our disk footprint 
