### PR TITLE
Fixed sed quotes to rename fasta header

### DIFF
--- a/modules/bcftools/consensus/main.nf
+++ b/modules/bcftools/consensus/main.nf
@@ -20,7 +20,7 @@ process BCFTOOLS_CONSENSUS {
     """
     cat $fasta | bcftools consensus $vcf $args > ${prefix}.fa
     header=\$(head -n 1 ${prefix}.fa | sed 's/>//g')
-    sed -i 's/\${header}/${meta.id}/g' ${prefix}.fa
+    sed -i "s/\${header}/${meta.id}/g" ${prefix}.fa
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Sed command won't rename the consensus fasta header until using double quote.

## PR checklist
- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [X] Remove all TODO statements.
- [X] Emit the `versions.yml` file.
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
