### PR TITLE
Add git aware option to pytest commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,6 @@ Closes #XXX <!-- If this PR fixes an issue, please link it here! -->
 - [ ] Add a resource `label`
 - [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
 - Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
-    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
-    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
-    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
+    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
+    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
+    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -86,7 +86,7 @@ jobs:
       # Test the module
       - name: Run pytest-workflow
         # only use one thread for pytest-workflow to avoid race condition on conda cache.
-        run: TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --tag ${{ matrix.tags }} --symlink --kwdof
+        run: TMPDIR=~ PROFILE=${{ matrix.profile }} pytest --tag ${{ matrix.tags }} --symlink --kwdof --git-aware
 
       - name: Output log on failure
         if: failure()


### PR DESCRIPTION
Adds `--git-aware` option to pytest to remove the warning [here](https://github.com/nf-core/tools/issues/1421#issuecomment-1062772387)

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd`
