### PR TITLE
Bump MultiQC to v1.13a (dev)

### DIFF
--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -3,8 +3,8 @@ process MULTIQC {
 
     conda (params.enable_conda ? 'bioconda::multiqc=1.12' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.12--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.12--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.13a--pyhdfd78af_0' :
+        'quay.io/biocontainers/multiqc:1.13a--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -3,8 +3,8 @@ process MULTIQC {
 
     conda (params.enable_conda ? 'bioconda::multiqc=1.12' : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.13a--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.13a--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.13a--pyhdfd78af_1' :
+        'quay.io/biocontainers/multiqc:1.13a--pyhdfd78af_1' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"


### PR DESCRIPTION
This bumps MultiQC to v1.13a, the dev version of MultiQC that should fix issues for smrnaseq and also some other pipelines where DupRadar (I think rnaseq? @drpatelh FYI) was used and the HTML report contained duplicated sections. 

Can be used until there is a new proper V1.13 release as @ewels suggested 🥳 

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
