### PR TITLE
bugfix: when there is a single input file, stageAs("?/*) returns the path directly, not in a list

### DIFF
--- a/modules/cat/fastq/main.nf
+++ b/modules/cat/fastq/main.nf
@@ -20,7 +20,7 @@ process CAT_FASTQ {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def readList = reads.collect{ it.toString() }
+    def readList = reads instanceof List ? reads.collect{ it.toString() } : [reads.toString()]
     if (meta.single_end) {
         if (readList.size >= 1) {
             """
@@ -51,7 +51,7 @@ process CAT_FASTQ {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def readList = reads.collect{ it.toString() }
+    def readList = reads instanceof List ? reads.collect{ it.toString() } : [reads.toString()]
     if (meta.single_end) {
         if (readList.size > 1) {
             """

--- a/modules/samtools/merge/main.nf
+++ b/modules/samtools/merge/main.nf
@@ -25,7 +25,7 @@ process SAMTOOLS_MERGE {
     script:
     def args = task.ext.args   ?: ''
     prefix   = task.ext.prefix ?: "${meta.id}"
-    def file_type = input_files[0].getExtension()
+    def file_type = input_files instanceof List ? input_files[0].getExtension() : input_files.getExtension()
     def reference = fasta ? "--reference ${fasta}" : ""
     """
     samtools \\
@@ -44,7 +44,7 @@ process SAMTOOLS_MERGE {
 
     stub:
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
-    def file_type = input_files[0].getExtension()
+    def file_type = input_files instanceof List ? input_files[0].getExtension() : input_files.getExtension()
     """
     touch ${prefix}.${file_type}
 


### PR DESCRIPTION
cf #1905 and https://nfcore.slack.com/archives/CJRH30T6V/p1658229950275629

Even though those input channels are intended to get multiple files, they may still get one. When this happens the input variable contains the path directly, rather than a size-1 list.
I searched all the nf-core modules that do this sort of `stageAs`, and fortunately there are only two that are vulnerable.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
