### PR TITLE
Update MOTUS/PROFILE  module to output log file

### DIFF
--- a/modules/motus/profile/main.nf
+++ b/modules/motus/profile/main.nf
@@ -15,6 +15,7 @@ process MOTUS_PROFILE {
     tuple val(meta), path("*.out"), emit: out
     tuple val(meta), path("*.bam"), optional: true, emit: bam
     tuple val(meta), path("*.mgc"), optional: true, emit: mgc
+    tuple val(meta), path("*.log"),               , emit: log
     path "versions.yml"           , emit: versions
 
     when:
@@ -36,7 +37,8 @@ process MOTUS_PROFILE {
         $refdb \\
         -t $task.cpus \\
         -n $prefix \\
-        -o ${prefix}.out
+        -o ${prefix}.out \\
+        2> ${prefix}.log
 
     ## mOTUs version number is not available from command line.
     ## mOTUs save the version number in index database folder.

--- a/modules/motus/profile/main.nf
+++ b/modules/motus/profile/main.nf
@@ -15,7 +15,7 @@ process MOTUS_PROFILE {
     tuple val(meta), path("*.out"), emit: out
     tuple val(meta), path("*.bam"), optional: true, emit: bam
     tuple val(meta), path("*.mgc"), optional: true, emit: mgc
-    tuple val(meta), path("*.log"),               , emit: log
+    tuple val(meta), path("*.log")                , emit: log
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/motus/profile/meta.yml
+++ b/modules/motus/profile/meta.yml
@@ -56,6 +56,10 @@ output:
       type: file
       description: Optional intermediate mgc read count table file saved with `-M`.
       pattern: "*.{mgc}"
+  - log:
+      type: file
+      description: Standard error logging file containing summary statistics
+      pattern: "*.log"
 
 authors:
   - "@jianhong"

--- a/tests/modules/motus/profile/test.yml
+++ b/tests/modules/motus/profile/test.yml
@@ -6,3 +6,5 @@
   files:
     - path: output/motus/test.out
       contains: ["#consensus_taxonomy\ttest"]
+    - path: output/motus/test.log
+      contains: ["Finished computation"]


### PR DESCRIPTION
This redirects the stderr which contains logging information into a log file. Potentially useful for MultiQC

Example:

![image](https://user-images.githubusercontent.com/17950287/178501814-3963523d-6497-4aaf-ac56-1bf2bd6c76b5.png)


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
