### PR TITLE
Add repository_type to .nf-core.yml

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,3 +1,4 @@
+repository_type: modules
 bump-versions:
   rseqc/junctionannotation: False
   rseqc/bamstat: False


### PR DESCRIPTION
Add config `repository_type`, to be used by nf-core/tools after https://github.com/nf-core/tools/pull/1391 is merged.
