### PR TITLE
Fix error messages mentioning suffix

### DIFF
--- a/modules/last/postmask/main.nf
+++ b/modules/last/postmask/main.nf
@@ -17,7 +17,7 @@ process LAST_POSTMASK {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if( "$maf" == "${prefix}.maf.gz" ) error "Input and output names are the same, use the suffix option to disambiguate"
+    if( "$maf" == "${prefix}.maf.gz" ) error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     last-postmask $args $maf | gzip --no-name > ${prefix}.maf.gz
 

--- a/modules/plink/extract/main.nf
+++ b/modules/plink/extract/main.nf
@@ -19,7 +19,7 @@ process PLINK_EXTRACT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if( "$bed" == "${prefix}.bed" ) error "Input and output names are the same, use the suffix option to disambiguate"
+    if( "$bed" == "${prefix}.bed" ) error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     plink \\
         --bfile ${meta.id} \\

--- a/modules/pmdtools/filter/main.nf
+++ b/modules/pmdtools/filter/main.nf
@@ -22,7 +22,7 @@ process PMDTOOLS_FILTER {
     def args3 = task.ext.args3 ?: ''
     def split_cpus = Math.floor(task.cpus/2)
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if ("$bam" == "${prefix}.bam") error "[pmdtools/filter] Input and output names are the same, use the suffix option to disambiguate!"
+    if ("$bam" == "${prefix}.bam") error "[pmdtools/filter] Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     //threshold and header flags activate filtering function of pmdtools
     """
     samtools \\

--- a/modules/samblaster/main.nf
+++ b/modules/samblaster/main.nf
@@ -19,7 +19,7 @@ process SAMBLASTER {
     def args2 = task.ext.args2 ?: ''
     def args3 = task.ext.args3 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if( "$bam" == "${prefix}.bam" ) error "Input and output names are the same, use the suffix option to disambiguate"
+    if( "$bam" == "${prefix}.bam" ) error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     samtools view -h $args2 $bam | \\
     samblaster $args | \\

--- a/modules/samtools/fixmate/main.nf
+++ b/modules/samtools/fixmate/main.nf
@@ -17,7 +17,7 @@ process SAMTOOLS_FIXMATE {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if ("$bam" == "${prefix}.bam") error "Input and output names are the same, use the suffix option to disambiguate!"
+    if ("$bam" == "${prefix}.bam") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
 
     """
     samtools \\


### PR DESCRIPTION
Fix several error messages that still were mentioning the deprecated `suffix` option. 

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
