### PR TITLE
Changed BAI as optional output

### DIFF
--- a/modules/gatk4/markduplicates/main.nf
+++ b/modules/gatk4/markduplicates/main.nf
@@ -12,7 +12,7 @@ process GATK4_MARKDUPLICATES {
 
     output:
     tuple val(meta), path("*.bam")    , emit: bam
-    tuple val(meta), path("*.bai")    , emit: bai
+    tuple val(meta), path("*.bai")    , optional:true, emit: bai
     tuple val(meta), path("*.metrics"), emit: metrics
     path "versions.yml"               , emit: versions
 


### PR DESCRIPTION
Changed BAI as optional output in GATk4 MarkDuplicates module:
Two reasons:
- It does not create an index by default. So the module does not work unless you specify `--CREATE_INDEX true`
- For large genomes, BAI does not need to be generated, so we want the module to work even without an index file output.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
