### PR TITLE
Adjust deeptools/bamcoverage with new mulled container

### DIFF
--- a/modules/deeptools/bamcoverage/main.nf
+++ b/modules/deeptools/bamcoverage/main.nf
@@ -2,13 +2,15 @@ process DEEPTOOLS_BAMCOVERAGE {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::deeptools=3.5.1" : null)
+    conda (params.enable_conda ? "bioconda::deeptools=3.5.1 bioconda::samtools=1.15.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/deeptools:3.5.1--py_0':
-        'quay.io/biocontainers/deeptools:3.5.1--py_0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:2c687053c0252667cca265c9f4118f2c205a604c-0':
+        'quay.io/biocontainers/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:2c687053c0252667cca265c9f4118f2c205a604c-0' }"
 
     input:
     tuple val(meta), path(input), path(input_index)
+    path(fasta)
+    path(fasta_fai)
 
     output:
     tuple val(meta), path("*.bigWig")   , emit: bigwig, optional: true
@@ -22,16 +24,44 @@ process DEEPTOOLS_BAMCOVERAGE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}.bigWig"
 
-    """
-    bamCoverage \\
-        --bam $input \\
-        $args \\
-        --numberOfProcessors ${task.cpus} \\
-        --outFileName ${prefix}
+    // cram_input is currently not working with deeptools
+    // therefore it's required to convert cram to bam first
+    def is_cram = input.Extension == "cram" ? true : false
+    def input_out = is_cram ? input.BaseName + ".bam" : "${input}"
+    def fai_reference = fasta_fai ? "--fai-reference ${fasta_fai}" : ""
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        deeptools: \$(bamCoverage --version | sed -e "s/bamCoverage //g")
-    END_VERSIONS
-    """
+    if (is_cram){
+        """
+        samtools view -T $fasta $input $fai_reference -@ $task.cpus -o $input_out
+        samtools index -b $input_out -@ $task.cpus
+
+        bamCoverage \\
+            --bam $input_out \\
+            $args \\
+            --numberOfProcessors ${task.cpus} \\
+            --outFileName ${prefix}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+            deeptools: \$(bamCoverage --version | sed -e "s/bamCoverage //g")
+        END_VERSIONS
+        """
+
+    }
+    else {
+        """
+        bamCoverage \\
+            --bam $input_out \\
+            $args \\
+            --numberOfProcessors ${task.cpus} \\
+            --outFileName ${prefix}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            deeptools: \$(bamCoverage --version | sed -e "s/bamCoverage //g")
+        END_VERSIONS
+        """
+    }
+
 }

--- a/modules/deeptools/bamcoverage/meta.yml
+++ b/modules/deeptools/bamcoverage/meta.yml
@@ -25,6 +25,14 @@ input:
       type: file
       description: BAM/CRAM index file
       pattern: "*.{bai,crai}"
+  - fasta:
+      type: file
+      description: Reference file the CRAM file was created with (required with CRAM input)
+      pattern: "*.{fasta,fa}"
+  - fasta_fai:
+      type: file
+      description: Index of the reference file (optional, but recommended)
+      pattern: "*.{fai}"
 
 output:
   - meta:
@@ -47,3 +55,4 @@ output:
 
 authors:
   - "@FriederikeHanssen"
+  - "@SusiJo"

--- a/tests/modules/deeptools/bamcoverage/main.nf
+++ b/tests/modules/deeptools/bamcoverage/main.nf
@@ -12,7 +12,7 @@ workflow test_deeptools_bamcoverage_bam {
           file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true)
         ]
 
-    DEEPTOOLS_BAMCOVERAGE ( input )
+    DEEPTOOLS_BAMCOVERAGE ( input, [], [] )
 }
 
 workflow test_deeptools_bamcoverage_cram {
@@ -22,6 +22,20 @@ workflow test_deeptools_bamcoverage_cram {
           file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
           file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true)
         ]
+    fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+    fasta_fai = file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)
 
-    DEEPTOOLS_BAMCOVERAGE ( input )
+    DEEPTOOLS_BAMCOVERAGE ( input, fasta, fasta_fai)
+}
+
+workflow test_deeptools_bamcoverage_cram_no_fasta_fai {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+          file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
+          file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram_crai'], checkIfExists: true)
+        ]
+    fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+
+    DEEPTOOLS_BAMCOVERAGE ( input, fasta, [])
 }

--- a/tests/modules/deeptools/bamcoverage/test.yml
+++ b/tests/modules/deeptools/bamcoverage/test.yml
@@ -1,21 +1,26 @@
 - name: deeptools bamcoverage test_deeptools_bamcoverage_bam
-  command: nextflow run tests/modules/deeptools/bamcoverage -entry test_deeptools_bamcoverage_bam -c tests/config/nextflow.config
+  command: nextflow run ./tests/modules/deeptools/bamcoverage -entry test_deeptools_bamcoverage_bam -c ./tests/config/nextflow.config  -c ./tests/modules/deeptools/bamcoverage/nextflow.config
   tags:
-    - deeptools
     - deeptools/bamcoverage
+    - deeptools
   files:
     - path: output/deeptools/test.bigWig
       md5sum: 95fe9383a9e6c02aea6b785cf074274f
-    - path: output/deeptools/versions.yml
-      md5sum: 68c94e73b7a8c0935578bad61fea54c1
 
 - name: deeptools bamcoverage test_deeptools_bamcoverage_cram
-  command: nextflow run tests/modules/deeptools/bamcoverage -entry test_deeptools_bamcoverage_cram -c tests/config/nextflow.config
+  command: nextflow run ./tests/modules/deeptools/bamcoverage -entry test_deeptools_bamcoverage_cram -c ./tests/config/nextflow.config  -c ./tests/modules/deeptools/bamcoverage/nextflow.config
   tags:
-    - deeptools
     - deeptools/bamcoverage
+    - deeptools
   files:
     - path: output/deeptools/test.bigWig
       md5sum: 95fe9383a9e6c02aea6b785cf074274f
-    - path: output/deeptools/versions.yml
-      md5sum: 665bbd2979c49bf3974a24bd44a88e94
+
+- name: deeptools bamcoverage test_deeptools_bamcoverage_cram_no_fasta_fai
+  command: nextflow run ./tests/modules/deeptools/bamcoverage -entry test_deeptools_bamcoverage_cram_no_fasta_fai -c ./tests/config/nextflow.config  -c ./tests/modules/deeptools/bamcoverage/nextflow.config
+  tags:
+    - deeptools/bamcoverage
+    - deeptools
+  files:
+    - path: output/deeptools/test.bigWig
+      md5sum: 95fe9383a9e6c02aea6b785cf074274f


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This PR uses a new container that first converts cram2bam before running `deeptools/bamcoverage`, as this was not working with real cram-input files. 

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
