### PR TITLE
Add optional variant catalog input

### DIFF
--- a/modules/stranger/main.nf
+++ b/modules/stranger/main.nf
@@ -9,6 +9,7 @@ process STRANGER {
 
     input:
     tuple val(meta), path(vcf)
+    path variant_catalog
 
     output:
     tuple val(meta), path("*.gz"), emit: vcf
@@ -20,10 +21,12 @@ process STRANGER {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def options_variant_catalog = variant_catalog ? "--repeats-file $variant_catalog" : ""
     """
     stranger \\
         $args \\
-        $vcf | gzip --no-name > ${prefix}.vcf.gz
+        $vcf \\
+        $options_variant_catalog | gzip --no-name > ${prefix}.vcf.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/stranger/meta.yml
+++ b/modules/stranger/meta.yml
@@ -24,6 +24,10 @@ input:
       type: file
       description: VCF with repeat expansions
       pattern: "*.{vcf.gz,vcf}"
+  - variant_catalog:
+      type: file
+      description: json file with repeat expansion sites to genotype
+      pattern: "*.{json}"
 
 output:
   - meta:

--- a/tests/modules/stranger/main.nf
+++ b/tests/modules/stranger/main.nf
@@ -5,15 +5,21 @@ nextflow.enable.dsl = 2
 include { EXPANSIONHUNTER } from '../../../modules/expansionhunter/main.nf'
 include { STRANGER } from '../../../modules/stranger/main.nf'
 
+
+input = [ [ id:'test', gender:'male' ], // meta map
+            file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
+            file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+        ]
+fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+variant_catalog = file(params.test_data['homo_sapiens']['genome']['repeat_expansions'], checkIfExists: true)
+
+
 workflow test_stranger {
-
-    input = [ [ id:'test', gender:'male' ], // meta map
-              file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-              file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
-            ]
-    fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
-    variant_catalog = file(params.test_data['homo_sapiens']['genome']['repeat_expansions'], checkIfExists: true)
-
     EXPANSIONHUNTER ( input, fasta, variant_catalog )
-    STRANGER ( EXPANSIONHUNTER.out.vcf )
+    STRANGER ( EXPANSIONHUNTER.out.vcf, variant_catalog )
+}
+
+workflow test_stranger_without_optional_variant_catalog {
+    EXPANSIONHUNTER ( input, fasta, variant_catalog )
+    STRANGER ( EXPANSIONHUNTER.out.vcf, Channel.empty() )
 }

--- a/tests/modules/stranger/main.nf
+++ b/tests/modules/stranger/main.nf
@@ -21,5 +21,5 @@ workflow test_stranger {
 
 workflow test_stranger_without_optional_variant_catalog {
     EXPANSIONHUNTER ( input, fasta, variant_catalog )
-    STRANGER ( EXPANSIONHUNTER.out.vcf, Channel.empty() )
+    STRANGER ( EXPANSIONHUNTER.out.vcf, [] )
 }

--- a/tests/modules/stranger/test.yml
+++ b/tests/modules/stranger/test.yml
@@ -8,6 +8,16 @@
     - path: output/expansionhunter/versions.yml
       md5sum: f3962a6eecfddf9682414c0f605a885a
     - path: output/stranger/test.vcf.gz
-      md5sum: bbe15159195681d5c18596d3ad85c78f
+      md5sum: 68b0ca1319851134ffa8793a4704dc11
     - path: output/stranger/versions.yml
       md5sum: 5ec35fd835fb1be50bc3e7c004310fc0
+
+- name: stranger test_stranger_without_optional_variant_catalog
+  command: nextflow run tests/modules/stranger -entry test_stranger_without_optional_variant_catalog -c tests/config/nextflow.config
+  tags:
+    - stranger
+  files:
+    - path: output/expansionhunter/test.vcf
+      md5sum: cfd4a1d35c0e469b99eb6aaa6d22de76
+    - path: output/expansionhunter/versions.yml
+      md5sum: c95af9e6d8cd9bd2ce1090ca4e7a6020

--- a/tests/modules/stranger/test.yml
+++ b/tests/modules/stranger/test.yml
@@ -21,3 +21,7 @@
       md5sum: cfd4a1d35c0e469b99eb6aaa6d22de76
     - path: output/expansionhunter/versions.yml
       md5sum: c95af9e6d8cd9bd2ce1090ca4e7a6020
+    - path: output/stranger/test.vcf.gz
+      md5sum: bbe15159195681d5c18596d3ad85c78f
+    - path: output/stranger/versions.yml
+      md5sum: 8558542a007e90ea5dcdceed3f12585d


### PR DESCRIPTION
This PR adds optional variant catalog input from a channel to stranger module. 

## PR checklist

Closes #1461

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
