### PR TITLE
Add manual version definition for artic modules

### DIFF
--- a/modules/artic/guppyplex/main.nf
+++ b/modules/artic/guppyplex/main.nf
@@ -20,6 +20,7 @@ process ARTIC_GUPPYPLEX {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION = '1.2.2' // WARN: Version information provided by tool on CLI is incorrect. Please update this string when bumping container versions.
     """
     artic \\
         guppyplex \\
@@ -30,7 +31,7 @@ process ARTIC_GUPPYPLEX {
     pigz -p $task.cpus *.fastq
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        artic: \$(artic --version 2>&1 | sed 's/^.*artic //; s/ .*\$//')
+        artic: $VERSION
     END_VERSIONS
     """
 }

--- a/modules/artic/minion/main.nf
+++ b/modules/artic/minion/main.nf
@@ -48,6 +48,7 @@ process ARTIC_MINION {
         model   = medaka_model_file ? "--medaka-model ./$medaka_model_file" : "--medaka-model $medaka_model_string"
     }
     def hd5_plugin_path = task.ext.hd5_plugin_path ? "export HDF5_PLUGIN_PATH=" + task.ext.hd5_plugin_path : "export HDF5_PLUGIN_PATH=/usr/local/lib/python3.6/site-packages/ont_fast5_api/vbz_plugin"
+    def VERSION = '1.2.2' // WARN: Version information provided by tool on CLI is incorrect. Please update this string when bumping container versions.
     """
     $hd5_plugin_path
 
@@ -66,7 +67,7 @@ process ARTIC_MINION {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        artic: \$(artic --version 2>&1 | sed 's/^.*artic //; s/ .*\$//')
+        artic: $VERSION
     END_VERSIONS
     """
 }


### PR DESCRIPTION
Looks like the version of `artic` was bumped after the latest release:
https://github.com/artic-network/fieldbioinformatics/compare/1.2.2...master

The Biocontainer would have been built relative to the code in the tagged version and not `master` which is why it is showing the incorrect version on the CLI:

```
$ docker run -it quay.io/biocontainers/artic:1.2.2--pyhdfd78af_0 bash
root@9e6ed8b35659:/# artic --version
artic 1.2.1
```

Don't think rebuilding the Bioconda recipe will fix this because the assets will be frozen relative to the 1.2.2 tagged release. The only solution right now is to manually define the version in the module.

