### PR TITLE
Add antismash download DB: missing container folders as output channels

### DIFF
--- a/modules/antismash/antismashlitedownloaddatabases/main.nf
+++ b/modules/antismash/antismashlitedownloaddatabases/main.nf
@@ -7,8 +7,9 @@ process ANTISMASH_ANTISMASHLITEDOWNLOADDATABASES {
         'quay.io/biocontainers/antismash-lite:6.0.1--pyhdfd78af_1' }"
 
     /*
-    These files are normally downloaded by download-antismash-databases itself, and must be retrieved for input by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines. This is solely for use for CI tests of the nf-core/module version of antiSMASH.
+    These files are normally downloaded/created by download-antismash-databases itself, and must be retrieved for input by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines. This is solely for use for CI tests of the nf-core/module version of antiSMASH.
     Reason: Upon execution, the tool checks if certain database files are present within the container and if not, it tries to create them in /usr/local/bin, for which only root user has write permissions. Mounting those database files with this module prevents the tool from trying to create them.
+    These files are also emitted as output channels in this module to enable the antismash-lite module to use them as mount volumes to the docker/singularity containers.
     */
 
     containerOptions {
@@ -26,6 +27,9 @@ process ANTISMASH_ANTISMASHLITEDOWNLOADDATABASES {
 
     output:
     path("antismash_db") , emit: database
+    path("css"), emit: css_dir
+    path("detection"), emit: detection_dir
+    path("modules"), emit: modules_dir
     path "versions.yml", emit: versions
 
     when:

--- a/modules/antismash/antismashlitedownloaddatabases/main.nf
+++ b/modules/antismash/antismashlitedownloaddatabases/main.nf
@@ -44,7 +44,7 @@ process ANTISMASH_ANTISMASHLITEDOWNLOADDATABASES {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        antismash: \$(antismash --version | sed 's/antiSMASH //')
+        antismash-lite: \$(antismash --version | sed 's/antiSMASH //')
     END_VERSIONS
     """
 }

--- a/modules/antismash/antismashlitedownloaddatabases/meta.yml
+++ b/modules/antismash/antismashlitedownloaddatabases/meta.yml
@@ -27,17 +27,17 @@ input:
   - database_css:
       type: directory
       description: |
-        antismash/outputs/html/css folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the use by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
+        antismash/outputs/html/css folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by ther use by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
       pattern: "css"
   - database_detection:
       type: directory
       description: |
-        antismash/detection folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the use by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
+        antismash/detection folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the user by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
       pattern: "detection"
   - database_modules:
       type: directory
       description: |
-        antismash/modules folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the use by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
+        antismash/modules folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the user by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
       pattern: "modules"
 
 output:
@@ -50,6 +50,21 @@ output:
       type: directory
       description: Download directory for antiSMASH databases
       pattern: "antismash_db"
+  - css_dir:
+      type: directory
+      description: |
+        antismash/outputs/html/css folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the user by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
+      pattern: "css"
+  - detection_dir:
+      type: directory
+      description: |
+        antismash/detection folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the user by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
+      pattern: "detection"
+  - modules_dir:
+      type: directory
+      description: |
+        antismash/modules folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the user by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
+      pattern: "modules"
 
 authors:
   - "@jasmezz"

--- a/modules/antismash/antismashlitedownloaddatabases/meta.yml
+++ b/modules/antismash/antismashlitedownloaddatabases/meta.yml
@@ -27,7 +27,7 @@ input:
   - database_css:
       type: directory
       description: |
-        antismash/outputs/html/css folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by ther use by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
+        antismash/outputs/html/css folder which is being created during the antiSMASH database downloading step. These files are normally downloaded by download-antismash-databases itself, and must be retrieved by the user by manually running the command with conda or a standalone installation of antiSMASH. Therefore we do not recommend using this module for production pipelines, but rather require users to specify their own local copy of the antiSMASH database in pipelines.
       pattern: "css"
   - database_detection:
       type: directory

--- a/tests/modules/antismash/antismashlitedownloaddatabases/test.yml
+++ b/tests/modules/antismash/antismashlitedownloaddatabases/test.yml
@@ -1,14 +1,23 @@
 - name: antismash antismashlitedownloaddatabases test_antismash_antismashlitedownloaddatabases
   command: nextflow run tests/modules/antismash/antismashlitedownloaddatabases -entry test_antismash_antismashlitedownloaddatabases -c tests/config/nextflow.config
   tags:
-    - antismash/antismashlitedownloaddatabases
     - antismash
+    - antismash/antismashlitedownloaddatabases
   files:
     - path: output/antismash/versions.yml
       md5sum: e2656c8d2bcc7469eba40eb1ee5c91b3
+    - path: output/untar1/versions.yml
+      md5sum: b724089c7a3b22557626e3d6cf79884d
+    - path: output/untar2/versions.yml
+      md5sum: 7182a024e050e5fb6b8830930e551adc
+    - path: output/untar3/versions.yml
+      md5sum: d27a9b44dd969d74d237e52ac89bd8e5
     - path: output/antismash/antismash_db
     - path: output/antismash/antismash_db/clusterblast
     - path: output/antismash/antismash_db/clustercompare
     - path: output/antismash/antismash_db/pfam
     - path: output/antismash/antismash_db/resfam
     - path: output/antismash/antismash_db/tigrfam
+    - path: output/antismash/css
+    - path: output/antismash/detection
+    - path: output/antismash/modules

--- a/tests/modules/antismash/antismashlitedownloaddatabases/test.yml
+++ b/tests/modules/antismash/antismashlitedownloaddatabases/test.yml
@@ -6,12 +6,6 @@
   files:
     - path: output/antismash/versions.yml
       md5sum: e2656c8d2bcc7469eba40eb1ee5c91b3
-    - path: output/untar1/versions.yml
-      md5sum: b724089c7a3b22557626e3d6cf79884d
-    - path: output/untar2/versions.yml
-      md5sum: 7182a024e050e5fb6b8830930e551adc
-    - path: output/untar3/versions.yml
-      md5sum: d27a9b44dd969d74d237e52ac89bd8e5
     - path: output/antismash/antismash_db
     - path: output/antismash/antismash_db/clusterblast
     - path: output/antismash/antismash_db/clustercompare

--- a/tests/modules/antismash/antismashlitedownloaddatabases/test.yml
+++ b/tests/modules/antismash/antismashlitedownloaddatabases/test.yml
@@ -5,7 +5,7 @@
     - antismash/antismashlitedownloaddatabases
   files:
     - path: output/antismash/versions.yml
-      md5sum: e2656c8d2bcc7469eba40eb1ee5c91b3
+      md5sum: 24859c67023abab99de295d3675a24b6
     - path: output/antismash/antismash_db
     - path: output/antismash/antismash_db/clusterblast
     - path: output/antismash/antismash_db/clustercompare


### PR DESCRIPTION
Some folders, which are not present in the container (only created during the antiSMASH database download), but required for antismashlite to work, are now emitted as output channels of this module. They can then be mounted as additional volumes when using docker/singularity containers of the antismashlite module.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
