### PR TITLE
Improves kraken2 output glob

### DIFF
--- a/modules/kraken2/kraken2/main.nf
+++ b/modules/kraken2/kraken2/main.nf
@@ -14,11 +14,11 @@ process KRAKEN2_KRAKEN2 {
     val save_reads_assignment
 
     output:
-    tuple val(meta), path('*classified*')     , optional:true, emit: classified_reads_fastq
-    tuple val(meta), path('*unclassified*')   , optional:true, emit: unclassified_reads_fastq
-    tuple val(meta), path('*classifiedreads*'), optional:true, emit: classified_reads_assignment
-    tuple val(meta), path('*report.txt')                     , emit: report
-    path "versions.yml"                                      , emit: versions
+    tuple val(meta), path('*classified{.,_}*')     , optional:true, emit: classified_reads_fastq
+    tuple val(meta), path('*unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
+    tuple val(meta), path('*classifiedreads*')    , optional:true, emit: classified_reads_assignment
+    tuple val(meta), path('*report.txt')                         , emit: report
+    path "versions.yml"                                          , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,9 +29,9 @@ process KRAKEN2_KRAKEN2 {
     def paired       = meta.single_end ? "" : "--paired"
     def classified   = meta.single_end ? "${prefix}.classified.fastq"   : "${prefix}.classified#.fastq"
     def unclassified = meta.single_end ? "${prefix}.unclassified.fastq" : "${prefix}.unclassified#.fastq"
-    def classified_command = save_output_fastqs ? "--classified-out ${classified}" : ""
-    def unclassified_command = save_output_fastqs ? "--unclassified-out ${unclassified}" : ""
-    def readclassification_command = save_reads_assignment ? "--output ${prefix}.kraken2.classifiedreads.txt" : ""
+    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ""
+    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ""
+    def readclassification_option = save_reads_assignment ? "--output ${prefix}.kraken2.classifiedreads.txt" : ""
     def compress_reads_command = save_output_fastqs ? "pigz -p $task.cpus *.fastq" : ""
 
     """
@@ -40,9 +40,9 @@ process KRAKEN2_KRAKEN2 {
         --threads $task.cpus \\
         --report ${prefix}.kraken2.report.txt \\
         --gzip-compressed \\
-        $unclassified_command \\
-        $classified_command \\
-        $readclassification_command \\
+        $unclassified_option \\
+        $classified_option \\
+        $readclassification_option \\
         $paired \\
         $args \\
         $reads

--- a/modules/kraken2/kraken2/main.nf
+++ b/modules/kraken2/kraken2/main.nf
@@ -14,11 +14,11 @@ process KRAKEN2_KRAKEN2 {
     val save_reads_assignment
 
     output:
-    tuple val(meta), path('*classified{.,_}*.fastq.gz')     , optional:true, emit: classified_reads_fastq
-    tuple val(meta), path('*unclassified{.,_}*.fastq.gz')   , optional:true, emit: unclassified_reads_fastq
-    tuple val(meta), path('*classifiedreads.txt')           , optional:true, emit: classified_reads_assignment
-    tuple val(meta), path('*report.txt')                                   , emit: report
-    path "versions.yml"                                                    , emit: versions
+    tuple val(meta), path('*.classified{.,_}*')     , optional:true, emit: classified_reads_fastq
+    tuple val(meta), path('*.unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
+    tuple val(meta), path('*classifiedreads.txt')   , optional:true, emit: classified_reads_assignment
+    tuple val(meta), path('*report.txt')                           , emit: report
+    path "versions.yml"                                            , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/kraken2/kraken2/main.nf
+++ b/modules/kraken2/kraken2/main.nf
@@ -14,11 +14,11 @@ process KRAKEN2_KRAKEN2 {
     val save_reads_assignment
 
     output:
-    tuple val(meta), path('*classified{.,_}*')     , optional:true, emit: classified_reads_fastq
-    tuple val(meta), path('*unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
-    tuple val(meta), path('*classifiedreads*')    , optional:true, emit: classified_reads_assignment
-    tuple val(meta), path('*report.txt')                         , emit: report
-    path "versions.yml"                                          , emit: versions
+    tuple val(meta), path('*classified{.,_}*.fastq.gz')     , optional:true, emit: classified_reads_fastq
+    tuple val(meta), path('*unclassified{.,_}*.fastq.gz')   , optional:true, emit: unclassified_reads_fastq
+    tuple val(meta), path('*classifiedreads.txt')           , optional:true, emit: classified_reads_assignment
+    tuple val(meta), path('*report.txt')                                   , emit: report
+    path "versions.yml"                                                    , emit: versions
 
     when:
     task.ext.when == null || task.ext.when


### PR DESCRIPTION
As per a request by @Midnighter 

- Previous classified_fastq output channel would include the unclassified and classifiedreads.txt files, this ensures they are not incorrectly picked up
- Also makes the FASTQ option  command injection variables clearer (distinguish from the atual pigz command)

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
