### PR TITLE
Nickhsmith patch 1

### DIFF
--- a/modules/manta/somatic/main.nf
+++ b/modules/manta/somatic/main.nf
@@ -11,8 +11,7 @@ process MANTA_SOMATIC {
     tuple val(meta), path(input_normal), path(input_index_normal), path(input_tumor), path(input_index_tumor)
     path fasta
     path fai
-    path target_bed
-    path target_bed_tbi
+    tuple path(target_bed), path(target_bed_tbi)
 
     output:
     tuple val(meta), path("*.candidate_small_indels.vcf.gz")     , emit: candidate_small_indels_vcf

--- a/modules/manta/tumoronly/main.nf
+++ b/modules/manta/tumoronly/main.nf
@@ -11,8 +11,7 @@ process MANTA_TUMORONLY {
     tuple val(meta), path(input), path(input_index)
     path fasta
     path fai
-    path target_bed
-    path target_bed_tbi
+    tuple path(target_bed), path(target_bed_tbi)
 
     output:
     tuple val(meta), path("*candidate_small_indels.vcf.gz")    , emit: candidate_small_indels_vcf


### PR DESCRIPTION
Match the input stylings of somatic and tumor_only to the germline as mentioned in #1344 
   
    input:
    tuple val(meta), path(input), path(index)
    path fasta
    path fasta_fai
    tuple path(target_bed), path(target_bed_tbi)