### PR TITLE
Revert PR #1147

### DIFF
--- a/modules/samtools/index/main.nf
+++ b/modules/samtools/index/main.nf
@@ -11,13 +11,10 @@ process SAMTOOLS_INDEX {
     tuple val(meta), path(input)
 
     output:
-    tuple val(meta), path("*.bam" , includeInputs:true), path("*.bai") , optional:true, emit: bam_bai
-    tuple val(meta), path("*.bai")                                     , optional:true, emit: bai
-    tuple val(meta), path("*.bam" , includeInputs:true), path("*.csi") , optional:true, emit: bam_csi
-    tuple val(meta), path("*.csi")                                     , optional:true, emit: csi
-    tuple val(meta), path("*.cram", includeInputs:true), path("*.crai"), optional:true, emit: cram_crai
-    tuple val(meta), path("*.crai")                                    , optional:true, emit: crai
-    path  "versions.yml"                                                              , emit: versions
+    tuple val(meta), path("*.bai") , optional:true, emit: bai
+    tuple val(meta), path("*.csi") , optional:true, emit: csi
+    tuple val(meta), path("*.crai"), optional:true, emit: crai
+    path  "versions.yml"           , emit: versions
 
     script:
     def args = task.ext.args ?: ''

--- a/tests/modules/samtools/index/test.yml
+++ b/tests/modules/samtools/index/test.yml
@@ -14,7 +14,7 @@
     - samtools/index
   files:
     - path: output/samtools/test.paired_end.recalibrated.sorted.cram.crai
-      md5sum: 537e3d8c937bcc4e34e1cf47cd71d484
+      md5sum: 14bc3bd5c89cacc8f4541f9062429029
 
 - name: samtools index test_samtools_index_csi
   command: nextflow run ./tests/modules/samtools/index -entry test_samtools_index_csi -c ./tests/config/nextflow.config -c ./tests/modules/samtools/index/nextflow.config


### PR DESCRIPTION
Reverts https://github.com/nf-core/modules/pull/1147 to keep with `emit` a single output file per channel as per the nf-core/modules guidelines.