### PR TITLE
Editing the CAT/CAT module to handle single files

### DIFF
--- a/modules/cat/cat/main.nf
+++ b/modules/cat/cat/main.nf
@@ -18,30 +18,28 @@ process CAT_CAT {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def file_list = files_in.collect { it.toString() }
-    if (file_list.size > 1) {
 
-        // | input     | output     | command1 | command2 |
-        // |-----------|------------|----------|----------|
-        // | gzipped   | gzipped    | cat      |          |
-        // | ungzipped | ungzipped  | cat      |          |
-        // | gzipped   | ungzipped  | zcat     |          |
-        // | ungzipped | gzipped    | cat      | pigz     |
+    // | input     | output     | command1 | command2 |
+    // |-----------|------------|----------|----------|
+    // | gzipped   | gzipped    | cat      |          |
+    // | ungzipped | ungzipped  | cat      |          |
+    // | gzipped   | ungzipped  | zcat     |          |
+    // | ungzipped | gzipped    | cat      | pigz     |
 
-        def in_zip   = file_list[0].endsWith('.gz')
-        def out_zip  = file_out.endsWith('.gz')
-        def command1 = (in_zip && !out_zip) ? 'zcat' : 'cat'
-        def command2 = (!in_zip && out_zip) ? "| pigz -c -p $task.cpus $args2" : ''
-        """
-        $command1 \\
-            $args \\
-            ${file_list.join(' ')} \\
-            $command2 \\
-            > $file_out
+    def in_zip   = file_list[0].endsWith('.gz')
+    def out_zip  = file_out.endsWith('.gz')
+    def command1 = (in_zip && !out_zip) ? 'zcat' : 'cat'
+    def command2 = (!in_zip && out_zip) ? "| pigz -c -p $task.cpus $args2" : ''
+    """
+    $command1 \\
+        $args \\
+        ${file_list.join(' ')} \\
+        $command2 \\
+        > $file_out
 
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-        END_VERSIONS
-        """
-    }
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
 }

--- a/tests/modules/cat/cat/main.nf
+++ b/tests/modules/cat/cat/main.nf
@@ -43,3 +43,12 @@ workflow test_cat_unzipped_zipped {
 
     CAT_CAT ( input, 'cat.txt.gz' )
 }
+
+workflow test_cat_one_file_unzipped_zipped {
+
+    input = [
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
+    ]
+
+    CAT_CAT ( input, 'cat.txt.gz' )
+}

--- a/tests/modules/cat/cat/test.yml
+++ b/tests/modules/cat/cat/test.yml
@@ -6,6 +6,8 @@
   files:
     - path: output/cat/cat.txt
       md5sum: f44b33a0e441ad58b2d3700270e2dbe2
+    - path: output/cat/versions.yml
+      md5sum: 36080ae8e44023a88e0f3589d8affb1a
 
 - name: cat zipped zipped
   command: nextflow run ./tests/modules/cat/cat -entry test_cat_zipped_zipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
@@ -14,6 +16,9 @@
     - cat/cat
   files:
     - path: output/cat/cat.txt.gz
+      md5sum: 1c3e5c5ddf6ebcaf56f3283905269974
+    - path: output/cat/versions.yml
+      md5sum: 5041ed256b71dadd5ca1dd30749b968d
 
 - name: cat zipped unzipped
   command: nextflow run ./tests/modules/cat/cat -entry test_cat_zipped_unzipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
@@ -23,6 +28,8 @@
   files:
     - path: output/cat/cat.txt
       md5sum: c439d3b60e7bc03e8802a451a0d9a5d9
+    - path: output/cat/versions.yml
+      md5sum: dbec957026e2485b72408ec9972baa50
 
 - name: cat unzipped zipped
   command: nextflow run ./tests/modules/cat/cat -entry test_cat_unzipped_zipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
@@ -31,3 +38,17 @@
     - cat/cat
   files:
     - path: output/cat/cat.txt.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+    - path: output/cat/versions.yml
+      md5sum: 438011291e3e616e6134aac0a41ed128
+
+- name: cat one file unzipped zipped
+  command: nextflow run ./tests/modules/cat/cat -entry test_cat_one_file_unzipped_zipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
+  tags:
+    - cat
+    - cat/cat
+  files:
+    - path: output/cat/cat.txt.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+    - path: output/cat/versions.yml
+      md5sum: d61a6725ed4a31db67ec7a43033278fd

--- a/tests/modules/cat/cat/test.yml
+++ b/tests/modules/cat/cat/test.yml
@@ -6,8 +6,6 @@
   files:
     - path: output/cat/cat.txt
       md5sum: f44b33a0e441ad58b2d3700270e2dbe2
-    - path: output/cat/versions.yml
-      md5sum: 36080ae8e44023a88e0f3589d8affb1a
 
 - name: cat zipped zipped
   command: nextflow run ./tests/modules/cat/cat -entry test_cat_zipped_zipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
@@ -16,9 +14,6 @@
     - cat/cat
   files:
     - path: output/cat/cat.txt.gz
-      md5sum: 1c3e5c5ddf6ebcaf56f3283905269974
-    - path: output/cat/versions.yml
-      md5sum: 5041ed256b71dadd5ca1dd30749b968d
 
 - name: cat zipped unzipped
   command: nextflow run ./tests/modules/cat/cat -entry test_cat_zipped_unzipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
@@ -28,8 +23,6 @@
   files:
     - path: output/cat/cat.txt
       md5sum: c439d3b60e7bc03e8802a451a0d9a5d9
-    - path: output/cat/versions.yml
-      md5sum: dbec957026e2485b72408ec9972baa50
 
 - name: cat unzipped zipped
   command: nextflow run ./tests/modules/cat/cat -entry test_cat_unzipped_zipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
@@ -38,9 +31,6 @@
     - cat/cat
   files:
     - path: output/cat/cat.txt.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
-    - path: output/cat/versions.yml
-      md5sum: 438011291e3e616e6134aac0a41ed128
 
 - name: cat one file unzipped zipped
   command: nextflow run ./tests/modules/cat/cat -entry test_cat_one_file_unzipped_zipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
@@ -49,6 +39,3 @@
     - cat/cat
   files:
     - path: output/cat/cat.txt.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
-    - path: output/cat/versions.yml
-      md5sum: d61a6725ed4a31db67ec7a43033278fd


### PR DESCRIPTION
The `cat/cat` module as is can't handle a single file. In a pipeline, if a previous step e.g. splits a fasta-file based on size and then `cat/cat` is run to gather the results it will work for more than one file, but it would be desirable if it also worked on a single file. Therefore I've edited the module to process single files as well as more than one file.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
