### PR TITLE
Proposal: Rename output from fastp module

### DIFF
--- a/modules/fastp/main.nf
+++ b/modules/fastp/main.nf
@@ -13,7 +13,7 @@ process FASTP {
     val   save_merged
 
     output:
-    tuple val(meta), path('*.trim.fastq.gz')  , optional:true, emit: reads
+    tuple val(meta), path('*.fastp.fastq.gz')       , optional:true, emit: reads
     tuple val(meta), path('*.json')           , emit: json
     tuple val(meta), path('*.html')           , emit: html
     tuple val(meta), path('*.log')            , emit: log
@@ -34,7 +34,7 @@ process FASTP {
         [ ! -f  ${prefix}.fastq.gz ] && ln -s $reads ${prefix}.fastq.gz
         fastp \\
             --in1 ${prefix}.fastq.gz \\
-            --out1 ${prefix}.trim.fastq.gz \\
+            --out1 ${prefix}.fastp.fastq.gz \\
             --thread $task.cpus \\
             --json ${prefix}.fastp.json \\
             --html ${prefix}.fastp.html \\
@@ -55,8 +55,8 @@ process FASTP {
         fastp \\
             --in1 ${prefix}_1.fastq.gz \\
             --in2 ${prefix}_2.fastq.gz \\
-            --out1 ${prefix}_1.trim.fastq.gz \\
-            --out2 ${prefix}_2.trim.fastq.gz \\
+            --out1 ${prefix}_1.fastp.fastq.gz \\
+            --out2 ${prefix}_2.fastp.fastq.gz \\
             --json ${prefix}.fastp.json \\
             --html ${prefix}.fastp.html \\
             $fail_fastq \\

--- a/modules/fastp/main.nf
+++ b/modules/fastp/main.nf
@@ -31,7 +31,7 @@ process FASTP {
     if (meta.single_end) {
         def fail_fastq = save_trimmed_fail ? "--failed_out ${prefix}.fail.fastq.gz" : ''
         """
-        [ ! -f  ${prefix}.fastq.gz ] && ln -s $reads ${prefix}.fastq.gz
+        [ ! -f  ${prefix}.fastq.gz ] && ln -sf $reads ${prefix}.fastq.gz
         fastp \\
             --in1 ${prefix}.fastq.gz \\
             --out1 ${prefix}.fastp.fastq.gz \\

--- a/modules/fastp/main.nf
+++ b/modules/fastp/main.nf
@@ -50,8 +50,8 @@ process FASTP {
         def fail_fastq  = save_trimmed_fail ? "--unpaired1 ${prefix}_1.fail.fastq.gz --unpaired2 ${prefix}_2.fail.fastq.gz" : ''
         def merge_fastq = save_merged ? "-m --merged_out ${prefix}.merged.fastq.gz" : ''
         """
-        [ ! -f  ${prefix}_1.fastq.gz ] && ln -s ${reads[0]} ${prefix}_1.fastq.gz
-        [ ! -f  ${prefix}_2.fastq.gz ] && ln -s ${reads[1]} ${prefix}_2.fastq.gz
+        [ ! -f  ${prefix}_1.fastq.gz ] && ln -sf ${reads[0]} ${prefix}_1.fastq.gz
+        [ ! -f  ${prefix}_2.fastq.gz ] && ln -sf ${reads[1]} ${prefix}_2.fastq.gz
         fastp \\
             --in1 ${prefix}_1.fastq.gz \\
             --in2 ${prefix}_2.fastq.gz \\

--- a/modules/fastp/main.nf
+++ b/modules/fastp/main.nf
@@ -13,7 +13,7 @@ process FASTP {
     val   save_merged
 
     output:
-    tuple val(meta), path('*.fastp.fastq.gz') ß, optional:true, emit: reads
+    tuple val(meta), path('*.fastp.fastq.gz') , optional:true, emit: reads
     tuple val(meta), path('*.json')           , emit: json
     tuple val(meta), path('*.html')           , emit: html
     tuple val(meta), path('*.log')            , emit: log

--- a/modules/fastp/main.nf
+++ b/modules/fastp/main.nf
@@ -13,7 +13,7 @@ process FASTP {
     val   save_merged
 
     output:
-    tuple val(meta), path('*.fastp.fastq.gz')       , optional:true, emit: reads
+    tuple val(meta), path('*.fastp.fastq.gz') ß, optional:true, emit: reads
     tuple val(meta), path('*.json')           , emit: json
     tuple val(meta), path('*.html')           , emit: html
     tuple val(meta), path('*.log')            , emit: log

--- a/modules/fastp/meta.yml
+++ b/modules/fastp/meta.yml
@@ -38,7 +38,7 @@ output:
   - reads:
       type: file
       description: The trimmed/modified/unmerged fastq reads
-      pattern: "*trim.fastq.gz"
+      pattern: "*fastp.fastq.gz"
   - json:
       type: file
       description: Results in JSON format

--- a/tests/modules/fastp/main.nf
+++ b/tests/modules/fastp/main.nf
@@ -49,8 +49,8 @@ workflow test_fastp_single_end_trim_fail {
 //
 workflow test_fastp_paired_end_trim_fail {
     input = [ [ id:'test', single_end:false ], // meta map
-              [ file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
+              [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
             ]
     save_trimmed_fail = true
     save_merged       = false

--- a/tests/modules/fastp/main.nf
+++ b/tests/modules/fastp/main.nf
@@ -49,8 +49,8 @@ workflow test_fastp_single_end_trim_fail {
 //
 workflow test_fastp_paired_end_trim_fail {
     input = [ [ id:'test', single_end:false ], // meta map
-              [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
+              [ file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
             ]
     save_trimmed_fail = true
     save_merged       = false

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -1,23 +1,21 @@
 - name: fastp test_fastp_single_end
-  command: nextflow run ./tests/modules/fastp -entry test_fastp_single_end -c ./tests/config/nextflow.config -c ./tests/modules/fastp/nextflow.config
+  command: nextflow run ./tests/modules/fastp -entry test_fastp_single_end -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
   tags:
     - fastp
   files:
+    - path: output/fastp/test.fastp.fastq.gz
+      md5sum: dc08e42319d0deab088da4d8600aa2bd
     - path: output/fastp/test.fastp.html
       contains:
         - "Q20 bases:</td><td class='col2'>12.922000 K (92.984097%)"
         - "single end (151 cycles)"
-    - path: output/fastp/test.fastp.log
-      contains:
-        - "Q20 bases: 12922(92.9841%)"
-        - "reads passed filter: 99"
-    - path: output/fastp/test.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test.fastp.json
-      md5sum: a517ba37b17a342b5428f2c1f8fe3dd7
+      md5sum: 7ee735cefb67f549dc857eefb9e7f123
+    - path: output/fastp/test.fastp.log
+      md5sum: 1a12e5579507689de5bff813fe494042
 
 - name: fastp test_fastp_paired_end
-  command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end -c ./tests/config/nextflow.config -c ./tests/modules/fastp/nextflow.config
+  command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
   tags:
     - fastp
   files:
@@ -25,40 +23,35 @@
       contains:
         - "Q20 bases:</td><td class='col2'>25.719000 K (93.033098%)"
         - "The input has little adapter percentage (~0.000000%), probably it's trimmed before."
-    - path: output/fastp/test.fastp.log
-      contains:
-        - "No adapter detected for read1"
-        - "Q30 bases: 12281(88.3716%)"
     - path: output/fastp/test.fastp.json
-      contains:
-        - '"passed_filter_reads": 198'
+      md5sum: cfc3e8b871b9bc770f1dc16432d64e67
+    - path: output/fastp/test.fastp.log
+      md5sum: 8b1e318b1ae7b1bc23da61d4b4904bf7
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
+      md5sum: dc08e42319d0deab088da4d8600aa2bd
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
+      md5sum: e59d0d65cc8c2801f1b970df601fc207
 
 - name: fastp test_fastp_single_end_trim_fail
-  command: nextflow run ./tests/modules/fastp -entry test_fastp_single_end_trim_fail -c ./tests/config/nextflow.config -c ./tests/modules/fastp/nextflow.config
+  command: nextflow run ./tests/modules/fastp -entry test_fastp_single_end_trim_fail -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
   tags:
     - fastp
   files:
+    - path: output/fastp/test.fail.fastq.gz
+      md5sum: d865374adfc4228cd17e5bf1e5a3df10
+    - path: output/fastp/test.fastp.fastq.gz
+      md5sum: dc08e42319d0deab088da4d8600aa2bd
     - path: output/fastp/test.fastp.html
       contains:
         - "Q20 bases:</td><td class='col2'>12.922000 K (92.984097%)"
         - "single end (151 cycles)"
-    - path: output/fastp/test.fastp.log
-      contains:
-        - "Q20 bases: 12922(92.9841%)"
-        - "reads passed filter: 99"
-    - path: output/fastp/test.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test.fastp.json
-      md5sum: 4be682c727942a45fc4c8600c28694a8
-    - path: output/fastp/test.fail.fastq.gz
-      md5sum: b57f2026eb259a0b0c0b3960c270258d
+      md5sum: feafc4181a2a61b4b52d9c2b59b419ad
+    - path: output/fastp/test.fastp.log
+      md5sum: f06f5dea2ba676557509e6eff412ec40
 
 - name: fastp test_fastp_paired_end_trim_fail
-  command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end_trim_fail -c ./tests/config/nextflow.config -c ./tests/modules/fastp/nextflow.config
+  command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end_trim_fail -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
   tags:
     - fastp
   files:
@@ -66,43 +59,33 @@
       contains:
         - "Q20 bases:</td><td class='col2'>25.719000 K (93.033098%)"
         - "The input has little adapter percentage (~0.000000%), probably it's trimmed before."
-    - path: output/fastp/test.fastp.log
-      contains:
-        - "No adapter detected for read1"
-        - "Q30 bases: 12281(88.3716%)"
     - path: output/fastp/test.fastp.json
-      contains:
-        - '"passed_filter_reads": 198'
-    - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
-    - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
+      md5sum: 5750c4e642f2473af496cfc3387c2874
+    - path: output/fastp/test.fastp.log
+      md5sum: d23a9c475354690af8d2b63e28fbd910
     - path: output/fastp/test_1.fail.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
+    - path: output/fastp/test_1.fastp.fastq.gz
+      md5sum: dc08e42319d0deab088da4d8600aa2bd
     - path: output/fastp/test_2.fail.fastq.gz
-      md5sum: 72d0002841967676ac936d08746a9128
+      md5sum: dd14e743d3d0d3e95e8c8b0d0893b415
+    - path: output/fastp/test_2.fastp.fastq.gz
+      md5sum: e59d0d65cc8c2801f1b970df601fc207
 
 - name: fastp test_fastp_paired_end_merged
-  command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end_merged -c ./tests/config/nextflow.config -c ./tests/modules/fastp/nextflow.config
+  command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end_merged -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
   tags:
     - fastp
   files:
     - path: output/fastp/test.fastp.html
       contains:
-        - "<div id='After_filtering__merged__quality'>"
-    - path: output/fastp/test.fastp.json
-      contains:
-        - '"merged_and_filtered": {'
-        - '"total_reads": 75'
-        - '"total_bases": 13683'
+        - "<div id='After_filtering__merged__quality'>"    - path: output/fastp/test.fastp.json
+      md5sum: 045785e81e3327920c88e6948b8e077f
     - path: output/fastp/test.fastp.log
-      contains:
-        - "Merged and filtered:"
-        - "total reads: 75"
-        - "total bases: 13683"
+      md5sum: 0090eae9e60f4145595df2a11a4a62b1
     - path: output/fastp/test.merged.fastq.gz
-      md5sum: 4955ca2c899729b17bd526d2626a8d73
+      md5sum: eb6298f0394e6bc5bf82174fd37b84ce
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 4a03721ee252b7c6e81e007550e6ab63
+      md5sum: c447931fbacba27b40da990a8a91d36b
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 7a4ddf8485c147cd7aaf0d4f6cd57ace
+      md5sum: 3d3326285c02e5db86802c9981f09a39

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -79,7 +79,8 @@
   files:
     - path: output/fastp/test.fastp.html
       contains:
-        - "<div id='After_filtering__merged__quality'>"    - path: output/fastp/test.fastp.json
+        - "<div id='After_filtering__merged__quality'>"
+    - path: output/fastp/test.fastp.json
       md5sum: 045785e81e3327920c88e6948b8e077f
     - path: output/fastp/test.fastp.log
       md5sum: 0090eae9e60f4145595df2a11a4a62b1

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -11,7 +11,7 @@
       contains:
         - "Q20 bases: 12922(92.9841%)"
         - "reads passed filter: 99"
-    - path: output/fastp/test.trim.fastq.gz
+    - path: output/fastp/test.fastp.fastq.gz
       md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test.fastp.json
       md5sum: a517ba37b17a342b5428f2c1f8fe3dd7
@@ -32,9 +32,9 @@
     - path: output/fastp/test.fastp.json
       contains:
         - '"passed_filter_reads": 198'
-    - path: output/fastp/test_1.trim.fastq.gz
+    - path: output/fastp/test_1.fastp.fastq.gz
       md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
-    - path: output/fastp/test_2.trim.fastq.gz
+    - path: output/fastp/test_2.fastp.fastq.gz
       md5sum: 532b190fb4dc7b2277ee5cf1464e598c
 
 - name: fastp test_fastp_single_end_trim_fail
@@ -50,7 +50,7 @@
       contains:
         - "Q20 bases: 12922(92.9841%)"
         - "reads passed filter: 99"
-    - path: output/fastp/test.trim.fastq.gz
+    - path: output/fastp/test.fastp.fastq.gz
       md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test.fastp.json
       md5sum: 4be682c727942a45fc4c8600c28694a8
@@ -73,9 +73,9 @@
     - path: output/fastp/test.fastp.json
       contains:
         - '"passed_filter_reads": 198'
-    - path: output/fastp/test_1.trim.fastq.gz
+    - path: output/fastp/test_1.fastp.fastq.gz
       md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
-    - path: output/fastp/test_2.trim.fastq.gz
+    - path: output/fastp/test_2.fastp.fastq.gz
       md5sum: 532b190fb4dc7b2277ee5cf1464e598c
     - path: output/fastp/test_1.fail.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
@@ -102,7 +102,7 @@
         - "total bases: 13683"
     - path: output/fastp/test.merged.fastq.gz
       md5sum: 4955ca2c899729b17bd526d2626a8d73
-    - path: output/fastp/test_1.trim.fastq.gz
+    - path: output/fastp/test_1.fastp.fastq.gz
       md5sum: 4a03721ee252b7c6e81e007550e6ab63
-    - path: output/fastp/test_2.trim.fastq.gz
+    - path: output/fastp/test_2.fastp.fastq.gz
       md5sum: 7a4ddf8485c147cd7aaf0d4f6cd57ace

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -12,7 +12,6 @@
     - path: output/fastp/test.fastp.json
       md5sum: 7ee735cefb67f549dc857eefb9e7f123
     - path: output/fastp/test.fastp.log
-      md5sum: 732e06b17fd8a3f5dd7fa0a21c9af254
 
 - name: fastp test_fastp_paired_end
   command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
@@ -48,7 +47,6 @@
     - path: output/fastp/test.fastp.json
       md5sum: feafc4181a2a61b4b52d9c2b59b419ad
     - path: output/fastp/test.fastp.log
-      md5sum: c996c3321c09122e7b5381104b2682d9
 
 - name: fastp test_fastp_paired_end_trim_fail
   command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end_trim_fail -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -12,6 +12,9 @@
     - path: output/fastp/test.fastp.json
       md5sum: 7ee735cefb67f549dc857eefb9e7f123
     - path: output/fastp/test.fastp.log
+      contains:
+        - "Q20 bases: 12922(92.9841%)"
+        - "reads passed filter: 99"
 
 - name: fastp test_fastp_paired_end
   command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
@@ -23,9 +26,12 @@
         - "Q20 bases:</td><td class='col2'>25.719000 K (93.033098%)"
         - "The input has little adapter percentage (~0.000000%), probably it's trimmed before."
     - path: output/fastp/test.fastp.json
-      md5sum: cfc3e8b871b9bc770f1dc16432d64e67
+      contains:
+        - '"passed_filter_reads": 198'
     - path: output/fastp/test.fastp.log
-      md5sum: 8b1e318b1ae7b1bc23da61d4b4904bf7
+      contains:
+        - "No adapter detected for read1"
+        - "Q30 bases: 12281(88.3716%)"
     - path: output/fastp/test_1.fastp.fastq.gz
       md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test_2.fastp.fastq.gz
@@ -47,6 +53,9 @@
     - path: output/fastp/test.fastp.json
       md5sum: feafc4181a2a61b4b52d9c2b59b419ad
     - path: output/fastp/test.fastp.log
+      contains:
+        - "Q20 bases: 12922(92.9841%)"
+        - "reads passed filter: 99"
 
 - name: fastp test_fastp_paired_end_trim_fail
   command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end_trim_fail -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
@@ -57,10 +66,13 @@
       contains:
         - "Q20 bases:</td><td class='col2'>25.719000 K (93.033098%)"
         - "The input has little adapter percentage (~0.000000%), probably it's trimmed before."
-    - path: output/fastp/test.fastp.json
-      md5sum: 5750c4e642f2473af496cfc3387c2874
     - path: output/fastp/test.fastp.log
-      md5sum: d23a9c475354690af8d2b63e28fbd910
+      contains:
+        - "No adapter detected for read1"
+        - "Q30 bases: 12281(88.3716%)"
+    - path: output/fastp/test.fastp.json
+      contains:
+        - '"passed_filter_reads": 198'
     - path: output/fastp/test_1.fail.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: output/fastp/test_1.fastp.fastq.gz
@@ -79,9 +91,15 @@
       contains:
         - "<div id='After_filtering__merged__quality'>"
     - path: output/fastp/test.fastp.json
-      md5sum: 045785e81e3327920c88e6948b8e077f
+      contains:
+        - '"merged_and_filtered": {'
+        - '"total_reads": 75'
+        - '"total_bases": 13683'
     - path: output/fastp/test.fastp.log
-      md5sum: fe113b1e870469511016b3ed5e8ed710
+      contains:
+        - "Merged and filtered:"
+        - "total reads: 75"
+        - "total bases: 13683"
     - path: output/fastp/test.merged.fastq.gz
       md5sum: 4955ca2c899729b17bd526d2626a8d73
     - path: output/fastp/test_1.fastp.fastq.gz

--- a/tests/modules/fastp/test.yml
+++ b/tests/modules/fastp/test.yml
@@ -4,7 +4,7 @@
     - fastp
   files:
     - path: output/fastp/test.fastp.fastq.gz
-      md5sum: dc08e42319d0deab088da4d8600aa2bd
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test.fastp.html
       contains:
         - "Q20 bases:</td><td class='col2'>12.922000 K (92.984097%)"
@@ -12,7 +12,7 @@
     - path: output/fastp/test.fastp.json
       md5sum: 7ee735cefb67f549dc857eefb9e7f123
     - path: output/fastp/test.fastp.log
-      md5sum: 1a12e5579507689de5bff813fe494042
+      md5sum: 732e06b17fd8a3f5dd7fa0a21c9af254
 
 - name: fastp test_fastp_paired_end
   command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
@@ -28,9 +28,9 @@
     - path: output/fastp/test.fastp.log
       md5sum: 8b1e318b1ae7b1bc23da61d4b4904bf7
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: dc08e42319d0deab088da4d8600aa2bd
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: e59d0d65cc8c2801f1b970df601fc207
+      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
 
 - name: fastp test_fastp_single_end_trim_fail
   command: nextflow run ./tests/modules/fastp -entry test_fastp_single_end_trim_fail -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
@@ -38,9 +38,9 @@
     - fastp
   files:
     - path: output/fastp/test.fail.fastq.gz
-      md5sum: d865374adfc4228cd17e5bf1e5a3df10
+      md5sum: b57f2026eb259a0b0c0b3960c270258d
     - path: output/fastp/test.fastp.fastq.gz
-      md5sum: dc08e42319d0deab088da4d8600aa2bd
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test.fastp.html
       contains:
         - "Q20 bases:</td><td class='col2'>12.922000 K (92.984097%)"
@@ -48,7 +48,7 @@
     - path: output/fastp/test.fastp.json
       md5sum: feafc4181a2a61b4b52d9c2b59b419ad
     - path: output/fastp/test.fastp.log
-      md5sum: f06f5dea2ba676557509e6eff412ec40
+      md5sum: c996c3321c09122e7b5381104b2682d9
 
 - name: fastp test_fastp_paired_end_trim_fail
   command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end_trim_fail -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
@@ -66,11 +66,11 @@
     - path: output/fastp/test_1.fail.fastq.gz
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: dc08e42319d0deab088da4d8600aa2bd
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test_2.fail.fastq.gz
-      md5sum: dd14e743d3d0d3e95e8c8b0d0893b415
+      md5sum: 72d0002841967676ac936d08746a9128
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: e59d0d65cc8c2801f1b970df601fc207
+      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
 
 - name: fastp test_fastp_paired_end_merged
   command: nextflow run ./tests/modules/fastp -entry test_fastp_paired_end_merged -c ./tests/config/nextflow.config  -c ./tests/modules/fastp/nextflow.config
@@ -83,10 +83,10 @@
     - path: output/fastp/test.fastp.json
       md5sum: 045785e81e3327920c88e6948b8e077f
     - path: output/fastp/test.fastp.log
-      md5sum: 0090eae9e60f4145595df2a11a4a62b1
+      md5sum: fe113b1e870469511016b3ed5e8ed710
     - path: output/fastp/test.merged.fastq.gz
-      md5sum: eb6298f0394e6bc5bf82174fd37b84ce
+      md5sum: 4955ca2c899729b17bd526d2626a8d73
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: c447931fbacba27b40da990a8a91d36b
+      md5sum: 4a03721ee252b7c6e81e007550e6ab63
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 3d3326285c02e5db86802c9981f09a39
+      md5sum: 7a4ddf8485c147cd7aaf0d4f6cd57ace


### PR DESCRIPTION
Since FastP can be used for many operations, I find it slightly confusing that in the results folders of the pipeline fastp-modified reads even if not trimmed contain `.trim.` in the file name. Ideally, I would like to set this via the `modules.config`, but seem like `prefix` is taken for some softlinking. 

Instead, I propose to just add the toolname.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
