### PR TITLE
Add if block to handled paired-end args specifically

### DIFF
--- a/modules/bismark/methylationextractor/main.nf
+++ b/modules/bismark/methylationextractor/main.nf
@@ -24,20 +24,47 @@ process BISMARK_METHYLATIONEXTRACTOR {
 
     script:
     def args = task.ext.args ?: ''
-    def seqtype  = meta.single_end ? '-s' : '-p'
-    """
-    bismark_methylation_extractor \\
-        --bedGraph \\
-        --counts \\
-        --gzip \\
-        --report \\
-        $seqtype \\
-        $args \\
-        $bam
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bismark: \$(echo \$(bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*\$//')
-    END_VERSIONS
-    """
+    // Some arguments are only applicable to paired_end data
+    def overlap          = params.no_overlap           ? '--no_overlap'                                  : '--include_overlap'
+    def ignore_r2        = params.ignore_r2 > 0        ? "--ignore_r2 ${params.ignore_r2}"               : ''
+    def ignore_3prime_r2 = params.ignore_3prime_r2 > 0 ? "--ignore_3prime_r2 ${params.ignore_3prime_r2}" : ''
+
+    if (meta.single_end) {
+        """
+        bismark_methylation_extractor \\
+            --bedGraph \\
+            --counts \\
+            --gzip \\
+            --report \\
+            -s \\
+            $args \\
+            $bam
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            bismark: \$(echo \$(bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*\$//')
+        END_VERSIONS
+        """
+    } else {
+        """
+        bismark_methylation_extractor \\
+            --bedGraph \\
+            --counts \\
+            --gzip \\
+            --report \\
+            -p \\
+            $args \\
+            $overlap \\
+            $ignore_r2 \\
+            $ignore_3prime_r2 \\
+            $bam
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            bismark: \$(echo \$(bismark -v 2>&1) | sed 's/^.*Bismark Version: v//; s/Copyright.*\$//')
+        END_VERSIONS
+        """
+    }
+
 }

--- a/tests/modules/bismark/methylationextractor/test.yml
+++ b/tests/modules/bismark/methylationextractor/test.yml
@@ -35,22 +35,22 @@
     - path: output/bismark/BismarkIndex/genome.fasta
       md5sum: 6e9fe4042a72f2345f644f239272b7e6
     - path: output/bismark/CHG_OB_test.paired_end.methylated.txt.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CHG_OT_test.paired_end.methylated.txt.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CHH_OB_test.paired_end.methylated.txt.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CHH_OT_test.paired_end.methylated.txt.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CpG_OB_test.paired_end.methylated.txt.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CpG_OT_test.paired_end.methylated.txt.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/test.paired_end.methylated.M-bias.txt
       md5sum: c51589e98227e5aa532fb84c6cf08b97
     - path: output/bismark/test.paired_end.methylated.bedGraph.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/test.paired_end.methylated.bismark.cov.gz
-      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/test.paired_end.methylated_splitting_report.txt
       md5sum: 82dbeec8e59afb5e768a61d1aee29a55

--- a/tests/modules/bismark/methylationextractor/test.yml
+++ b/tests/modules/bismark/methylationextractor/test.yml
@@ -35,22 +35,14 @@
     - path: output/bismark/BismarkIndex/genome.fasta
       md5sum: 6e9fe4042a72f2345f644f239272b7e6
     - path: output/bismark/CHG_OB_test.paired_end.methylated.txt.gz
-      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CHG_OT_test.paired_end.methylated.txt.gz
-      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CHH_OB_test.paired_end.methylated.txt.gz
-      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CHH_OT_test.paired_end.methylated.txt.gz
-      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CpG_OB_test.paired_end.methylated.txt.gz
-      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/CpG_OT_test.paired_end.methylated.txt.gz
-      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/test.paired_end.methylated.M-bias.txt
       md5sum: c51589e98227e5aa532fb84c6cf08b97
     - path: output/bismark/test.paired_end.methylated.bedGraph.gz
-      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/test.paired_end.methylated.bismark.cov.gz
-      contains: "[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]"
     - path: output/bismark/test.paired_end.methylated_splitting_report.txt
       md5sum: 82dbeec8e59afb5e768a61d1aee29a55

