### PR TITLE
Make hmmer/hmmalign output files with correct prefix

### DIFF
--- a/modules/hmmer/hmmalign/main.nf
+++ b/modules/hmmer/hmmalign/main.nf
@@ -25,7 +25,7 @@ process HMMER_HMMALIGN {
     hmmalign \\
         $args \\
         $hmm \\
-        $fasta | gzip -c > ${meta.id}.sthlm.gz
+        $fasta | gzip -c > ${prefix}.sthlm.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/tests/modules/hmmer/hmmalign/main.nf
+++ b/tests/modules/hmmer/hmmalign/main.nf
@@ -2,7 +2,8 @@
 
 nextflow.enable.dsl = 2
 
-include { HMMER_HMMALIGN } from '../../../../modules/hmmer/hmmalign/main.nf'
+include { HMMER_HMMALIGN as HMMER_HMMALIGN        } from '../../../../modules/hmmer/hmmalign/main.nf'
+include { HMMER_HMMALIGN as HMMER_HMMALIGN_PREFIX } from '../../../../modules/hmmer/hmmalign/main.nf'
 
 workflow test_hmmer_hmmalign {
 
@@ -14,4 +15,16 @@ workflow test_hmmer_hmmalign {
     hmm   = file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/bac.16S_rRNA.hmm.gz')
 
     HMMER_HMMALIGN ( input, hmm )
+}
+
+workflow test_hmmer_hmmalign_prefix {
+
+    input = [
+        [ id:'test' ], // meta map
+        file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/e_coli_k12_16s.fna.gz')      // Change to params.test_data syntax after the data is included in tests/config/test_data.config
+    ]
+
+    hmm   = file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/bac.16S_rRNA.hmm.gz')
+
+    HMMER_HMMALIGN_PREFIX ( input, hmm )
 }

--- a/tests/modules/hmmer/hmmalign/nextflow.config
+++ b/tests/modules/hmmer/hmmalign/nextflow.config
@@ -2,4 +2,7 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    withName: HMMER_HMMALIGN_PREFIX {
+        ext.prefix = { "${meta.id}.prefix" }
+    }
 }

--- a/tests/modules/hmmer/hmmalign/test.yml
+++ b/tests/modules/hmmer/hmmalign/test.yml
@@ -6,3 +6,11 @@
   files:
     - path: output/hmmer/test.sthlm.gz
       md5sum: ddaa8b96291edf4e1a929a224329161b
+- name: hmmer hmmalign test_hmmer_hmmalign_prefix
+  command: nextflow run ./tests/modules/hmmer/hmmalign -entry test_hmmer_hmmalign_prefix -c ./tests/config/nextflow.config -c ./tests/modules/hmmer/hmmalign/nextflow.config
+  tags:
+    - hmmer
+    - hmmer/hmmalign
+  files:
+    - path: output/hmmer/test.prefix.sthlm.gz
+      md5sum: ddaa8b96291edf4e1a929a224329161b


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

The module output was prefixed with `meta.id` not `prefix`, fixed that, with a test.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
