### PR TITLE
Bump SAMtools version for custom/getchromsizes

### DIFF
--- a/modules/custom/getchromsizes/main.nf
+++ b/modules/custom/getchromsizes/main.nf
@@ -2,10 +2,10 @@ process CUSTOM_GETCHROMSIZES {
     tag "$fasta"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::samtools=1.15" : null)
+    conda (params.enable_conda ? "bioconda::samtools=1.15.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.15--h1170115_1' :
-        'quay.io/biocontainers/samtools:1.15--h1170115_1' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.15.1--h1170115_0' :
+        'quay.io/biocontainers/samtools:1.15.1--h1170115_0' }"
 
     input:
     path fasta


### PR DESCRIPTION
All SAMtools modules have been updated to 1.15 and this PR does the same for `custom/getchromsizes` so a single container is downloaded when running pipelines (if possible).