### PR TITLE
Fix modules warned or failed with nf-core modules lint

### DIFF
--- a/modules/ataqv/ataqv/main.nf
+++ b/modules/ataqv/ataqv/main.nf
@@ -5,7 +5,7 @@ process ATAQV_ATAQV {
     conda (params.enable_conda ? "bioconda::ataqv=1.2.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ataqv:1.2.1--py39ha23c084_2' :
-        'quay.io/biocontainers/ataqv:1.2.1--py36hfdecbe1_2' }"
+        'quay.io/biocontainers/ataqv:1.2.1--py39ha23c084_2' }"
 
     input:
     tuple val(meta), path(bam), path(bai), path(peak_file)

--- a/modules/bcftools/index/main.nf
+++ b/modules/bcftools/index/main.nf
@@ -13,7 +13,7 @@ process BCFTOOLS_INDEX {
     output:
     tuple val(meta), path("*.csi"), optional:true, emit: csi
     tuple val(meta), path("*.tbi"), optional:true, emit: tbi
-    path "versions.yml"          , emit: version
+    path "versions.yml"           , emit: versions
 
     script:
     def args = task.ext.args ?: ''

--- a/modules/bowtie2/build/main.nf
+++ b/modules/bowtie2/build/main.nf
@@ -5,7 +5,7 @@ process BOWTIE2_BUILD {
     conda (params.enable_conda ? 'bioconda::bowtie2=2.4.4' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/bowtie2:2.4.4--py39hbb4e92a_0' :
-        'quay.io/biocontainers/bowtie2:2.4.4--py36hd4290be_0' }"
+        'quay.io/biocontainers/bowtie2:2.4.4--py39hbb4e92a_0' }"
 
     input:
     path fasta

--- a/modules/cutadapt/main.nf
+++ b/modules/cutadapt/main.nf
@@ -5,7 +5,7 @@ process CUTADAPT {
     conda (params.enable_conda ? 'bioconda::cutadapt=3.4' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/cutadapt:3.4--py39h38f01e4_1' :
-        'quay.io/biocontainers/cutadapt:3.4--py37h73a75cf_1' }"
+        'quay.io/biocontainers/cutadapt:3.4--py39h38f01e4_1' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/fgbio/fastqtobam/main.nf
+++ b/modules/fgbio/fastqtobam/main.nf
@@ -13,7 +13,7 @@ process FGBIO_FASTQTOBAM {
 
     output:
     tuple val(meta), path("*_umi_converted.bam"), emit: umibam
-    path "versions.yml"                         , emit: version
+    path "versions.yml"                         , emit: versions
 
     script:
     def args = task.ext.args ?: ''

--- a/modules/gtdbtk/classifywf/main.nf
+++ b/modules/gtdbtk/classifywf/main.nf
@@ -2,6 +2,7 @@ def VERSION = '1.5.0' // Version information not provided by tool on CLI
 
 process GTDBTK_CLASSIFYWF {
     tag "${meta.assembler}-${meta.id}"
+    label 'process_medium'
 
     conda (params.enable_conda ? "bioconda::gtdbtk=1.5.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/idr/main.nf
+++ b/modules/idr/main.nf
@@ -5,7 +5,7 @@ process IDR {
     conda (params.enable_conda ? "bioconda::idr=2.0.4.2" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/idr:2.0.4.2--py39hcbe4a3b_5' :
-        'quay.io/biocontainers/idr:2.0.4.2--py38h9af456f_5' }"
+        'quay.io/biocontainers/idr:2.0.4.2--py39hcbe4a3b_5' }"
 
     input:
     path peaks

--- a/modules/jupyternotebook/main.nf
+++ b/modules/jupyternotebook/main.nf
@@ -9,7 +9,7 @@ process JUPYTERNOTEBOOK {
     //ipykernel, jupytext, papermill and nbconvert Python packages.
     conda (params.enable_conda ? "ipykernel=6.0.3 jupytext=1.11.4 nbconvert=6.1.0 papermill=2.3.3 matplotlib=3.4.2" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-514b1a5d280c7043110b2a8d0a87b57ba392a963%3A879972fc8bdc81ee92f2bce3b4805d89a772bf84-0' :
+        'https://depot.galaxyproject.org/singularity/mulled-v2-514b1a5d280c7043110b2a8d0a87b57ba392a963:879972fc8bdc81ee92f2bce3b4805d89a772bf84-0' :
         'quay.io/biocontainers/mulled-v2-514b1a5d280c7043110b2a8d0a87b57ba392a963:879972fc8bdc81ee92f2bce3b4805d89a772bf84-0' }"
 
     input:

--- a/modules/krona/kronadb/main.nf
+++ b/modules/krona/kronadb/main.nf
@@ -8,8 +8,6 @@ process KRONA_KRONADB {
         'https://depot.galaxyproject.org/singularity/krona:2.7.1--pl526_5' :
         'quay.io/biocontainers/krona:2.7.1--pl526_5' }"
 
-    input:
-
     output:
     path 'taxonomy/taxonomy.tab', emit: db
     path "versions.yml"         , emit: versions

--- a/modules/malt/run/main.nf
+++ b/modules/malt/run/main.nf
@@ -1,6 +1,5 @@
 process MALT_RUN {
-
-    label 'process_high_memory'
+    label 'process_high'
 
     conda (params.enable_conda ? "bioconda::malt=0.53" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/paraclu/main.nf
+++ b/modules/paraclu/main.nf
@@ -6,7 +6,7 @@ process PARACLU {
 
     conda (params.enable_conda ? "bioconda::paraclu=10" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/paraclu%3A10--h9a82719_1' :
+        'https://depot.galaxyproject.org/singularity/paraclu:10--h9a82719_1' :
         'quay.io/biocontainers/paraclu:10--h9a82719_1' }"
 
     input:

--- a/modules/pirate/main.nf
+++ b/modules/pirate/main.nf
@@ -4,7 +4,7 @@ process PIRATE {
 
     conda (params.enable_conda ? "bioconda::pirate=1.0.4" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pirate%3A1.0.4--hdfd78af_1' :
+        'https://depot.galaxyproject.org/singularity/pirate:1.0.4--hdfd78af_1' :
         'quay.io/biocontainers/pirate:1.0.4--hdfd78af_1' }"
 
     input:

--- a/modules/porechop/main.nf
+++ b/modules/porechop/main.nf
@@ -5,7 +5,7 @@ process PORECHOP {
     conda (params.enable_conda ? "bioconda::porechop=0.2.4" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/porechop:0.2.4--py39h7cff6ad_2' :
-        'quay.io/biocontainers/porechop:0.2.4--py38h8c62d01_2' }"
+        'quay.io/biocontainers/porechop:0.2.4--py39h7cff6ad_2' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/rmarkdownnotebook/main.nf
+++ b/modules/rmarkdownnotebook/main.nf
@@ -9,7 +9,7 @@ process RMARKDOWNNOTEBOOK {
     //yaml and rmarkdown R packages.
     conda (params.enable_conda ? "r-base=4.1.0 r-rmarkdown=2.9 r-yaml=2.2.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-31ad840d814d356e5f98030a4ee308a16db64ec5%3A0e852a1e4063fdcbe3f254ac2c7469747a60e361-0' :
+        'https://depot.galaxyproject.org/singularity/mulled-v2-31ad840d814d356e5f98030a4ee308a16db64ec5:0e852a1e4063fdcbe3f254ac2c7469747a60e361-0' :
         'quay.io/biocontainers/mulled-v2-31ad840d814d356e5f98030a4ee308a16db64ec5:0e852a1e4063fdcbe3f254ac2c7469747a60e361-0' }"
 
     input:

--- a/modules/spatyper/main.nf
+++ b/modules/spatyper/main.nf
@@ -4,7 +4,7 @@ process SPATYPER {
 
     conda (params.enable_conda ? "bioconda::spatyper=0.3.3" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/spatyper%3A0.3.3--pyhdfd78af_3' :
+        'https://depot.galaxyproject.org/singularity/spatyper:0.3.3--pyhdfd78af_3' :
         'quay.io/biocontainers/spatyper:0.3.3--pyhdfd78af_3' }"
 
     input:

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -282,6 +282,14 @@ cellranger/gtf:
   - modules/cellranger/gtf/**
   - tests/modules/cellranger/gtf/**
 
+cellranger/mkfastq:
+  - modules/cellranger/mkfastq/**
+  - tests/modules/cellranger/mkfastq/**
+
+cellranger/mkgtf:
+  - modules/cellranger/mkgtf/**
+  - tests/modules/cellranger/mkgtf/**
+
 cellranger/mkref:
   - modules/cellranger/mkref/**
   - tests/modules/cellranger/mkref/**


### PR DESCRIPTION
Fixed some of these whilst developing https://github.com/nf-core/tools/pull/1374

* Now properly allow for `input:` and `output:` not being specified in module
* Allow for containers from other biocontainers resource
* Allow for `stageAs` syntax as defined here: https://github.com/nf-core/modules/blob/cde237e7cec07798e5754b72aeca44efe89fc6db/modules/cat/fastq/main.nf#L11
* Fix mismatching container versions and replace `%3A` notation with `:`
* Add missing modules to `pytest_modules.yml`
* Fix modules using `version` instead of `versions` in `emit` statement

Most of the remaining lint warnings are for modules that needs a version bump and those that generate empty files.