### PR TITLE
Add module: gatk4/leftalignandtrimvariants

### DIFF
--- a/modules/gatk4/leftalignandtrimvariants/main.nf
+++ b/modules/gatk4/leftalignandtrimvariants/main.nf
@@ -1,0 +1,46 @@
+process GATK4_LEFTALIGNANDTRIMVARIANTS {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::gatk4=4.2.6.1" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gatk4:4.2.6.1--hdfd78af_0':
+        'quay.io/biocontainers/gatk4:4.2.6.1--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(vcf), path(tbi)
+    path  fasta
+    path  fai
+    path  dict
+
+    output:
+    tuple val(meta), path("*.vcf.gz"), emit: vcf
+    tuple val(meta), path("*.tbi")   , emit: tbi
+    path "versions.yml"		         , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def avail_mem = 3
+    if (!task.memory) {
+        log.info '[GATK LeftAlignAndTrimVariants] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.'
+    } else {
+        avail_mem = task.memory.toGiga()
+    }
+    """
+    gatk --java-options "-Xmx${avail_mem}G" LeftAlignAndTrimVariants \\
+        --variant $vcf \\
+        --output ${prefix}.vcf.gz \\
+        --reference $fasta \\
+        --tmp-dir . \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gatk4: \$(echo \$(gatk --version 2>&1) | sed 's/^.*(GATK) v//; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/gatk4/leftalignandtrimvariants/meta.yml
+++ b/modules/gatk4/leftalignandtrimvariants/meta.yml
@@ -1,0 +1,62 @@
+name: "gatk4_leftalignandtrimvariants"
+description: Left align and trim variants using GATK4 LeftAlignAndTrimVariants.
+keywords:
+  - normalize
+  - norm
+  - vcf
+tools:
+  - gatk4:
+    description: |
+      Developed in the Data Sciences Platform at the Broad Institute, the toolkit offers a wide variety of tools
+      with a primary focus on variant discovery and genotyping. Its powerful processing engine
+      and high-performance computing features make it capable of taking on projects of any size.
+    homepage: https://gatk.broadinstitute.org/hc/en-us
+    documentation: https://gatk.broadinstitute.org/hc/en-us/categories/360002369672s
+    doi: 10.1158/1538-7445.AM2017-3590
+    licence: ["Apache-2.0"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - vcf:
+      type: file
+      description: |
+        The vcf file to be normalized
+        e.g. 'file1.vcf.gz'
+  - vcf:
+      type: file
+      description: |
+        Index of the vcf file to be normalized
+        e.g. 'file1.vcf.gz.tbi'
+  - fasta:
+      type: file
+      description: The reference fasta file
+      pattern: "*.fasta"
+  - fai:
+      type: file
+      description: Index of reference fasta file
+      pattern: "*.fasta.fai"
+  - dict:
+      type: file
+      description: GATK sequence dictionary
+      pattern: "*.dict"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - vcf:
+      type: file
+      description: VCF normalized output file
+      pattern: "*.{vcf.gz}"
+authors:
+  - "@adamrtalbot"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -859,6 +859,10 @@ gatk4/learnreadorientationmodel:
   - modules/gatk4/learnreadorientationmodel/**
   - tests/modules/gatk4/learnreadorientationmodel/**
 
+gatk4/leftalignandtrimvariants:
+  - modules/gatk4/leftalignandtrimvariants/**
+  - tests/modules/gatk4/leftalignandtrimvariants/**
+
 gatk4/markduplicates:
   - modules/gatk4/markduplicates/**
   - tests/modules/gatk4/markduplicates/**

--- a/tests/modules/gatk4/leftalignandtrimvariants/main.nf
+++ b/tests/modules/gatk4/leftalignandtrimvariants/main.nf
@@ -1,0 +1,19 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { GATK4_LEFTALIGNANDTRIMVARIANTS } from '../../../../modules/gatk4/leftalignandtrimvariants/main.nf'
+
+workflow test_gatk4_leftalignandtrimvariants {
+
+    input = [ [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true),
+    ]
+
+    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fai   = file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
+    dict  = file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true)
+
+    GATK4_LEFTALIGNANDTRIMVARIANTS ( input, fasta, fai, dict )
+}

--- a/tests/modules/gatk4/leftalignandtrimvariants/nextflow.config
+++ b/tests/modules/gatk4/leftalignandtrimvariants/nextflow.config
@@ -1,0 +1,9 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    withName: 'GATK4_LEFTALIGNANDTRIMVARIANTS' {
+        ext.args   = "--split-multi-allelics --dont-trim-alleles --keep-original-ac"
+        ext.prefix = { "${meta.id}.normalised" }
+    }
+}

--- a/tests/modules/gatk4/leftalignandtrimvariants/test.yml
+++ b/tests/modules/gatk4/leftalignandtrimvariants/test.yml
@@ -1,0 +1,11 @@
+- name: gatk4 leftalignandtrimvariants test_gatk4_leftalignandtrimvariants
+  command: nextflow run ./tests/modules/gatk4/leftalignandtrimvariants -entry test_gatk4_leftalignandtrimvariants -c ./tests/config/nextflow.config  -c ./tests/modules/gatk4/leftalignandtrimvariants/nextflow.config
+  tags:
+    - gatk4
+    - gatk4/leftalignandtrimvariants
+  files:
+    - path: output/gatk4/test.normalised.vcf.gz
+      contains:
+        - "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT"
+        - "MT192765.1\t10502\t.\tTAGATTATGACTGTGTCTCTTTTTGTTACATGCACCA\tTAGAT"
+    - path: output/gatk4/test.normalised.vcf.gz.tbi


### PR DESCRIPTION
Additions:
 - GATK4/LeftAlignAndTrimVariants module
 - Use sars-ncov2 test data as this normalises a larger INDEL correctly.

Fixes #1801

## PR checklist

Closes #1801 

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
