### PR TITLE
Bump picard version from 2.25.7 to 2.26.7 for log4j vulnerability

### DIFF
--- a/modules/hmmcopy/generatemap/main.nf
+++ b/modules/hmmcopy/generatemap/main.nf
@@ -1,5 +1,5 @@
 def VERSION = '0.1.1'
-    
+
 process HMMCOPY_GENERATEMAP {
     tag '$bam'
     label 'process_long'

--- a/modules/picard/collecthsmetrics/main.nf
+++ b/modules/picard/collecthsmetrics/main.nf
@@ -2,10 +2,10 @@ process PICARD_COLLECTHSMETRICS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::picard=2.26.2" : null)
+    conda (params.enable_conda ? "bioconda::picard=2.26.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picard:2.26.2--hdfd78af_0' :
-        'quay.io/biocontainers/picard:2.26.2--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picard:2.26.7--hdfd78af_0' :
+        'quay.io/biocontainers/picard:2.26.7--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/picard/collectmultiplemetrics/main.nf
+++ b/modules/picard/collectmultiplemetrics/main.nf
@@ -2,10 +2,10 @@ process PICARD_COLLECTMULTIPLEMETRICS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::picard=2.25.7' : null)
+    conda (params.enable_conda ? "bioconda::picard=2.26.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picard:2.25.7--hdfd78af_0' :
-        'quay.io/biocontainers/picard:2.25.7--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picard:2.26.7--hdfd78af_0' :
+        'quay.io/biocontainers/picard:2.26.7--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/picard/collectwgsmetrics/main.nf
+++ b/modules/picard/collectwgsmetrics/main.nf
@@ -2,10 +2,10 @@ process PICARD_COLLECTWGSMETRICS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::picard=2.25.7' : null)
+    conda (params.enable_conda ? "bioconda::picard=2.26.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picard:2.25.7--hdfd78af_0' :
-        'quay.io/biocontainers/picard:2.25.7--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picard:2.26.7--hdfd78af_0' :
+        'quay.io/biocontainers/picard:2.26.7--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/picard/filtersamreads/main.nf
+++ b/modules/picard/filtersamreads/main.nf
@@ -2,10 +2,10 @@ process PICARD_FILTERSAMREADS {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? 'bioconda::picard=2.25.7' : null)
+    conda (params.enable_conda ? "bioconda::picard=2.26.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picard:2.25.7--hdfd78af_0' :
-        'quay.io/biocontainers/picard:2.25.7--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picard:2.26.7--hdfd78af_0' :
+        'quay.io/biocontainers/picard:2.26.7--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam), path(readlist)

--- a/modules/picard/markduplicates/main.nf
+++ b/modules/picard/markduplicates/main.nf
@@ -2,10 +2,10 @@ process PICARD_MARKDUPLICATES {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::picard=2.25.7' : null)
+    conda (params.enable_conda ? "bioconda::picard=2.26.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picard:2.25.7--hdfd78af_0' :
-        'quay.io/biocontainers/picard:2.25.7--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picard:2.26.7--hdfd78af_0' :
+        'quay.io/biocontainers/picard:2.26.7--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/picard/mergesamfiles/main.nf
+++ b/modules/picard/mergesamfiles/main.nf
@@ -2,10 +2,10 @@ process PICARD_MERGESAMFILES {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::picard=2.25.7' : null)
+    conda (params.enable_conda ? "bioconda::picard=2.26.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picard:2.25.7--hdfd78af_0' :
-        'quay.io/biocontainers/picard:2.25.7--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picard:2.26.7--hdfd78af_0' :
+        'quay.io/biocontainers/picard:2.26.7--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bams)

--- a/modules/picard/sortsam/main.nf
+++ b/modules/picard/sortsam/main.nf
@@ -2,10 +2,10 @@ process PICARD_SORTSAM {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? 'bioconda::picard=2.25.7' : null)
+    conda (params.enable_conda ? "bioconda::picard=2.26.7" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/picard:2.25.7--hdfd78af_0' :
-        'quay.io/biocontainers/picard:2.25.7--hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/picard:2.26.7--hdfd78af_0' :
+        'quay.io/biocontainers/picard:2.26.7--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam)


### PR DESCRIPTION
As bought to our attention in https://github.com/nf-core/rnaseq/issues/734