### PR TITLE
Let DESeq2 module be flexible with CSV/ TSV, and use semicolons in blocking field

### DIFF
--- a/modules/nf-core/deseq2/differential/meta.yml
+++ b/modules/nf-core/deseq2/differential/meta.yml
@@ -19,11 +19,11 @@ input:
   - sample:
       type: file
       description: |
-        CSV-format sample sheet with sample metadata
+        CSV or TSV format sample sheet with sample metadata
   - counts:
       type: file
       description: |
-        Raw TSV-format expression matrix as output from the nf-core RNA-seq workflow
+        Raw TSV or CSV format expression matrix as output from the nf-core RNA-seq workflow
   - contrast_meta:
       type: map
       description: |

--- a/modules/nf-core/deseq2/differential/templates/deseq_de.R
+++ b/modules/nf-core/deseq2/differential/templates/deseq_de.R
@@ -28,23 +28,23 @@ parse_args <- function(x){
 #' @return output Data frame
 
 read_delim_flexible <- function(file, header = TRUE, row.names = NULL){
-  
-  ext <- tolower(tail(strsplit(basename(file), split = "\\\\.")[[1]], 1))
-  
-  if (ext == "tsv" || ext == "txt") {
-    separator <- "\\t"
-  } else if (ext == "csv") {
-    separator <- ","
-  } else {
-    stop(paste("Unknown separator for", ext))
-  }
-    
-  read.delim(
-    file,
-    sep = separator,
-    header = header,
-    row.names = row.names
-  )
+
+    ext <- tolower(tail(strsplit(basename(file), split = "\\\\.")[[1]], 1))
+
+    if (ext == "tsv" || ext == "txt") {
+        separator <- "\\t"
+    } else if (ext == "csv") {
+        separator <- ","
+    } else {
+        stop(paste("Unknown separator for", ext))
+    }
+
+    read.delim(
+        file,
+        sep = separator,
+        header = header,
+        row.names = row.names
+    )
 }
 
 ################################################
@@ -124,7 +124,7 @@ library(BiocParallel)
 ################################################
 
 count.table <-
-  read_delim_flexible(
+    read_delim_flexible(
         file = opt\$count_file,
         header = TRUE,
         row.names = opt\$gene_id_col

--- a/tests/modules/nf-core/deseq2/differential/main.nf
+++ b/tests/modules/nf-core/deseq2/differential/main.nf
@@ -40,6 +40,8 @@ workflow test_deseq2_differential {
     )
 }
 
+// This second test checks that a CSV format matrix works the same as a TSV one
+
 workflow test_deseq2_differential_csv {
 
     expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true)

--- a/tests/modules/nf-core/deseq2/differential/main.nf
+++ b/tests/modules/nf-core/deseq2/differential/main.nf
@@ -4,22 +4,58 @@ nextflow.enable.dsl = 2
 
 include { DESEQ2_DIFFERENTIAL } from '../../../../../modules/nf-core/deseq2/differential/main.nf'
 
+process tsv_to_csv {
+
+    input:
+    path expression_matrix
+
+    output:
+    path 'test.csv'
+
+    script:
+    """
+    sed 's/\t/,/g' ${expression_matrix} > test.csv.tmp
+    mv test.csv.tmp test.csv
+    """
+
+}
+
 workflow test_deseq2_differential {
 
-    expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true) 
-    expression_matrix_file = file(params.test_data['mus_musculus']['genome']['rnaseq_matrix'], checkIfExists: true) 
-    expression_contrasts = file(params.test_data['mus_musculus']['genome']['rnaseq_contrasts'], checkIfExists: true) 
+    expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true)
+    expression_matrix_file = file(params.test_data['mus_musculus']['genome']['rnaseq_matrix'], checkIfExists: true)
+    expression_contrasts = file(params.test_data['mus_musculus']['genome']['rnaseq_contrasts'], checkIfExists: true)
 
     Channel.fromPath(expression_contrasts)
-        .splitCsv ( header:true, sep:',' )  
+        .splitCsv ( header:true, sep:',' )
         .map{
             tuple(it, expression_sample_sheet, expression_matrix_file)
         }
         .set{
             input
-        }      
+        }
 
     DESEQ2_DIFFERENTIAL (
-        input        
+        input
+    )
+}
+
+workflow test_deseq2_differential_csv {
+
+    expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true)
+    expression_matrix_file = file(params.test_data['mus_musculus']['genome']['rnaseq_matrix'], checkIfExists: true)
+    expression_contrasts = file(params.test_data['mus_musculus']['genome']['rnaseq_contrasts'], checkIfExists: true)
+
+
+    ch_samples_and_matrix  = tsv_to_csv(expression_matrix_file)
+        .map{
+            tuple(expression_sample_sheet, it)
+        }
+
+    ch_contrasts = Channel.fromPath(expression_contrasts)
+        .splitCsv ( header:true, sep:',' )
+
+    DESEQ2_DIFFERENTIAL (
+        ch_contrasts.combine(ch_samples_and_matrix)
     )
 }

