### PR TITLE
Fix tiddit/sv

### DIFF
--- a/modules/tiddit/sv/main.nf
+++ b/modules/tiddit/sv/main.nf
@@ -24,7 +24,7 @@ process TIDDIT_SV {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def reference = fasta == "dummy_file.txt" ? "--ref $fasta" : ""
+    def reference = fasta ? "--ref $fasta" : ""
     """
     tiddit \\
         --sv \\

--- a/tests/modules/tiddit/sv/test.yml
+++ b/tests/modules/tiddit/sv/test.yml
@@ -9,6 +9,7 @@
     - path: output/tiddit/test.signals.tab
       md5sum: dab4b2fec4ddf8eb1c23005b0770150e
     - path: output/tiddit/test.vcf
+      md5sum: bdce14ae8292bf3deb81f6f255baf859
 
 - name: tiddit sv no ref
   command: nextflow run ./tests/modules/tiddit/sv -entry test_tiddit_sv_no_ref -c ./tests/config/nextflow.config -c ./tests/modules/tiddit/sv/nextflow.config
@@ -21,3 +22,4 @@
     - path: output/tiddit/test.signals.tab
       md5sum: dab4b2fec4ddf8eb1c23005b0770150e
     - path: output/tiddit/test.vcf
+      md5sum: 3d0e83a8199b2bdb81cfe3e6b12bf64b


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

`TIDDIT_SV` is currently broken as the input `fasta` option is ignored unless it's named "dummy_file.txt":

https://github.com/nf-core/modules/blob/68f1c27169946f931ea4318911de5681f88b2961/modules/tiddit/sv/main.nf#L27

This PR fixes that bug and adds md5sum's to the unit test VCF's that were previously missing.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
