### PR TITLE
Bump ataqv version

### DIFF
--- a/modules/ataqv/ataqv/main.nf
+++ b/modules/ataqv/ataqv/main.nf
@@ -2,10 +2,10 @@ process ATAQV_ATAQV {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::ataqv=1.2.1" : null)
+    conda (params.enable_conda ? "bioconda::ataqv=1.3.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ataqv:1.2.1--py39ha23c084_2' :
-        'quay.io/biocontainers/ataqv:1.2.1--py39ha23c084_2' }"
+        'https://depot.galaxyproject.org/singularity/ataqv:1.3.0--py39hccc85d7_2' :
+        'quay.io/biocontainers/ataqv:1.3.0--py39hccc85d7_2' }"
 
     input:
     tuple val(meta), path(bam), path(bai), path(peak_file)

--- a/tests/modules/ataqv/ataqv/test.yml
+++ b/tests/modules/ataqv/ataqv/test.yml
@@ -15,7 +15,6 @@
     - ataqv/ataqv
   files:
     - path: output/ataqv/1.problems
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: output/ataqv/test.ataqv.json
       contains:
         - '"forward_mate_reads": 101'


### PR DESCRIPTION

Bump ataqv to 1.3.0

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
