### PR TITLE
Fix fail on CAT_FASTQ receiving single file

### DIFF
--- a/tests/modules/cat/fastq/main.nf
+++ b/tests/modules/cat/fastq/main.nf
@@ -56,3 +56,15 @@ workflow test_cat_fastq_single_end_single_file {
 
     CAT_FASTQ( input )
 }
+
+workflow test_cat_fastq_paired_end_single_file {
+    input = [
+        [ id:'test', single_end: false ],
+        [
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+        ]
+    ]
+
+    CAT_FASTQ( input )
+}

--- a/tests/modules/cat/fastq/main.nf
+++ b/tests/modules/cat/fastq/main.nf
@@ -47,3 +47,12 @@ workflow test_cat_fastq_paired_end_same_name {
 
     CAT_FASTQ ( input )
 }
+
+workflow test_cat_fastq_single_end_single_file {
+    input = [
+        [ id:'test', single_end: true ],
+        [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
+    ]
+
+    CAT_FASTQ( input )
+}

--- a/tests/modules/cat/fastq/test.yml
+++ b/tests/modules/cat/fastq/test.yml
@@ -46,3 +46,14 @@
   files:
     - path: ./output/cat/test.merged.fastq.gz
       md5sum: e325ef7deb4023447a1f074e285761af
+
+- name: cat fastq paired-end-single-file
+  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_paired_end_single_file -c ./tests/config/nextflow.config -c ./tests/modules/cat/fastq/nextflow.config
+  tags:
+    - cat
+    - cat/fastq
+  files:
+    - path: ./output/cat/test_1.merged.fastq.gz
+      md5sum: e325ef7deb4023447a1f074e285761af
+    - path: ./output/cat/test_2.merged.fastq.gz
+      md5sum: 22342ee8873e5bfa51b4707bb1d56ec6

--- a/tests/modules/cat/fastq/test.yml
+++ b/tests/modules/cat/fastq/test.yml
@@ -37,3 +37,12 @@
       md5sum: 63f817db7a29a03eb538104495556f66
     - path: ./output/cat/test_2.merged.fastq.gz
       md5sum: fe9f266f43a6fc3dcab690a18419a56e
+
+- name: cat fastq single-end-single-file
+  command: nextflow run ./tests/modules/cat/fastq -entry test_cat_fastq_single_end_single_file -c ./tests/config/nextflow.config -c ./tests/modules/cat/fastq/nextflow.config
+  tags:
+    - cat
+    - cat/fastq
+  files:
+    - path: ./output/cat/test.merged.fastq.gz
+      md5sum: e325ef7deb4023447a1f074e285761af


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #1670 <!-- If this PR fixes an issue, please link it here! -->

Fixes the bug where CAT_FASTQ would fail upon receiving a single file or single pair of files.



- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [na] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [na] If necessary, include test data in your PR.
- [na] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [na] Add a resource `label`
- [na] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
