### PR TITLE
Multithreaded samtools commands

### DIFF
--- a/modules/samtools/ampliconclip/main.nf
+++ b/modules/samtools/ampliconclip/main.nf
@@ -31,6 +31,7 @@ process SAMTOOLS_AMPLICONCLIP {
     """
     samtools \\
         ampliconclip \\
+        --threads ${task.cpus-1} \\
         $args \\
         $rejects \\
         $stats \\

--- a/modules/samtools/depth/main.nf
+++ b/modules/samtools/depth/main.nf
@@ -23,6 +23,7 @@ process SAMTOOLS_DEPTH {
     """
     samtools \\
         depth \\
+        --threads ${task.cpus-1} \\
         $args \\
         -o ${prefix}.tsv \\
         $bam

--- a/modules/samtools/idxstats/main.nf
+++ b/modules/samtools/idxstats/main.nf
@@ -24,6 +24,7 @@ process SAMTOOLS_IDXSTATS {
     """
     samtools \\
         idxstats \\
+        --threads ${task.cpus-1} \\
         $bam \\
         > ${prefix}.idxstats
 

--- a/tests/modules/samtools/ampliconclip/test.yml
+++ b/tests/modules/samtools/ampliconclip/test.yml
@@ -5,7 +5,7 @@
     - samtools/ampliconclip
   files:
     - path: output/samtools/test.bam
-      md5sum: d270363a7fb3d96be2df211099efc75b
+      md5sum: 69e4ba713447864231f6cbbaf036c51d
 
 - name: samtools ampliconclip no stats with rejects
   command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_no_stats_with_rejects -c ./tests/config/nextflow.config -c ./tests/modules/samtools/ampliconclip/nextflow.config
@@ -14,9 +14,9 @@
     - samtools/ampliconclip
   files:
     - path: output/samtools/test.bam
-      md5sum: e7c4e64c259212e1670f6de96a5549b4
+      md5sum: dd2ed9d7cc4ddc070ece2dccc577f94b
     - path: output/samtools/test.cliprejects.bam
-      md5sum: b7c057b11950c2271a0c92236bee94b7
+      md5sum: 7d641f6da838f41d75eaabbd897f60bd
 
 - name: samtools ampliconclip with stats with rejects
   command: nextflow run ./tests/modules/samtools/ampliconclip -entry test_samtools_ampliconclip_with_stats_with_rejects -c ./tests/config/nextflow.config -c ./tests/modules/samtools/ampliconclip/nextflow.config
@@ -25,8 +25,8 @@
     - samtools/ampliconclip
   files:
     - path: output/samtools/test.bam
-      md5sum: e75992d4ff69cbaed9a089231be86b5e
+      md5sum: 6c19afc0873fba2f4e530eabf61c0735
     - path: output/samtools/test.cliprejects.bam
-      md5sum: 729f03e7a2801d2c56c32bef8f3d6ead
+      md5sum: 1dfb61aa80d8e90add324ed61ed17061
     - path: output/samtools/test.clipstats.txt
-      md5sum: fc23355e1743d47f2541f2cb1a7a0cda
+      md5sum: 05ead360a98fab6a678056e326c4f1f3


### PR DESCRIPTION
These three samtools commands are all multi-threaded, but it was not exposed in Nextflow

Following the convention of other samtools modules, there is a "minus 1" because of that description of the `--threads` option in the man page:
```
  -@, --threads INT
               Number of additional threads to use [0]
```

but I don't really know whether `--threads 1` will really make those commands use 2 CPUs

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
