### PR TITLE
add qname feature to samtools/view

### DIFF
--- a/modules/samtools/view/main.nf
+++ b/modules/samtools/view/main.nf
@@ -10,6 +10,7 @@ process SAMTOOLS_VIEW {
     input:
     tuple val(meta), path(input), path(index)
     path fasta
+    path qname
 
     output:
     tuple val(meta), path("*.bam"),  emit: bam,     optional: true
@@ -27,6 +28,7 @@ process SAMTOOLS_VIEW {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def reference = fasta ? "--reference ${fasta}" : ""
+    def readnames = qname ? "--qname-file ${qname}": ""
     def file_type = args.contains("--output-fmt sam") ? "sam" :
                     args.contains("--output-fmt bam") ? "bam" :
                     args.contains("--output-fmt cram") ? "cram" :
@@ -37,6 +39,7 @@ process SAMTOOLS_VIEW {
         view \\
         --threads ${task.cpus-1} \\
         ${reference} \\
+        ${readnames} \\
         $args \\
         -o ${prefix}.${file_type} \\
         $input

--- a/modules/samtools/view/meta.yml
+++ b/modules/samtools/view/meta.yml
@@ -33,6 +33,10 @@ input:
       type: optional file
       description: Reference file the CRAM was created with
       pattern: "*.{fasta,fa}"
+  - qname:
+      type: optional file
+      description: File with read names to output only select alignments
+      pattern: "*.{txt,list}"
 output:
   - meta:
       type: map

--- a/modules/samtools/view/meta.yml
+++ b/modules/samtools/view/meta.yml
@@ -34,7 +34,7 @@ input:
       description: Reference file the CRAM was created with
       pattern: "*.{fasta,fa}"
   - qname:
-      type: optional file
+      type: file
       description: File with read names to output only select alignments
       pattern: "*.{txt,list}"
 output:

--- a/modules/samtools/view/meta.yml
+++ b/modules/samtools/view/meta.yml
@@ -35,7 +35,7 @@ input:
       pattern: "*.{fasta,fa}"
   - qname:
       type: file
-      description: File with read names to output only select alignments
+      description: Optional file with read names to output only select alignments
       pattern: "*.{txt,list}"
 output:
   - meta:

--- a/tests/modules/samtools/view/main.nf
+++ b/tests/modules/samtools/view/main.nf
@@ -10,7 +10,7 @@ workflow test_samtools_view {
                 []
             ]
 
-    SAMTOOLS_VIEW ( input, [] )
+    SAMTOOLS_VIEW ( input, [], [] )
 }
 
 workflow test_samtools_view_cram {
@@ -20,7 +20,7 @@ workflow test_samtools_view_cram {
             ]
     fasta   = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
 
-    SAMTOOLS_VIEW ( input, fasta )
+    SAMTOOLS_VIEW ( input, fasta, [] )
 }
 
 workflow test_samtools_view_convert {
@@ -30,7 +30,7 @@ workflow test_samtools_view_convert {
             ]
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
 
-    SAMTOOLS_VIEW ( input, fasta )
+    SAMTOOLS_VIEW ( input, fasta, [] )
 }
 
 workflow test_samtools_view_index {
@@ -40,7 +40,7 @@ workflow test_samtools_view_index {
             ]
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
 
-    SAMTOOLS_VIEW ( input, fasta )
+    SAMTOOLS_VIEW ( input, fasta, [] )
 }
 
 workflow test_samtools_view_stubs {
@@ -49,5 +49,5 @@ workflow test_samtools_view_stubs {
                 []
             ]
 
-    SAMTOOLS_VIEW ( input, [] )
+    SAMTOOLS_VIEW ( input, [], [] )
 }

--- a/tests/modules/samtools/view/main.nf
+++ b/tests/modules/samtools/view/main.nf
@@ -43,6 +43,18 @@ workflow test_samtools_view_index {
     SAMTOOLS_VIEW ( input, fasta, [] )
 }
 
+workflow test_samtools_view_filter {
+    input = [ [ id: 'test' ], // meta map
+                file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true),
+                []
+            ]
+    fasta = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+
+    qname = Channel.of("testN:2817", "testN:2814").collectFile(name: "readnames.list", newLine: true)
+
+    SAMTOOLS_VIEW ( input, fasta, qname )
+}
+
 workflow test_samtools_view_stubs {
     input = [ [ id:'test', single_end:false ], // meta map
                 file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true),

--- a/tests/modules/samtools/view/nextflow.config
+++ b/tests/modules/samtools/view/nextflow.config
@@ -10,4 +10,9 @@ process {
         ext.args = "--output-fmt bam --write-index"
     }
 
+    withName: 'test_samtools_view_filter:SAMTOOLS_VIEW' {
+        ext.args = "--output-fmt bam --write-index"
+    }
+
+
 }

--- a/tests/modules/samtools/view/test.yml
+++ b/tests/modules/samtools/view/test.yml
@@ -1,8 +1,8 @@
 - name: samtools view test_samtools_view
   command: nextflow run ./tests/modules/samtools/view -entry test_samtools_view -c ./tests/config/nextflow.config  -c ./tests/modules/samtools/view/nextflow.config
   tags:
-    - samtools
     - samtools/view
+    - samtools
   files:
     - path: output/samtools/test.bam
       md5sum: e6a9285be7b1c616dc4e17679fce5f1e
@@ -10,16 +10,16 @@
 - name: samtools view test_samtools_view_cram
   command: nextflow run ./tests/modules/samtools/view -entry test_samtools_view_cram -c ./tests/config/nextflow.config  -c ./tests/modules/samtools/view/nextflow.config
   tags:
-    - samtools
     - samtools/view
+    - samtools
   files:
     - path: output/samtools/test.cram
 
 - name: samtools view test_samtools_view_convert
   command: nextflow run ./tests/modules/samtools/view -entry test_samtools_view_convert -c ./tests/config/nextflow.config  -c ./tests/modules/samtools/view/nextflow.config
   tags:
-    - samtools
     - samtools/view
+    - samtools
   files:
     - path: output/samtools/test.bam
       md5sum: 4f4a97da17db79c78b1912da3cdc1d8f
@@ -27,8 +27,8 @@
 - name: samtools view test_samtools_view_index
   command: nextflow run ./tests/modules/samtools/view -entry test_samtools_view_index -c ./tests/config/nextflow.config  -c ./tests/modules/samtools/view/nextflow.config
   tags:
-    - samtools
     - samtools/view
+    - samtools
   files:
     - path: output/samtools/test.bam
       md5sum: b2d2482cea94adfc9628473792b0d215
@@ -38,8 +38,8 @@
 - name: samtools view test_samtools_view_stubs
   command: nextflow run ./tests/modules/samtools/view -entry test_samtools_view_stubs -c ./tests/config/nextflow.config  -c ./tests/modules/samtools/view/nextflow.config
   tags:
-    - samtools
     - samtools/view
+    - samtools
   files:
     - path: output/samtools/test.bam
       md5sum: e6a9285be7b1c616dc4e17679fce5f1e

--- a/tests/modules/samtools/view/test.yml
+++ b/tests/modules/samtools/view/test.yml
@@ -35,6 +35,17 @@
     - path: output/samtools/test.bam.csi
       md5sum: 343a2085b436cab2123147dafd255607
 
+- name: samtools view test_samtools_view_filter
+  command: nextflow run ./tests/modules/samtools/view -entry test_samtools_view_filter -c ./tests/config/nextflow.config  -c ./tests/modules/samtools/view/nextflow.config
+  tags:
+    - samtools/view
+    - samtools
+  files:
+    - path: output/samtools/test.bam
+      md5sum: d8e20876423cb1123a559e4347115249
+    - path: output/samtools/test.bam.csi
+      md5sum: b1d688576e59529271333aa50b3ad3ae
+
 - name: samtools view test_samtools_view_stubs
   command: nextflow run ./tests/modules/samtools/view -entry test_samtools_view_stubs -c ./tests/config/nextflow.config  -c ./tests/modules/samtools/view/nextflow.config
   tags:


### PR DESCRIPTION
`--qname` or `-N` flag with a read names list allows `samtools/view` to filter alignments

I could not figure out a test for the datasets available.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [x ] Follow the naming conventions.
- [ x] Follow the parameters requirements.
- [ x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
