### PR TITLE
Fix filtlong to remove hardcoded output names

### DIFF
--- a/modules/filtlong/main.nf
+++ b/modules/filtlong/main.nf
@@ -11,7 +11,7 @@ process FILTLONG {
     tuple val(meta), path(shortreads), path(longreads)
 
     output:
-    tuple val(meta), path("${meta.id}_lr_filtlong.fastq.gz"), emit: reads
+    tuple val(meta), path("*.fastq.gz"), emit: reads
     path "versions.yml"                                     , emit: versions
 
     when:
@@ -21,12 +21,13 @@ process FILTLONG {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def short_reads = !shortreads ? "" : meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}"
+    if ("$longreads" == "${prefix}.fastq.gz") error "Longread FASTQ input and output names are the same, set prefix in module configuration to disambiguate!"
     """
     filtlong \\
         $short_reads \\
         $args \\
         $longreads \\
-        | gzip -n > ${prefix}_lr_filtlong.fastq.gz
+        | gzip -n > ${prefix}.fastq.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/tests/modules/filtlong/nextflow.config
+++ b/tests/modules/filtlong/nextflow.config
@@ -3,6 +3,6 @@ process {
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
     ext.args = "--min_length 10"
-    ext.prefix = "${meta.id}_lr"
+    ext.prefix = "test_lr"
 
 }

--- a/tests/modules/filtlong/nextflow.config
+++ b/tests/modules/filtlong/nextflow.config
@@ -3,5 +3,6 @@ process {
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
     ext.args = "--min_length 10"
+    ext.prefix = "${meta.id}_lr"
 
 }

--- a/tests/modules/filtlong/test.yml
+++ b/tests/modules/filtlong/test.yml
@@ -3,7 +3,7 @@
   tags:
     - filtlong
   files:
-    - path: output/filtlong/test_lr_filtlong.fastq.gz
+    - path: output/filtlong/test_lr.fastq.gz
       contains:
         - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"
 
@@ -12,7 +12,7 @@
   tags:
     - filtlong
   files:
-    - path: output/filtlong/test_lr_filtlong.fastq.gz
+    - path: output/filtlong/test_lr.fastq.gz
       contains:
         - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"
 
@@ -21,6 +21,6 @@
   tags:
     - filtlong
   files:
-    - path: output/filtlong/test_lr_filtlong.fastq.gz
+    - path: output/filtlong/test_lr.fastq.gz
       contains:
         - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"


### PR DESCRIPTION
Now the tool runs properly, I realised that the module goes against the [module guidelines](https://nf-co.re/docs/contributing/modules#naming-conventions) in that it hardcodes it's 'own' file name (breaking taxprofiler's publishDir directive). 

This is is something that should be specified in `modules.config`. I've added a check for this accordingly.



## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