--- a/tests/modules/bismark/methylationextractor/test.yml
+++ b/tests/modules/bismark/methylationextractor/test.yml
@@ -1,16 +1,56 @@
-- name: bismark methylation extractor test workflow
-  command: nextflow run ./tests/modules/bismark/methylationextractor -entry test_bismark_methylationextractor -c ./tests/config/nextflow.config -c ./tests/modules/bismark/methylationextractor/nextflow.config
+- name: bismark methylationextractor test_bismark_methylationextractor
+  command: nextflow run ./tests/modules/bismark/methylationextractor -entry test_bismark_methylationextractor -c ./tests/config/nextflow.config  -c ./tests/modules/bismark/methylationextractor/nextflow.config
   tags:
     - bismark
     - bismark/methylationextractor
   files:
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/CT_conversion/BS_CT.1.bt2
+      md5sum: 10a8854e5eeb95629f46d24b0d8da70c
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/CT_conversion/BS_CT.2.bt2
+      md5sum: bc5d407e6fce3e1cdb4b23ab2a20f707
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/CT_conversion/BS_CT.3.bt2
+      md5sum: 4ed93abba181d8dfab2e303e33114777
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/CT_conversion/BS_CT.4.bt2
+      md5sum: 6c4f549575e5882ff3a97ae10ae2e7be
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/CT_conversion/BS_CT.rev.1.bt2
+      md5sum: d37d586b41b6a36efb25839961d242cb
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/CT_conversion/BS_CT.rev.2.bt2
+      md5sum: 48bf400de85cd7324fbf6bf38fe2dc95
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa
+      md5sum: 903b9f357eea4a5f36e21e78e0fe1dfa
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/GA_conversion/BS_GA.1.bt2
+      md5sum: a6fa4068ed10872568f32568c66cb600
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/GA_conversion/BS_GA.2.bt2
+      md5sum: fc5b634e2f5137801e3801d62ad05f74
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/GA_conversion/BS_GA.3.bt2
+      md5sum: 4ed93abba181d8dfab2e303e33114777
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/GA_conversion/BS_GA.4.bt2
+      md5sum: b1e855685ed634daa7df8e180c9b2fc4
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/GA_conversion/BS_GA.rev.1.bt2
+      md5sum: 17f51e65f44477962226a83b369b2bc4
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/GA_conversion/BS_GA.rev.2.bt2
+      md5sum: d36044c5dfe37af0411f60d446585bc6
+    - path: output/bismark/BismarkIndex/Bisulfite_Genome/GA_conversion/genome_mfa.GA_conversion.fa
+      md5sum: e529375ec2039112161465b5169fcd59
+    - path: output/bismark/BismarkIndex/genome.fasta
+      md5sum: 6e9fe4042a72f2345f644f239272b7e6
     - path: output/bismark/CHG_OB_test.paired_end.methylated.txt.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/bismark/CHG_OT_test.paired_end.methylated.txt.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/bismark/CHH_OB_test.paired_end.methylated.txt.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/bismark/CHH_OT_test.paired_end.methylated.txt.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/bismark/CpG_OB_test.paired_end.methylated.txt.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/bismark/CpG_OT_test.paired_end.methylated.txt.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/bismark/test.paired_end.methylated.M-bias.txt
-      md5sum: 0b100924d46b3c35115f1206f34c4a59
+      md5sum: c51589e98227e5aa532fb84c6cf08b97
+    - path: output/bismark/test.paired_end.methylated.bedGraph.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
+    - path: output/bismark/test.paired_end.methylated.bismark.cov.gz
+      contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
     - path: output/bismark/test.paired_end.methylated_splitting_report.txt
-      md5sum: f28a9dd8de8c42b8900b190b8f79647a
+      md5sum: 82dbeec8e59afb5e768a61d1aee29a55


### PR DESCRIPTION
Following the lead of `trimgalore`, I've added an `if` block into the `methylationextractor` subcommand for paired vs single-end data. The `overlap`, `ignore_r2`, and `ignore_3prime_r2` arguments are specific to the paired-end case. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 (no single-end methylated bam test file available, skipping)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [ ] Follow the parameters requirements. 

!! Pretty sure this does violate the parameter requirements. But `trimgalore` does the same thing, so maybe bismark can too?

- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
