### PR TITLE
CI: print out pytest logs on failure

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -93,6 +93,16 @@ jobs:
         # only use one thread for pytest-workflow to avoid race condition on conda cache.
         run: TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --tag ${{ matrix.tags }} --symlink --kwdof
 
+      - name: Output log on failure
+        if: failure()
+        run: |
+          echo "======> log.out <======="
+          cat /home/runner/pytest_workflow_*/*/log.out
+          echo
+          echo
+          echo "======> log.err <======="
+          cat /home/runner/pytest_workflow_*/*/log.err
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist


If nextflow fails within `pytest` it is relatively hard to figure out what's going on. At the moment it is necessary to download the artifacts and retrieve the log files from there. This PR prints out the logfiles to the github actions log in case of failure, which I find more convenient. 

If something goes wrong within a work directory, it will still be necessary to obtain the artifact. 

---
- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
