### PR TITLE
check for successful command completion

### DIFF
--- a/modules/nf-core/biscuit/pileup/main.nf
+++ b/modules/nf-core/biscuit/pileup/main.nf
@@ -36,11 +36,11 @@ process BISCUIT_PILEUP {
         \$INDEX \\
         $input \\
         | bgzip -@ $bgzip_cpus $args2 > ${prefix}.vcf.gz
-    
-    # Pileup doesn't always exit with nonzero status in case of error. 
-    if grep -E "\\[main\\] Real time:" .command.err; then 
+
+    # Pileup doesn't always exit with nonzero status in case of error.
+    if grep -E "\\[main\\] Real time:" .command.err; then
         exit 0
-    else 
+    else
         exit 1
     fi
 

--- a/modules/nf-core/biscuit/pileup/main.nf
+++ b/modules/nf-core/biscuit/pileup/main.nf
@@ -36,6 +36,13 @@ process BISCUIT_PILEUP {
         \$INDEX \\
         $input \\
         | bgzip -@ $bgzip_cpus $args2 > ${prefix}.vcf.gz
+    
+    # Pileup doesn't always exit with nonzero status in case of error. 
+    if grep -E "\\[main\\] Real time:" .command.err; then 
+        exit 0
+    else 
+        exit 1
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Pileup might not always exit with non-zero status on errors. Add some bash to work around this.