### PR TITLE
Bump multiqc version 1.12

### DIFF
--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -1,10 +1,10 @@
 process MULTIQC {
     label 'process_medium'
 
-    conda (params.enable_conda ? 'bioconda::multiqc=1.11' : null)
+    conda (params.enable_conda ? 'bioconda::multiqc=1.12' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.11--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
+        'quay.io/biocontainers/multiqc:1.12--pyhdfd78af_0' }"
 
     input:
     path multiqc_files


### PR DESCRIPTION
Bump multiqc version `1.12`

- [x] This comment contains a description of changes (with reason).
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
