### PR TITLE
Update Krona modules to use ext.args

### DIFF
--- a/modules/krona/kronadb/main.nf
+++ b/modules/krona/kronadb/main.nf
@@ -18,7 +18,9 @@ process KRONA_KRONADB {
     script:
     def args = task.ext.args ?: ''
     """
-    ktUpdateTaxonomy.sh taxonomy
+    ktUpdateTaxonomy.sh \\
+        $args \\
+        taxonomy
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/krona/ktimporttaxonomy/main.nf
+++ b/modules/krona/ktimporttaxonomy/main.nf
@@ -23,7 +23,10 @@ process KRONA_KTIMPORTTAXONOMY {
     script:
     def args = task.ext.args ?: ''
     """
-    ktImportTaxonomy "$report" -tax taxonomy
+    ktImportTaxonomy \\
+       "$report" \\
+       $args \\
+       -tax taxonomy
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -110,6 +110,10 @@ params {
 
                 test_sequencing_summary                        = "${test_data_dir}/genomics/sarscov2/nanopore/sequencing_summary/test.sequencing_summary.txt"
             }
+            'metagenome' {
+                classified_reads_alignment                     = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.reads.txt
+                report                                         = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.report.txt
+            }
         }
         'homo_sapiens' {
             'genome' {

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -112,7 +112,7 @@ params {
             }
             'metagenome' {
                 classified_reads_alignment                     = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.reads.txt
-                report                                         = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.report.txt
+                report_txt                                     = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.report.txt
             }
         }
         'homo_sapiens' {

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -111,7 +111,7 @@ params {
                 test_sequencing_summary                        = "${test_data_dir}/genomics/sarscov2/nanopore/sequencing_summary/test.sequencing_summary.txt"
             }
             'metagenome' {
-                classified_reads_alignment                     = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.reads.txt"
+                classified_reads_assignment                    = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.reads.txt"
                 report                                         = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.report.txt"
             }
         }

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -112,7 +112,7 @@ params {
             }
             'metagenome' {
                 classified_reads_alignment                     = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.reads.txt
-                report_txt                                     = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.report.txt
+                report                                         = '${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.report.txt
             }
         }
         'homo_sapiens' {

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -111,8 +111,8 @@ params {
                 test_sequencing_summary                        = "${test_data_dir}/genomics/sarscov2/nanopore/sequencing_summary/test.sequencing_summary.txt"
             }
             'metagenome' {
-                classified_reads_alignment                     = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.reads.txt
-                report                                         = '${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.report.txt
+                classified_reads_alignment                     = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.reads.txt"
+                report                                         = "${test_data_dir}/genomics/sarscov2/metagenome/test_1.kraken2.report.txt"
             }
         }
         'homo_sapiens' {

--- a/tests/modules/krona/ktimporttaxonomy/main.nf
+++ b/tests/modules/krona/ktimporttaxonomy/main.nf
@@ -28,6 +28,6 @@ workflow test_krona_ktimporttaxonomy_report {
     ]
     taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
 
-    TDOWNLOAD_DB()
+    DOWNLOAD_DB()
     TAXONOMY_REPORT ( input, DOWNLOAD_DB.out.db )
 }

--- a/tests/modules/krona/ktimporttaxonomy/main.nf
+++ b/tests/modules/krona/ktimporttaxonomy/main.nf
@@ -2,9 +2,11 @@
 
 nextflow.enable.dsl = 2
 
-include { KRONA_KTIMPORTTAXONOMY_READS }  from '../../../../modules/krona/ktimporttaxonomy/main.nf'
+include { KRONA_KTIMPORTTAXONOMY as TAXONOMY_READS  } from '../../../../modules/krona/ktimporttaxonomy/main.nf'
 
-include { KRONA_KTIMPORTTAXONOMY_REPORT } from '../../../../modules/krona/ktimporttaxonomy/main.nf'
+include { KRONA_KTIMPORTTAXONOMY as TAXONOMY_REPORT } from '../../../../modules/krona/ktimporttaxonomy/main.nf'
+
+include { KRONA_KRONADB          as DOWNLOAD_DB     } from '../../../../modules/krona/kronadb/main.nf'
 
 workflow test_krona_ktimporttaxonomy_reads {
 
@@ -12,9 +14,10 @@ workflow test_krona_ktimporttaxonomy_reads {
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['metagenome']['test_1.kraken2.reads.txt'], checkIfExists: true)
     ]
-    taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
+    // taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
 
-    KRONA_KTIMPORTTAXONOMY_READS ( input, taxonomy )
+    DOWNLOAD_DB()
+    TAXONOMY_READS ( input, DOWNLOAD_DB.out.db )
 }
 
 workflow test_krona_ktimporttaxonomy_report {
@@ -25,5 +28,6 @@ workflow test_krona_ktimporttaxonomy_report {
     ]
     taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
 
-    KRONA_KTIMPORTTAXONOMY_REPORT ( input, taxonomy )
+    TDOWNLOAD_DB()
+    TAXONOMY_REPORT ( input, DOWNLOAD_DB.out.db )
 }

