### PR TITLE
Explicitly name the output files to avoid the gzi index being flown through the `output` channel

### DIFF
--- a/modules/tabix/bgzip/main.nf
+++ b/modules/tabix/bgzip/main.nf
@@ -11,9 +11,9 @@ process TABIX_BGZIP {
     tuple val(meta), path(input)
 
     output:
-    tuple val(meta), path("${prefix}*"), emit: output
-    tuple val(meta), path("*gzi")      , emit: gzi, optional: true
-    path  "versions.yml"               , emit: versions
+    tuple val(meta), path("${output}")    , emit: output
+    tuple val(meta), path("${output}.gzi"), emit: gzi, optional: true
+    path  "versions.yml"                  , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -21,12 +21,13 @@ process TABIX_BGZIP {
     script:
     def args = task.ext.args ?: ''
     prefix   = task.ext.prefix ?: "${meta.id}"
-    in_bgzip = input.toString().endsWith(".gz")
+    in_bgzip = ["gz", "bgz", "bgzf"].contains(input.getExtension())
+    output   = in_bgzip ? input.getBaseName() : "${prefix}.${input.getExtension()}.gz"
     command1 = in_bgzip ? '-d' : '-c'
-    command2 = in_bgzip ? ''   : " > ${prefix}.${input.getExtension()}.gz"
+    command2 = in_bgzip ? ''   : " > ${output}"
     // Name the index according to $prefix, unless a name has been requested
     if ((args.matches("(^| )-i\\b") || args.matches("(^| )--index(\$| )")) && !args.matches("(^| )-I\\b") && !args.matches("(^| )--index-name\\b")) {
-        args = args + " -I ${prefix}.${input.getExtension()}.gz.gzi"
+        args = args + " -I ${output}.gzi"
     }
     """
     bgzip $command1 $args -@${task.cpus} $input $command2


### PR DESCRIPTION
This is a fix for the issue I've mentioned on Slack (https://nfcore.slack.com/archives/CJRH30T6V/p1664528844937629)

The problem was that the `.gzi` file, when available, was flown through both output channels (`output` and `gzi`). I considered regular expressions as advised in the Slack thread, but it felt like it'd be a tricky regex to write.
Seeing the other discussion that I was referred to (about DeepVariant), I also had the idea of being more explicit about the file names I'm expecting, which is actually straightforward in the case of bgzip, since it simply removes the extension.

At the same time, I've added a few more valid bgzip extensions, cf https://github.com/samtools/htslib/blob/develop/bgzip.c#L82

I've tested locally that the output of the channels is correct. If you've got any idea how to embed those checks in the CI, I'm all open

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