--- a/tests/modules/nf-core/deseq2/differential/nextflow.config
+++ b/tests/modules/nf-core/deseq2/differential/nextflow.config
@@ -5,5 +5,8 @@ process {
     withName: 'test_deseq2_differential:DESEQ2_DIFFERENTIAL' {
         ext.args = "--vs_method rlog"
     }
+    withName: 'test_deseq2_differential_csv:DESEQ2_DIFFERENTIAL' {
+        ext.args = "--vs_method rlog"
+    }
 
 }

--- a/tests/modules/nf-core/deseq2/differential/test.yml
+++ b/tests/modules/nf-core/deseq2/differential/test.yml
@@ -20,3 +20,28 @@
       md5sum: 827cdf01f366d72d6e4b500e9862ba74
     - path: output/deseq2/treatment-mCherry-hND6.rlog.tsv
       md5sum: 8b674051048e826a59aec97aba752e78
+
+- name: deseq2 differential test_deseq2_differential_csv
+  command: nextflow run ./tests/modules/nf-core/deseq2/differential -entry test_deseq2_differential_csv -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/deseq2/differential/nextflow.config
+  tags:
+    - deseq2
+    - deseq2/differential
+  files:
+    - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.results.tsv
+      md5sum: 2402bf409e0497674374528728591059
+    - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.sizefactors.tsv
+      md5sum: 6332f21889ecac387bb12eeb04f23849
+    - path: output/deseq2/treatment-mCherry-hND6-sample_number.normalised_counts.tsv
+      md5sum: 827cdf01f366d72d6e4b500e9862ba74
+    - path: output/deseq2/treatment-mCherry-hND6-sample_number.rlog.tsv
+      md5sum: 8b674051048e826a59aec97aba752e78
+    - path: output/deseq2/treatment-mCherry-hND6.deseq2.results.tsv
+      md5sum: 269cdbe2b9c18393b448dd435e7f5c9a
+    - path: output/deseq2/treatment-mCherry-hND6.deseq2.sizefactors.tsv
+      md5sum: 6332f21889ecac387bb12eeb04f23849
+    - path: output/deseq2/treatment-mCherry-hND6.normalised_counts.tsv
+      md5sum: 827cdf01f366d72d6e4b500e9862ba74
+    - path: output/deseq2/treatment-mCherry-hND6.rlog.tsv
+      md5sum: 8b674051048e826a59aec97aba752e78
+    - path: output/tsv/test.csv
+      md5sum: f8e51c79c9add0d07eb46aba6a09d33c


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

This PR:

- Adds a basic method for being flexible with input files (CSV or TSV). There's a lot of inconsistency in what's used, and maybe it's better if the module is just flexible. This makes it respond to file extensions.
- Fixes a previous assumption about a comma-separated field in a comma-separated file. I think it's better if the blocking definition is semicolon-separated where multiple values are supplied, so that things don't break when that is stored in a CSV file like [the example](https://github.com/nf-core/test-datasets/blob/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.contrasts.csv).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
