### PR TITLE
Modify MULTIQC: separate logo from config file 

### DIFF
--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -8,7 +8,8 @@ process MULTIQC {
 
     input:
     path  multiqc_files, stageAs: "?/*"
-    tuple path(multiqc_config), path(multiqc_logo)
+    path(multiqc_config)
+    path(multiqc_logo)
 
     output:
     path "*multiqc_report.html", emit: report

--- a/modules/multiqc/meta.yml
+++ b/modules/multiqc/meta.yml
@@ -19,11 +19,11 @@ input:
         List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
   - multiqc_config:
       type: file
-      description: Config yml for MultiQC
+      description: Optional config yml for MultiQC
       pattern: "*.{yml,yaml}"
   - multiqc_logo:
       type: file
-      description: Logo file for MultiQC
+      description: Optional logo file for MultiQC
       pattern: "*.{png}"
 output:
   - report:

--- a/tests/modules/multiqc/main.nf
+++ b/tests/modules/multiqc/main.nf
@@ -13,7 +13,7 @@ workflow test_multiqc {
     ]
 
     FASTQC  ( input )
-    MULTIQC ( FASTQC.out.zip.collect { it[1] }, [[],[]] )
+    MULTIQC ( FASTQC.out.zip.collect { it[1] }, [],[] )
 }
 
 workflow test_multiqc_fn_collision {
@@ -29,5 +29,17 @@ workflow test_multiqc_fn_collision {
     FASTQC2  ( fqc_input )
     mqc_input = mqc_input.mix(FASTQC2.out.zip.collect { it[1] })
 
-    MULTIQC ( mqc_input, [[],[]] )
+    MULTIQC ( mqc_input, [],[] )
+}
+
+workflow test_multiqc_config {
+    fqc_input = [
+        [ id: 'test', single_end: false ],
+        [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)]
+    ]
+    mqc_config = file("https://github.com/nf-core/tools/raw/dev/nf_core/pipeline-template/assets/multiqc_config.yml", checkIfExists: true)
+    mqc_input = Channel.empty()
+
+    FASTQC  ( input )
+    MULTIQC ( FASTQC.out.zip.collect { it[1] }, mqc_config,[] )
 }

--- a/tests/modules/multiqc/main.nf
+++ b/tests/modules/multiqc/main.nf
@@ -33,7 +33,7 @@ workflow test_multiqc_fn_collision {
 }
 
 workflow test_multiqc_config {
-    fqc_input = [
+    input = [
         [ id: 'test', single_end: false ],
         [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)]
     ]

--- a/tests/modules/multiqc/test.yml
+++ b/tests/modules/multiqc/test.yml
@@ -3,11 +3,39 @@
   tags:
     - multiqc
   files:
+    - path: output/multiqc/multiqc_data/multiqc.log
+      contains: ["MultiQC complete"]
+    - path: output/multiqc/multiqc_data/multiqc_citations.txt
+      md5sum: ["10.1093/bioinformatics/btw354"]
+    - path: output/multiqc/multiqc_data/multiqc_data.json
+      contains: ["report_data_sources"]
     - path: output/multiqc/multiqc_report.html
+      contains: ["Abandon hope all ye who enter here.."]
 
 - name: multiqc test_multiqc_fn_collision
   command: nextflow run ./tests/modules/multiqc -entry test_multiqc_fn_collision -c ./tests/config/nextflow.config  -c ./tests/modules/multiqc/nextflow.config
   tags:
     - multiqc
   files:
+    - path: output/multiqc/multiqc_data/multiqc.log
+      contains: ["MultiQC complete"]
+    - path: output/multiqc/multiqc_data/multiqc_citations.txt
+      md5sum: ["10.1093/bioinformatics/btw354"]
+    - path: output/multiqc/multiqc_data/multiqc_data.json
+      contains: ["report_data_sources"]
     - path: output/multiqc/multiqc_report.html
+      contains: ["Abandon hope all ye who enter here.."]
+
+- name: multiqc test_multiqc_config
+  command: nextflow run ./tests/modules/multiqc -entry test_multiqc_config -c ./tests/config/nextflow.config  -c ./tests/modules/multiqc/nextflow.config
+  tags:
+    - multiqc
+  files:
+    - path: output/multiqc/multiqc_data/multiqc.log
+      contains: ["MultiQC complete"]
+    - path: output/multiqc/multiqc_data/multiqc_citations.txt
+      md5sum: ["10.1093/bioinformatics/btw354"]
+    - path: output/multiqc/multiqc_data/multiqc_data.json
+      contains: ["report_data_sources"]
+    - path: output/multiqc/multiqc_report.html
+      contains: ["Abandon hope all ye who enter here.."]

--- a/tests/modules/multiqc/test.yml
+++ b/tests/modules/multiqc/test.yml
@@ -6,7 +6,7 @@
     - path: output/multiqc/multiqc_data/multiqc.log
       contains: ["MultiQC complete"]
     - path: output/multiqc/multiqc_data/multiqc_citations.txt
-      md5sum: ["10.1093/bioinformatics/btw354"]
+      contains: ["10.1093/bioinformatics/btw354"]
     - path: output/multiqc/multiqc_data/multiqc_data.json
       contains: ["report_data_sources"]
     - path: output/multiqc/multiqc_report.html
@@ -20,7 +20,7 @@
     - path: output/multiqc/multiqc_data/multiqc.log
       contains: ["MultiQC complete"]
     - path: output/multiqc/multiqc_data/multiqc_citations.txt
-      md5sum: ["10.1093/bioinformatics/btw354"]
+      contains: ["10.1093/bioinformatics/btw354"]
     - path: output/multiqc/multiqc_data/multiqc_data.json
       contains: ["report_data_sources"]
     - path: output/multiqc/multiqc_report.html
@@ -34,7 +34,7 @@
     - path: output/multiqc/multiqc_data/multiqc.log
       contains: ["MultiQC complete"]
     - path: output/multiqc/multiqc_data/multiqc_citations.txt
-      md5sum: ["10.1093/bioinformatics/btw354"]
+      contains: ["10.1093/bioinformatics/btw354"]
     - path: output/multiqc/multiqc_data/multiqc_data.json
       contains: ["report_data_sources"]
     - path: output/multiqc/multiqc_report.html


### PR DESCRIPTION
Given both the config file and logo are both optional, and not necessarily required together, this separates the two input channels to make the module more flexible re: input

I will also update the pipeline template accordingly

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
