### PR TITLE
Fix filtlong - makes running without shortreads work correctly, and also ensures all tests produce …

### DIFF
--- a/modules/filtlong/main.nf
+++ b/modules/filtlong/main.nf
@@ -20,7 +20,7 @@ process FILTLONG {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def short_reads = meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}"
+    def short_reads = !shortreads ? "" : meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}"
     """
     filtlong \\
         $short_reads \\

--- a/tests/modules/filtlong/nextflow.config
+++ b/tests/modules/filtlong/nextflow.config
@@ -2,4 +2,6 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    ext.args = "--min_length 10"
+
 }

--- a/tests/modules/filtlong/test.yml
+++ b/tests/modules/filtlong/test.yml
@@ -1,23 +1,23 @@
 - name: filtlong test_filtlong
-  command: nextflow run ./tests/modules/filtlong -entry test_filtlong -c ./tests/config/nextflow.config -c ./tests/modules/filtlong/nextflow.config
+  command: nextflow run ./tests/modules/filtlong -entry test_filtlong -c ./tests/config/nextflow.config  -c ./tests/modules/filtlong/nextflow.config
   tags:
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
+      md5sum: ff2b6e10fea0c45f10e8739a5bca25ed
 
 - name: filtlong test_filtlong_illumina_se
-  command: nextflow run ./tests/modules/filtlong -entry test_filtlong_illumina_se -c ./tests/config/nextflow.config -c ./tests/modules/filtlong/nextflow.config
+  command: nextflow run ./tests/modules/filtlong -entry test_filtlong_illumina_se -c ./tests/config/nextflow.config  -c ./tests/modules/filtlong/nextflow.config
   tags:
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
+      md5sum: ff2b6e10fea0c45f10e8739a5bca25ed
 
 - name: filtlong test_filtlong_illumina_pe
-  command: nextflow run ./tests/modules/filtlong -entry test_filtlong_illumina_pe -c ./tests/config/nextflow.config -c ./tests/modules/filtlong/nextflow.config
+  command: nextflow run ./tests/modules/filtlong -entry test_filtlong_illumina_pe -c ./tests/config/nextflow.config  -c ./tests/modules/filtlong/nextflow.config
   tags:
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
+      md5sum: ff2b6e10fea0c45f10e8739a5bca25ed

--- a/tests/modules/filtlong/test.yml
+++ b/tests/modules/filtlong/test.yml
@@ -4,7 +4,8 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: ff2b6e10fea0c45f10e8739a5bca25ed
+      contains:
+        - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"
 
 - name: filtlong test_filtlong_illumina_se
   command: nextflow run ./tests/modules/filtlong -entry test_filtlong_illumina_se -c ./tests/config/nextflow.config  -c ./tests/modules/filtlong/nextflow.config
@@ -12,7 +13,8 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: ff2b6e10fea0c45f10e8739a5bca25ed
+      contains:
+        - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"
 
 - name: filtlong test_filtlong_illumina_pe
   command: nextflow run ./tests/modules/filtlong -entry test_filtlong_illumina_pe -c ./tests/config/nextflow.config  -c ./tests/modules/filtlong/nextflow.config
@@ -20,4 +22,5 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr_filtlong.fastq.gz
-      md5sum: ff2b6e10fea0c45f10e8739a5bca25ed
+      contains:
+        - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"


### PR DESCRIPTION
…non-empty fastq.gz files

Noticed when adding to taxprofiler that the FILTLONG module actually did not work when not supplying short reads, as the command was propogated with `-1 null -2 null` and actually produced empty `.fastq.gz` files.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
