### PR TITLE
antismashlite: Support GBK input

### DIFF
--- a/modules/antismash/antismashlite/main.nf
+++ b/modules/antismash/antismashlite/main.nf
@@ -45,7 +45,7 @@ process ANTISMASH_ANTISMASHLITE {
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
-    gff_flag = gff ? "--genefinding-gff3 ${gff}" : "" 
+    gff_flag = gff ? "--genefinding-gff3 ${gff}" : ""
 
     """
     ## We specifically do not include on-the-fly annotations (--genefinding-tool none) as

--- a/modules/antismash/antismashlite/main.nf
+++ b/modules/antismash/antismashlite/main.nf
@@ -45,11 +45,12 @@ process ANTISMASH_ANTISMASHLITE {
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
-    gff_flag = "--genefinding-gff3 ${gff}"
+    gff_flag = ("${gff}" == "") ? "": "--genefinding-gff3 ${gff}"
 
     """
-    ## We specifically do not include annotations (--genefinding-tool none) as
+    ## We specifically do not include on-the-fly annotations (--genefinding-tool none) as
     ## this should be run as a separate module for versioning purposes
+
     antismash \\
         $args \\
         $gff_flag \\

--- a/modules/antismash/antismashlite/main.nf
+++ b/modules/antismash/antismashlite/main.nf
@@ -45,7 +45,7 @@ process ANTISMASH_ANTISMASHLITE {
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
-    gff_flag = ("${gff}" == "") ? "": "--genefinding-gff3 ${gff}"
+    gff_flag = gff ? "--genefinding-gff3 ${gff}" : "" 
 
     """
     ## We specifically do not include on-the-fly annotations (--genefinding-tool none) as

--- a/modules/antismash/antismashlite/meta.yml
+++ b/modules/antismash/antismashlite/meta.yml
@@ -37,7 +37,9 @@ input:
       pattern: "*.{gbk, gb, gbff, genbank, embl, fasta, fna}"
   - databases:
       type: directory
-      description: downloaded AntiSMASH databases e.g. data/databases
+      description: |
+        Downloaded AntiSMASH databases (e.g. in the AntiSMASH installation directory
+        "data/databases")
       pattern: "*/"
   - antismash_dir:
       type: directory
@@ -51,6 +53,7 @@ input:
       pattern: "*/"
   - gff:
       type: file
+      description: Annotations in GFF3 format (only if sequence_input is in FASTA format)
       pattern: "*.gff"
 
 output:


### PR DESCRIPTION
Adding the option to not supply GFF files as AntiSMASH input, thus enabling GBK support.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
