### PR TITLE
Added the meta map to minimap2/index

### DIFF
--- a/modules/minimap2/index/main.nf
+++ b/modules/minimap2/index/main.nf
@@ -7,11 +7,11 @@ process MINIMAP2_INDEX {
         'quay.io/biocontainers/minimap2:2.21--h5bf99c6_0' }"
 
     input:
-    path fasta
+    tuple val(meta), path(fasta)
 
     output:
-    path "*.mmi"        , emit: index
-    path "versions.yml" , emit: versions
+    tuple val(meta), path("*.mmi"), emit: index
+    path "versions.yml"           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/minimap2/index/meta.yml
+++ b/modules/minimap2/index/meta.yml
@@ -12,11 +12,21 @@ tools:
       documentation: https://github.com/lh3/minimap2#uguide
       licence: ["MIT"]
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - fasta:
       type: file
       description: |
         Reference database in FASTA format.
 output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - mmi:
       type: file
       description: Minimap2 fasta index.

--- a/tests/modules/minimap2/index/main.nf
+++ b/tests/modules/minimap2/index/main.nf
@@ -8,5 +8,5 @@ workflow test_minimap2_index {
 
     fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    MINIMAP2_INDEX ( fasta )
+    MINIMAP2_INDEX ( [ [id:'test'], fasta ] )
 }


### PR DESCRIPTION
Follow-up of #1921 and #1917; this time for `minimap2/index`

This PR brings support for the meta map into `minimap2/index`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
