### PR TITLE
Add task.ext.args to phantompeakqualtools and finish the module

### DIFF
--- a/modules/phantompeakqualtools/main.nf
+++ b/modules/phantompeakqualtools/main.nf
@@ -26,7 +26,7 @@ process PHANTOMPEAKQUALTOOLS {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     RUN_SPP=`which run_spp.R`
-    Rscript --max-ppsize=500000 -e "library(caTools); source(\\"\$RUN_SPP\\")" -c="$bam" -savp="${prefix}.spp.pdf" -savd="${prefix}.spp.Rdata" -out="${prefix}.spp.out" -p=$task.cpus
+    Rscript $args -e "library(caTools); source(\\"\$RUN_SPP\\")" -c="$bam" -savp="${prefix}.spp.pdf" -savd="${prefix}.spp.Rdata" -out="${prefix}.spp.out" -p=$task.cpus
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/phantompeakqualtools/main.nf
+++ b/modules/phantompeakqualtools/main.nf
@@ -26,7 +26,7 @@ process PHANTOMPEAKQUALTOOLS {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     RUN_SPP=`which run_spp.R`
-    Rscript -e "library(caTools); source(\\"\$RUN_SPP\\")" -c="$bam" -savp="${prefix}.spp.pdf" -savd="${prefix}.spp.Rdata" -out="${prefix}.spp.out" -p=$task.cpus
+    Rscript --max-ppsize=500000 -e "library(caTools); source(\\"\$RUN_SPP\\")" -c="$bam" -savp="${prefix}.spp.pdf" -savd="${prefix}.spp.Rdata" -out="${prefix}.spp.out" -p=$task.cpus
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/phantompeakqualtools/meta.yml
+++ b/modules/phantompeakqualtools/meta.yml
@@ -1,0 +1,60 @@
+name: "phantompeakqualtools"
+
+description:
+keywords:
+  - "ChIP-Seq"
+  - "QC"
+  - "phantom peaks"
+tools:
+  - "phantompeakqualtools":
+      description: |
+        "This package computes informative enrichment and quality measures
+        for ChIP-seq/DNase-seq/FAIRE-seq/MNase-seq data. It can also be used
+        to obtain robust estimates of the predominant fragment length or
+        characteristic tag shift values in these assays."
+      homepage: "None"
+      documentation: "https://github.com/kundajelab/phantompeakqualtools"
+      tool_dev_url: "https://github.com/kundajelab/phantompeakqualtools"
+      doi: "https://doi.org/10.1101/gr.136184.111"
+      licence: "['BSD-3-clause']"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bam:
+      type: file
+      description: BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - spp:
+      type: file
+      description: |
+        A ChIP-Seq Processing Pipeline file containing
+        peakshift/phantomPeak results
+      pattern: "*.{out}"
+  - pdf:
+      type: file
+      description: A pdf containing save cross-correlation plots
+      pattern: "*.{pdf}"
+  - rdata:
+      type: file
+      description: Rdata file containing the R session
+      pattern: "*.{Rdata}"
+
+authors:
+  - "@drpatelh"
+  - "@Emiller88"
+  - "@JoseEspinosa"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -1303,6 +1303,10 @@ peddy:
   - modules/peddy/**
   - tests/modules/peddy/**
 
+phantompeakqualtools:
+  - modules/phantompeakqualtools/**
+  - tests/modules/phantompeakqualtools/**
+
 phyloflash:
   - modules/phyloflash/**
   - tests/modules/phyloflash/**

--- a/tests/modules/phantompeakqualtools/main.nf
+++ b/tests/modules/phantompeakqualtools/main.nf
@@ -1,0 +1,25 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { PHANTOMPEAKQUALTOOLS } from '../../../modules/phantompeakqualtools/main.nf'
+
+workflow test_phantompeakqualtools_single_end {
+
+    input = [
+        [ id:'test', single_end:true ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_single_end_bam'], checkIfExists: true)
+    ]
+
+    PHANTOMPEAKQUALTOOLS ( input )
+}
+
+workflow test_phantompeakqualtools_paired_end {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
+
+    PHANTOMPEAKQUALTOOLS ( input )
+}

--- a/tests/modules/phantompeakqualtools/nextflow.config
+++ b/tests/modules/phantompeakqualtools/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+}

--- a/tests/modules/phantompeakqualtools/test.yml
+++ b/tests/modules/phantompeakqualtools/test.yml
@@ -1,0 +1,23 @@
+- name: phantompeakqualtools test_phantompeakqualtools_single_end
+  command: nextflow run tests/modules/phantompeakqualtools -entry test_phantompeakqualtools_single_end -c tests/config/nextflow.config
+  tags:
+    - phantompeakqualtools
+  files:
+    - path: output/phantompeakqualtools/test.spp.Rdata
+    - path: output/phantompeakqualtools/test.spp.out
+      md5sum: b01d976506b6fe45b66c821b1e8a1d15
+    - path: output/phantompeakqualtools/test.spp.pdf
+    - path: output/phantompeakqualtools/versions.yml
+      md5sum: 6c2ede1aac4c574e3c72fbe09f15c03f
+
+- name: phantompeakqualtools test_phantompeakqualtools_paired_end
+  command: nextflow run tests/modules/phantompeakqualtools -entry test_phantompeakqualtools_paired_end -c tests/config/nextflow.config
+  tags:
+    - phantompeakqualtools
+  files:
+    - path: output/phantompeakqualtools/test.spp.Rdata
+    - path: output/phantompeakqualtools/test.spp.out
+      md5sum: eed46e75eab119224f397a7a8b5924e6
+    - path: output/phantompeakqualtools/test.spp.pdf
+    - path: output/phantompeakqualtools/versions.yml
+      md5sum: 383d2dd583fcb40451bde0d3840bdb72

--- a/tests/modules/phantompeakqualtools/test.yml
+++ b/tests/modules/phantompeakqualtools/test.yml
@@ -5,10 +5,10 @@
   files:
     - path: output/phantompeakqualtools/test.spp.Rdata
     - path: output/phantompeakqualtools/test.spp.out
-      md5sum: b01d976506b6fe45b66c821b1e8a1d15
+      md5sum: eed46e75eab119224f397a7a8b5924e6
     - path: output/phantompeakqualtools/test.spp.pdf
     - path: output/phantompeakqualtools/versions.yml
-      md5sum: 6c2ede1aac4c574e3c72fbe09f15c03f
+      md5sum: 383d2dd583fcb40451bde0d3840bdb72
 
 - name: phantompeakqualtools test_phantompeakqualtools_paired_end
   command: nextflow run tests/modules/phantompeakqualtools -entry test_phantompeakqualtools_paired_end -c tests/config/nextflow.config

--- a/tests/modules/phantompeakqualtools/test.yml
+++ b/tests/modules/phantompeakqualtools/test.yml
@@ -5,10 +5,10 @@
   files:
     - path: output/phantompeakqualtools/test.spp.Rdata
     - path: output/phantompeakqualtools/test.spp.out
-      md5sum: eed46e75eab119224f397a7a8b5924e6
+      md5sum: b01d976506b6fe45b66c821b1e8a1d15
     - path: output/phantompeakqualtools/test.spp.pdf
     - path: output/phantompeakqualtools/versions.yml
-      md5sum: 383d2dd583fcb40451bde0d3840bdb72
+      md5sum: 6c2ede1aac4c574e3c72fbe09f15c03f
 
 - name: phantompeakqualtools test_phantompeakqualtools_paired_end
   command: nextflow run tests/modules/phantompeakqualtools -entry test_phantompeakqualtools_paired_end -c tests/config/nextflow.config


### PR DESCRIPTION
As explained [here](https://github.com/nf-core/chipseq/issues/220), when the data set is too big the `phantompeakqualtools` throws an exception. Adding the option fixes the problem `--max-ppsize=500000`. On this PR, `task.ext.args` to the  `phantompeakqualtools` command and also, all the missing bits of the module were added (tests + meta.yml file)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
