### PR TITLE
Bugfix for CecllRanger Dockerfile

### DIFF
--- a/modules/cellranger/mkfastq/Dockerfile
+++ b/modules/cellranger/mkfastq/Dockerfile
@@ -28,7 +28,7 @@ RUN \
     mv *.rpm bcl2fastq2-$BCL2FASTQ2_VER.rpm && \
     rpm2cpio ./bcl2fastq2-$BCL2FASTQ2_VER.rpm | cpio -idmv && \
     export PATH=/tmp/usr/local/bin/:$PATH && \
-    ln -s /tmp/usr/local/bin/bcl2fastq /usr/bin/bcl2fastq && \
+    mv /tmp/usr/local/bin/bcl2fastq /usr/bin/bcl2fastq && \
     rm -rf bcl2fastq2-$BCL2FASTQ2_VER.*
 
 # Install cellranger


### PR DESCRIPTION
The dockerfile was fine, but the `ln -s` component to `/tmp` was overridden for anyone using Singularity with the container - thus breaking `bcl2fastq` usage. Therefore, replaced that to make sure things work smoothly and can confirm this works now fine.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
