### PR TITLE
Updated dumpsoftwareversions.py to match the pipeline template

### DIFF
--- a/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
+++ b/modules/custom/dumpsoftwareversions/templates/dumpsoftwareversions.py
@@ -58,11 +58,12 @@ versions_by_module = {}
 for process, process_versions in versions_by_process.items():
     module = process.split(":")[-1]
     try:
-        assert versions_by_module[module] == process_versions, (
-            "We assume that software versions are the same between all modules. "
-            "If you see this error-message it means you discovered an edge-case "
-            "and should open an issue in nf-core/tools. "
-        )
+        if versions_by_module[module] != process_versions:
+            raise AssertionError(
+                "We assume that software versions are the same between all modules. "
+                "If you see this error-message it means you discovered an edge-case "
+                "and should open an issue in nf-core/tools. "
+            )
     except KeyError:
         versions_by_module[module] = process_versions
 

--- a/tests/modules/custom/dumpsoftwareversions/main.nf
+++ b/tests/modules/custom/dumpsoftwareversions/main.nf
@@ -42,7 +42,7 @@ workflow test_custom_dumpsoftwareversions {
     // cases where subworkflows have a module with the same name.
     fastqc1 ( input )
     fastqc2 ( input )
-    MULTIQC ( fastqc2.out.zip.collect { it[1] }, [[],[]] )
+    MULTIQC ( fastqc2.out.zip.collect { it[1] }, [], [], [] )
 
     fastqc1
         .out


### PR DESCRIPTION
Otherwise `nf-core lint` complains that "Local copy of module does not match remote"

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
