### PR TITLE
Added the optional .gzi output of "samtools faidx"

### DIFF
--- a/modules/samtools/faidx/main.nf
+++ b/modules/samtools/faidx/main.nf
@@ -12,6 +12,7 @@ process SAMTOOLS_FAIDX {
 
     output:
     tuple val(meta), path ("*.fai"), emit: fai
+    tuple val(meta), path ("*.gzi"), emit: gzi, optional: true
     path "versions.yml"            , emit: versions
 
     when:

--- a/modules/samtools/faidx/meta.yml
+++ b/modules/samtools/faidx/meta.yml
@@ -33,6 +33,10 @@ output:
       type: file
       description: FASTA index file
       pattern: "*.{fai}"
+  - gzi:
+      type: file
+      description: Optional gzip index file for compressed inputs
+      pattern: "*.gzi"
   - versions:
       type: file
       description: File containing software versions

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -6,6 +6,7 @@ params {
         'sarscov2' {
             'genome' {
                 genome_fasta                                   = "${test_data_dir}/genomics/sarscov2/genome/genome.fasta"
+                genome_fasta_gz                                = "${test_data_dir}/genomics/sarscov2/genome/genome.fasta.gz"
                 genome_fasta_fai                               = "${test_data_dir}/genomics/sarscov2/genome/genome.fasta.fai"
                 genome_dict                                    = "${test_data_dir}/genomics/sarscov2/genome/genome.dict"
                 genome_gff3                                    = "${test_data_dir}/genomics/sarscov2/genome/genome.gff3"

--- a/tests/modules/samtools/faidx/main.nf
+++ b/tests/modules/samtools/faidx/main.nf
@@ -11,3 +11,11 @@ workflow test_samtools_faidx {
 
     SAMTOOLS_FAIDX ( input )
 }
+
+workflow test_samtools_faidx_bgzip {
+
+    input = [ [ id:'test', single_end:false ], // meta map
+              file(params.test_data['sarscov2']['genome']['genome_fasta_gz'], checkIfExists: true) ]
+
+    SAMTOOLS_FAIDX ( input )
+}

--- a/tests/modules/samtools/faidx/test.yml
+++ b/tests/modules/samtools/faidx/test.yml
@@ -7,3 +7,14 @@
     - path: output/samtools/genome.fasta.fai
       md5sum: 9da2a56e2853dc8c0b86a9e7229c9fe5
     - path: output/samtools/versions.yml
+- name: samtools faidx test_samtools_faidx_bgzip
+  command: nextflow run tests/modules/samtools/faidx -entry test_samtools_faidx_bgzip -c tests/config/nextflow.config
+  tags:
+    - samtools
+    - samtools/faidx
+  files:
+    - path: output/samtools/genome.fasta.gz.fai
+      md5sum: 9da2a56e2853dc8c0b86a9e7229c9fe5
+    - path: output/samtools/genome.fasta.gz.gzi
+      md5sum: 7dea362b3fac8e00956a4952a3d4f474
+    - path: output/samtools/versions.yml


### PR DESCRIPTION
When the input is a compressed Fasta file (i.e. with bgzip), `samtools faidx` also creates the `.gzi` file to enable random access into the fasta file.

This PR registers an optional .gzi output in the `samtools/faidx` module

The test data are waiting to be merged, cf https://github.com/nf-core/test-datasets/pull/579

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
