### PR TITLE
Fix untar for centrifuge

### DIFF
--- a/modules/centrifuge/main.nf
+++ b/modules/centrifuge/main.nf
@@ -10,6 +10,7 @@ process CENTRIFUGE {
     input:
     tuple val(meta), path(reads)
     path db
+    val db_name
     val save_unaligned
     val save_aligned
     val sam_format
@@ -30,6 +31,7 @@ process CENTRIFUGE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def paired = meta.single_end ? "-U ${reads}" :  "-1 ${reads[0]} -2 ${reads[1]}"
+    def db_name = db.toString().replace(".tar.gz","")
     def unaligned = ''
     def aligned = ''
     if (meta.single_end) {
@@ -42,7 +44,7 @@ process CENTRIFUGE {
     def sam_output = sam_format ? "--out-fmt 'sam'" : ''
     """
     centrifuge \\
-        -x ${db}/${db} \\
+        -x ${db}/$db_name \\
         -p $task.cpus \\
         $paired \\
         --report-file ${prefix}.report.txt \\
@@ -51,7 +53,7 @@ process CENTRIFUGE {
         $aligned \\
         $sam_output \\
         $args
-    centrifuge-kreport -x ${db}/${db} ${prefix}.results.txt > ${prefix}.kreport.txt
+    centrifuge-kreport -x $db_name ${prefix}.results.txt > ${prefix}.kreport.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/centrifuge/main.nf
+++ b/modules/centrifuge/main.nf
@@ -44,7 +44,7 @@ process CENTRIFUGE {
     def sam_output = sam_format ? "--out-fmt 'sam'" : ''
     """
     centrifuge \\
-        -x ${db}/$db_name \\
+        -x ${db}/${db_name} \\
         -p $task.cpus \\
         $paired \\
         --report-file ${prefix}.report.txt \\

--- a/modules/centrifuge/main.nf
+++ b/modules/centrifuge/main.nf
@@ -30,7 +30,6 @@ process CENTRIFUGE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def paired = meta.single_end ? "-U ${reads}" :  "-1 ${reads[0]} -2 ${reads[1]}"
-    def db_name = db.toString().replace(".tar.gz","")
     def unaligned = ''
     def aligned = ''
     if (meta.single_end) {
@@ -42,9 +41,8 @@ process CENTRIFUGE {
     }
     def sam_output = sam_format ? "--out-fmt 'sam'" : ''
     """
-    tar -xf $db
     centrifuge \\
-        -x $db_name \\
+        -x ${db}/${db} \\
         -p $task.cpus \\
         $paired \\
         --report-file ${prefix}.report.txt \\
@@ -53,7 +51,7 @@ process CENTRIFUGE {
         $aligned \\
         $sam_output \\
         $args
-    centrifuge-kreport -x $db_name ${prefix}.results.txt > ${prefix}.kreport.txt
+    centrifuge-kreport -x ${db}/${db} ${prefix}.results.txt > ${prefix}.kreport.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/centrifuge/meta.yml
+++ b/modules/centrifuge/meta.yml
@@ -29,7 +29,7 @@ input:
       pattern: "*.tar.gz"
   - db_name:
       type: string
-      description: Centrifuge filenames without the suffix ".cf"
+      description: Centrifuge database filenames without the suffix ".cf"
   - save_unaligned:
       type: value
       description: If true unmapped fastq files are saved

--- a/modules/centrifuge/meta.yml
+++ b/modules/centrifuge/meta.yml
@@ -27,6 +27,8 @@ input:
       type: directory
       description: Centrifuge database in .tar.gz format
       pattern: "*.tar.gz"
+  - db_name: string
+      description: Centrifuge filenames without the suffix ".cf"
   - save_unaligned:
       type: value
       description: If true unmapped fastq files are saved

--- a/modules/centrifuge/meta.yml
+++ b/modules/centrifuge/meta.yml
@@ -27,7 +27,8 @@ input:
       type: directory
       description: Centrifuge database in .tar.gz format
       pattern: "*.tar.gz"
-  - db_name: string
+  - db_name:
+      type: string
       description: Centrifuge filenames without the suffix ".cf"
   - save_unaligned:
       type: value

--- a/tests/modules/centrifuge/main.nf
+++ b/tests/modules/centrifuge/main.nf
@@ -10,13 +10,13 @@ workflow test_centrifuge_single_end {
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
             ]
     db    =  [ [], file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz', checkIfExists: true) ]
-
+    db_name = file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz').toString().replace(".tar.gz","")
     save_unaligned = true
     save_aligned = false
     sam_format = false
 
     UNTAR ( db )
-    CENTRIFUGE ( input, UNTAR.out.untar.map{ it[1] }, save_unaligned, save_aligned, sam_format )
+    CENTRIFUGE ( input, UNTAR.out.untar.map{ it[1] },db_name, save_unaligned, save_aligned, sam_format )
 
 }
 
@@ -26,13 +26,13 @@ workflow test_centrifuge_paired_end {
                 file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
             ]
      db    =  [ [], file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz', checkIfExists: true) ]
-
+     db_name = file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz').toString().replace(".tar.gz","")
      save_unaligned = true
      save_aligned = false
      sam_format = false
 
     UNTAR ( db )
-    CENTRIFUGE ( input, UNTAR.out.untar.map{ it[1] }, save_unaligned, save_aligned, sam_format )
+    CENTRIFUGE ( input, UNTAR.out.untar.map{ it[1] }, db_name, save_unaligned, save_aligned, sam_format )
 
 
 }

--- a/tests/modules/centrifuge/main.nf
+++ b/tests/modules/centrifuge/main.nf
@@ -26,7 +26,7 @@ workflow test_centrifuge_paired_end {
                 file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
             ]
      db    =  [ [], file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz', checkIfExists: true) ]
-     db_name = file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz').toString().replace(".tar.gz","")
+     db_name = "minigut_cf"
      save_unaligned = true
      save_aligned = false
      sam_format = false

--- a/tests/modules/centrifuge/main.nf
+++ b/tests/modules/centrifuge/main.nf
@@ -2,18 +2,21 @@
 
 nextflow.enable.dsl = 2
 
+include { UNTAR      } from '../../../modules/untar/main.nf'
 include { CENTRIFUGE } from '../../../modules/centrifuge/main.nf'
 
 workflow test_centrifuge_single_end {
     input = [ [ id:'test', single_end:true ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
             ]
-    db   =  file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz", checkIfExists: true)
+    db    =  [ [], file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz', checkIfExists: true) ]
+
     save_unaligned = true
     save_aligned = false
     sam_format = false
 
-    CENTRIFUGE ( input, db, save_unaligned, save_aligned, sam_format )
+    UNTAR ( db )
+    CENTRIFUGE ( input, UNTAR.out.untar.map{ it[1] }, save_unaligned, save_aligned, sam_format )
 
 }
 
@@ -22,12 +25,14 @@ workflow test_centrifuge_paired_end {
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
                 file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
             ]
-     db   =  file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz", checkIfExists: true)
+     db    =  [ [], file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz', checkIfExists: true) ]
+
      save_unaligned = true
      save_aligned = false
      sam_format = false
 
-    CENTRIFUGE ( input, db, save_unaligned, save_aligned, sam_format )
+    UNTAR ( db )
+    CENTRIFUGE ( input, UNTAR.out.untar.map{ it[1] }, save_unaligned, save_aligned, sam_format )
 
 
 }

--- a/tests/modules/centrifuge/main.nf
+++ b/tests/modules/centrifuge/main.nf
@@ -10,7 +10,7 @@ workflow test_centrifuge_single_end {
               [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
             ]
     db    =  [ [], file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz', checkIfExists: true) ]
-    db_name = file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/minigut_cf.tar.gz').toString().replace(".tar.gz","")
+    db_name = "minigut_cf"
     save_unaligned = true
     save_aligned = false
     sam_format = false

--- a/tests/modules/centrifuge/test.yml
+++ b/tests/modules/centrifuge/test.yml
@@ -4,10 +4,17 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
+  
     - path: output/centrifuge/test.report.txt
+      md5sum: 0d038ed45d52951652cc40bce5f22e3d
     - path: output/centrifuge/test.results.txt
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/test.unmapped.fastq.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/versions.yml
+      md5sum: aa7d5fabe61c77a1931bcc29fd80d147
+    - path: output/untar/versions.yml
+      md5sum: b9d29b7ce04414109f81cfe1681350b6
 
 - name: centrifuge test_centrifuge_paired_end
   command: nextflow run tests/modules/centrifuge -entry test_centrifuge_paired_end -c tests/config/nextflow.config
@@ -15,9 +22,16 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
+      md5sum: af1a51fe57eb6d428350ff4a4bf759d4
     - path: output/centrifuge/test.report.txt
+      md5sum: 0d038ed45d52951652cc40bce5f22e3d
     - path: output/centrifuge/test.results.txt
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/test.unmapped.fastq.1.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/test.unmapped.fastq.2.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/versions.yml
-
+      md5sum: 7d4a1b72b00aaba01f5c7c323062d32e
+    - path: output/untar/versions.yml
+      md5sum: 1a7488c94c0a6284ee259b5340682a08

--- a/tests/modules/centrifuge/test.yml
+++ b/tests/modules/centrifuge/test.yml
@@ -4,15 +4,10 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
-      md5sum: af1a51fe57eb6d428350ff4a4bf759d4
     - path: output/centrifuge/test.report.txt
-      md5sum: 0d038ed45d52951652cc40bce5f22e3d
     - path: output/centrifuge/test.results.txt
     - path: output/centrifuge/test.unmapped.fastq.gz
     - path: output/centrifuge/versions.yml
-      md5sum: aa7d5fabe61c77a1931bcc29fd80d147
-    - path: output/untar/versions.yml
-      md5sum: b9d29b7ce04414109f81cfe1681350b6
 
 - name: centrifuge test_centrifuge_paired_end
   command: nextflow run tests/modules/centrifuge -entry test_centrifuge_paired_end -c tests/config/nextflow.config
@@ -20,13 +15,9 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
-      md5sum: af1a51fe57eb6d428350ff4a4bf759d4
     - path: output/centrifuge/test.report.txt
-      md5sum: 0d038ed45d52951652cc40bce5f22e3d
     - path: output/centrifuge/test.results.txt
     - path: output/centrifuge/test.unmapped.fastq.1.gz
     - path: output/centrifuge/test.unmapped.fastq.2.gz
     - path: output/centrifuge/versions.yml
-      md5sum: 7d4a1b72b00aaba01f5c7c323062d32e
-    - path: output/untar/versions.yml
-      md5sum: 1a7488c94c0a6284ee259b5340682a08
+

--- a/tests/modules/centrifuge/test.yml
+++ b/tests/modules/centrifuge/test.yml
@@ -15,7 +15,7 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
-    - path: output/centrifuge/test.report.tx
+    - path: output/centrifuge/test.report.txt
     - path: output/centrifuge/test.results.txt
     - path: output/centrifuge/test.unmapped.fastq.1.gz
     - path: output/centrifuge/test.unmapped.fastq.2.gz

--- a/tests/modules/centrifuge/test.yml
+++ b/tests/modules/centrifuge/test.yml
@@ -4,10 +4,15 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
+      md5sum: af1a51fe57eb6d428350ff4a4bf759d4
     - path: output/centrifuge/test.report.txt
+      md5sum: 0d038ed45d52951652cc40bce5f22e3d
     - path: output/centrifuge/test.results.txt
     - path: output/centrifuge/test.unmapped.fastq.gz
     - path: output/centrifuge/versions.yml
+      md5sum: aa7d5fabe61c77a1931bcc29fd80d147
+    - path: output/untar/versions.yml
+      md5sum: b9d29b7ce04414109f81cfe1681350b6
 
 - name: centrifuge test_centrifuge_paired_end
   command: nextflow run tests/modules/centrifuge -entry test_centrifuge_paired_end -c tests/config/nextflow.config
@@ -15,8 +20,13 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
+      md5sum: af1a51fe57eb6d428350ff4a4bf759d4
     - path: output/centrifuge/test.report.txt
+      md5sum: 0d038ed45d52951652cc40bce5f22e3d
     - path: output/centrifuge/test.results.txt
     - path: output/centrifuge/test.unmapped.fastq.1.gz
     - path: output/centrifuge/test.unmapped.fastq.2.gz
     - path: output/centrifuge/versions.yml
+      md5sum: 7d4a1b72b00aaba01f5c7c323062d32e
+    - path: output/untar/versions.yml
+      md5sum: 1a7488c94c0a6284ee259b5340682a08

--- a/tests/modules/centrifuge/test.yml
+++ b/tests/modules/centrifuge/test.yml
@@ -4,17 +4,10 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
-  
     - path: output/centrifuge/test.report.txt
-      md5sum: 0d038ed45d52951652cc40bce5f22e3d
     - path: output/centrifuge/test.results.txt
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/test.unmapped.fastq.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/versions.yml
-      md5sum: aa7d5fabe61c77a1931bcc29fd80d147
-    - path: output/untar/versions.yml
-      md5sum: b9d29b7ce04414109f81cfe1681350b6
 
 - name: centrifuge test_centrifuge_paired_end
   command: nextflow run tests/modules/centrifuge -entry test_centrifuge_paired_end -c tests/config/nextflow.config
@@ -22,16 +15,8 @@
     - centrifuge
   files:
     - path: output/centrifuge/test.kreport.txt
-      md5sum: af1a51fe57eb6d428350ff4a4bf759d4
-    - path: output/centrifuge/test.report.txt
-      md5sum: 0d038ed45d52951652cc40bce5f22e3d
+    - path: output/centrifuge/test.report.tx
     - path: output/centrifuge/test.results.txt
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/test.unmapped.fastq.1.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/test.unmapped.fastq.2.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/centrifuge/versions.yml
-      md5sum: 7d4a1b72b00aaba01f5c7c323062d32e
-    - path: output/untar/versions.yml
-      md5sum: 1a7488c94c0a6284ee259b5340682a08


### PR DESCRIPTION
Update centrifuge module so that the database is extracted using the untar module

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
