### PR TITLE
Upgraded getchromsizes to support meta and output the gzi index

### DIFF
--- a/modules/custom/getchromsizes/main.nf
+++ b/modules/custom/getchromsizes/main.nf
@@ -13,6 +13,7 @@ process CUSTOM_GETCHROMSIZES {
     output:
     tuple val(meta), path ("*.sizes"), emit: sizes
     tuple val(meta), path ("*.fai")  , emit: fai
+    tuple val(meta), path ("*.gzi")  , emit: gzi, optional: true
     path  "versions.yml"             , emit: versions
 
     when:

--- a/modules/custom/getchromsizes/main.nf
+++ b/modules/custom/getchromsizes/main.nf
@@ -29,4 +29,15 @@ process CUSTOM_GETCHROMSIZES {
         getchromsizes: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
     END_VERSIONS
     """
+
+    stub:
+    """
+    touch ${fasta}.fai
+    touch ${fasta}.sizes
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        getchromsizes: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
 }

--- a/modules/custom/getchromsizes/main.nf
+++ b/modules/custom/getchromsizes/main.nf
@@ -26,7 +26,7 @@ process CUSTOM_GETCHROMSIZES {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        custom: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        getchromsizes: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
     END_VERSIONS
     """
 }

--- a/modules/custom/getchromsizes/main.nf
+++ b/modules/custom/getchromsizes/main.nf
@@ -1,6 +1,6 @@
 process CUSTOM_GETCHROMSIZES {
     tag "$fasta"
-    label 'process_low'
+    label 'process_single'
 
     conda (params.enable_conda ? "bioconda::samtools=1.15.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/custom/getchromsizes/main.nf
+++ b/modules/custom/getchromsizes/main.nf
@@ -8,12 +8,12 @@ process CUSTOM_GETCHROMSIZES {
         'quay.io/biocontainers/samtools:1.15.1--h1170115_0' }"
 
     input:
-    path fasta
+    tuple val(meta), path(fasta)
 
     output:
-    path '*.sizes'      , emit: sizes
-    path '*.fai'        , emit: fai
-    path  "versions.yml", emit: versions
+    tuple val(meta), path ("*.sizes"), emit: sizes
+    tuple val(meta), path ("*.fai")  , emit: fai
+    path  "versions.yml"             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/custom/getchromsizes/meta.yml
+++ b/modules/custom/getchromsizes/meta.yml
@@ -38,6 +38,10 @@ output:
       type: file
       description: FASTA index file
       pattern: "*.{fai}"
+  - gzi:
+      type: file
+      description: Optional gzip index file for compressed inputs
+      pattern: "*.gzi"
   - versions:
       type: file
       description: File containing software versions

--- a/modules/custom/getchromsizes/meta.yml
+++ b/modules/custom/getchromsizes/meta.yml
@@ -46,3 +46,4 @@ output:
 authors:
   - "@tamara-hodgetts"
   - "@chris-cheshire"
+  - "@muffato"

--- a/modules/custom/getchromsizes/meta.yml
+++ b/modules/custom/getchromsizes/meta.yml
@@ -22,7 +22,7 @@ input:
   - fasta:
       type: file
       description: FASTA file
-      pattern: "*.{fa,fasta}"
+      pattern: "*.{fa,fasta,fna,fas}"
 
 output:
   - meta:

--- a/modules/custom/getchromsizes/meta.yml
+++ b/modules/custom/getchromsizes/meta.yml
@@ -14,12 +14,22 @@ tools:
       licence: ["MIT"]
 
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - fasta:
       type: file
       description: FASTA file
       pattern: "*.{fasta}"
 
 output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - sizes:
       type: file
       description: File containing chromosome lengths

--- a/modules/custom/getchromsizes/meta.yml
+++ b/modules/custom/getchromsizes/meta.yml
@@ -22,7 +22,7 @@ input:
   - fasta:
       type: file
       description: FASTA file
-      pattern: "*.{fasta}"
+      pattern: "*.{fa,fasta}"
 
 output:
   - meta:
@@ -40,7 +40,7 @@ output:
       pattern: "*.{fai}"
   - versions:
       type: file
-      description: File containing software version
+      description: File containing software versions
       pattern: "versions.yml"
 
 authors:

--- a/tests/modules/custom/getchromsizes/main.nf
+++ b/tests/modules/custom/getchromsizes/main.nf
@@ -11,3 +11,11 @@ workflow test_custom_getchromsizes {
 
     CUSTOM_GETCHROMSIZES ( input )
 }
+
+workflow test_custom_getchromsizes_bgzip {
+
+    input = [ [ id:'test', single_end:false ], // meta map
+              file(params.test_data['sarscov2']['genome']['genome_fasta_gz'], checkIfExists: true) ]
+
+    CUSTOM_GETCHROMSIZES ( input )
+}

--- a/tests/modules/custom/getchromsizes/main.nf
+++ b/tests/modules/custom/getchromsizes/main.nf
@@ -5,8 +5,9 @@ nextflow.enable.dsl = 2
 include { CUSTOM_GETCHROMSIZES } from '../../../../modules/custom/getchromsizes/main.nf'
 
 workflow test_custom_getchromsizes {
-    
-    input = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) 
+
+    input = [ [ id:'test', single_end:false ], // meta map
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
 
     CUSTOM_GETCHROMSIZES ( input )
 }

--- a/tests/modules/custom/getchromsizes/test.yml
+++ b/tests/modules/custom/getchromsizes/test.yml
@@ -8,3 +8,19 @@
       md5sum: 9da2a56e2853dc8c0b86a9e7229c9fe5
     - path: output/custom/genome.fasta.sizes
       md5sum: a57c401f27ae5133823fb09fb21c8a3c
+    - path: output/custom/versions.yml
+      md5sum: 3e4a23a0852f4ec34296224d87446d9a
+- name: custom getchromsizes_bgzip
+  command: nextflow run ./tests/modules/custom/getchromsizes -entry test_custom_getchromsizes_bgzip -c ./tests/config/nextflow.config -c ./tests/modules/custom/getchromsizes/nextflow.config
+  tags:
+    - custom
+    - custom/getchromsizes
+  files:
+    - path: output/custom/genome.fasta.gz.fai
+      md5sum: 9da2a56e2853dc8c0b86a9e7229c9fe5
+    - path: output/custom/genome.fasta.gz.gzi
+      md5sum: 7dea362b3fac8e00956a4952a3d4f474
+    - path: output/custom/genome.fasta.gz.sizes
+      md5sum: a57c401f27ae5133823fb09fb21c8a3c
+    - path: output/custom/versions.yml
+      md5sum: 22871934dfac30a6109068fd79b2d0ba


### PR DESCRIPTION
Similar to #1935 : output the gzi index since `samtools faidx` may create it.
I also added `meta` everywhere since it was missing !

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
