### PR TITLE
cat/fastq: update conditional

### DIFF
--- a/modules/cat/fastq/main.nf
+++ b/modules/cat/fastq/main.nf
@@ -22,7 +22,7 @@ process CAT_FASTQ {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def readList = reads.collect{ it.toString() }
     if (meta.single_end) {
-        if (readList.size > 1) {
+        if (readList.size >= 1) {
             """
             cat ${readList.join(' ')} > ${prefix}.merged.fastq.gz
 
@@ -33,7 +33,7 @@ process CAT_FASTQ {
             """
         }
     } else {
-        if (readList.size > 2) {
+        if (readList.size >= 2) {
             def read1 = []
             def read2 = []
             readList.eachWithIndex{ v, ix -> ( ix & 1 ? read2 : read1 ) << v }


### PR DESCRIPTION
This patch fixes an issue where the script output is `null` when the number of files is equal to 1 (SE) or 2 (PE)

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
