### PR TITLE
Changed tbi as optional output in GATK4 HaplotypeCaller

### DIFF
--- a/modules/gatk4/haplotypecaller/main.nf
+++ b/modules/gatk4/haplotypecaller/main.nf
@@ -17,8 +17,9 @@ process GATK4_HAPLOTYPECALLER {
 
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf
-    tuple val(meta), path("*.tbi")   , emit: tbi
     path "versions.yml"              , emit: versions
+
+    tuple val(meta), path("*.tbi")   , optional:true, emit: tbi
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/gatk4/haplotypecaller/main.nf
+++ b/modules/gatk4/haplotypecaller/main.nf
@@ -17,8 +17,8 @@ process GATK4_HAPLOTYPECALLER {
 
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf
-     tuple val(meta), path("*.tbi")   , optional:true, emit: tbi
-     path "versions.yml"              , emit: versions
+    tuple val(meta), path("*.tbi")   , optional:true, emit: tbi
+    path "versions.yml"              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/gatk4/haplotypecaller/main.nf
+++ b/modules/gatk4/haplotypecaller/main.nf
@@ -17,9 +17,8 @@ process GATK4_HAPLOTYPECALLER {
 
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf
-    path "versions.yml"              , emit: versions
-
-    tuple val(meta), path("*.tbi")   , optional:true, emit: tbi
+     tuple val(meta), path("*.tbi")   , optional:true, emit: tbi
+     path "versions.yml"              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when


### PR DESCRIPTION
When working with larger chromosomes (e.g. Chromosome 1 of _Monodelphis domestica_ has a size of 748055161bp), GATK HaplotypeCaller fails to create a TBI index for the VCF file. The current implementation of BAI and TBI in HTSLib is limited to 512Mb [doi: 10.1093/gigascience/giab007]. In such cases, we will have to turn off index creation (--create-output-variant-index false) to get the variant calls. So this PR is to make the *.tbi as an optional output to handle such large genomes for variant calling.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
