### PR TITLE
Bump Nextclade version to 1.10.1

### DIFF
--- a/modules/nextclade/datasetget/main.nf
+++ b/modules/nextclade/datasetget/main.nf
@@ -2,10 +2,10 @@ process NEXTCLADE_DATASETGET {
     tag "$dataset"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::nextclade=1.9.0" : null)
+    conda (params.enable_conda ? "bioconda::nextclade=1.10.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nextclade:1.9.0--h9ee0642_0' :
-        'quay.io/biocontainers/nextclade:1.9.0--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/nextclade:1.10.1--h9ee0642_0' :
+        'quay.io/biocontainers/nextclade:1.10.1--h9ee0642_0' }"
 
     input:
     val dataset

--- a/modules/nextclade/run/main.nf
+++ b/modules/nextclade/run/main.nf
@@ -2,10 +2,10 @@ process NEXTCLADE_RUN {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::nextclade=1.9.0" : null)
+    conda (params.enable_conda ? "bioconda::nextclade=1.10.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nextclade:1.9.0--h9ee0642_0' :
-        'quay.io/biocontainers/nextclade:1.9.0--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/nextclade:1.10.1--h9ee0642_0' :
+        'quay.io/biocontainers/nextclade:1.10.1--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/tests/modules/nextclade/datasetget/main.nf
+++ b/tests/modules/nextclade/datasetget/main.nf
@@ -8,7 +8,8 @@ workflow test_nextclade_datasetget {
 
     dataset = 'sars-cov-2'
     reference = 'MN908947'
-    tag = '2022-01-05T19:54:31Z'
+    tag = '2022-01-18T12:00:00Z'
 
     NEXTCLADE_DATASETGET ( dataset, reference, tag )
+
 }

--- a/tests/modules/nextclade/datasetget/test.yml
+++ b/tests/modules/nextclade/datasetget/test.yml
@@ -9,12 +9,14 @@
     - path: output/nextclade/sars-cov-2/primers.csv
       md5sum: 5990c3483bf66ce607aeb90a44e7ef2e
     - path: output/nextclade/sars-cov-2/qc.json
-      md5sum: 018fa0c0b0d2e824954e37e01495d549
+      md5sum: c512f51fda0212b21ffff05779180963
     - path: output/nextclade/sars-cov-2/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: output/nextclade/sars-cov-2/sequences.fasta
       md5sum: 41129d255b99e0e92bdf20e866b99a1b
     - path: output/nextclade/sars-cov-2/tag.json
-      md5sum: 2f6d8e806d9064571ee4188ef1304c9c
+      md5sum: 402ac2b87e2a6a64a3fbf5ad16497af3
     - path: output/nextclade/sars-cov-2/tree.json
-      md5sum: f8fb33ed62b59142ac20998eb599df6c
+      md5sum: b8f32f547ff9e2131d6fc66b68fc54b1
+    - path: output/nextclade/sars-cov-2/virus_properties.json
+      md5sum: 5f2de3949e07cb633f3d9e4a7654dc81

--- a/tests/modules/nextclade/run/main.nf
+++ b/tests/modules/nextclade/run/main.nf
@@ -9,7 +9,7 @@ workflow test_nextclade_run {
 
     dataset = 'sars-cov-2'
     reference = 'MN908947'
-    tag = '2022-01-05T19:54:31Z'
+    tag = '2022-01-18T12:00:00Z'
 
     NEXTCLADE_DATASETGET ( dataset, reference, tag )
 
@@ -20,3 +20,4 @@ workflow test_nextclade_run {
 
     NEXTCLADE_RUN ( input, NEXTCLADE_DATASETGET.out.dataset )
 }
+

--- a/tests/modules/nextclade/run/test.yml
+++ b/tests/modules/nextclade/run/test.yml
@@ -6,8 +6,8 @@
   files:
     - path: output/nextclade/test.json
     - path: output/nextclade/test.csv
-      md5sum: 3b87a4da190ba2e1fdc8418dc3a7ffdb
+      md5sum: 570c1aa2d5fd25c23d0042c1b06108e1
     - path: output/nextclade/test.tsv
-      md5sum: 449393288e8734a02def139c550a8d9b
+      md5sum: dd76e1a4c760785489be4e4a860b4d00
     - path: output/nextclade/test.tree.json
-      md5sum: 9c6e33cb7ff860bee6194847bd2c855c
+      md5sum: 3591b4dc1542995a7ffcffcb1f52b524


### PR DESCRIPTION

Factors in breaking changes introduced in [1.10.1](https://github.com/nextstrain/nextclade/releases/tag/1.10.0)