### PR TITLE
Change intervals to be part of sample specific input

### DIFF
--- a/modules/gatk4/applybqsr/main.nf
+++ b/modules/gatk4/applybqsr/main.nf
@@ -8,11 +8,10 @@ process GATK4_APPLYBQSR {
         'quay.io/biocontainers/gatk4:4.2.4.0--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(input), path(input_index), path(bqsr_table)
+    tuple val(meta), path(input), path(input_index), path(bqsr_table), path (intervals)
     path  fasta
     path  fai
     path  dict
-    path  intervals
 
     output:
     tuple val(meta), path("*.bam"), emit: bam

--- a/modules/gatk4/applybqsr/main.nf
+++ b/modules/gatk4/applybqsr/main.nf
@@ -8,19 +8,22 @@ process GATK4_APPLYBQSR {
         'quay.io/biocontainers/gatk4:4.2.4.0--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(input), path(input_index), path(bqsr_table), path (intervals)
+    tuple val(meta), path(input), path(input_index), path(bqsr_table), path(intervals)
     path  fasta
     path  fai
     path  dict
 
     output:
-    tuple val(meta), path("*.bam"), emit: bam
-    path "versions.yml"           , emit: versions
+    tuple val(meta), path("*.bam"),  emit: bam, optional: true
+    tuple val(meta), path("*.cram"), emit: cram, optional: true
+    path "versions.yml"           ,  emit: versions
 
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def interval = intervals ? "-L ${intervals}" : ""
+    def file_type = input.getExtension()
+
     def avail_mem = 3
     if (!task.memory) {
         log.info '[GATK ApplyBQSR] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
@@ -34,7 +37,7 @@ process GATK4_APPLYBQSR {
         --bqsr-recal-file $bqsr_table \\
         $interval \\
         --tmp-dir . \\
-        -O ${prefix}.bam \\
+        -O ${prefix}.${file_type} \\
         $args
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/gatk4/applybqsr/meta.yml
+++ b/modules/gatk4/applybqsr/meta.yml
@@ -31,6 +31,9 @@ input:
   - bqsr_table:
       type: file
       description: Recalibration table from gatk4_baserecalibrator
+  - intervals:
+      type: file
+      description: Bed file with the genomic regions included in the library (optional)
   - fasta:
       type: file
       description: The reference fasta file
@@ -43,9 +46,7 @@ input:
       type: file
       description: GATK sequence dictionary
       pattern: "*.dict"
-  - intervalsBed:
-      type: file
-      description: Bed file with the genomic regions included in the library (optional)
+
 
 output:
   - meta:

--- a/modules/gatk4/baserecalibrator/main.nf
+++ b/modules/gatk4/baserecalibrator/main.nf
@@ -8,11 +8,10 @@ process GATK4_BASERECALIBRATOR {
         'quay.io/biocontainers/gatk4:4.2.4.0--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(input), path(input_index)
+    tuple val(meta), path(input), path(input_index), path (intervals)
     path fasta
     path fai
     path dict
-    path intervalsBed
     path knownSites
     path knownSites_tbi
 
@@ -23,7 +22,7 @@ process GATK4_BASERECALIBRATOR {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def intervalsCommand = intervalsBed ? "-L ${intervalsBed}" : ""
+    def intervalsCommand = intervals ? "-L ${intervals}" : ""
     def sitesCommand = knownSites.collect{"--known-sites ${it}"}.join(' ')
     def avail_mem = 3
     if (!task.memory) {

--- a/modules/gatk4/baserecalibrator/main.nf
+++ b/modules/gatk4/baserecalibrator/main.nf
@@ -8,7 +8,7 @@ process GATK4_BASERECALIBRATOR {
         'quay.io/biocontainers/gatk4:4.2.4.0--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(input), path(input_index), path (intervals)
+    tuple val(meta), path(input), path(input_index), path(intervals)
     path fasta
     path fai
     path dict
@@ -24,12 +24,14 @@ process GATK4_BASERECALIBRATOR {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def intervalsCommand = intervals ? "-L ${intervals}" : ""
     def sitesCommand = knownSites.collect{"--known-sites ${it}"}.join(' ')
+
     def avail_mem = 3
     if (!task.memory) {
         log.info '[GATK BaseRecalibrator] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
     } else {
         avail_mem = task.memory.giga
     }
+
     """
     gatk --java-options "-Xmx${avail_mem}g" BaseRecalibrator  \
         -R $fasta \

--- a/modules/gatk4/baserecalibrator/meta.yml
+++ b/modules/gatk4/baserecalibrator/meta.yml
@@ -28,6 +28,9 @@ input:
       type: file
       description: BAI/CRAI file from alignment
       pattern: "*.{bai,crai}"
+  - intervals:
+      type: file
+      description: Bed file with the genomic regions included in the library (optional)
   - fasta:
       type: file
       description: The reference fasta file
@@ -40,9 +43,6 @@ input:
       type: file
       description: GATK sequence dictionary
       pattern: "*.dict"
-  - intervalsBed:
-      type: file
-      description: Bed file with the genomic regions included in the library (optional)
   - knownSites:
       type: file
       description: Bed file with the genomic regions included in the library (optional)

--- a/modules/gatk4/genotypegvcfs/main.nf
+++ b/modules/gatk4/genotypegvcfs/main.nf
@@ -8,13 +8,12 @@ process GATK4_GENOTYPEGVCFS {
         'quay.io/biocontainers/gatk4:4.2.4.0--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(gvcf), path(gvcf_index)
+    tuple val(meta), path(gvcf), path(gvcf_index), path (intervals)
     path  fasta
     path  fasta_index
     path  fasta_dict
     path  dbsnp
     path  dbsnp_index
-    path  intervals_bed
 
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf
@@ -25,7 +24,7 @@ process GATK4_GENOTYPEGVCFS {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def dbsnp_options    = dbsnp ? "-D ${dbsnp}" : ""
-    def interval_options = intervals_bed ? "-L ${intervals_bed}" : ""
+    def interval_options = intervals ? "-L ${intervals}" : ""
     def gvcf_options     = gvcf.name.endsWith(".vcf") || gvcf.name.endsWith(".vcf.gz") ? "$gvcf" : "gendb://$gvcf"
     def avail_mem = 3
     if (!task.memory) {

--- a/modules/gatk4/genotypegvcfs/main.nf
+++ b/modules/gatk4/genotypegvcfs/main.nf
@@ -8,7 +8,7 @@ process GATK4_GENOTYPEGVCFS {
         'quay.io/biocontainers/gatk4:4.2.4.0--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(gvcf), path(gvcf_index), path (intervals)
+    tuple val(meta), path(gvcf), path(gvcf_index), path(intervals)
     path  fasta
     path  fasta_index
     path  fasta_dict

--- a/modules/gatk4/genotypegvcfs/meta.yml
+++ b/modules/gatk4/genotypegvcfs/meta.yml
@@ -25,6 +25,9 @@ input:
       description: |
         Tuple of gVCF(.gz) file (first) and its index (second) or the path to a GenomicsDB (and empty)
       pattern: ["*.{vcf,vcf.gz}", "*.{idx,tbi}"]
+  - intervals:
+      type: file
+      description: Bed file with the genomic regions included in the library (optional)
   - fasta:
       type: file
       description: Reference fasta file
@@ -45,10 +48,6 @@ input:
       type: tuple of files
       description: dbSNP VCF index file
       pattern: "*.tbi"
-  - intervals_bed:
-      type: file
-      description: An intevals BED file
-      pattern: "*.bed"
 
 output:
   - meta:

--- a/modules/gatk4/haplotypecaller/main.nf
+++ b/modules/gatk4/haplotypecaller/main.nf
@@ -8,13 +8,12 @@ process GATK4_HAPLOTYPECALLER {
         'quay.io/biocontainers/gatk4:4.2.4.0--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(input), path(input_index)
+    tuple val(meta), path(input), path(input_index), path(intervals)
     path fasta
     path fai
     path dict
     path dbsnp
     path dbsnp_tbi
-    path interval
 
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf
@@ -24,7 +23,7 @@ process GATK4_HAPLOTYPECALLER {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def interval_option = interval ? "-L ${interval}" : ""
+    def interval_option = intervals ? "-L ${intervals}" : ""
     def dbsnp_option    = dbsnp ? "-D ${dbsnp}" : ""
     def avail_mem       = 3
     if (!task.memory) {

--- a/modules/gatk4/haplotypecaller/meta.yml
+++ b/modules/gatk4/haplotypecaller/meta.yml
@@ -29,6 +29,9 @@ input:
       type: file
       description: BAI/CRAI file from alignment
       pattern: "*.{bai,crai}"
+  - intervals:
+      type: file
+      description: Bed file with the genomic regions included in the library (optional)
   - fasta:
       type: file
       description: The reference fasta file
@@ -47,9 +50,6 @@ input:
   - dbsnp_tbi:
       type: file
       description: VCF index of dbsnp (optional)
-  - interval:
-      type: file
-      description: Bed file with the genomic regions included in the library (optional)
 
 output:
   - meta:

--- a/tests/modules/gatk4/applybqsr/main.nf
+++ b/tests/modules/gatk4/applybqsr/main.nf
@@ -26,10 +26,10 @@ workflow test_gatk4_applybqsr_intervals {
                 file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
               ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-    fai = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
-    dict = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
+    fai   = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
+    dict  = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
 
-  GATK4_APPLYBQSR ( input, fasta, fai, dict, intervals )
+  GATK4_APPLYBQSR ( input, fasta, fai, dict )
 }
 
 workflow test_gatk4_applybqsr_cram {
@@ -43,5 +43,5 @@ workflow test_gatk4_applybqsr_cram {
     fai = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
     dict = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
 
-  GATK4_APPLYBQSR ( input, fasta, fai, dict, intervals )
+  GATK4_APPLYBQSR ( input, fasta, fai, dict )
 }

--- a/tests/modules/gatk4/applybqsr/main.nf
+++ b/tests/modules/gatk4/applybqsr/main.nf
@@ -8,25 +8,26 @@ workflow test_gatk4_applybqsr {
     input = [ [ id:'test' ], // meta map
               file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
               file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
-              file(params.test_data['sarscov2']['illumina']['test_baserecalibrator_table'], checkIfExists: true)
+              file(params.test_data['sarscov2']['illumina']['test_baserecalibrator_table'], checkIfExists: true),
+              []
             ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
     dict = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
 
-    GATK4_APPLYBQSR ( input, fasta, fai, dict, [] )
+    GATK4_APPLYBQSR ( input, fasta, fai, dict )
 }
 
 workflow test_gatk4_applybqsr_intervals {
     input = [ [ id:'test' ], // meta map
                 file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
                 file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
-                file(params.test_data['sarscov2']['illumina']['test_baserecalibrator_table'], checkIfExists: true)
+                file(params.test_data['sarscov2']['illumina']['test_baserecalibrator_table'], checkIfExists: true),
+                file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
               ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
     dict = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
-    intervals = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
 
   GATK4_APPLYBQSR ( input, fasta, fai, dict, intervals )
 }
@@ -35,12 +36,12 @@ workflow test_gatk4_applybqsr_cram {
     input = [ [ id:'test' ], // meta map
                 file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
                 file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true),
-                file(params.test_data['homo_sapiens']['illumina']['test_baserecalibrator_table'], checkIfExists: true)
+                file(params.test_data['homo_sapiens']['illumina']['test_baserecalibrator_table'], checkIfExists: true),
+                file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
               ]
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
     dict = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
-    intervals = file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
 
   GATK4_APPLYBQSR ( input, fasta, fai, dict, intervals )
 }

--- a/tests/modules/gatk4/applybqsr/test.yml
+++ b/tests/modules/gatk4/applybqsr/test.yml
@@ -26,7 +26,7 @@
     - gatk4
     - gatk4/applybqsr
   files:
-    - path: output/gatk4/test.bam
-      md5sum: a333f80284a89a8daab28d3686a0b365
+    - path: output/gatk4/test.cram
+      md5sum: f4e948d6c5aae1b5bfcca9b73779e60e
     - path: output/gatk4/versions.yml
       md5sum: 57933f27b3a31b05af3f7c248d365396

--- a/tests/modules/gatk4/applybqsr/test.yml
+++ b/tests/modules/gatk4/applybqsr/test.yml
@@ -27,6 +27,6 @@
     - gatk4/applybqsr
   files:
     - path: output/gatk4/test.cram
-      md5sum: f4e948d6c5aae1b5bfcca9b73779e60e
+      md5sum: b7659b3b2adaabbe73658dc059dbfdf6
     - path: output/gatk4/versions.yml
       md5sum: 57933f27b3a31b05af3f7c248d365396

--- a/tests/modules/gatk4/baserecalibrator/main.nf
+++ b/tests/modules/gatk4/baserecalibrator/main.nf
@@ -23,7 +23,6 @@ workflow test_gatk4_baserecalibrator_cram {
    input = [ [ id:'test' ], // meta map
                 file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
                 file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true),
-                file(params.test_data['homo_sapiens']['illumina']['test_baserecalibrator_table'], checkIfExists: true),
                 []
               ]
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
@@ -47,7 +46,7 @@ workflow test_gatk4_baserecalibrator_intervals {
     sites = file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true)
     sites_tbi = file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true)
 
-    GATK4_BASERECALIBRATOR ( input, fasta, fai, dict, intervals, sites, sites_tbi )
+    GATK4_BASERECALIBRATOR ( input, fasta, fai, dict, sites, sites_tbi )
 }
 
 workflow test_gatk4_baserecalibrator_multiple_sites {

--- a/tests/modules/gatk4/baserecalibrator/main.nf
+++ b/tests/modules/gatk4/baserecalibrator/main.nf
@@ -7,7 +7,8 @@ include { GATK4_BASERECALIBRATOR } from '../../../../modules/gatk4/baserecalibra
 workflow test_gatk4_baserecalibrator {
     input     = [ [ id:'test' ], // meta map
                     file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true)
+                    file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+                    []
                   ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
@@ -15,14 +16,15 @@ workflow test_gatk4_baserecalibrator {
     sites = file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true)
     sites_tbi = file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true)
 
-    GATK4_BASERECALIBRATOR ( input, fasta, fai, dict, [], sites, sites_tbi )
+    GATK4_BASERECALIBRATOR ( input, fasta, fai, dict, sites, sites_tbi )
 }
 
 workflow test_gatk4_baserecalibrator_cram {
    input = [ [ id:'test' ], // meta map
                 file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
                 file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true),
-                file(params.test_data['homo_sapiens']['illumina']['test_baserecalibrator_table'], checkIfExists: true)
+                file(params.test_data['homo_sapiens']['illumina']['test_baserecalibrator_table'], checkIfExists: true),
+                []
               ]
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
@@ -30,18 +32,18 @@ workflow test_gatk4_baserecalibrator_cram {
     sites = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz'], checkIfExists: true)
     sites_tbi = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz_tbi'], checkIfExists: true)
 
-    GATK4_BASERECALIBRATOR ( input, fasta, fai, dict, [], sites, sites_tbi )
+    GATK4_BASERECALIBRATOR ( input, fasta, fai, dict, sites, sites_tbi )
 }
 
 workflow test_gatk4_baserecalibrator_intervals {
     input     = [ [ id:'test' ], // meta map
                   file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                  file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true)
+                  file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+                  file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
                 ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
     dict = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
-    intervals = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
     sites = file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true)
     sites_tbi = file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true)
 
@@ -51,7 +53,8 @@ workflow test_gatk4_baserecalibrator_intervals {
 workflow test_gatk4_baserecalibrator_multiple_sites {
     input     = [ [ id:'test' ], // meta map
                   file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                  file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true)
+                  file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+                  []
                 ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
@@ -63,5 +66,5 @@ workflow test_gatk4_baserecalibrator_multiple_sites {
                   file(params.test_data['sarscov2']['illumina']['test2_vcf_gz_tbi'], checkIfExists: true)
                 ]
 
-  GATK4_BASERECALIBRATOR ( input, fasta, fai, dict, [], sites, sites_tbi )
+  GATK4_BASERECALIBRATOR ( input, fasta, fai, dict, sites, sites_tbi )
 }

--- a/tests/modules/gatk4/genotypegvcfs/main.nf
+++ b/tests/modules/gatk4/genotypegvcfs/main.nf
@@ -139,7 +139,8 @@ workflow test_gatk4_genotypegvcfs_gendb_input_intervals {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
-    input = Channel.of([ id:'test' ]).combine(gendb).add(file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true))
+    input = Channel.of([ id:'test' ]).combine(gendb)
+    input = input.add(file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true))
 
     GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [] )
 }
@@ -159,7 +160,8 @@ workflow test_gatk4_genotypegvcfs_gendb_input_dbsnp_intervals {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
-    input = Channel.of([ id:'test' ]).combine(gendb).add(file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true))
+    input = Channel.of([ id:'test' ]).combine(gendb)
+    input = input.add(file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true))
 
     GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex )
 }

--- a/tests/modules/gatk4/genotypegvcfs/main.nf
+++ b/tests/modules/gatk4/genotypegvcfs/main.nf
@@ -18,7 +18,7 @@ workflow test_gatk4_genotypegvcfs_vcf_input {
     fastaIndex   = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
     fastaDict    = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
 
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [],)
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [])
 }
 
 // Basic parameters with compressed VCF input
@@ -53,7 +53,7 @@ workflow test_gatk4_genotypegvcfs_gz_input_dbsnp {
     dbsnp        = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz'], checkIfExists: true)
     dbsnpIndex   = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz_tbi'], checkIfExists: true)
 
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex, [] )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex)
 }
 
 // Basic parameters + optional intervals
@@ -77,7 +77,8 @@ workflow test_gatk4_genotypegvcfs_gz_input_dbsnp_intervals {
     input = [ [ id:'test' ], // meta map
               file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz'], checkIfExists: true),
               file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true),
-              file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true) ]
+              file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
+            ]
 
     fasta        = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fastaIndex   = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
@@ -101,7 +102,7 @@ workflow test_gatk4_genotypegvcfs_gendb_input {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
-    input = Channel.of([ id:'test' ]).combine(gendb)
+    input = Channel.of([ id:'test' ]).combine(gendb).add([])
 
     GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [])
 }
@@ -121,7 +122,7 @@ workflow test_gatk4_genotypegvcfs_gendb_input_dbsnp {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
-    input = Channel.of([ id:'test' ]).combine(gendb)
+    input = Channel.of([ id:'test' ]).combine(gendb).add([])
 
     GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex)
 }

--- a/tests/modules/gatk4/genotypegvcfs/main.nf
+++ b/tests/modules/gatk4/genotypegvcfs/main.nf
@@ -139,8 +139,8 @@ workflow test_gatk4_genotypegvcfs_gendb_input_intervals {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
+    gendb.add([file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)])
     input = Channel.of([ id:'test' ]).combine(gendb)
-    input = input.add(file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true))
 
     GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [] )
 }
@@ -160,8 +160,8 @@ workflow test_gatk4_genotypegvcfs_gendb_input_dbsnp_intervals {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
+    gendb.add([file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)])
     input = Channel.of([ id:'test' ]).combine(gendb)
-    input = input.add(file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true))
 
     GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex )
 }

--- a/tests/modules/gatk4/genotypegvcfs/main.nf
+++ b/tests/modules/gatk4/genotypegvcfs/main.nf
@@ -102,7 +102,9 @@ workflow test_gatk4_genotypegvcfs_gendb_input {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
-    input = Channel.of([ id:'test' ]).combine(gendb).add([])
+    gendb.add([])
+
+    input = Channel.of([ id:'test' ]).combine(gendb)
 
     GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [])
 }
@@ -122,7 +124,8 @@ workflow test_gatk4_genotypegvcfs_gendb_input_dbsnp {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
-    input = Channel.of([ id:'test' ]).combine(gendb).add([])
+    gendb.add([])
+    input = Channel.of([ id:'test' ]).combine(gendb)
 
     GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex)
 }

--- a/tests/modules/gatk4/genotypegvcfs/main.nf
+++ b/tests/modules/gatk4/genotypegvcfs/main.nf
@@ -10,13 +10,15 @@ workflow test_gatk4_genotypegvcfs_vcf_input {
 
     input = [ [ id:'test' ], // meta map
               file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf'], checkIfExists: true),
-              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_idx'], checkIfExists: true) ]
+              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_idx'], checkIfExists: true),
+              []
+            ]
 
     fasta        = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fastaIndex   = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
     fastaDict    = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
 
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [], [] )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [],)
 }
 
 // Basic parameters with compressed VCF input
@@ -24,13 +26,15 @@ workflow test_gatk4_genotypegvcfs_gz_input {
 
     input = [ [ id:'test' ], // meta map
               file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz'], checkIfExists: true),
-              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true) ]
+              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true),
+              []
+            ]
 
     fasta        = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fastaIndex   = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
     fastaDict    = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
 
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [], [] )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [])
 }
 
 // Basic parameters + optional dbSNP
@@ -38,7 +42,9 @@ workflow test_gatk4_genotypegvcfs_gz_input_dbsnp {
 
     input = [ [ id:'test' ], // meta map
               file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz'], checkIfExists: true),
-              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true) ]
+              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true),
+              []
+            ]
 
     fasta        = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fastaIndex   = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
@@ -55,15 +61,14 @@ workflow test_gatk4_genotypegvcfs_gz_input_intervals {
 
     input = [ [ id:'test' ], // meta map
               file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz'], checkIfExists: true),
-              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true) ]
+              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true),
+              file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true) ]
 
     fasta        = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fastaIndex   = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
     fastaDict    = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
 
-    intervalsBed = file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
-
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [], intervalsBed )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [])
 }
 
 // Basic parameters + optional dbSNP + optional intervals
@@ -71,7 +76,8 @@ workflow test_gatk4_genotypegvcfs_gz_input_dbsnp_intervals {
 
     input = [ [ id:'test' ], // meta map
               file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz'], checkIfExists: true),
-              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true) ]
+              file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_gz_tbi'], checkIfExists: true),
+              file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true) ]
 
     fasta        = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fastaIndex   = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
@@ -80,9 +86,7 @@ workflow test_gatk4_genotypegvcfs_gz_input_dbsnp_intervals {
     dbsnp        = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz'], checkIfExists: true)
     dbsnpIndex   = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz_tbi'], checkIfExists: true)
 
-    intervalsBed = file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
-
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex, intervalsBed )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex )
 }
 
 // Basic parameters with GenomicsDB input
@@ -99,7 +103,7 @@ workflow test_gatk4_genotypegvcfs_gendb_input {
     gendb.add([])
     input = Channel.of([ id:'test' ]).combine(gendb)
 
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [], [] )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [])
 }
 
 // Basic parameters with GenomicsDB + optional dbSNP
@@ -119,7 +123,7 @@ workflow test_gatk4_genotypegvcfs_gendb_input_dbsnp {
     gendb.add([])
     input = Channel.of([ id:'test' ]).combine(gendb)
 
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex, [] )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex)
 }
 
 // Basic parameters with GenomicsDB + optional intervals
@@ -136,9 +140,9 @@ workflow test_gatk4_genotypegvcfs_gendb_input_intervals {
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
-    input = Channel.of([ id:'test' ]).combine(gendb)
+    input = Channel.of([ id:'test' ]).combine(gendb).add(file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true))
 
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [], intervalsBed )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, [], [] )
 }
 
 // Basic parameters with GenomicsDB + optional dbSNP + optional intervals
@@ -151,14 +155,12 @@ workflow test_gatk4_genotypegvcfs_gendb_input_dbsnp_intervals {
     dbsnp        = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz'], checkIfExists: true)
     dbsnpIndex   = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz_tbi'], checkIfExists: true)
 
-    intervalsBed = file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
-
     test_genomicsdb = file(params.test_data['homo_sapiens']['illumina']['test_genomicsdb_tar_gz'], checkIfExists: true)
 
     UNTAR ( test_genomicsdb )
     gendb = UNTAR.out.untar.collect()
     gendb.add([])
-    input = Channel.of([ id:'test' ]).combine(gendb)
+    input = Channel.of([ id:'test' ]).combine(gendb).add(file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true))
 
-    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex, intervalsBed )
+    GATK4_GENOTYPEGVCFS ( input, fasta, fastaIndex, fastaDict, dbsnp, dbsnpIndex )
 }

--- a/tests/modules/gatk4/genotypegvcfs/main.nf
+++ b/tests/modules/gatk4/genotypegvcfs/main.nf
@@ -133,8 +133,6 @@ workflow test_gatk4_genotypegvcfs_gendb_input_intervals {
     fastaIndex   = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
     fastaDict    = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
 
-    intervalsBed = file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
-
     test_genomicsdb = file(params.test_data['homo_sapiens']['illumina']['test_genomicsdb_tar_gz'], checkIfExists: true)
 
     UNTAR ( test_genomicsdb )

--- a/tests/modules/gatk4/genotypegvcfs/test.yml
+++ b/tests/modules/gatk4/genotypegvcfs/test.yml
@@ -55,7 +55,7 @@
     - gatk4/genotypegvcfs
   files:
     - path: output/gatk4/test.genotyped.vcf.gz
-      contains: ['AC=1;AF=0.500;AN=2;BaseQRankSum=0.00;DP=211;ExcessHet=0.0000;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=0.00;QD=0.95;ReadPosRankSum=1.09;SOR=0.680']
+      contains: ['AC=1;AF=0.500;AN=2;BaseQRankSum=0.00;DB;DP=211;ExcessHet=0.0000;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=0.00;QD=0.95;ReadPosRankSum=1.09;SOR=0.680']
     - path: output/gatk4/test.genotyped.vcf.gz.tbi
 
 - name: gatk4 genotypegvcfs test_gatk4_genotypegvcfs_gendb_input_dbsnp
@@ -79,7 +79,7 @@
     - path: output/gatk4/test.genotyped.vcf.gz.tbi
 
 - name: gatk4 genotypegvcfs test_gatk4_genotypegvcfs_gendb_input_dbsnp_intervals
-  command: nextflow run ./tests/modules/gatk4/genotypegvcfs -entry test_gatk4_genotypegvcfs_gendb_input_dbsnp_intervals -c ./tests/config/nextflow.config -c ./tests/modules/gatk4/genotypegvcfs/nextflow.config
+  command:
   tags:
     - gatk4
     - gatk4/genotypegvcfs

--- a/tests/modules/gatk4/genotypegvcfs/test.yml
+++ b/tests/modules/gatk4/genotypegvcfs/test.yml
@@ -79,7 +79,7 @@
     - path: output/gatk4/test.genotyped.vcf.gz.tbi
 
 - name: gatk4 genotypegvcfs test_gatk4_genotypegvcfs_gendb_input_dbsnp_intervals
-  command:
+  command: nextflow run ./tests/modules/gatk4/genotypegvcfs -entry test_gatk4_genotypegvcfs_gendb_input_dbsnp_intervals -c ./tests/config/nextflow.config -c ./tests/modules/gatk4/genotypegvcfs/nextflow.config
   tags:
     - gatk4
     - gatk4/genotypegvcfs

--- a/tests/modules/gatk4/genotypegvcfs/test.yml
+++ b/tests/modules/gatk4/genotypegvcfs/test.yml
@@ -55,7 +55,7 @@
     - gatk4/genotypegvcfs
   files:
     - path: output/gatk4/test.genotyped.vcf.gz
-      contains: ['AC=1;AF=0.500;AN=2;BaseQRankSum=0.00;DB;DP=211;ExcessHet=0.0000;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=0.00;QD=0.95;ReadPosRankSum=1.09;SOR=0.680']
+      contains: ['AC=1;AF=0.500;AN=2;BaseQRankSum=0.00;DP=211;ExcessHet=0.0000;FS=0.000;MLEAC=1;MLEAF=0.500;MQ=60.00;MQRankSum=0.00;QD=0.95;ReadPosRankSum=1.09;SOR=0.680']
     - path: output/gatk4/test.genotyped.vcf.gz.tbi
 
 - name: gatk4 genotypegvcfs test_gatk4_genotypegvcfs_gendb_input_dbsnp

--- a/tests/modules/gatk4/haplotypecaller/main.nf
+++ b/tests/modules/gatk4/haplotypecaller/main.nf
@@ -7,31 +7,34 @@ include { GATK4_HAPLOTYPECALLER } from '../../../../modules/gatk4/haplotypecalle
 workflow test_gatk4_haplotypecaller {
     input     = [ [ id:'test' ], // meta map
                   file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                  file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true)
+                  file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+                  []
                 ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
     dict = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
 
-    GATK4_HAPLOTYPECALLER ( input, fasta, fai, dict, [], [], [] )
+    GATK4_HAPLOTYPECALLER ( input, fasta, fai, dict, [], [])
 }
 
 workflow test_gatk4_haplotypecaller_cram {
     input = [ [ id:'test' ], // meta map
                 file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
-                file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true)
+                file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true),
+                []
               ]
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     fai = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
     dict = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
 
-    GATK4_HAPLOTYPECALLER ( input, fasta, fai, dict, [], [], [] )
+    GATK4_HAPLOTYPECALLER ( input, fasta, fai, dict, [], [])
 }
 
 workflow test_gatk4_haplotypecaller_intervals_dbsnp {
    input = [ [ id:'test' ], // meta map
                 file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
-                file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true)
+                file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true),
+                file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
             ]
 
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
@@ -39,7 +42,6 @@ workflow test_gatk4_haplotypecaller_intervals_dbsnp {
     dict = file(params.test_data['homo_sapiens']['genome']['genome_dict'], checkIfExists: true)
     sites = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz'], checkIfExists: true)
     sites_tbi = file(params.test_data['homo_sapiens']['genome']['dbsnp_146_hg38_vcf_gz_tbi'], checkIfExists: true)
-    intervals = file(params.test_data['homo_sapiens']['genome']['genome_bed'], checkIfExists: true)
 
-    GATK4_HAPLOTYPECALLER ( input, fasta, fai, dict, sites, sites_tbi, intervals )
+    GATK4_HAPLOTYPECALLER ( input, fasta, fai, dict, sites, sites_tbi )
 }


### PR DESCRIPTION
In sarek we use these modules with multiple intervals per sample. So to make sure that all samples are run with all intervals, I propose to change the interval input to go along with the sample. 

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
