### PR TITLE
elprep/filter: fix output glob

### DIFF
--- a/modules/elprep/filter/main.nf
+++ b/modules/elprep/filter/main.nf
@@ -23,7 +23,7 @@ process ELPREP_FILTER {
 
 
     output:
-    tuple val(meta), path("**.{bam,sam}")           ,emit: bam
+    tuple val(meta), path("output/**.{bam,sam}")    ,emit: bam
     tuple val(meta), path("*.metrics.txt")          ,optional: true, emit: metrics
     tuple val(meta), path("*.recall")               ,optional: true, emit: recall
     tuple val(meta), path("*.vcf.gz")               ,optional: true, emit: gvcf
@@ -65,7 +65,7 @@ process ELPREP_FILTER {
     def assembly_regions_cmd = get_assembly_regions ? " --assembly-regions ${prefix}.assembly_regions.igv": ""
 
     """
-    elprep filter ${bam} ${prefix}.${suffix} \\
+    elprep filter ${bam} output/${prefix}.${suffix} \\
         ${reference_sequences_cmd} \\
         ${filter_regions_cmd} \\
         ${markdup_cmd} \\

--- a/tests/modules/elprep/filter/test.yml
+++ b/tests/modules/elprep/filter/test.yml
@@ -6,7 +6,7 @@
   files:
     - path: output/elprep/test.activity_profile.igv
     - path: output/elprep/test.assembly_regions.igv
-    - path: output/elprep/test.bam
+    - path: output/elprep/output/test.bam
     - path: output/elprep/test.g.vcf.gz
     - path: output/elprep/test.metrics.txt
     - path: output/elprep/test.recall


### PR DESCRIPTION
This PR fixes the output glob for `elprep filter` to avoid globbing the input data into the outputs

## PR checklist
- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
