### PR TITLE
Update filtlong module to output log file

### DIFF
--- a/modules/filtlong/main.nf
+++ b/modules/filtlong/main.nf
@@ -12,7 +12,8 @@ process FILTLONG {
 
     output:
     tuple val(meta), path("*.fastq.gz"), emit: reads
-    path "versions.yml"                                     , emit: versions
+    tuple val(meta), path("*.log")     , emit: log
+    path "versions.yml"                 , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,6 +28,7 @@ process FILTLONG {
         $short_reads \\
         $args \\
         $longreads \\
+        2> ${prefix}.log \\
         | gzip -n > ${prefix}.fastq.gz
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/filtlong/meta.yml
+++ b/modules/filtlong/meta.yml
@@ -45,6 +45,11 @@ output:
       type: file
       description: Filtered (compressed) fastq file
       pattern: "*.fastq.gz"
+  - log:
+      type: file
+      description: Standard error logging file containing summary statistics
+      pattern: "*.log"
 
 authors:
   - "@d4straub"
+  - "@sofstam"

--- a/tests/modules/filtlong/test.yml
+++ b/tests/modules/filtlong/test.yml
@@ -4,8 +4,8 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr.fastq.gz
-      contains:
-        - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"
+    - path: output/filtlong/test_lr.log
+      contains: ["Scoring long reads"]
 
 - name: filtlong test_filtlong_illumina_se
   command: nextflow run ./tests/modules/filtlong -entry test_filtlong_illumina_se -c ./tests/config/nextflow.config  -c ./tests/modules/filtlong/nextflow.config
@@ -13,8 +13,8 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr.fastq.gz
-      contains:
-        - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"
+    - path: output/filtlong/test_lr.log
+      contains: ["Scoring long reads"]
 
 - name: filtlong test_filtlong_illumina_pe
   command: nextflow run ./tests/modules/filtlong -entry test_filtlong_illumina_pe -c ./tests/config/nextflow.config  -c ./tests/modules/filtlong/nextflow.config
@@ -22,5 +22,5 @@
     - filtlong
   files:
     - path: output/filtlong/test_lr.fastq.gz
-      contains:
-        - "@00068f7a-51b3-4933-8fc6-7d6e29181ff9"
+    - path: output/filtlong/test_lr.log
+      contains: ["Scoring long reads"]


### PR DESCRIPTION
This redirects the stderr which contains logging information into a log file. Potentially useful for MultiQC

Example:

<img width="642" alt="Screenshot 2022-07-12 at 16 10 29" src="https://user-images.githubusercontent.com/91951607/178510319-31ed51e8-4aaf-454c-8eef-413637b321a0.png">


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
