### PR TITLE
CAT: Use meta map and supply output file name via modules.config

### DIFF
--- a/modules/cat/cat/main.nf
+++ b/modules/cat/cat/main.nf
@@ -29,7 +29,7 @@ process CAT_CAT {
     // | ungzipped | gzipped    | cat      | pigz     |
 
     // Use input file ending as default
-    prefix = task.ext.prefix ?: "${meta.id}.${file_list[0].substring(file_list[0].lastIndexOf('.'))}"
+    prefix = task.ext.prefix ?: "${meta.id}${file_list[0].substring(file_list[0].lastIndexOf('.'))}"
     out_zip  = prefix.endsWith('.gz')
     in_zip   = file_list[0].endsWith('.gz')
     command1 = (in_zip && !out_zip) ? 'zcat' : 'cat'

--- a/modules/cat/cat/main.nf
+++ b/modules/cat/cat/main.nf
@@ -1,4 +1,5 @@
 process CAT_CAT {
+    tag "$meta.id"
     label 'process_low'
 
     conda (params.enable_conda ? "conda-forge::pigz=2.3.4" : null)

--- a/modules/cat/cat/meta.yml
+++ b/modules/cat/cat/meta.yml
@@ -12,13 +12,15 @@ tools:
       tool_dev_url: None
       licence: ["GPL-3.0-or-later"]
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - files_in:
       type: file
       description: List of compressed / uncompressed files
       pattern: "*"
-  - file_out:
-      type: value
-      description: Full name of output file with or without .gz extension
 
 output:
   - versions:
@@ -32,3 +34,4 @@ output:
 
 authors:
   - "@erikrikarddaniel"
+  - "@FriederikeHanssen"

--- a/tests/modules/cat/cat/main.nf
+++ b/tests/modules/cat/cat/main.nf
@@ -10,8 +10,8 @@ workflow test_cat_unzipped_unzipped {
 
     input = [
         [ id:'test', single_end:true ], // meta map
-        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
-        file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true)
+        [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
+        file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true) ]
     ]
 
     CAT_CAT ( input )

--- a/tests/modules/cat/cat/main.nf
+++ b/tests/modules/cat/cat/main.nf
@@ -2,46 +2,51 @@
 
 nextflow.enable.dsl = 2
 
-include { CAT_CAT } from '../../../../modules/cat/cat/main.nf'
+include { CAT_CAT                        } from '../../../../modules/cat/cat/main.nf'
+include { CAT_CAT as CAT_UNZIPPED_ZIPPED } from '../../../../modules/cat/cat/main.nf'
 
 workflow test_cat_unzipped_unzipped {
 
     input = [
+        [ id:'test', single_end:true ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
         file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true)
     ]
 
-    CAT_CAT ( input, 'cat.txt' )
+    CAT_CAT ( input )
 }
 
 workflow test_cat_zipped_zipped {
 
     input = [
+         [ id:'test', single_end:true ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_gff3_gz'], checkIfExists: true),
         file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
     ]
 
-    CAT_CAT ( input, 'cat.txt.gz' )
+    CAT_CAT ( input )
 }
 
 workflow test_cat_zipped_unzipped {
 
     input = [
+        [ id:'test', single_end:true ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_gff3_gz'], checkIfExists: true),
         file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
     ]
 
-    CAT_CAT ( input, 'cat.txt' )
+    CAT_CAT ( input )
 }
 
 workflow test_cat_unzipped_zipped {
 
     input = [
+        [ id:'test', single_end:true ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
         file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true)
     ]
 
-    CAT_CAT ( input, 'cat.txt.gz' )
+    CAT_UNZIPPED_ZIPPED ( input )
 }
 
 workflow test_cat_one_file_unzipped_zipped {
@@ -50,5 +55,5 @@ workflow test_cat_one_file_unzipped_zipped {
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
     ]
 
-    CAT_CAT ( input, 'cat.txt.gz' )
+    CAT_UNZIPPED_ZIPPED ( input )
 }

--- a/tests/modules/cat/cat/main.nf
+++ b/tests/modules/cat/cat/main.nf
@@ -4,6 +4,7 @@ nextflow.enable.dsl = 2
 
 include { CAT_CAT                        } from '../../../../modules/cat/cat/main.nf'
 include { CAT_CAT as CAT_UNZIPPED_ZIPPED } from '../../../../modules/cat/cat/main.nf'
+include { CAT_CAT as CAT_ZIPPED_UNZIPPED } from '../../../../modules/cat/cat/main.nf'
 
 workflow test_cat_unzipped_unzipped {
 
@@ -20,8 +21,8 @@ workflow test_cat_zipped_zipped {
 
     input = [
          [ id:'test', single_end:true ], // meta map
-        file(params.test_data['sarscov2']['genome']['genome_gff3_gz'], checkIfExists: true),
-        file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
+        [file(params.test_data['sarscov2']['genome']['genome_gff3_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)]
     ]
 
     CAT_CAT ( input )
@@ -31,19 +32,19 @@ workflow test_cat_zipped_unzipped {
 
     input = [
         [ id:'test', single_end:true ], // meta map
-        file(params.test_data['sarscov2']['genome']['genome_gff3_gz'], checkIfExists: true),
-        file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
+        [file(params.test_data['sarscov2']['genome']['genome_gff3_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)]
     ]
 
-    CAT_CAT ( input )
+    CAT_ZIPPED_UNZIPPED ( input )
 }
 
 workflow test_cat_unzipped_zipped {
 
     input = [
         [ id:'test', single_end:true ], // meta map
-        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
-        file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true)
+        [file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
+        file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true)]
     ]
 
     CAT_UNZIPPED_ZIPPED ( input )
@@ -52,7 +53,8 @@ workflow test_cat_unzipped_zipped {
 workflow test_cat_one_file_unzipped_zipped {
 
     input = [
-        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
+        [ id:'test', single_end:true ], // meta map
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
 
     CAT_UNZIPPED_ZIPPED ( input )

--- a/tests/modules/cat/cat/nextflow.config
+++ b/tests/modules/cat/cat/nextflow.config
@@ -2,4 +2,8 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    withName: CAT_UNZIPPED_ZIPPED {
+        ext.prefix = 'cat.txt.gz'
+    }
 }
+

--- a/tests/modules/cat/cat/nextflow.config
+++ b/tests/modules/cat/cat/nextflow.config
@@ -5,5 +5,9 @@ process {
     withName: CAT_UNZIPPED_ZIPPED {
         ext.prefix = 'cat.txt.gz'
     }
+
+    withName: CAT_ZIPPED_UNZIPPED {
+        ext.prefix = 'cat.txt'
+    }
 }
 

--- a/tests/modules/cat/cat/test.yml
+++ b/tests/modules/cat/cat/test.yml
@@ -4,7 +4,7 @@
     - cat
     - cat/cat
   files:
-    - path: output/cat/test.txt
+    - path: output/cat/test.fasta
       md5sum: f44b33a0e441ad58b2d3700270e2dbe2
 
 - name: cat zipped zipped
@@ -21,7 +21,7 @@
     - cat
     - cat/cat
   files:
-    - path: output/cat/test.txt
+    - path: output/cat/cat.txt
       md5sum: c439d3b60e7bc03e8802a451a0d9a5d9
 
 - name: cat unzipped zipped

--- a/tests/modules/cat/cat/test.yml
+++ b/tests/modules/cat/cat/test.yml
@@ -4,7 +4,7 @@
     - cat
     - cat/cat
   files:
-    - path: output/cat/cat.txt
+    - path: output/cat/test.txt
       md5sum: f44b33a0e441ad58b2d3700270e2dbe2
 
 - name: cat zipped zipped
@@ -13,7 +13,7 @@
     - cat
     - cat/cat
   files:
-    - path: output/cat/cat.txt.gz
+    - path: output/cat/test.gz
 
 - name: cat zipped unzipped
   command: nextflow run ./tests/modules/cat/cat -entry test_cat_zipped_unzipped -c ./tests/config/nextflow.config -c ./tests/modules/cat/cat/nextflow.config
@@ -21,7 +21,7 @@
     - cat
     - cat/cat
   files:
-    - path: output/cat/cat.txt
+    - path: output/cat/test.txt
       md5sum: c439d3b60e7bc03e8802a451a0d9a5d9
 
 - name: cat unzipped zipped


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

The current cat module doesn't take in a meta map, ths would be helpful to have when concatenating i.e. sample specific files. 

Also, the output file name is currently specified as an input val, which is very different from the other modules. I would therefore propose that in general it should be supplied via `task.ext.prefix` and as a default option use the file ending of the `input` files

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
