### PR TITLE
DRAFT: Extend output from snpeff

### DIFF
--- a/modules/snpeff/main.nf
+++ b/modules/snpeff/main.nf
@@ -15,6 +15,8 @@ process SNPEFF {
     output:
     tuple val(meta), path("*.ann.vcf"), emit: vcf
     path "*.csv"                      , emit: report
+    path "*.html"                     , emit: summary_html
+    path "*.genes.txt"                , emit: genes_txt
     path "versions.yml"               , emit: versions
 
     when:

--- a/modules/snpeff/meta.yml
+++ b/modules/snpeff/meta.yml
@@ -36,8 +36,16 @@ output:
       pattern: "*.ann.vcf"
   - report:
       type: file
-      description: snpEff report file
+      description: snpEff report csv file
+      pattern: "*.csv"
+  - summary_html:
+      type: file
+      description: snpEff summary statistics in html file
       pattern: "*.html"
+  - genes_txt:
+      type: file
+      description: txt (tab separated) file having counts of the number of variants affecting each transcript and gene
+      pattern: "*.genes.txt"
   - versions:
       type: file
       description: File containing software versions

--- a/tests/modules/snpeff/test.yml
+++ b/tests/modules/snpeff/test.yml
@@ -6,3 +6,8 @@
     - path: output/snpeff/test.ann.vcf
       md5sum: e933384e572fc5ed0cce0faf1c0b2cc9
     - path: output/snpeff/test.csv
+      md5sum: 3fd15c34d65052b6dd3e559de5788a72
+    - path: output/snpeff/test.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/snpeff/snpEff_summary.html
+      md5sum: ddf60e18161faa3cb5b2ce6056329b48

--- a/tests/modules/snpeff/test.yml
+++ b/tests/modules/snpeff/test.yml
@@ -6,8 +6,6 @@
     - path: output/snpeff/test.ann.vcf
       md5sum: e933384e572fc5ed0cce0faf1c0b2cc9
     - path: output/snpeff/test.csv
-      md5sum: 3fd15c34d65052b6dd3e559de5788a72
     - path: output/snpeff/test.genes.txt
       md5sum: 130536bf0237d7f3f746d32aaa32840a
     - path: output/snpeff/snpEff_summary.html
-      md5sum: ddf60e18161faa3cb5b2ce6056329b48


### PR DESCRIPTION
In the Sarek-pipeline, we need the snpEff-module to also output the genes-txt-file and the summary-html-file.

Concerning the test `/home/aspe/dev/fork_modules/tests/modules/snpeff/test.yml`, the test-vcf-file `test.ann.vcf` does contain some variants, but `test.genes.txt` doesn't contain any genes:

```
$ cat test.genes.txt
# The following table is formatted as tab separated values.
#GeneName	GeneId	TranscriptId	BioType
```

The `summary.html`-file indicate there there were 9 errors (and the vcf contains 9 variants):

<img width="757" alt="image" src="https://user-images.githubusercontent.com/37172585/179354776-769a8215-2345-4284-9dad-00d3f1f12867.png">
Should those errors give raise to concern?

 <!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
