### PR TITLE
subworkflow bcl_demultiplex: allow tarred inputs

### DIFF
--- a/subworkflows/nf-core/bcl_demultiplex/meta.yml
+++ b/subworkflows/nf-core/bcl_demultiplex/meta.yml
@@ -20,8 +20,8 @@ input:
       description: |
         CSV file containing information about samples to be demultiplexed in Illumina SampleSheet format
   - flowcell:
-      type: directory
-      description: Directory containing Illumina BCL data, sequencer output directory
+      type: file
+      description: Directory or tar archive containing Illumina BCL data, sequencer output directory
   - demultiplexer:
       type: string
       description: Which demultiplexer to use, bcl2fastq or bclconvert

--- a/tests/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/tests/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -12,15 +12,7 @@ workflow test_bcl_demultiplex_bclconvert {
             file(params.test_data['homo_sapiens']['illumina']['test_flowcell_samplesheet'], checkIfExists: true),
             file(params.test_data['homo_sapiens']['illumina']['test_flowcell'], checkIfExists: true)])
 
-    ch_flowcell
-    .multiMap { meta, ss, run ->
-        samplesheet: [meta, ss]
-        tar: [meta, run]
-    }.set{ ch_fc_split }
-
-    ch_flowcell_untar = ch_fc_split.samplesheet.join( UNTAR ( ch_fc_split.tar ).untar )
-
-    BCL_DEMULTIPLEX ( ch_flowcell_untar, "bclconvert" )
+    BCL_DEMULTIPLEX ( ch_flowcell, "bclconvert" )
 }
 
 workflow test_bcl_demultiplex_bcl2fastq {
@@ -30,13 +22,5 @@ workflow test_bcl_demultiplex_bcl2fastq {
             file(params.test_data['homo_sapiens']['illumina']['test_flowcell_samplesheet'], checkIfExists: true),
             file(params.test_data['homo_sapiens']['illumina']['test_flowcell'], checkIfExists: true)])
 
-    ch_flowcell
-    .multiMap { meta, ss, run ->
-        samplesheet: [meta, ss]
-        tar: [meta, run]
-    }.set{ ch_fc_split }
-
-    ch_flowcell_untar = ch_fc_split.samplesheet.join( UNTAR ( ch_fc_split.tar ).untar )
-
-    BCL_DEMULTIPLEX ( ch_flowcell_untar, "bcl2fastq" )
+    BCL_DEMULTIPLEX ( ch_flowcell, "bcl2fastq" )
 }


### PR DESCRIPTION
Allow tar archives as bcl dir.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
