### PR TITLE
Add missing bacteroides_fragilis genome.gbff.gz

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -335,6 +335,7 @@ params {
         'bacteroides_fragilis' {
             'genome' {
                 genome_fna_gz                   = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz"
+                genome_gbff_gz                  = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/genome/genome.gbff.gz"
                 genome_paf                      = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/genome/genome.paf"
                 genome_mapping_potential_arg    = "${test_data_dir}/genomics/prokaryotes/bacteroides_fragilis/genome/genome.mapping.potential.ARG"
 


### PR DESCRIPTION
This PR adds the [GBFF test data](https://github.com/nf-core/test-datasets/blob/modules/data/genomics/prokaryotes/bacteroides_fragilis/genome/genome.gbff.gz) of the *Bacteroides fragilis* prokaryotic genome as present in the [test-datasets repo](https://github.com/nf-core/test-datasets/tree/modules/data/genomics/prokaryotes/bacteroides_fragilis/genome) to the test_data.config file. It is not apparent why this single file was missing (maybe got removed in the recent folder structure reshuffle).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`