### PR TITLE
Fix indentation in bwa/aln meta

### DIFF
--- a/modules/bwa/aln/meta.yml
+++ b/modules/bwa/aln/meta.yml
@@ -21,10 +21,10 @@ tools:
 
 input:
   - meta:
-    type: map
-    description: |
-      Groovy Map containing sample information
-      e.g. [ id:'test', single_end:false ]
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - reads:
       type: file
       description: |


### PR DESCRIPTION
I guess we should probably lint for proper `meta.yml` structure.