### PR TITLE
fix untar output dir

### DIFF
--- a/modules/untar/main.nf
+++ b/modules/untar/main.nf
@@ -21,12 +21,18 @@ process UNTAR {
     def args  = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     untar     = archive.toString() - '.tar.gz'
+
     """
+    mkdir output
+
     tar \\
+        -C output --strip-components 1 \\
         -xzvf \\
         $args \\
         $archive \\
-        $args2 \\
+        $args2
+
+    mv output ${untar}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -323,6 +323,8 @@ params {
                 test_sv_vcf                                   =  "${test_data_dir}/genomics/homo_sapiens/illumina/vcf/sv_query.vcf.gz"
 
                 test_pytor                                    = "${test_data_dir}/genomics/homo_sapiens/illumina/pytor/test.pytor"
+
+                test_flowcell                                 = "${test_data_dir}/genomics/homo_sapiens/illumina/bcl/flowcell.tar.gz"
             }
             'pacbio' {
                 primers                         = "${test_data_dir}/genomics/homo_sapiens/pacbio/fasta/primers.fasta"

--- a/tests/modules/untar/main.nf
+++ b/tests/modules/untar/main.nf
@@ -12,3 +12,13 @@ workflow test_untar {
 
     UNTAR ( input )
 }
+
+
+workflow test_untar_different_output_path {
+    input = [
+        [],
+        file(params.test_data['homo_sapiens']['illumina']['test_flowcell'], checkIfExists: true)
+    ]
+
+    UNTAR ( input )
+}

--- a/tests/modules/untar/test.yml
+++ b/tests/modules/untar/test.yml
@@ -1,5 +1,5 @@
-- name: untar
-  command: nextflow run ./tests/modules/untar -entry test_untar -c ./tests/config/nextflow.config -c ./tests/modules/untar/nextflow.config
+- name: untar test_untar
+  command: nextflow run ./tests/modules/untar -entry test_untar -c ./tests/config/nextflow.config  -c ./tests/modules/untar/nextflow.config
   tags:
     - untar
   files:
@@ -9,3 +9,11 @@
       md5sum: a033d00cf6759407010b21700938f543
     - path: output/untar/kraken2/taxo.k2d
       md5sum: 094d5891cdccf2f1468088855c214b2c
+
+- name: untar test_untar_different_output_path
+  command: nextflow run ./tests/modules/untar -entry test_untar_different_output_path -c ./tests/config/nextflow.config  -c ./tests/modules/untar/nextflow.config
+  tags:
+    - untar
+  files:
+    - path: output/untar/flowcell/RunInfo.xml
+      md5sum: 03038959f4dd181c86bc97ae71fe270a


### PR DESCRIPTION
Fix output when the tar archive has a different name than the tarred dir.
- added test
- no breaking change

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
