### PR TITLE
Add functionality to handle vbz compression

### DIFF
--- a/modules/artic/minion/main.nf
+++ b/modules/artic/minion/main.nf
@@ -44,6 +44,7 @@ process ARTIC_MINION {
         model = file(medaka_model).exists() ? "--medaka-model ./$medaka_model" : "--medaka-model $medaka_model"
     }
     """
+    HDF5_PLUGIN_PATH=/usr/local/lib/python3.6/site-packages/ont_fast5_api/vbz_plugin \\
     artic \\
         minion \\
         $args \\

--- a/modules/artic/minion/main.nf
+++ b/modules/artic/minion/main.nf
@@ -43,8 +43,9 @@ process ARTIC_MINION {
         summary = ""
         model = file(medaka_model).exists() ? "--medaka-model ./$medaka_model" : "--medaka-model $medaka_model"
     }
+    def hd5_plugin_path = params.options.hd5_plugin_path ? "HDF5_PLUGIN_PATH=" + params.options.hd5_plugin_path : "HDF5_PLUGIN_PATH=/usr/local/lib/python3.6/site-packages/ont_fast5_api/vbz_plugin"
     """
-    HDF5_PLUGIN_PATH=/usr/local/lib/python3.6/site-packages/ont_fast5_api/vbz_plugin \\
+    $hd5_plugin_path \\
     artic \\
         minion \\
         $args \\

--- a/modules/artic/minion/main.nf
+++ b/modules/artic/minion/main.nf
@@ -43,9 +43,10 @@ process ARTIC_MINION {
         summary = ""
         model = file(medaka_model).exists() ? "--medaka-model ./$medaka_model" : "--medaka-model $medaka_model"
     }
-    def hd5_plugin_path = params.options.hd5_plugin_path ? "HDF5_PLUGIN_PATH=" + params.options.hd5_plugin_path : "HDF5_PLUGIN_PATH=/usr/local/lib/python3.6/site-packages/ont_fast5_api/vbz_plugin"
+    def hd5_plugin_path = task.ext.hd5_plugin_path ? "HDF5_PLUGIN_PATH=" + task.ext.hd5_plugin_path : "HDF5_PLUGIN_PATH=/usr/local/lib/python3.6/site-packages/ont_fast5_api/vbz_plugin"
     """
-    $hd5_plugin_path \\
+    $hd5_plugin_path
+
     artic \\
         minion \\
         $args \\


### PR DESCRIPTION
In order for nanopolish to be able handle the default compression for Mk1C Minions (vbz) it must be aware of where to find the plugin. Exporting the HDF5_PLUGIN_PATH found in the conda install (also used to make the biocontainer image) is the solution

See also
https://github.com/jts/nanopolish/issues/899#issuecomment-826920235


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
