### PR TITLE
Add kaiju module

### DIFF
--- a/modules/kaiju/main.nf
+++ b/modules/kaiju/main.nf
@@ -1,0 +1,50 @@
+process KAIJU {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda (params.enable_conda ? "bioconda::kaiju=1.8.2" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/kaiju:1.8.2--h5b5514e_1':
+        'quay.io/biocontainers/kaiju:1.8.2--h5b5514e_1' }"
+
+    input:
+    tuple val(meta), path(reads)
+    tuple path(db), path(dbnodes), path(dbnames)
+    val(taxon_rank)
+
+    output:
+    tuple val(meta), path('*.results.tsv'), emit: results
+    tuple val(meta), path('*.report.tsv') , emit: report
+    path "versions.yml"                   , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def input = meta.single_end ? "-i ${reads}" : "-i ${reads[0]} -j ${reads[1]}"
+    """
+    kaiju \\
+        $args \\
+        -z $task.cpus \\
+        -t ${dbnodes} \\
+        -f ${db} \\
+        -o ${prefix}.results.tsv \\
+        $input
+
+    kaiju2table \\
+        $args2 \\
+        -t ${dbnodes} \\
+        -n ${dbnames} \\
+        -r ${taxon_rank} \\
+        -o ${prefix}.report.tsv \\
+        ${prefix}.results.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
+    END_VERSIONS
+    """
+}

