### PR TITLE
Decrease indent in seqtk/seq versions.yml output

### DIFF
--- a/modules/seqtk/seq/main.nf
+++ b/modules/seqtk/seq/main.nf
@@ -33,8 +33,8 @@ process SEQTK_SEQ {
         gzip -c > ${prefix}.seqtk-seq.${extension}.gz
 
     cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            seqtk: \$(echo \$(seqtk 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
+    "${task.process}":
+        seqtk: \$(echo \$(seqtk 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
     END_VERSIONS
     """
 }

--- a/tests/modules/seqtk/seq/test.yml
+++ b/tests/modules/seqtk/seq/test.yml
@@ -7,7 +7,7 @@
     - path: output/seqtk/test.seqtk-seq.fasta.gz
       md5sum: 50d73992c8c7e56dc095ef47ec52a754
     - path: output/seqtk/versions.yml
-      md5sum: 2b89cd4a6e28f35fcfbbd2188384f944
+      md5sum: 6555e1061080c44f828de0b40b299e41
 
 - name: seqtk seq test_seqtk_seq_fq
   command: nextflow run tests/modules/seqtk/seq -entry test_seqtk_seq_fq -c tests/config/nextflow.config
@@ -18,4 +18,4 @@
     - path: output/seqtk/test.seqtk-seq.fasta.gz
       md5sum: 2f009f1647971a97b4edec726a99dc1a
     - path: output/seqtk/versions.yml
-      md5sum: 3467a76d3540bee8f58de050512bddaa
+      md5sum: feb70feb3165d5c19fa50c16e46e6772


### PR DESCRIPTION
Fixes the indent levels in `versions.yml` for seqtk/seq module, making it compatible with custom/dumpsoftwareversions.

## PR checklist

Closes #1383

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [NA] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
    - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
    - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
    - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
