### PR TITLE
Update DIAMOND module to output log file

### DIFF
--- a/modules/diamond/blastx/main.nf
+++ b/modules/diamond/blastx/main.nf
@@ -21,6 +21,7 @@ process DIAMOND_BLASTX {
     tuple val(meta), path('*.sam')  , optional: true, emit: sam
     tuple val(meta), path('*.tsv')  , optional: true, emit: tsv
     tuple val(meta), path('*.paf')  , optional: true, emit: paf
+    tuple val(meta), path("*.log")                  , emit: log
     path "versions.yml"                               , emit: versions
 
     when:
@@ -54,7 +55,11 @@ process DIAMOND_BLASTX {
         --query $fasta \\
         --outfmt ${outfmt} ${columns} \\
         $args \\
-        --out ${prefix}.${out_ext}
+        --out ${prefix}.${out_ext} \\
+        --log \\
+        2> ${prefix}.diamond.log
+
+    rm diamond.log
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/diamond/blastx/meta.yml
+++ b/modules/diamond/blastx/meta.yml
@@ -70,7 +70,12 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
+  - log:
+      type: file
+      description: Log file containing stdout information
+      pattern: "*diamond.log"
 
 authors:
   - "@spficklin"
   - "@jfy133"
+  - "@mjamy"

--- a/tests/modules/diamond/blastx/test.yml
+++ b/tests/modules/diamond/blastx/test.yml
@@ -1,18 +1,21 @@
 - name: diamond blastx test_diamond_blastx
-  command: nextflow run tests/modules/diamond/blastx -entry test_diamond_blastx -c tests/config/nextflow.config
+  command: nextflow run ./tests/modules/diamond/blastx -entry test_diamond_blastx -c ./tests/config/nextflow.config  -c ./tests/modules/diamond/blastx/nextflow.config
   tags:
-    - diamond
     - diamond/blastx
+    - diamond
   files:
+    - path: output/diamond/proteome.fasta.dmnd
+    - path: output/diamond/test.diamond_blastx.diamond.log
+      contains: ["queries aligned"]
     - path: output/diamond/test.diamond_blastx.txt
-    - path: output/diamond/versions.yml
 
 - name: diamond blastx test_diamond_blastx_daa
-  command: nextflow run tests/modules/diamond/blastx -entry test_diamond_blastx_daa -c tests/config/nextflow.config
+  command: nextflow run ./tests/modules/diamond/blastx -entry test_diamond_blastx_daa -c ./tests/config/nextflow.config  -c ./tests/modules/diamond/blastx/nextflow.config
   tags:
-    - diamond
     - diamond/blastx
+    - diamond
   files:
+    - path: output/diamond/proteome.fasta.dmnd
     - path: output/diamond/test.diamond_blastx.daa
-      md5sum: 0df4a833408416f32981415873facc11
-    - path: output/diamond/versions.yml
+    - path: output/diamond/test.diamond_blastx.diamond.log
+      contains: ["queries aligned"]


### PR DESCRIPTION
This redirects the stderr which contains logging information into a log file. Potentially useful for MultiQC.

Example:

<img width="707" alt="image" src="https://user-images.githubusercontent.com/40695699/178771232-d4b3459c-4fdb-438e-b89f-115f9244a13e.png">


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
