### PR TITLE
Added support for meta in bwamem2/index

### DIFF
--- a/modules/bwamem2/index/main.nf
+++ b/modules/bwamem2/index/main.nf
@@ -8,11 +8,11 @@ process BWAMEM2_INDEX {
         'quay.io/biocontainers/bwa-mem2:2.2.1--he513fc3_0' }"
 
     input:
-    path fasta
+    tuple val(meta), path(fasta)
 
     output:
-    path "bwamem2"      , emit: index
-    path "versions.yml" , emit: versions
+    tuple val(meta), path("bwamem2"), emit: index
+    path "versions.yml"             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/bwamem2/index/meta.yml
+++ b/modules/bwamem2/index/meta.yml
@@ -14,6 +14,11 @@ tools:
       documentation: https://github.com/bwa-mem2/bwa-mem2#usage
       licence: ["MIT"]
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - fasta:
       type: file
       description: Input genome fasta file

--- a/modules/bwamem2/index/meta.yml
+++ b/modules/bwamem2/index/meta.yml
@@ -23,6 +23,11 @@ input:
       type: file
       description: Input genome fasta file
 output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - index:
       type: file
       description: BWA genome index files

--- a/modules/bwamem2/mem/main.nf
+++ b/modules/bwamem2/mem/main.nf
@@ -13,14 +13,13 @@ process BWAMEM2_MEM {
     val   sort_bam
 
     output:
-    tuple val(merged_meta), path("*.bam"), emit: bam
-    path  "versions.yml"                 , emit: versions
+    tuple val(meta), path("*.bam"), emit: bam
+    path  "versions.yml"          , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    merged_meta = meta2 + meta    // Priority given to the reads' meta map
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/bwamem2/mem/main.nf
+++ b/modules/bwamem2/mem/main.nf
@@ -9,17 +9,18 @@ process BWAMEM2_MEM {
 
     input:
     tuple val(meta), path(reads)
-    path  index
+    tuple val(meta2), path(index)
     val   sort_bam
 
     output:
-    tuple val(meta), path("*.bam"), emit: bam
-    path  "versions.yml"          , emit: versions
+    tuple val(merged_meta), path("*.bam"), emit: bam
+    path  "versions.yml"                 , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
+    merged_meta = meta2 + meta    // Priority given to the reads' meta map
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/bwamem2/mem/meta.yml
+++ b/modules/bwamem2/mem/meta.yml
@@ -21,13 +21,18 @@ input:
   - meta:
       type: map
       description: |
-        Groovy Map containing sample information
+        Groovy Map containing sample information (about the reads)
         e.g. [ id:'test', single_end:false ]
   - reads:
       type: file
       description: |
         List of input FastQ files of size 1 and 2 for single-end and paired-end data,
         respectively.
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing sample information (about the reference genome)
+        e.g. [ id:'mus_musculus', assembly:'GRCm38' ]
   - index:
       type: file
       description: BWA genome index files
@@ -37,6 +42,11 @@ input:
       description: use samtools sort (true) or samtools view (false)
       pattern: "true or false"
 output:
+  - merged_meta:
+      type: map
+      description: |
+        Groovy Map containing sample information, combined from the reads and index parameters
+        e.g. [ id:'test', single_end:false, assembly:'GRCm38' ]
   - bam:
       type: file
       description: Output BAM file containing read alignments

--- a/modules/bwamem2/mem/meta.yml
+++ b/modules/bwamem2/mem/meta.yml
@@ -21,18 +21,13 @@ input:
   - meta:
       type: map
       description: |
-        Groovy Map containing sample information (about the reads)
+        Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
   - reads:
       type: file
       description: |
         List of input FastQ files of size 1 and 2 for single-end and paired-end data,
         respectively.
-  - meta2:
-      type: map
-      description: |
-        Groovy Map containing sample information (about the reference genome)
-        e.g. [ id:'mus_musculus', assembly:'GRCm38' ]
   - index:
       type: file
       description: BWA genome index files
@@ -42,11 +37,11 @@ input:
       description: use samtools sort (true) or samtools view (false)
       pattern: "true or false"
 output:
-  - merged_meta:
+  - meta:
       type: map
       description: |
-        Groovy Map containing sample information, combined from the reads and index parameters
-        e.g. [ id:'test', single_end:false, assembly:'GRCm38' ]
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - bam:
       type: file
       description: Output BAM file containing read alignments

--- a/tests/modules/bwamem2/index/main.nf
+++ b/tests/modules/bwamem2/index/main.nf
@@ -7,5 +7,5 @@ include { BWAMEM2_INDEX } from '../../../../modules/bwamem2/index/main.nf'
 workflow test_bwamem2_index {
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    BWAMEM2_INDEX ( fasta )
+    BWAMEM2_INDEX ( [ [id:'test'], fasta] )
 }

--- a/tests/modules/bwamem2/mem/main.nf
+++ b/tests/modules/bwamem2/mem/main.nf
@@ -17,7 +17,7 @@ workflow test_bwamem2_mem_single_end {
     ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    BWAMEM2_INDEX ( fasta )
+    BWAMEM2_INDEX ( [ [:], fasta ] )
     BWAMEM2_MEM ( input, BWAMEM2_INDEX.out.index, false )
 }
 
@@ -33,7 +33,7 @@ workflow test_bwamem2_mem_single_end_sort {
     ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    BWAMEM2_INDEX ( fasta )
+    BWAMEM2_INDEX ( [ [:], fasta ] )
     BWAMEM2_MEM ( input, BWAMEM2_INDEX.out.index, true )
 }
 
@@ -51,7 +51,7 @@ workflow test_bwamem2_mem_paired_end {
     ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    BWAMEM2_INDEX ( fasta )
+    BWAMEM2_INDEX ( [ [:], fasta ] )
     BWAMEM2_MEM ( input, BWAMEM2_INDEX.out.index, false )
 }
 
@@ -68,6 +68,6 @@ workflow test_bwamem2_mem_paired_end_sort {
     ]
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    BWAMEM2_INDEX ( fasta )
+    BWAMEM2_INDEX ( [ [:], fasta ] )
     BWAMEM2_MEM ( input, BWAMEM2_INDEX.out.index, true )
 }


### PR DESCRIPTION
I think bwamem2/index and minimap2/index should consider meta in their input and output. This would make it much easier to plug them in workflows (no need to do `.map { it[1] }`).

## PR checklist

Closes #1917

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
