### PR TITLE
change stringtie name to stringtie_stringtie

### DIFF
--- a/modules/stringtie/stringtie/main.nf
+++ b/modules/stringtie/stringtie/main.nf
@@ -1,4 +1,4 @@
-process STRINGTIE {
+process STRINGTIE_STRINGTIE {
     tag "$meta.id"
     label 'process_medium'
 

--- a/modules/stringtie/stringtie/meta.yml
+++ b/modules/stringtie/stringtie/meta.yml
@@ -1,4 +1,4 @@
-name: stringtie
+name: stringtie_stringtie
 description: Transcript assembly and quantification for RNA-Se
 keywords:
   - transcript

--- a/tests/modules/stringtie/stringtie/main.nf
+++ b/tests/modules/stringtie/stringtie/main.nf
@@ -2,29 +2,29 @@
 
 nextflow.enable.dsl = 2
 
-include { STRINGTIE } from '../../../../modules/stringtie/stringtie/main.nf'
+include { STRINGTIE_STRINGTIE } from '../../../../modules/stringtie/stringtie/main.nf'
 //
 // Test with forward strandedness
 //
-workflow test_stringtie_forward {
+workflow test_stringtie_stringtie_forward {
     input = [
         [ id:'test', strandedness:'forward' ], // meta map
         [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ]
     ]
     annotation_gtf = file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
 
-    STRINGTIE ( input, annotation_gtf )
+    STRINGTIE_STRINGTIE ( input, annotation_gtf )
 }
 
 //
 // Test with reverse strandedness
 //
-workflow test_stringtie_reverse {
+workflow test_stringtie_stringtie_reverse {
     input = [
         [ id:'test', strandedness:'reverse' ], // meta map
         [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ]
     ]
     annotation_gtf = file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
 
-    STRINGTIE ( input, annotation_gtf )
+    STRINGTIE_STRINGTIE ( input, annotation_gtf )
 }

--- a/tests/modules/stringtie/stringtie/test.yml
+++ b/tests/modules/stringtie/stringtie/test.yml
@@ -1,5 +1,5 @@
-- name: stringtie stringtie forward
-  command: nextflow run ./tests/modules/stringtie/stringtie/ -entry test_stringtie_forward -c ./tests/config/nextflow.config -c ./tests/modules/stringtie/stringtie/nextflow.config
+- name: stringtie stringtie test_stringtie_stringtie_forward
+  command: nextflow run ./tests/modules/stringtie/stringtie/ -entry test_stringtie_stringtie_forward -c ./tests/config/nextflow.config -c ./tests/modules/stringtie/stringtie/nextflow.config
   tags:
     - stringtie
     - stringtie/stringtie
@@ -20,8 +20,8 @@
     - path: ./output/stringtie/test.ballgown/e2t.ctab
       md5sum: e981c0038295ae54b63cedb1083f1540
 
-- name: stringtie stringtie reverse
-  command: nextflow run ./tests/modules/stringtie/stringtie/ -entry test_stringtie_reverse -c ./tests/config/nextflow.config -c ./tests/modules/stringtie/stringtie/nextflow.config
+- name: stringtie stringtie test_stringtie_stringtie_reverse
+  command: nextflow run ./tests/modules/stringtie/stringtie/ -entry test_stringtie_stringtie_reverse -c ./tests/config/nextflow.config -c ./tests/modules/stringtie/stringtie/nextflow.config
   tags:
     - stringtie
     - stringtie/stringtie


### PR DESCRIPTION
The name of the process was set to STRINGTIE. 
It has been changed to STRINGTIE_STRINGTIE to follow naming conventions.

## PR checklist

- [x] This comment contains a description of changes (with reason).