--- a/tests/modules/krona/ktimporttaxonomy/main.nf
+++ b/tests/modules/krona/ktimporttaxonomy/main.nf
@@ -2,15 +2,28 @@
 
 nextflow.enable.dsl = 2
 
-include { KRONA_KTIMPORTTAXONOMY } from '../../../../modules/krona/ktimporttaxonomy/main.nf'
+include { KRONA_KTIMPORTTAXONOMY_READS }  from '../../../../modules/krona/ktimporttaxonomy/main.nf'
 
-workflow test_krona_ktimporttaxonomy {
+include { KRONA_KTIMPORTTAXONOMY_REPORT } from '../../../../modules/krona/ktimporttaxonomy/main.nf'
+
+workflow test_krona_ktimporttaxonomy_reads {
 
     input = [
         [ id:'test', single_end:false ], // meta map
-        file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
+        file(params.test_data['sarscov2']['metagenome']['test_1.kraken2.reads.txt'], checkIfExists: true)
     ]
     taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
 
-    KRONA_KTIMPORTTAXONOMY ( input, taxonomy )
+    KRONA_KTIMPORTTAXONOMY_READS ( input, taxonomy )
+}
+
+workflow test_krona_ktimporttaxonomy_report {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['sarscov2']['metagenome']['test_1.kraken2.report.txt'], checkIfExists: true)
+    ]
+    taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
+
+    KRONA_KTIMPORTTAXONOMY_REPORT ( input, taxonomy )
 }

--- a/tests/modules/krona/ktimporttaxonomy/main.nf
+++ b/tests/modules/krona/ktimporttaxonomy/main.nf
@@ -12,7 +12,7 @@ workflow test_krona_ktimporttaxonomy_reads {
 
     input = [
         [ id:'test', single_end:false ], // meta map
-        file(params.test_data['sarscov2']['metagenome']['test_1.kraken2.reads.txt'], checkIfExists: true)
+        file(params.test_data['sarscov2']['metagenome']['classified_reads_assignment'], checkIfExists: true)
     ]
     // taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
 
@@ -24,7 +24,7 @@ workflow test_krona_ktimporttaxonomy_report {
 
     input = [
         [ id:'test', single_end:false ], // meta map
-        file(params.test_data['sarscov2']['metagenome']['test_1.kraken2.report.txt'], checkIfExists: true)
+        file(params.test_data['sarscov2']['metagenome']['report'], checkIfExists: true)
     ]
     taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
 

--- a/tests/modules/krona/ktimporttaxonomy/main.nf
+++ b/tests/modules/krona/ktimporttaxonomy/main.nf
@@ -3,9 +3,7 @@
 nextflow.enable.dsl = 2
 
 include { KRONA_KTIMPORTTAXONOMY as TAXONOMY_READS  } from '../../../../modules/krona/ktimporttaxonomy/main.nf'
-
 include { KRONA_KTIMPORTTAXONOMY as TAXONOMY_REPORT } from '../../../../modules/krona/ktimporttaxonomy/main.nf'
-
 include { KRONA_KRONADB          as DOWNLOAD_DB     } from '../../../../modules/krona/kronadb/main.nf'
 
 workflow test_krona_ktimporttaxonomy_reads {

--- a/tests/modules/krona/ktimporttaxonomy/main.nf
+++ b/tests/modules/krona/ktimporttaxonomy/main.nf
@@ -12,7 +12,6 @@ workflow test_krona_ktimporttaxonomy_reads {
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['metagenome']['classified_reads_assignment'], checkIfExists: true)
     ]
-    // taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
 
     DOWNLOAD_DB()
     TAXONOMY_READS ( input, DOWNLOAD_DB.out.db )
@@ -24,7 +23,6 @@ workflow test_krona_ktimporttaxonomy_report {
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['metagenome']['report'], checkIfExists: true)
     ]
-    taxonomy = file(params.test_data['generic']['txt']['hello'], checkIfExists: true)
 
     DOWNLOAD_DB()
     TAXONOMY_REPORT ( input, DOWNLOAD_DB.out.db )

--- a/tests/modules/krona/ktimporttaxonomy/nextflow.config
+++ b/tests/modules/krona/ktimporttaxonomy/nextflow.config
@@ -2,4 +2,12 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    withName: CLASSIFIED_READS {
+        ext.args = '-t 3'
+    }
+
+    withName: CLASSIFIED_REPORT {
+        ext.args = '-m 3 -t 5'
+    }
+
 }

