### PR TITLE
Bump version 0.1.5 to chromap/chromap

### DIFF
--- a/modules/chromap/chromap/main.nf
+++ b/modules/chromap/chromap/main.nf
@@ -1,13 +1,11 @@
-def VERSION = '0.1' // Version information not provided by tool on CLI
-
 process CHROMAP_CHROMAP {
     tag "$meta.id"
     label 'process_medium'
 
     conda (params.enable_conda ? "bioconda::chromap=0.1 bioconda::samtools=1.13" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:2cad7c5aa775241887eff8714259714a39baf016-0' :
-        'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:2cad7c5aa775241887eff8714259714a39baf016-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:724a1037d59f6a19c9d4e7bdba77b52b37de0dc3-0' :
+        'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:724a1037d59f6a19c9d4e7bdba77b52b37de0dc3-0' }"
 
     input:
     tuple val(meta), path(reads)
@@ -45,7 +43,7 @@ process CHROMAP_CHROMAP {
         args_list << "--pairs-natural-chr-order $pairs_chr_order"
     }
     def final_args = args_list.join(' ')
-    def compression_cmds = "gzip ${prefix}.${file_extension}"
+    def compression_cmds = "gzip -n ${prefix}.${file_extension}"
     if (args.contains("--SAM")) {
         compression_cmds = """
         samtools view $args2 -@ $task.cpus -bh \\
@@ -67,7 +65,8 @@ process CHROMAP_CHROMAP {
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            chromap: $VERSION
+            chromap: \$(echo \$(chromap --version 2>&1))
+            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
         END_VERSIONS
         """
     } else {
@@ -85,7 +84,8 @@ process CHROMAP_CHROMAP {
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            chromap: $VERSION
+            chromap: \$(echo \$(chromap --version 2>&1))
+            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
         END_VERSIONS
         """
     }

--- a/modules/chromap/chromap/main.nf
+++ b/modules/chromap/chromap/main.nf
@@ -2,7 +2,7 @@ process CHROMAP_CHROMAP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::chromap=0.1 bioconda::samtools=1.14" : null)
+    conda (params.enable_conda ? "bioconda::chromap=0.1.5 bioconda::samtools=1.14" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:724a1037d59f6a19c9d4e7bdba77b52b37de0dc3-0' :
         'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:724a1037d59f6a19c9d4e7bdba77b52b37de0dc3-0' }"

--- a/modules/chromap/chromap/main.nf
+++ b/modules/chromap/chromap/main.nf
@@ -2,7 +2,7 @@ process CHROMAP_CHROMAP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::chromap=0.1 bioconda::samtools=1.13" : null)
+    conda (params.enable_conda ? "bioconda::chromap=0.1 bioconda::samtools=1.14" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:724a1037d59f6a19c9d4e7bdba77b52b37de0dc3-0' :
         'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:724a1037d59f6a19c9d4e7bdba77b52b37de0dc3-0' }"

--- a/tests/modules/chromap/chromap/test.yml
+++ b/tests/modules/chromap/chromap/test.yml
@@ -5,9 +5,9 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f889d5f61d80823766af33277d27d386
+      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bed.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
+      md5sum: 25e40bde24c7b447292cd68573728694
 
 - name: chromap chromap test_chromap_chromap_paired_end
   command: nextflow run ./tests/modules/chromap/chromap -entry test_chromap_chromap_paired_end -c ./tests/config/nextflow.config -c ./tests/modules/chromap/chromap/nextflow.config
@@ -16,9 +16,9 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f889d5f61d80823766af33277d27d386
+      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bed.gz
-      md5sum: cafd8fb21977f5ae69e9008b220ab169
+      md5sum: 7cdc8448882b75811e0c784f5f20aef2
 
 - name: chromap chromap test_chromap_chromap_paired_bam
   command: nextflow run ./tests/modules/chromap/chromap -entry test_chromap_chromap_paired_bam -c ./tests/config/nextflow.config -c ./tests/modules/chromap/chromap/nextflow.config
@@ -27,6 +27,5 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f889d5f61d80823766af33277d27d386
+      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bam
-      md5sum: bd1e3fe0f3abd1430ae191754f16a3ed

--- a/tests/modules/chromap/chromap/test.yml
+++ b/tests/modules/chromap/chromap/test.yml
@@ -5,6 +5,7 @@
     - chromap
   files:
     - path: output/chromap/genome.index
+      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bed.gz
       md5sum: 25e40bde24c7b447292cd68573728694
 
@@ -15,6 +16,7 @@
     - chromap
   files:
     - path: output/chromap/genome.index
+      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bed.gz
       md5sum: 7cdc8448882b75811e0c784f5f20aef2
 
@@ -25,4 +27,6 @@
     - chromap
   files:
     - path: output/chromap/genome.index
+      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bam
+      md5sum: 73e2c76007e3c61df625668e01b3f42f

--- a/tests/modules/chromap/chromap/test.yml
+++ b/tests/modules/chromap/chromap/test.yml
@@ -5,7 +5,6 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bed.gz
       md5sum: 25e40bde24c7b447292cd68573728694
 
@@ -16,7 +15,6 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bed.gz
       md5sum: 7cdc8448882b75811e0c784f5f20aef2
 
@@ -27,6 +25,5 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bam
       md5sum: 73e2c76007e3c61df625668e01b3f42f

--- a/tests/modules/chromap/chromap/test.yml
+++ b/tests/modules/chromap/chromap/test.yml
@@ -5,7 +5,6 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bed.gz
       md5sum: 25e40bde24c7b447292cd68573728694
 
@@ -16,7 +15,6 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bed.gz
       md5sum: 7cdc8448882b75811e0c784f5f20aef2
 
@@ -27,5 +25,4 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f3ebce1e855639631b0e93ed57b39215
     - path: output/chromap/test.bam

--- a/tests/modules/chromap/index/test.yml
+++ b/tests/modules/chromap/index/test.yml
@@ -5,5 +5,5 @@
     - chromap
   files:
     - path: output/chromap/genome.index
-      md5sum: f3ebce1e855639631b0e93ed57b39215
+
 

--- a/tests/modules/chromap/index/test.yml
+++ b/tests/modules/chromap/index/test.yml
@@ -5,3 +5,5 @@
     - chromap
   files:
     - path: output/chromap/genome.index
+      md5sum: f3ebce1e855639631b0e93ed57b39215
+


### PR DESCRIPTION
The previous version of `chromap` was not producing `sam` files that were parsable by samtools. The version of  `chromap` and `samtools` have been updated to 0.1.5 and 1.14, respectively.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
