### PR TITLE
elprep/split: fix output glob

### DIFF
--- a/modules/elprep/split/main.nf
+++ b/modules/elprep/split/main.nf
@@ -11,16 +11,16 @@ process ELPREP_SPLIT {
     tuple val(meta), path(bam)
 
     output:
-    tuple val(meta), path("**.{bam,sam}"), emit: bam
+    tuple val(meta), path("output/**.{bam,sam}"), emit: bam
     path "versions.yml"           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    meta.single_end ? args += " --single-end": ""
+    def args        = task.ext.args ?: ''
+    def prefix      = task.ext.prefix ?: "${meta.id}"
+    def single_end  = meta.single_end ? " --single-end": ""
 
     """
     # create directory and move all input so elprep can find and merge them before splitting
@@ -31,8 +31,9 @@ process ELPREP_SPLIT {
 
     elprep split \\
         input \\
-        . \\
+        output/ \\
         $args \\
+        $single_end \\
         --nr-of-threads $task.cpus \\
         --output-prefix $prefix
 

--- a/tests/modules/elprep/split/test.yml
+++ b/tests/modules/elprep/split/test.yml
@@ -4,7 +4,7 @@
     - elprep
     - elprep/split
   files:
-    - path: output/elprep/splits/test-group00001.bam
-    - path: output/elprep/splits/test-unmapped.bam
-    - path: output/elprep/test-spread.bam
+    - path: output/elprep/output/splits/test-group00001.bam
+    - path: output/elprep/output/splits/test-unmapped.bam
+    - path: output/elprep/output/test-spread.bam
     - path: output/elprep/versions.yml


### PR DESCRIPTION
Fix output glob and write outputs to subdir. This avoids globbing input data into the outputs.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