--- a/tests/modules/krona/ktimporttaxonomy/nextflow.config
+++ b/tests/modules/krona/ktimporttaxonomy/nextflow.config
@@ -2,11 +2,11 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
-    withName: CLASSIFIED_READS {
+    withName: KRONA_KTIMPORTTAXONOMY_READS {
         ext.args = '-t 3'
     }
 
-    withName: CLASSIFIED_REPORT {
+    withName: KRONA_KTIMPORTTAXONOMY_REPORT {
         ext.args = '-m 3 -t 5'
     }
 

--- a/tests/modules/krona/ktimporttaxonomy/nextflow.config
+++ b/tests/modules/krona/ktimporttaxonomy/nextflow.config
@@ -2,11 +2,11 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
-    withName: KRONA_KTIMPORTTAXONOMY_READS {
+    withName: TAXONOMY_READS {
         ext.args = '-t 3'
     }
 
-    withName: KRONA_KTIMPORTTAXONOMY_REPORT {
+    withName: TAXONOMY_REPORT {
         ext.args = '-m 3 -t 5'
     }
 

--- a/tests/modules/krona/ktimporttaxonomy/nextflow.config
+++ b/tests/modules/krona/ktimporttaxonomy/nextflow.config
@@ -2,11 +2,11 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
-    withName: KRONA_KTIMPORTTAXONOMY_READS {
+    withName: CLASSIFIED_READS {
         ext.args = '-t 3'
     }
 
-    withName: KRONA_KTIMPORTTAXONOMY_REPORT {
+    withName: CLASSIFIED_REPORT {
         ext.args = '-m 3 -t 5'
     }
 

--- a/tests/modules/krona/ktimporttaxonomy/test.yml
+++ b/tests/modules/krona/ktimporttaxonomy/test.yml
@@ -9,7 +9,8 @@
     - path: output/download/versions.yml
       md5sum: 5bf3137779303fb36e4c5373704a4bb6
     - path: output/taxonomy/taxonomy.krona.html
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains:
+        - "DOCTYPE html PUBLIC"
     - path: output/taxonomy/versions.yml
       md5sum: ea32399c9fd3bc1d4fc1081cb3a345d5
 
@@ -24,6 +25,7 @@
     - path: output/download/versions.yml
       md5sum: ea7720c3555ad61eb06b46454c87407e
     - path: output/taxonomy/taxonomy.krona.html
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains:
+        - "DOCTYPE html PUBLIC"
     - path: output/taxonomy/versions.yml
       md5sum: 4d46e08ff46dbd1e7075b93903b72400

--- a/tests/modules/krona/ktimporttaxonomy/test.yml
+++ b/tests/modules/krona/ktimporttaxonomy/test.yml
@@ -1,9 +1,29 @@
-- name: krona ktimporttaxonomy test_krona_ktimporttaxonomy
-  command: nextflow run ./tests/modules/krona/ktimporttaxonomy -entry test_krona_ktimporttaxonomy -c ./tests/config/nextflow.config -c ./tests/modules/krona/ktimporttaxonomy/nextflow.config
+- name: krona ktimporttaxonomy test_krona_ktimporttaxonomy_reads
+  command: nextflow run tests/modules/krona/ktimporttaxonomy -entry test_krona_ktimporttaxonomy_reads -c tests/config/nextflow.config
   tags:
     - krona/ktimporttaxonomy
     - krona
   files:
-    - path: output/krona/taxonomy.krona.html
-      contains:
-        - "DOCTYPE html PUBLIC"
+    - path: output/download/taxonomy/taxonomy.tab
+      md5sum: 0d13b5b3838f12d1f51827464345e0f0
+    - path: output/download/versions.yml
+      md5sum: 5bf3137779303fb36e4c5373704a4bb6
+    - path: output/taxonomy/taxonomy.krona.html
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+    - path: output/taxonomy/versions.yml
+      md5sum: ea32399c9fd3bc1d4fc1081cb3a345d5
+
+- name: krona ktimporttaxonomy test_krona_ktimporttaxonomy_report
+  command: nextflow run tests/modules/krona/ktimporttaxonomy -entry test_krona_ktimporttaxonomy_report -c tests/config/nextflow.config
+  tags:
+    - krona/ktimporttaxonomy
+    - krona
+  files:
+    - path: output/download/taxonomy/taxonomy.tab
+      md5sum: 0d13b5b3838f12d1f51827464345e0f0
+    - path: output/download/versions.yml
+      md5sum: ea7720c3555ad61eb06b46454c87407e
+    - path: output/taxonomy/taxonomy.krona.html
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+    - path: output/taxonomy/versions.yml
+      md5sum: 4d46e08ff46dbd1e7075b93903b72400


### PR DESCRIPTION
## PR checklist

- [ ] The following changes have been introduced: 
(a) the `ext.args` variable was instantiated but not used in the code, and has therefore been added to the code of both *kronadb* and *ktimporttaxonomy* modules
(b) the tests previously executed were not representative of the tool functionality: these have been modified to use the newly added test data, as well as the database actually imported by *kronadb*
- [ ] nothing new has been introduced in terms of functionality, output channel names or other breaking changes
- [ ] available test data have been used
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