--- a/modules/kaiju/meta.yml
+++ b/modules/kaiju/meta.yml
@@ -1,0 +1,61 @@
+name: kaiju
+description: Taxonomic classification of metagenomic sequence data using a protein reference database
+keywords:
+  - classify
+  - metagenomics
+  - fastq
+  - db
+tools:
+  - kaiju:
+      description: Fast and sensitive taxonomic classification for metagenomics
+      homepage: https://kaiju.binf.ku.dk/
+      documentation: https://github.com/bioinformatics-centre/kaiju/blob/master/README.md
+      tool_dev_url: https://github.com/bioinformatics-centre/kaiju
+      doi: "10.1038/ncomms11257"
+      licence: ['GNU GPL v3']
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input fastq/fasta files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+      pattern: "*.{fastq,fastq.gz,fasta,fasta.gz}"
+  - db:
+      type: files
+      description: |
+        List containing the 3 Kaiju database files
+        e.g. [ 'database.fmi', 'nodes.dmp', 'names.dmp' ]
+  - taxon_rank:
+      type: string
+      description: |
+        Taxonomic rank to display in report
+        e.g. [ 'phylum', 'class', 'order', 'family', 'genus', 'species']
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - results:
+      type: file
+      description: Results with taxonomic classification of each read
+      pattern: "*.results.tsv"
+  - report:
+      type: file
+      description: Summary report of classifications for a taxonomic rank
+      pattern: "*.report.tsv"
+
+authors:
+  - "@talnor"
+  - "@sofstam"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -202,6 +202,10 @@ bedtools/subtract:
   - modules/bedtools/subtract/**
   - tests/modules/bedtools/subtract/**
 
+biobambam/bammarkduplicates2:
+  - modules/biobambam/bammarkduplicates2/**
+  - tests/modules/biobambam/bammarkduplicates2/**
+
 biscuit/align:
   - modules/biscuit/index/**
   - modules/biscuit/align/**
@@ -244,10 +248,6 @@ biscuit/qc:
 biscuit/vcf2bed:
   - modules/biscuit/vcf2bed/**
   - tests/modules/biscuit/vcf2bed/**
-
-biobambam/bammarkduplicates2:
-  - modules/biobambam/bammarkduplicates2/**
-  - tests/modules/biobambam/bammarkduplicates2/**
 
 bismark/align:
   - modules/bismark/align/**
@@ -921,6 +921,10 @@ ivar/variants:
 jupyternotebook:
   - modules/jupyternotebook/**
   - tests/modules/jupyternotebook/**
+
+kaiju:
+  - modules/kaiju/**
+  - tests/modules/kaiju/**
 
 kallisto/index:
   - modules/kallisto/index/**

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -28,6 +28,10 @@ params {
                 ncbi_taxmap_zip                                = "${test_data_dir}/genomics/sarscov2/genome/db/maltextract/ncbi_taxmap.zip"
                 taxon_list_txt                                 = "${test_data_dir}/genomics/sarscov2/genome/db/maltextract/taxon_list.txt"
 
+                kaiju_fmi                                      = "${test_data_dir}/genomics/sarscov2/genome/db/kaiju/proteins.fmi"
+                kaiju_nodes                                    = "${test_data_dir}/genomics/sarscov2/genome/db/kaiju/nodes.dmp"
+                kaiju_names                                    = "${test_data_dir}/genomics/sarscov2/genome/db/kaiju/names.dmp"
+
                 all_sites_fas                                  = "${test_data_dir}/genomics/sarscov2/genome/alignment/all_sites.fas"
                 informative_sites_fas                          = "${test_data_dir}/genomics/sarscov2/genome/alignment/informative_sites.fas"
 

--- a/tests/modules/kaiju/main.nf
+++ b/tests/modules/kaiju/main.nf
@@ -1,0 +1,38 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { KAIJU } from '../../../modules/kaiju/main.nf'
+
+workflow test_kaiju_single_end {
+
+    input = [
+        [ id:'test', single_end:true ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+    ]
+    db    = [
+        file(params.test_data['sarscov2']['genome']['kaiju_fmi'], checkIfExists: true), // database
+        file(params.test_data['sarscov2']['genome']['kaiju_nodes'], checkIfExists: true), // taxon nodes
+        file(params.test_data['sarscov2']['genome']['kaiju_names'], checkIfExists: true) // taxon names
+    ]
+    taxon_rank = "species"
+
+    KAIJU ( input, db, taxon_rank )
+}
+
+workflow test_kaiju_paired_end {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+          file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
+    ]
+    db    = [
+        file(params.test_data['sarscov2']['genome']['kaiju_fmi'], checkIfExists: true), // database
+        file(params.test_data['sarscov2']['genome']['kaiju_nodes'], checkIfExists: true), // taxon nodes
+        file(params.test_data['sarscov2']['genome']['kaiju_names'], checkIfExists: true) // taxon names
+    ]
+    taxon_rank = "species"
+
+    KAIJU ( input, db, taxon_rank )
+}

--- a/tests/modules/kaiju/nextflow.config
+++ b/tests/modules/kaiju/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    
+}

--- a/tests/modules/kaiju/test.yml
+++ b/tests/modules/kaiju/test.yml
@@ -1,0 +1,23 @@
+- name: kaiju test_kaiju_single_end
+  command: nextflow run tests/modules/kaiju -entry test_kaiju_single_end -c tests/config/nextflow.config
+  tags:
+    - kaiju
+  files:
+    - path: output/kaiju/test.report.tsv
+      md5sum: b7481a8bbc4613664bd9afd2ea493592
+    - path: output/kaiju/test.results.tsv
+      contains: ["C\tERR5069949.2257580\t2697049"]
+    - path: output/kaiju/versions.yml
+      md5sum: a4b8aa6ac2069468c33a4ae34f539022
+
+- name: kaiju test_kaiju_paired_end
+  command: nextflow run tests/modules/kaiju -entry test_kaiju_paired_end -c tests/config/nextflow.config
+  tags:
+    - kaiju
+  files:
+    - path: output/kaiju/test.report.tsv
+      md5sum: aab51084d8645a8d9f3439ced5ada7e7
+    - path: output/kaiju/test.results.tsv
+      contains: ["C\tERR5069949.2257580\t2697049"]
+    - path: output/kaiju/versions.yml
+      md5sum: a60696633acc4386bf768c64ba43af2e


### PR DESCRIPTION
This PR adds a kaiju module for taxonomic classification. This is needed for [taxprofiler](https://github.com/nf-core/taxprofiler/issues/3). 

## PR checklist

Closes #1398 

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
