### PR TITLE
Fix homer/maketagdirectory output collision

### DIFF
--- a/modules/homer/maketagdirectory/main.nf
+++ b/modules/homer/maketagdirectory/main.nf
@@ -14,9 +14,9 @@ process HOMER_MAKETAGDIRECTORY {
     path fasta
 
     output:
-    tuple val(meta), path("*_tagdir"), emit: tagdir
+    tuple val(meta), path("*_tagdir")            , emit: tagdir
     tuple val(meta), path("*_tagdir/tagInfo.txt"), emit: taginfo
-    path  "versions.yml"            , emit: versions
+    path  "versions.yml"                         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/homer/maketagdirectory/main.nf
+++ b/modules/homer/maketagdirectory/main.nf
@@ -14,7 +14,8 @@ process HOMER_MAKETAGDIRECTORY {
     path fasta
 
     output:
-    tuple val(meta), path("tag_dir"), emit: tagdir
+    tuple val(meta), path("*_tagdir"), emit: tagdir
+    tuple val(meta), path("*_tagdir/tagInfo.txt"), emit: taginfo
     path  "versions.yml"            , emit: versions
 
     when:
@@ -25,7 +26,7 @@ process HOMER_MAKETAGDIRECTORY {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     makeTagDirectory \\
-        tag_dir \\
+        ${prefix}_tagdir \\
         -genome $fasta \\
         $args \\
         $bam

--- a/modules/homer/maketagdirectory/meta.yml
+++ b/modules/homer/maketagdirectory/meta.yml
@@ -57,10 +57,14 @@ output:
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  - tag_dir:
+  - tagdir:
       type: directory
       description: The "Tag Directory"
-      pattern: "tag_dir"
+      pattern: "*_tagdir"
+  - taginfo:
+      type: directory
+      description: The tagInfo.txt included to ensure there's proper output
+      pattern: "*_tagdir/tagInfo.txt"
   - versions:
       type: file
       description: File containing software versions

--- a/tests/modules/homer/findpeaks/test.yml
+++ b/tests/modules/homer/findpeaks/test.yml
@@ -5,4 +5,4 @@
     - homer/findpeaks
   files:
     - path: output/homer/test.peaks.txt
-      md5sum: f75ac1fea67f1e307a1ad4d059a9b6cc
+      md5sum: 86e15beaa4b439585786478e58418c0c

--- a/tests/modules/homer/maketagdirectory/test.yml
+++ b/tests/modules/homer/maketagdirectory/test.yml
@@ -11,7 +11,7 @@
     - path: output/homer/test_tagdir/tagCountDistribution.txt
       md5sum: fd4ee7ce7c5dfd7c9d739534b8180578
     - path: output/homer/test_tagdir/tagInfo.txt
-      md5sum: ff56f30411b221b847aa4e6e9a6098a1
+      md5sum: c9bb2ca53bb101d74c1ec92d2b0ad26e
     - path: output/homer/test_tagdir/tagLengthDistribution.txt
       md5sum: e5aa2b9843ca9c04ace297280aed6af4
 
@@ -21,15 +21,15 @@
     - homer
     - homer/maketagdirectory
   files:
-    - path: output/homer/test_tagdir/MT192765.1.tags.tsv
+    - path: output/homer/meta_test_tagdir/MT192765.1.tags.tsv
       md5sum: e29522171ca2169b57396495f8b97485
-    - path: output/homer/test_tagdir/tagAutocorrelation.txt
+    - path: output/homer/meta_test_tagdir/tagAutocorrelation.txt
       md5sum: 62b107c4971b94126fb89a0bc2800455
-    - path: output/homer/test_tagdir/tagCountDistribution.txt
+    - path: output/homer/meta_test_tagdir/tagCountDistribution.txt
       md5sum: fd4ee7ce7c5dfd7c9d739534b8180578
-    - path: output/homer/test_tagdir/tagInfo.txt
-      md5sum: ff56f30411b221b847aa4e6e9a6098a1
-    - path: output/homer/test_tagdir/tagLengthDistribution.txt
+    - path: output/homer/meta_test_tagdir/tagInfo.txt
+      md5sum: cb907ebf9afc042bb61196d624e793c8
+    - path: output/homer/meta_test_tagdir/tagLengthDistribution.txt
       md5sum: e5aa2b9843ca9c04ace297280aed6af4
 
 - name: homer maketagdirectory bam
@@ -45,6 +45,6 @@
     - path: output/homer/test_tagdir/tagCountDistribution.txt
       md5sum: afc6d007096c3872bbe84c9dc8edb832
     - path: output/homer/test_tagdir/tagInfo.txt
-      md5sum: fbaf46eeb8a0723fa8b5eabd93f9d821
+      md5sum: aebf6ff15fd0a238ee6a94d623c578ca
     - path: output/homer/test_tagdir/tagLengthDistribution.txt
       md5sum: 44f231adb2a705ae81950808c55cf248

--- a/tests/modules/homer/maketagdirectory/test.yml
+++ b/tests/modules/homer/maketagdirectory/test.yml
@@ -4,15 +4,15 @@
     - homer
     - homer/maketagdirectory
   files:
-    - path: output/homer/tag_dir/MT192765.1.tags.tsv
+    - path: output/homer/test_tagdir/MT192765.1.tags.tsv
       md5sum: e29522171ca2169b57396495f8b97485
-    - path: output/homer/tag_dir/tagAutocorrelation.txt
+    - path: output/homer/test_tagdir/tagAutocorrelation.txt
       md5sum: 62b107c4971b94126fb89a0bc2800455
-    - path: output/homer/tag_dir/tagCountDistribution.txt
+    - path: output/homer/test_tagdir/tagCountDistribution.txt
       md5sum: fd4ee7ce7c5dfd7c9d739534b8180578
-    - path: output/homer/tag_dir/tagInfo.txt
+    - path: output/homer/test_tagdir/tagInfo.txt
       md5sum: ff56f30411b221b847aa4e6e9a6098a1
-    - path: output/homer/tag_dir/tagLengthDistribution.txt
+    - path: output/homer/test_tagdir/tagLengthDistribution.txt
       md5sum: e5aa2b9843ca9c04ace297280aed6af4
 
 - name: homer maketagdirectory meta
@@ -21,15 +21,15 @@
     - homer
     - homer/maketagdirectory
   files:
-    - path: output/homer/tag_dir/MT192765.1.tags.tsv
+    - path: output/homer/test_tagdir/MT192765.1.tags.tsv
       md5sum: e29522171ca2169b57396495f8b97485
-    - path: output/homer/tag_dir/tagAutocorrelation.txt
+    - path: output/homer/test_tagdir/tagAutocorrelation.txt
       md5sum: 62b107c4971b94126fb89a0bc2800455
-    - path: output/homer/tag_dir/tagCountDistribution.txt
+    - path: output/homer/test_tagdir/tagCountDistribution.txt
       md5sum: fd4ee7ce7c5dfd7c9d739534b8180578
-    - path: output/homer/tag_dir/tagInfo.txt
+    - path: output/homer/test_tagdir/tagInfo.txt
       md5sum: ff56f30411b221b847aa4e6e9a6098a1
-    - path: output/homer/tag_dir/tagLengthDistribution.txt
+    - path: output/homer/test_tagdir/tagLengthDistribution.txt
       md5sum: e5aa2b9843ca9c04ace297280aed6af4
 
 - name: homer maketagdirectory bam
@@ -38,13 +38,13 @@
     - homer
     - homer/maketagdirectory
   files:
-    - path: output/homer/tag_dir/MT192765.1.tags.tsv
+    - path: output/homer/test_tagdir/MT192765.1.tags.tsv
       md5sum: 365808c4751ef6dd7085ac52037a22bc
-    - path: output/homer/tag_dir/tagAutocorrelation.txt
+    - path: output/homer/test_tagdir/tagAutocorrelation.txt
       md5sum: 8b396f2aef1cdd3af4fab57b142d3250
-    - path: output/homer/tag_dir/tagCountDistribution.txt
+    - path: output/homer/test_tagdir/tagCountDistribution.txt
       md5sum: afc6d007096c3872bbe84c9dc8edb832
-    - path: output/homer/tag_dir/tagInfo.txt
+    - path: output/homer/test_tagdir/tagInfo.txt
       md5sum: fbaf46eeb8a0723fa8b5eabd93f9d821
-    - path: output/homer/tag_dir/tagLengthDistribution.txt
+    - path: output/homer/test_tagdir/tagLengthDistribution.txt
       md5sum: 44f231adb2a705ae81950808c55cf248

--- a/tests/modules/homer/pos2bed/test.yml
+++ b/tests/modules/homer/pos2bed/test.yml
@@ -4,7 +4,7 @@
     - "homer"
     - "homer/pos2bed"
   files:
-    - path: "output/homer/test.bed"
-      md5sum: 0b9ebd8f06b9c820a551fbdb2d7635ee
+    - path: output/homer/test.bed
+      md5sum: 5d6ddd9c7e621a66f6f045b9b5abecb4
     - path: output/homer/versions.yml
       md5sum: 1485f4b2d76484e8fe3310e2505de2fd


### PR DESCRIPTION
This fixes the `maketagdirectory` caching. A follow-up to #1437.