### PR TITLE
include intervals_index

### DIFF
--- a/modules/gatk4/genotypegvcfs/main.nf
+++ b/modules/gatk4/genotypegvcfs/main.nf
@@ -8,7 +8,7 @@ process GATK4_GENOTYPEGVCFS {
         'quay.io/biocontainers/gatk4:4.2.5.0--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(gvcf), path(gvcf_index), path(intervals)
+    tuple val(meta), path(gvcf), path(gvcf_index), path(intervals), path(intervals_index)
     path  fasta
     path  fasta_index
     path  fasta_dict

--- a/modules/gatk4/genotypegvcfs/meta.yml
+++ b/modules/gatk4/genotypegvcfs/meta.yml
@@ -27,7 +27,10 @@ input:
       pattern: ["*.{vcf,vcf.gz}", "*.{idx,tbi}"]
   - intervals:
       type: file
-      description: Bed file with the genomic regions included in the library (optional)
+      description: Interval file with the genomic regions included in the library (optional)
+  - intervals_index:
+      type: file
+      description: Interval index file (optional)
   - fasta:
       type: file
       description: Reference fasta file


### PR DESCRIPTION
In order to run the GATK `GenotypeGVCFs` tool with an interval file (such as a .bed file) you need to have the corresponding index file. Otherwise you get the following error message
```
A USER ERROR has occurred: An index is required but was not found for file genome.bed.gz: work/6c/541fce2dc670597f62a571c72288c6/genome.bed.gz. Support for unindexed block-compressed files has been temporarily disabled. Try running IndexFeatureFile on the input.
```

including the index file fixes this problem
