### PR TITLE
epang: Missing .gz in output spec

### DIFF
--- a/modules/epang/main.nf
+++ b/modules/epang/main.nf
@@ -16,10 +16,10 @@ process EPANG {
     path binaryfile
 
     output:
-    tuple val(meta), path("./."), emit: epang   , optional: true
-    path "*.epa_result.jplace"  , emit: jplace  , optional: true
-    path "*.epa_info.log"       , emit: log
-    path "versions.yml"         , emit: versions
+    tuple val(meta), path("./.") , emit: epang   , optional: true
+    path "*.epa_result.jplace.gz", emit: jplace  , optional: true
+    path "*.epa_info.log"        , emit: log
+    path "versions.yml"          , emit: versions
 
     when:
     task.ext.when == null || task.ext.when


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

I had forgotten to add `.gz` to the output channel spec when changing the module to output gzipped files -- fixed.

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
