### PR TITLE
Update test_data.config to include kaiju.tar.gz

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -28,9 +28,8 @@ params {
                 kraken2_bracken                                = "${test_data_dir}/genomics/sarscov2/genome/db/kraken2_bracken"
                 kraken2_bracken_tar_gz                         = "${test_data_dir}/genomics/sarscov2/genome/db/kraken2_bracken.tar.gz"
 
-                kaiju_fmi                                      = "${test_data_dir}/genomics/sarscov2/genome/db/kaiju/proteins.fmi"
-                kaiju_nodes                                    = "${test_data_dir}/genomics/sarscov2/genome/db/kaiju/nodes.dmp"
-                kaiju_names                                    = "${test_data_dir}/genomics/sarscov2/genome/db/kaiju/names.dmp"
+                kaiju                                          = "${test_data_dir}/genomics/sarscov2/genome/db/kaiju"
+                kaiju_tar_gz                                   = "${test_data_dir}/genomics/sarscov2/genome/db/kaiju.tar.gz"
 
                 ncbi_taxmap_zip                                = "${test_data_dir}/genomics/sarscov2/genome/db/maltextract/ncbi_taxmap.zip"
                 taxon_list_txt                                 = "${test_data_dir}/genomics/sarscov2/genome/db/maltextract/taxon_list.txt"


### PR DESCRIPTION
This PR updates the `test_data.config` file to include kaiju database directory in tar format.
