### PR TITLE
first attempt to add update module version workflow

### DIFF
--- a/.github/workflows/module-update.yml
+++ b/.github/workflows/module-update.yml
@@ -85,6 +85,15 @@ jobs:
           token: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
 
+      - name: Commit changes
+        run: |
+          git config user.email "core@nf-co.re"
+          git config user.name "nf-core-bot"
+          git config push.default upstream
+          git add .
+          git status
+          git commit -m "[automated] Update module version"
+
       - uses: gr2m/create-or-update-pull-request-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR checklist

Closes nf-core/tools#1434

This workflow is intended to run nightly. It runs the linting of all modules with `--fix-version` option to check for available module version updates. If changes are made, it opens a PR.

- [ ] This comment contains a description of changes (with reason).