### PR TITLE
New Module: `gstama/polyacleanup`

### DIFF
--- a/modules/gstama/polyacleanup/main.nf
+++ b/modules/gstama/polyacleanup/main.nf
@@ -16,6 +16,9 @@ process GSTAMA_POLYACLEANUP {
     tuple val(meta), path("*_tama_tails.fa")             , emit: tails
     path "versions.yml"                                  , emit: versions
 
+    when:
+    task.ext.when == null || task.ext.when
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/gstama/polyacleanup/main.nf
+++ b/modules/gstama/polyacleanup/main.nf
@@ -11,10 +11,10 @@ process GSTAMA_POLYACLEANUP {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path("*_tama.fa")                   , emit: fasta
-    tuple val(meta), path("*_tama_polya_flnc_report.txt"), emit: report
-    tuple val(meta), path("*_tama_tails.fa")             , emit: tails
-    path "versions.yml"                                  , emit: versions
+    tuple val(meta), path("*_tama.fa.gz")                   , emit: fasta
+    tuple val(meta), path("*_tama_polya_flnc_report.txt.gz"), emit: report
+    tuple val(meta), path("*_tama_tails.fa.gz")             , emit: tails
+    path "versions.yml"                                     , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -28,6 +28,9 @@ process GSTAMA_POLYACLEANUP {
         -f $fasta \\
         -p ${prefix} \\
         $args
+    gzip ${prefix}.fa
+    gzip ${prefix}_polya_flnc_report.txt
+    gzip ${prefix}_tails.fa
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/gstama/polyacleanup/main.nf
+++ b/modules/gstama/polyacleanup/main.nf
@@ -1,0 +1,34 @@
+process GSTAMA_POLYACLEANUP {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::gs-tama=1.0.3" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gs-tama:1.0.3--hdfd78af_0':
+        'quay.io/biocontainers/gs-tama:1.0.3--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("*_tama.fa")                   , emit: fasta
+    tuple val(meta), path("*_tama_polya_flnc_report.txt"), emit: report
+    tuple val(meta), path("*_tama_tails.fa")             , emit: tails
+    path "versions.yml"                                  , emit: versions
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if( "$fasta" == "${prefix}.fasta" | "$fasta" == "${prefix}.fa" ) error "Input and output names are the same, set prefix in module configuration"
+    """
+    tama_flnc_polya_cleanup.py \\
+        -f $fasta \\
+        -p ${prefix} \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gstama: \$( tama_collapse.py -version | grep 'tc_version_date_'|sed 's/tc_version_date_//g' )
+    END_VERSIONS
+    """
+}

--- a/modules/gstama/polyacleanup/meta.yml
+++ b/modules/gstama/polyacleanup/meta.yml
@@ -1,0 +1,55 @@
+name: gstama_polyacleanup
+description: Helper script, remove remaining polyA sequences from Full Length Non Chimeric reads (Pacbio isoseq3)
+keywords:
+  - gstama
+  - gstama/polyacleanup
+  - long-read
+  - isoseq
+  - tama
+  - trancriptome
+  - annotation
+tools:
+  - gstama:
+      description: Gene-Switch Transcriptome Annotation by Modular Algorithms
+      homepage: https://github.com/sguizard/gs-tama
+      documentation: https://github.com/GenomeRIK/tama/wiki
+      tool_dev_url: https://github.com/sguizard/gs-tama
+      doi: "https://doi.org/10.1186/s12864-020-07123-7"
+      licence: ['GPL v3 License']
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: Full Length Non Chimeric reads in fasta format
+      pattern: "*.{fa,fasta}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - fasta:
+      type: file
+      description: The Full Length Non Chimeric reads clened from remaining polyA tails. The sequences are in FASTA format.
+      pattern: "*_tama.fa"
+  - report:
+      type: file
+      description: A text file describing the number of polyA tails removed and their length.
+      pattern: "*_tama_polya_flnc_report.txt"
+  - tails:
+      type: file
+      description: A fasta file of trimmed polyA tails.
+      pattern: "*_tama_tails.fa"
+
+authors:
+  - "@sguizard"

--- a/modules/gstama/polyacleanup/meta.yml
+++ b/modules/gstama/polyacleanup/meta.yml
@@ -15,7 +15,7 @@ tools:
       documentation: https://github.com/GenomeRIK/tama/wiki
       tool_dev_url: https://github.com/sguizard/gs-tama
       doi: "https://doi.org/10.1186/s12864-020-07123-7"
-      licence: ['GPL v3 License']
+      licence: ["GPL v3 License"]
 
 input:
   - meta:

--- a/modules/gstama/polyacleanup/meta.yml
+++ b/modules/gstama/polyacleanup/meta.yml
@@ -40,16 +40,16 @@ output:
       pattern: "versions.yml"
   - fasta:
       type: file
-      description: The Full Length Non Chimeric reads clened from remaining polyA tails. The sequences are in FASTA format.
-      pattern: "*_tama.fa"
+      description: The Full Length Non Chimeric reads clened from remaining polyA tails. The sequences are in FASTA format compressed with gzip.
+      pattern: "*_tama.fa.gz"
   - report:
       type: file
-      description: A text file describing the number of polyA tails removed and their length.
-      pattern: "*_tama_polya_flnc_report.txt"
+      description: A text file describing the number of polyA tails removed and their length. Compressed with gzip.
+      pattern: "*_tama_polya_flnc_report.txt.gz"
   - tails:
       type: file
-      description: A fasta file of trimmed polyA tails.
-      pattern: "*_tama_tails.fa"
+      description: A gzip compressed FASTA file of trimmed polyA tails.
+      pattern: "*_tama_tails.fa.gz"
 
 authors:
   - "@sguizard"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -811,6 +811,10 @@ gstama/merge:
   - modules/gstama/merge/**
   - tests/modules/gstama/merge/**
 
+gstama/polyacleanup:
+  - modules/gstama/polyacleanup/**
+  - tests/modules/gstama/polyacleanup/**
+
 gtdbtk/classifywf:
   - modules/gtdbtk/classifywf/**
   - tests/modules/gtdbtk/classifywf/**

--- a/tests/modules/gstama/polyacleanup/main.nf
+++ b/tests/modules/gstama/polyacleanup/main.nf
@@ -1,0 +1,15 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { GSTAMA_POLYACLEANUP } from '../../../../modules/gstama/polyacleanup/main.nf'
+
+workflow test_gstama_polyacleanup {
+
+    input = [
+        [ id:'test' ], // meta map
+        file(params.test_data['homo_sapiens']['genome']['transcriptome_fasta'], checkIfExists: true)
+    ]
+
+    GSTAMA_POLYACLEANUP ( input )
+}

--- a/tests/modules/gstama/polyacleanup/nextflow.config
+++ b/tests/modules/gstama/polyacleanup/nextflow.config
@@ -1,0 +1,6 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    ext.prefix = { "${meta.id}_tama" }
+
+}

--- a/tests/modules/gstama/polyacleanup/test.yml
+++ b/tests/modules/gstama/polyacleanup/test.yml
@@ -1,0 +1,14 @@
+- name: gstama polyacleanup test_gstama_polyacleanup
+  command: nextflow run tests/modules/gstama/polyacleanup -entry test_gstama_polyacleanup -c tests/config/nextflow.config
+  tags:
+    - gstama/polyacleanup
+    - gstama
+  files:
+    - path: output/gstama/test_tama.fa
+      md5sum: f0a2c3ca8f19d2197c6b5b273093ebf0
+    - path: output/gstama/test_tama_polya_flnc_report.txt
+      md5sum: 83ba9d11a59ff516f45dd45c78613206
+    - path: output/gstama/test_tama_tails.fa
+      md5sum: 20a02db3d29cc45b39880e1ad5ee243b
+    - path: output/gstama/versions.yml
+      md5sum: 07ebb812ae13a350d955fab7600b2542

--- a/tests/modules/gstama/polyacleanup/test.yml
+++ b/tests/modules/gstama/polyacleanup/test.yml
@@ -1,14 +1,14 @@
 - name: gstama polyacleanup test_gstama_polyacleanup
   command: nextflow run tests/modules/gstama/polyacleanup -entry test_gstama_polyacleanup -c tests/config/nextflow.config
   tags:
-    - gstama/polyacleanup
     - gstama
+    - gstama/polyacleanup
   files:
-    - path: output/gstama/test_tama.fa
-      md5sum: f0a2c3ca8f19d2197c6b5b273093ebf0
-    - path: output/gstama/test_tama_polya_flnc_report.txt
-      md5sum: 83ba9d11a59ff516f45dd45c78613206
-    - path: output/gstama/test_tama_tails.fa
-      md5sum: 20a02db3d29cc45b39880e1ad5ee243b
+    - path: output/gstama/test_tama.fa.gz
+      md5sum: 9c768387478e5f966a42c369c0270b09
+    - path: output/gstama/test_tama_polya_flnc_report.txt.gz
+      md5sum: fe3606979ed11538aacd83159f4cff03
+    - path: output/gstama/test_tama_tails.fa.gz
+      md5sum: ba21256c0afe0bda71b3ee66b4c761bf
     - path: output/gstama/versions.yml
       md5sum: 07ebb812ae13a350d955fab7600b2542


### PR DESCRIPTION
A module for TAMA's tama_flnc_polya_cleanup.py script (https://github.com/GenomeRIK/tama/wiki/TAMA-GO:-Sequence-Cleanup). This script is used to remove remaining polyA tails from Full Length Non Chimeric reads (isoseq 3). 


## PR checklist
- [X] This comment contains a description of changes (with reason).
- [X] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [X] Remove all TODO statements.
- [X] Emit the `versions.yml` file.
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [X] Add a resource `label`
- [X] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
