### PR TITLE
Added an output channel for the gzi index

### DIFF
--- a/modules/tabix/bgzip/main.nf
+++ b/modules/tabix/bgzip/main.nf
@@ -12,7 +12,7 @@ process TABIX_BGZIP {
 
     output:
     tuple val(meta), path("${prefix}*"), emit: output
-    tuple val(meta), path("index/*gzi"), emit: gzi, optional: true
+    tuple val(meta), path("*gzi")      , emit: gzi, optional: true
     path  "versions.yml"               , emit: versions
 
     when:
@@ -24,9 +24,8 @@ process TABIX_BGZIP {
     in_bgzip = input.toString().endsWith(".gz")
     command1 = in_bgzip ? '-d' : '-c'
     command2 = in_bgzip ? ''   : " > ${prefix}.${input.getExtension()}.gz"
-    gzi_args = args.matches("(^| )-i\\b") ? "-I index/${prefix}.${input.getExtension()}.gz.gzi" : ''
+    gzi_args = args.matches("(^| )-i\\b") ? "-I ${prefix}.${input.getExtension()}.gz.gzi" : ''
     """
-    mkdir -p index
     bgzip $command1 $args $gzi_args -@${task.cpus} $input $command2
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/tabix/bgzip/main.nf
+++ b/modules/tabix/bgzip/main.nf
@@ -24,9 +24,12 @@ process TABIX_BGZIP {
     in_bgzip = input.toString().endsWith(".gz")
     command1 = in_bgzip ? '-d' : '-c'
     command2 = in_bgzip ? ''   : " > ${prefix}.${input.getExtension()}.gz"
-    gzi_args = args.matches("(^| )-i\\b") ? "-I ${prefix}.${input.getExtension()}.gz.gzi" : ''
+    // Name the index according to $prefix, unless a name has been requested
+    if ((args.matches("(^| )-i\\b") || args.matches("(^| )--index(\$| )")) && !args.matches("(^| )-I\\b") && !args.matches("(^| )--index-name\\b")) {
+        args = args + " -I ${prefix}.${input.getExtension()}.gz.gzi"
+    }
     """
-    bgzip $command1 $args $gzi_args -@${task.cpus} $input $command2
+    bgzip $command1 $args -@${task.cpus} $input $command2
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/tabix/bgzip/main.nf
+++ b/modules/tabix/bgzip/main.nf
@@ -12,6 +12,7 @@ process TABIX_BGZIP {
 
     output:
     tuple val(meta), path("${prefix}*"), emit: output
+    tuple val(meta), path("index/*gzi"), emit: gzi, optional: true
     path  "versions.yml"               , emit: versions
 
     when:
@@ -23,8 +24,10 @@ process TABIX_BGZIP {
     in_bgzip = input.toString().endsWith(".gz")
     command1 = in_bgzip ? '-d' : '-c'
     command2 = in_bgzip ? ''   : " > ${prefix}.${input.getExtension()}.gz"
+    gzi_args = args.matches("(^| )-i\\b") ? "-I index/${prefix}.${input.getExtension()}.gz.gzi" : ''
     """
-    bgzip $command1 $args -@${task.cpus} $input $command2
+    mkdir -p index
+    bgzip $command1 $args $gzi_args -@${task.cpus} $input $command2
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/tabix/bgzip/meta.yml
+++ b/modules/tabix/bgzip/meta.yml
@@ -32,6 +32,10 @@ output:
       type: file
       description: Output compressed/decompressed file
       pattern: "*."
+  - gzi:
+      type: file
+      description: Optional gzip index file for compressed inputs
+      pattern: "*.gzi"
   - versions:
       type: file
       description: File containing software versions

--- a/tests/modules/tabix/bgzip/main.nf
+++ b/tests/modules/tabix/bgzip/main.nf
@@ -3,6 +3,7 @@
 nextflow.enable.dsl = 2
 
 include { TABIX_BGZIP } from '../../../../modules/tabix/bgzip/main.nf'
+include { TABIX_BGZIP as TABIX_BGZIP_WITH_GZI } from '../../../../modules/tabix/bgzip/main.nf'
 
 workflow test_tabix_bgzip_compress {
     input = [ [ id:'test' ], // meta map
@@ -10,6 +11,14 @@ workflow test_tabix_bgzip_compress {
             ]
 
     TABIX_BGZIP ( input )
+}
+
+workflow test_tabix_bgzip_compress_gzi {
+    input = [ [ id:'test' ], // meta map
+              [ file(params.test_data['sarscov2']['illumina']['test_vcf'], checkIfExists: true) ]
+            ]
+
+    TABIX_BGZIP_WITH_GZI ( input )
 }
 
 workflow test_tabix_bgzip_decompress {

--- a/tests/modules/tabix/bgzip/nextflow.config
+++ b/tests/modules/tabix/bgzip/nextflow.config
@@ -2,4 +2,7 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    withName: TABIX_BGZIP_WITH_GZI {
+        ext.args = ' -i'
+    }
 }

--- a/tests/modules/tabix/bgzip/test.yml
+++ b/tests/modules/tabix/bgzip/test.yml
@@ -6,7 +6,7 @@
   files:
     - path: ./output/tabix/test.vcf.gz
       md5sum: fc178eb342a91dc0d1d568601ad8f8e2
-    - path: ./output/tabix/index/test.vcf.gz.gzi
+    - path: ./output/tabix/test.vcf.gz.gzi
       should_exist: false
 - name: tabix bgzip compress gzi
   command: nextflow run ./tests/modules/tabix/bgzip -entry test_tabix_bgzip_compress_gzi -c ./tests/config/nextflow.config -c ./tests/modules/tabix/bgzip/nextflow.config
@@ -16,7 +16,7 @@
   files:
     - path: ./output/tabix/test.vcf.gz
       md5sum: fc178eb342a91dc0d1d568601ad8f8e2
-    - path: ./output/tabix/index/test.vcf.gz.gzi
+    - path: ./output/tabix/test.vcf.gz.gzi
       md5sum: 7dea362b3fac8e00956a4952a3d4f474
 - name: tabix bgzip decompress
   command: nextflow run ./tests/modules/tabix/bgzip -entry test_tabix_bgzip_decompress -c ./tests/config/nextflow.config -c ./tests/modules/tabix/bgzip/nextflow.config

--- a/tests/modules/tabix/bgzip/test.yml
+++ b/tests/modules/tabix/bgzip/test.yml
@@ -6,6 +6,18 @@
   files:
     - path: ./output/tabix/test.vcf.gz
       md5sum: fc178eb342a91dc0d1d568601ad8f8e2
+    - path: ./output/tabix/index/test.vcf.gz.gzi
+      should_exist: false
+- name: tabix bgzip compress gzi
+  command: nextflow run ./tests/modules/tabix/bgzip -entry test_tabix_bgzip_compress_gzi -c ./tests/config/nextflow.config -c ./tests/modules/tabix/bgzip/nextflow.config
+  tags:
+    - tabix
+    - tabix/bgzip
+  files:
+    - path: ./output/tabix/test.vcf.gz
+      md5sum: fc178eb342a91dc0d1d568601ad8f8e2
+    - path: ./output/tabix/index/test.vcf.gz.gzi
+      md5sum: 7dea362b3fac8e00956a4952a3d4f474
 - name: tabix bgzip decompress
   command: nextflow run ./tests/modules/tabix/bgzip -entry test_tabix_bgzip_decompress -c ./tests/config/nextflow.config -c ./tests/modules/tabix/bgzip/nextflow.config
   tags:


### PR DESCRIPTION
When bgzip is given the `-i` option, it creates an index (in gzi format). The index needs to be considered an output so that it can be published. This PR adds an optional output channel to capture the index.

The `-I` option is automatically injected to name the index according to the convention.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
