### PR TITLE
add module for plasmidfinder

### DIFF
--- a/modules/plasmidfinder/main.nf
+++ b/modules/plasmidfinder/main.nf
@@ -1,0 +1,48 @@
+def VERSION = '2.1.6' // Version information not provided by tool on CLI
+
+process PLASMIDFINDER {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::plasmidfinder=2.1.6=py310hdfd78af_1" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/plasmidfinder:2.1.6--py310hdfd78af_1':
+        'quay.io/biocontainers/plasmidfinder:2.1.6--py310hdfd78af_1' }"
+
+    input:
+    tuple val(meta), path(seqs)
+
+    output:
+    tuple val(meta), path("*.json")                 , emit: json
+    tuple val(meta), path("*.txt")                  , emit: txt
+    tuple val(meta), path("*.tsv")                  , emit: tsv
+    tuple val(meta), path("*-hit_in_genome_seq.fsa"), emit: genome_seq
+    tuple val(meta), path("*-plasmid_seqs.fsa")     , emit: plasmid_seq
+    path "versions.yml"                             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    plasmidfinder.py \\
+        $args \\
+        -i $seqs \\
+        -o ./ \\
+        -x
+
+    # Rename hard-coded outputs with prefix to avoid name collisions
+    mv data.json ${prefix}.json
+    mv results.txt ${prefix}.txt
+    mv results_tab.tsv ${prefix}.tsv
+    mv Hit_in_genome_seq.fsa ${prefix}-hit_in_genome_seq.fsa
+    mv Plasmid_seqs.fsa ${prefix}-plasmid_seqs.fsa
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        plasmidfinder: $VERSION
+    END_VERSIONS
+    """
+}

--- a/modules/plasmidfinder/meta.yml
+++ b/modules/plasmidfinder/meta.yml
@@ -1,0 +1,58 @@
+name: "plasmidfinder"
+description: Identify plasmids in bacterial sequences and assemblies
+keywords:
+  - fasta
+  - fastq
+  - plasmid
+tools:
+  - "plasmidfinder":
+      description: "PlasmidFinder allows identification of plasmids in total or partial sequenced isolates of bacteria."
+      homepage: "https://cge.cbs.dtu.dk/services/PlasmidFinder/"
+      documentation: "https://bitbucket.org/genomicepidemiology/plasmidfinder"
+      tool_dev_url: "https://bitbucket.org/genomicepidemiology/plasmidfinder"
+      doi: "10.1128/AAC.02412-14"
+      licence: "['Apache-2.0']"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - seqs:
+      type: file
+      description: Input FASTA or FASTQ formatted genome sequences
+      pattern: "*.{fastq.gz,fq.gz,fastq.gz,fna.gz,fa.gz}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - json:
+      type: file
+      description: The results from analysis in JSON format
+      pattern: "*.json"
+  - txt:
+      type: file
+      description: The summary of results from analysis
+      pattern: "*.txt"
+  - tsv:
+      type: file
+      description: The results from analysis in TSV format
+      pattern: "*.tsv"
+  - genome_seq:
+      type: file
+      description: FASTA of sequences in the input with a hit
+      pattern: "*-hit_in_genome_seq.fsa"
+  - plasmid_seq:
+      type: file
+      description: FASTA of plasmid sequences with a hit against the input
+      pattern: "*-plasmid_seqs.fsa"
+authors:
+  - "@rpetit3"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -1575,6 +1575,10 @@ pirate:
   - modules/pirate/**
   - tests/modules/pirate/**
 
+plasmidfinder:
+  - modules/plasmidfinder/**
+  - tests/modules/plasmidfinder/**
+
 plasmidid:
   - modules/plasmidid/**
   - tests/modules/plasmidid/**

--- a/tests/modules/plasmidfinder/main.nf
+++ b/tests/modules/plasmidfinder/main.nf
@@ -1,0 +1,13 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { PLASMIDFINDER } from '../../../modules/plasmidfinder/main.nf'
+
+workflow test_plasmidfinder {
+    
+    input = [ [ id:'test', single_end:false ], // meta map
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+
+    PLASMIDFINDER ( input )
+}

--- a/tests/modules/plasmidfinder/nextflow.config
+++ b/tests/modules/plasmidfinder/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    
+}

--- a/tests/modules/plasmidfinder/test.yml
+++ b/tests/modules/plasmidfinder/test.yml
@@ -1,0 +1,13 @@
+- name: plasmidfinder test_plasmidfinder
+  command: nextflow run ./tests/modules/plasmidfinder -entry test_plasmidfinder -c ./tests/config/nextflow.config  -c ./tests/modules/plasmidfinder/nextflow.config
+  tags:
+    - plasmidfinder
+  files:
+    - path: output/plasmidfinder/test-hit_in_genome_seq.fsa
+    - path: output/plasmidfinder/test-plasmid_seqs.fsa
+    - path: output/plasmidfinder/test.json
+      md5sum: ["plasmidfinder", "filename", "results", "Rep_trans"]
+    - path: output/plasmidfinder/test.tsv
+      md5sum: ["Database", "Accession", "Query"]
+    - path: output/plasmidfinder/test.txt
+      md5sum: ["plasmidfinder", "Results", "Contig", "found"]


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes https://github.com/nf-core/modules/issues/1772

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`


Few things.

#### Hard-coded bioconda build number
I had to force the build number in relation to https://github.com/bioconda/bioconda-recipes/pull/35314 Previous builds didn't not include the required database, and it being only ~500kb, I submitted a new build to include it.

```
bioconda::plasmidfinder=2.1.6=py310hdfd78af_1
```

#### Avoid name collisions
PlasmidFinder does not include a `--prefix` parameter, so I manually move the output files to include the `$prefix` this should help avoid downstream name collisions.
