### PR TITLE
Update MULTIQC for an additional custom config

### DIFF
--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -9,6 +9,7 @@ process MULTIQC {
     input:
     path  multiqc_files, stageAs: "?/*"
     path(multiqc_config)
+    path(multiqc_logo)
 
     output:
     path "*multiqc_report.html", emit: report

--- a/modules/multiqc/main.nf
+++ b/modules/multiqc/main.nf
@@ -9,6 +9,7 @@ process MULTIQC {
     input:
     path  multiqc_files, stageAs: "?/*"
     path(multiqc_config)
+    path(extra_multiqc_config)
     path(multiqc_logo)
 
     output:
@@ -23,11 +24,13 @@ process MULTIQC {
     script:
     def args = task.ext.args ?: ''
     def config = multiqc_config ? "--config $multiqc_config" : ''
+    def extra_config = extra_multiqc_config ? "--config $extra_multiqc_config" : ''
     """
     multiqc \\
         --force \\
-        $config \\
         $args \\
+        $config \\
+        $extra_config \\
         .
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/multiqc/meta.yml
+++ b/modules/multiqc/meta.yml
@@ -22,6 +22,10 @@ input:
       type: file
       description: Optional config yml for MultiQC
       pattern: "*.{yml,yaml}"
+  - multiqc_logo:
+      type: file
+      description: Optional logo file for MultiQC
+      pattern: "*.{png}"
 
 output:
   - report:

--- a/modules/multiqc/meta.yml
+++ b/modules/multiqc/meta.yml
@@ -22,6 +22,10 @@ input:
       type: file
       description: Optional config yml for MultiQC
       pattern: "*.{yml,yaml}"
+  - extra_multiqc_config:
+      type: file
+      description: Second optional config yml for MultiQC. Will override common sections in multiqc_config.
+      pattern: "*.{yml,yaml}"
   - multiqc_logo:
       type: file
       description: Optional logo file for MultiQC

--- a/tests/modules/multiqc/main.nf
+++ b/tests/modules/multiqc/main.nf
@@ -13,7 +13,7 @@ workflow test_multiqc {
     ]
 
     FASTQC  ( input )
-    MULTIQC ( FASTQC.out.zip.collect { it[1] }, [], [] )
+    MULTIQC ( FASTQC.out.zip.collect { it[1] }, [], [], [] )
 }
 
 workflow test_multiqc_fn_collision {
@@ -29,7 +29,7 @@ workflow test_multiqc_fn_collision {
     FASTQC2  ( fqc_input )
     mqc_input = mqc_input.mix(FASTQC2.out.zip.collect { it[1] })
 
-    MULTIQC ( mqc_input, [], [] )
+    MULTIQC ( mqc_input, [], [], [] )
 }
 
 workflow test_multiqc_config {
@@ -41,5 +41,5 @@ workflow test_multiqc_config {
     mqc_input = Channel.empty()
 
     FASTQC  ( input )
-    MULTIQC ( FASTQC.out.zip.collect { it[1] }, mqc_config, [] )
+    MULTIQC ( FASTQC.out.zip.collect { it[1] }, mqc_config, [], [] )
 }

--- a/tests/modules/multiqc/main.nf
+++ b/tests/modules/multiqc/main.nf
@@ -13,7 +13,7 @@ workflow test_multiqc {
     ]
 
     FASTQC  ( input )
-    MULTIQC ( FASTQC.out.zip.collect { it[1] }, [] )
+    MULTIQC ( FASTQC.out.zip.collect { it[1] }, [], [] )
 }
 
 workflow test_multiqc_fn_collision {
@@ -29,7 +29,7 @@ workflow test_multiqc_fn_collision {
     FASTQC2  ( fqc_input )
     mqc_input = mqc_input.mix(FASTQC2.out.zip.collect { it[1] })
 
-    MULTIQC ( mqc_input, [] )
+    MULTIQC ( mqc_input, [], [] )
 }
 
 workflow test_multiqc_config {
@@ -41,5 +41,5 @@ workflow test_multiqc_config {
     mqc_input = Channel.empty()
 
     FASTQC  ( input )
-    MULTIQC ( FASTQC.out.zip.collect { it[1] }, mqc_config )
+    MULTIQC ( FASTQC.out.zip.collect { it[1] }, mqc_config, [] )
 }


### PR DESCRIPTION
Adds ability to have one(!) other custom config to the MultiQC module.

This allows nf-core pipelines to have the default pipeline one, and then a user to modify sections by supplying their second config file, the contents of which [overrides anything common](https://multiqc.info/docs/#configuring-multiqc) with the pipeline base config file. 

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
