### PR TITLE
Add helper script to find duplicate test YAML md5s

### DIFF
--- a/.github/check_duplicate_md5s.py
+++ b/.github/check_duplicate_md5s.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+from rich import print
+from rich.table import Table
+import click
+import glob
+import os
+import yaml
+
+
+@click.command()
+@click.option(
+    "--min_dups",
+    default=5,
+    show_default=True,
+    help="Minimum number of duplicates to report",
+)
+@click.option(
+    "--search_dir",
+    default=f"{os.path.dirname(__file__)}/../tests/**/test.yml",
+    show_default=True,
+    help="Glob directory pattern used to find test YAML files",
+)
+def find_duplicate_md5s(min_dups, search_dir):
+    """
+    Find duplicate file MD5 sums in test YAML files.
+    """
+    md5_filenames = {}
+    md5_counts = {}
+
+    # Loop through all files in tests/ called test.yml
+    for test_yml in glob.glob(search_dir, recursive=True):
+        # Open file and parse YAML
+        with open(test_yml, "r") as fh:
+            test_config = yaml.safe_load(fh)
+            # Loop through tests and check for duplicate md5s
+            for test in test_config:
+                for test_file in test.get("files", []):
+                    if "md5sum" in test_file:
+                        md5 = test_file["md5sum"]
+                        md5_filenames[md5] = md5_filenames.get(md5, []) + [
+                            os.path.basename(test_file.get("path"))
+                        ]
+                        md5_counts[md5] = md5_counts.get(md5, 0) + 1
+
+    # Set up rich table
+    table = Table(title="Duplicate MD5s", row_styles=["dim", ""])
+    table.add_column("MD5", style="cyan", no_wrap=True)
+    table.add_column("Count", style="magenta", justify="right")
+    table.add_column("Filenames", style="green")
+
+    # Add rows - sort md5_counts by value
+    for md5 in sorted(md5_counts, key=md5_counts.get):
+        if md5_counts[md5] >= min_dups:
+            table.add_row(md5, str(md5_counts[md5]), ", ".join(set(md5_filenames[md5])))
+
+    print(table)
+
+
+if __name__ == "__main__":
+    find_duplicate_md5s()

--- a/.github/check_duplicate_md5s.py
+++ b/.github/check_duplicate_md5s.py
@@ -26,7 +26,8 @@ def find_duplicate_md5s(min_dups, search_dir):
     Find duplicate file MD5 sums in test YAML files.
     """
     md5_filenames = {}
-    md5_counts = {}
+    md5_output_fn_counts = {}
+    module_counts = {}
 
     # Loop through all files in tests/ called test.yml
     for test_yml in glob.glob(search_dir, recursive=True):
@@ -41,18 +42,38 @@ def find_duplicate_md5s(min_dups, search_dir):
                         md5_filenames[md5] = md5_filenames.get(md5, []) + [
                             os.path.basename(test_file.get("path"))
                         ]
-                        md5_counts[md5] = md5_counts.get(md5, 0) + 1
+                        md5_output_fn_counts[md5] = md5_output_fn_counts.get(md5, 0) + 1
+                        # Log the module that this md5 was in
+                        modname = os.path.basename(os.path.dirname(test_yml))
+                        # If tool/subtool show the whole thing
+                        # Ugly code but trying to stat os-agnostic
+                        if os.path.basename(
+                            os.path.dirname(os.path.dirname(test_yml))
+                        ) not in ["modules", "config", "subworkflows"]:
+                            modname = "{}/{}".format(
+                                os.path.basename(
+                                    os.path.dirname(os.path.dirname(test_yml))
+                                ),
+                                os.path.basename(os.path.dirname(test_yml)),
+                            )
+                        module_counts[md5] = module_counts.get(md5, []) + [modname]
 
     # Set up rich table
     table = Table(title="Duplicate MD5s", row_styles=["dim", ""])
     table.add_column("MD5", style="cyan", no_wrap=True)
     table.add_column("Count", style="magenta", justify="right")
+    table.add_column("Num modules", style="blue", justify="right")
     table.add_column("Filenames", style="green")
 
-    # Add rows - sort md5_counts by value
-    for md5 in sorted(md5_counts, key=md5_counts.get):
-        if md5_counts[md5] >= min_dups:
-            table.add_row(md5, str(md5_counts[md5]), ", ".join(set(md5_filenames[md5])))
+    # Add rows - sort md5_output_fn_counts by value
+    for md5 in sorted(md5_output_fn_counts, key=md5_output_fn_counts.get):
+        if md5_output_fn_counts[md5] >= min_dups:
+            table.add_row(
+                md5,
+                str(md5_output_fn_counts[md5]),
+                str(len(set(module_counts[md5]))),
+                ", ".join(set(md5_filenames[md5])),
+            )
 
     print(table)
 


### PR DESCRIPTION
Related to https://github.com/nf-core/tools/pull/1358 - quick script to make it easy to find instances of duplicate md5sums.

![image](https://user-images.githubusercontent.com/465550/145975187-0c4f00b4-2387-406c-936f-6a52d9980e56.png)


```console
❯ python .github/check_duplicate_md5s.py --help
Usage: check_duplicate_md5s.py [OPTIONS]

  Find duplicate file MD5 sums in test YAML files.

Options:
  --min_dups INTEGER  Minimum number of duplicates to report  [default: 5]
  --search_dir TEXT   Glob directory pattern used to find test YAML files
                      [default: .github/../tests/**/test.yml]

  --help              Show this message and exit.
```

This script is not currently run anywhere automatically (in any CI), so is only an undocumented helper script for maintainers.

## PR checklist

- [x] This comment contains a description of changes (with reason).
