### PR TITLE
epang: Output gzipped jplace

### DIFF
--- a/modules/epang/main.nf
+++ b/modules/epang/main.nf
@@ -45,8 +45,8 @@ process EPANG {
         $splitarg \\
         $binaryarg
 
-    [ -e epa_result.jplace ] && mv epa_result.jplace ${prefix}.epa_result.jplace
-    [ -e epa_info.log ]      && mv epa_info.log      ${prefix}.epa_info.log
+    [ -e epa_result.jplace ] && gzip -c epa_result.jplace > ${prefix}.epa_result.jplace.gz
+    [ -e epa_info.log ]      && cp epa_info.log ${prefix}.epa_info.log
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/epang/main.nf
+++ b/modules/epang/main.nf
@@ -45,7 +45,10 @@ process EPANG {
         $splitarg \\
         $binaryarg
 
-    [ -e epa_result.jplace ] && gzip -c epa_result.jplace > ${prefix}.epa_result.jplace.gz
+    if [ -e epa_result.jplace ]; then
+        gzip epa_result.jplace
+        cp epa_result.jplace.gz ${prefix}.epa_result.jplace.gz
+    fi
     [ -e epa_info.log ]      && cp epa_info.log ${prefix}.epa_info.log
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/epang/meta.yml
+++ b/modules/epang/meta.yml
@@ -55,8 +55,8 @@ output:
       description: directory in which EPA-NG was run
   - jplace:
       type: file
-      description: file with placement information
-      pattern: "*.jplace"
+      description: gzipped file with placement information
+      pattern: "*.jplace.gz"
   - log:
       type: file
       description: log file from placement

--- a/tests/modules/epang/test.yml
+++ b/tests/modules/epang/test.yml
@@ -6,7 +6,7 @@
     - path: output/epang/test.epa_info.log
       contains:
         - "INFO 3 Sequences done"
-    - path: output/epang/test.epa_result.jplace
+    - path: output/epang/test.epa_result.jplace.gz
       contains:
         - '"placements":'
         - '"metadata": {"invocation": "epa-ng --model LG --threads 2 --query query.alnfaa.gz --ref-msa reference.alnfaa.gz --tree reference.newick "}'


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

The module did not adhere to the recommendation of outputting gzipped files because I didn't think that downstream tools would handle them easily. It turned out I was wrong. I've changed the module to output a gzipped file through the `jplace` output channel. 

I also changed it to output _copies_ of the jplace and log files with prefix from `$prefix` to the `jplace` and `log` output channels, in order to keep the original file names for anyone wanting to use the directory output channel.

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
