### PR TITLE
NGSCheckMate doesn't generate a pdf for only one sample, made optional output

### DIFF
--- a/modules/ngscheckmate/ncm/main.nf
+++ b/modules/ngscheckmate/ncm/main.nf
@@ -12,7 +12,7 @@ process NGSCHECKMATE_NCM {
     path fasta
 
     output:
-    path "*.pdf"            , emit: pdf
+    path "*.pdf"            , emit: pdf, optional: true
     path "*_corr_matrix.txt", emit: corr_matrix
     path "*_matched.txt"    , emit: matched
     path "*_all.txt"        , emit: all


### PR DESCRIPTION
NGSCheckMate doesn't generate a pdf showing how samples relate to each other if only one sample is included. This PR just makes the output pdf channel optional to stop failures in that case.

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [X] If necessary, include test data in your PR.
- [X] Remove all TODO statements.
- [X] Emit the `versions.yml` file.
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [X] Add a resource `label`
- [X] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
