### PR TITLE
Remove task.cpus from the command of the phantompeakqualtools module

### DIFF
--- a/modules/phantompeakqualtools/main.nf
+++ b/modules/phantompeakqualtools/main.nf
@@ -26,7 +26,7 @@ process PHANTOMPEAKQUALTOOLS {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     RUN_SPP=`which run_spp.R`
-    Rscript $args -e "library(caTools); source(\\"\$RUN_SPP\\")" -c="$bam" -savp="${prefix}.spp.pdf" -savd="${prefix}.spp.Rdata" -out="${prefix}.spp.out" -p=$task.cpus
+    Rscript $args -e "library(caTools); source(\\"\$RUN_SPP\\")" -c="$bam" -savp="${prefix}.spp.pdf" -savd="${prefix}.spp.Rdata" -out="${prefix}.spp.out"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
When running the dev version of the chipseq pipeline in my cluster with the test_full  dataset and it turned out that the process `phantompeakqualtools` was taking too long to run and being killed. If the the argument to set the number of cpus used by run_spp.R (i.e. -p=$task.cpus) from the [command in the process](https://github.com/nf-core/chipseq/blob/c1975ca9d9a6dbb53d1584ad27e6884b2c0228da/modules/nf-core/modules/phantompeakqualtools/main.nf#L29) section then the process speeds up to only 1h and something. So seems that the way multithreading is handled in the script is not efficient enough. Hence I disabled this option from the module and this option can be now pass as an optional parmeter, see below:
```
withName: 'PHANTOMPEAKQUALTOOLS' {
        ext.args   = { "-p=$task.cpus" }
```

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
