### PR TITLE
Bump container version for STAR to 2.7.10a

### DIFF
--- a/modules/star/align/main.nf
+++ b/modules/star/align/main.nf
@@ -2,16 +2,15 @@ process STAR_ALIGN {
     tag "$meta.id"
     label 'process_high'
 
-    // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? 'bioconda::star=2.7.9a' : null)
+    conda (params.enable_conda ? "bioconda::star=2.7.10a bioconda::samtools=1.15.1 conda-forge::gawk=5.1.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/star:2.7.9a--h9ee0642_0' :
-        'quay.io/biocontainers/star:2.7.9a--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:afaaa4c6f5b308b4b6aa2dd8e99e1466b2a6b0cd-0' :
+        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:afaaa4c6f5b308b4b6aa2dd8e99e1466b2a6b0cd-0' }"
 
     input:
     tuple val(meta), path(reads)
-    path  index
-    path  gtf
+    path index
+    path gtf
     val star_ignore_sjdbgtf
     val seq_platform
     val seq_center
@@ -67,6 +66,8 @@ process STAR_ALIGN {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         star: \$(STAR --version | sed -e "s/STAR_//g")
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        gawk: \$(echo \$(gawk --version 2>&1) | sed 's/^.*GNU Awk //; s/, .*\$//')
     END_VERSIONS
     """
 }

--- a/modules/star/genomegenerate/main.nf
+++ b/modules/star/genomegenerate/main.nf
@@ -2,19 +2,18 @@ process STAR_GENOMEGENERATE {
     tag "$fasta"
     label 'process_high'
 
-    // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::star=2.7.9a bioconda::samtools=1.15.1 conda-forge::gawk=5.1.0" : null)
+    conda (params.enable_conda ? "bioconda::star=2.7.10a bioconda::samtools=1.15.1 conda-forge::gawk=5.1.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1c4c32d87798d425c970ececfbadd155e7560277-0' :
-        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1c4c32d87798d425c970ececfbadd155e7560277-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:afaaa4c6f5b308b4b6aa2dd8e99e1466b2a6b0cd-0' :
+        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:afaaa4c6f5b308b4b6aa2dd8e99e1466b2a6b0cd-0' }"
 
     input:
     path fasta
     path gtf
 
     output:
-    path "star"         , emit: index
-    path "versions.yml" , emit: versions
+    path "star"        , emit: index
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,7 +21,7 @@ process STAR_GENOMEGENERATE {
     script:
     def args = task.ext.args ?: ''
     def args_list = args.tokenize()
-    def memory   = task.memory ? "--limitGenomeGenerateRAM ${task.memory.toBytes() - 100000000}" : ''
+    def memory = task.memory ? "--limitGenomeGenerateRAM ${task.memory.toBytes() - 100000000}" : ''
     if (args_list.contains('--genomeSAindexNbases')) {
         """
         mkdir star

--- a/tests/modules/star/align/test.yml
+++ b/tests/modules/star/align/test.yml
@@ -36,7 +36,7 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
     - path: output/star/test.Aligned.out.bam
-      md5sum: b9f5e2f6a624b64c300fe25dc3ac801f
+      md5sum: 63de6af2210e138b49d7b4d570c6e67f
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
@@ -80,7 +80,7 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
     - path: output/star/test.Aligned.out.bam
-      md5sum: 38d08f0b944a2a1b981a250d675aa0d9
+      md5sum: 7cdef439bc8092bfefb4d091bf8ee6ab
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
@@ -124,7 +124,7 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
     - path: output/star/test.Aligned.out.bam
-      md5sum: c740d5177067c1fcc48ab7a16cd639d7
+      md5sum: 5dbc36fce7b72628c809bbc7d3d67973
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
@@ -168,9 +168,9 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
     - path: output/star/test.Aligned.out.bam
-      md5sum: a1bd1b40950a58ea2776908076160052
+      md5sum: d85858bf55a523121dde762046a34c5c
     - path: output/star/test.Chimeric.out.junction
-      md5sum: 327629eb54032212f29e1c32cbac6975
+      md5sum: ae87d1a24180f5a35cf6b47fdfdd0539
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out


### PR DESCRIPTION
Bumping here to be able to use default nf-core/module in rnaseq and a custom one for iGenomes. See https://github.com/nf-core/rnaseq/issues/834