### PR TITLE
[stringtie/stringtie] make gtf input optional

### DIFF
--- a/modules/nf-core/stringtie/merge/meta.yml
+++ b/modules/nf-core/stringtie/merge/meta.yml
@@ -20,7 +20,7 @@ input:
   - annotation_gtf:
       type: file
       description: |
-        Annotation gtf file.
+        Annotation gtf file (optional).
       pattern: "*.gtf"
 output:
   - merged_gtf:

--- a/modules/nf-core/stringtie/stringtie/main.nf
+++ b/modules/nf-core/stringtie/stringtie/main.nf
@@ -9,7 +9,7 @@ process STRINGTIE_STRINGTIE {
 
     input:
     tuple val(meta), path(bam)
-    path  gtf
+    path  annotation_gtf
 
     output:
     tuple val(meta), path("*.coverage.gtf")   , emit: coverage_gtf
@@ -22,8 +22,9 @@ process STRINGTIE_STRINGTIE {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args      = task.ext.args ?: ''
+    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def reference = annotation_gtf ? "-G $annotation_gtf" : ""
 
     def strandedness = ''
     if (meta.strandedness == 'forward') {
@@ -35,7 +36,7 @@ process STRINGTIE_STRINGTIE {
     stringtie \\
         $bam \\
         $strandedness \\
-        -G $gtf \\
+        $reference \\
         -o ${prefix}.transcripts.gtf \\
         -A ${prefix}.gene.abundance.txt \\
         -C ${prefix}.coverage.gtf \\

--- a/modules/nf-core/stringtie/stringtie/main.nf
+++ b/modules/nf-core/stringtie/stringtie/main.nf
@@ -12,10 +12,10 @@ process STRINGTIE_STRINGTIE {
     path  annotation_gtf
 
     output:
-    tuple val(meta), path("*.coverage.gtf")   , emit: coverage_gtf
     tuple val(meta), path("*.transcripts.gtf"), emit: transcript_gtf
     tuple val(meta), path("*.abundance.txt")  , emit: abundance
-    tuple val(meta), path("*.ballgown")       , emit: ballgown
+    tuple val(meta), path("*.coverage.gtf")   , optional: true, emit: coverage_gtf
+    tuple val(meta), path("*.ballgown")       , optional: true, emit: ballgown
     path  "versions.yml"                      , emit: versions
 
     when:
@@ -25,6 +25,8 @@ process STRINGTIE_STRINGTIE {
     def args      = task.ext.args ?: ''
     def prefix    = task.ext.prefix ?: "${meta.id}"
     def reference = annotation_gtf ? "-G $annotation_gtf" : ""
+    def ballgown  = annotation_gtf ? "-b ${prefix}.ballgown" : ""
+    def coverage  = annotation_gtf ? "-C ${prefix}.coverage.gtf" : ""
 
     def strandedness = ''
     if (meta.strandedness == 'forward') {
@@ -39,8 +41,8 @@ process STRINGTIE_STRINGTIE {
         $reference \\
         -o ${prefix}.transcripts.gtf \\
         -A ${prefix}.gene.abundance.txt \\
-        -C ${prefix}.coverage.gtf \\
-        -b ${prefix}.ballgown \\
+        $coverage \\
+        $ballgown \\
         -p $task.cpus \\
         $args
 

--- a/modules/nf-core/stringtie/stringtie/meta.yml
+++ b/modules/nf-core/stringtie/stringtie/meta.yml
@@ -23,10 +23,10 @@ input:
       type: file
       description: |
         Stringtie transcript gtf output(s).
-  - gtf:
+  - annotation_gtf:
       type: file
       description: |
-        Annotation gtf file.
+        Annotation gtf file (optional).
 output:
   - meta:
       type: map

--- a/tests/modules/nf-core/stringtie/stringtie/main.nf
+++ b/tests/modules/nf-core/stringtie/stringtie/main.nf
@@ -3,10 +3,23 @@
 nextflow.enable.dsl = 2
 
 include { STRINGTIE_STRINGTIE } from '../../../../../modules/nf-core/stringtie/stringtie/main.nf'
+
 //
 // Test with forward strandedness
 //
 workflow test_stringtie_forward {
+    input = [
+        [ id:'test', strandedness:'forward' ], // meta map
+        [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ]
+    ]
+
+    STRINGTIE_STRINGTIE ( input, [] )
+}
+
+//
+// Test with forward strandedness and reference annotation
+//
+workflow test_stringtie_forward_annotation {
     input = [
         [ id:'test', strandedness:'forward' ], // meta map
         [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ]
@@ -20,6 +33,18 @@ workflow test_stringtie_forward {
 // Test with reverse strandedness
 //
 workflow test_stringtie_reverse {
+    input = [
+        [ id:'test', strandedness:'reverse' ], // meta map
+        [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ]
+    ]
+
+    STRINGTIE_STRINGTIE ( input, [] )
+}
+
+//
+// Test with reverse strandedness and reference annotation
+//
+workflow test_stringtie_reverse_annotation {
     input = [
         [ id:'test', strandedness:'reverse' ], // meta map
         [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ]

--- a/tests/modules/nf-core/stringtie/stringtie/test.yml
+++ b/tests/modules/nf-core/stringtie/stringtie/test.yml
@@ -6,6 +6,16 @@
   files:
     - path: ./output/stringtie/test.transcripts.gtf
     - path: ./output/stringtie/test.gene.abundance.txt
+      md5sum: d6f5c8cadb8458f1df0427cf790246e3
+
+- name: stringtie stringtie forward annotation
+  command: nextflow run ./tests/modules/nf-core/stringtie/stringtie/ -entry test_stringtie_forward_annotation -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/stringtie/stringtie/nextflow.config
+  tags:
+    - stringtie
+    - stringtie/stringtie
+  files:
+    - path: ./output/stringtie/test.transcripts.gtf
+    - path: ./output/stringtie/test.gene.abundance.txt
       md5sum: 7d8bce7f2a922e367cedccae7267c22e
     - path: ./output/stringtie/test.coverage.gtf
     - path: ./output/stringtie/test.ballgown/e_data.ctab
@@ -21,6 +31,16 @@
 
 - name: stringtie stringtie reverse
   command: nextflow run ./tests/modules/nf-core/stringtie/stringtie/ -entry test_stringtie_reverse -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/stringtie/stringtie/nextflow.config
+  tags:
+    - stringtie
+    - stringtie/stringtie
+  files:
+    - path: ./output/stringtie/test.transcripts.gtf
+    - path: ./output/stringtie/test.gene.abundance.txt
+      md5sum: d6f5c8cadb8458f1df0427cf790246e3
+
+- name: stringtie stringtie reverse annotation
+  command: nextflow run ./tests/modules/nf-core/stringtie/stringtie/ -entry test_stringtie_reverse_annotation -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/stringtie/stringtie/nextflow.config
   tags:
     - stringtie
     - stringtie/stringtie


### PR DESCRIPTION
As done in #2049 for `stringtie/merge`, this PR makes the GTF input optional (enables passing an empty list `[]` to not use a reference annotation during assembly).

Also, made the variable name consistent between `stringtie/merge` and `stringtie/stringtie`, and updated the `meta.yml` to reflect the changes.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
