### PR TITLE
Bump chromap version 0.2.1

### DIFF
--- a/modules/chromap/chromap/main.nf
+++ b/modules/chromap/chromap/main.nf
@@ -2,10 +2,10 @@ process CHROMAP_CHROMAP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::chromap=0.2.0 bioconda::samtools=1.14" : null)
+    conda (params.enable_conda ? "bioconda::chromap=0.2.1 bioconda::samtools=1.15" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:ed3529ef5253d7ccbc688b6a4c5c447152685757-0' :
-        'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:ed3529ef5253d7ccbc688b6a4c5c447152685757-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:bd74d08a359024829a7aec1638a28607bbcd8a58-0' :
+        'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:bd74d08a359024829a7aec1638a28607bbcd8a58-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/chromap/index/main.nf
+++ b/modules/chromap/index/main.nf
@@ -1,11 +1,11 @@
 process CHROMAP_INDEX {
-    tag '$fasta'
+    tag "$fasta"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::chromap=0.2.0" : null)
+    conda (params.enable_conda ? "bioconda::chromap=0.2.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/chromap:0.2.0--hd03093a_1' :
-        'quay.io/biocontainers/chromap:0.2.0--hd03093a_1' }"
+        'https://depot.galaxyproject.org/singularity/chromap:0.2.1--hd03093a_0' :
+        'quay.io/biocontainers/chromap:0.2.1--hd03093a_0' }"
 
     input:
     path fasta

--- a/tests/modules/chromap/chromap/test.yml
+++ b/tests/modules/chromap/chromap/test.yml
@@ -8,7 +8,7 @@
     - path: output/chromap/test.bed.gz
       md5sum: 25e40bde24c7b447292cd68573728694
     - path: output/chromap/versions.yml
-      md5sum: 2d3d2959ac20d98036807964896829e7
+      md5sum: d24cfc35ad958206a5bc5694221b4fae
 
 - name: chromap chromap test_chromap_chromap_paired_end
   command: nextflow run ./tests/modules/chromap/chromap -entry test_chromap_chromap_paired_end -c ./tests/config/nextflow.config -c ./tests/modules/chromap/chromap/nextflow.config
@@ -20,7 +20,7 @@
     - path: output/chromap/test.bed.gz
       md5sum: 7cdc8448882b75811e0c784f5f20aef2
     - path: output/chromap/versions.yml
-      md5sum: 51cff66779161d8a602cce5989017395
+      md5sum: 68ffe268a9d460956de4aad2a55ffd68
 
 - name: chromap chromap test_chromap_chromap_paired_bam
   command: nextflow run ./tests/modules/chromap/chromap -entry test_chromap_chromap_paired_bam -c ./tests/config/nextflow.config -c ./tests/modules/chromap/chromap/nextflow.config
@@ -30,6 +30,6 @@
   files:
     - path: output/chromap/genome.index
     - path: output/chromap/test.bam
-      md5sum: f255c7441d5a1f307fc642d2aa19647e
+      md5sum: df467417407408e42992dc3dd15b22f5
     - path: output/chromap/versions.yml
-      md5sum: f91910c44169549c3923931de5c3afcb
+      md5sum: ea732b4c6f1312d09745b66c3963dd3f

--- a/tests/modules/chromap/index/test.yml
+++ b/tests/modules/chromap/index/test.yml
@@ -6,4 +6,4 @@
   files:
     - path: output/chromap/genome.index
     - path: output/chromap/versions.yml
-      md5sum: b75dec647f9dc5f4887f36d1db7a9ccd
+      md5sum: fc5c80190d0622ea3e979e6862f8e32b


### PR DESCRIPTION
Bump version 0.2.1 of `chromap`

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
