### PR TITLE
Pass variance stabilisation options for DESeq2

### DIFF
--- a/modules/nf-core/deseq2/differential/templates/deseq_de.R
+++ b/modules/nf-core/deseq2/differential/templates/deseq_de.R
@@ -338,7 +338,7 @@ for (vs_method_name in strsplit(opt\$vs_method, ',')){
     }else if (vs_method_name == 'rlog'){
         vs_mat <- rlog(dds, blind = opt\$vs_blind, fitType = opt\$fit_type)
     }
-    
+
     write.table(
         format(data.frame(gene_id=rownames(counts(dds)), assay(vs_mat)), nsmall = 8),
         file = paste(output_prefix, vs_method_name,'tsv', sep = '.'),

--- a/modules/nf-core/deseq2/differential/templates/deseq_de.R
+++ b/modules/nf-core/deseq2/differential/templates/deseq_de.R
@@ -81,7 +81,9 @@ opt <- list(
     minmu = 0.5,
     vs_method = 'vst', # 'rlog', 'vst', or 'rlog,vst'
     shrink_lfc = TRUE,
-    cores = 1
+    cores = 1,
+    vs_blind = TRUE,
+    vst_nsub = 1000
 )
 opt_types <- lapply(opt, class)
 
@@ -331,9 +333,14 @@ write.table(
 # Note very limited rounding for consistency of results
 
 for (vs_method_name in strsplit(opt\$vs_method, ',')){
-    vs_func <- get(vs_method_name)
+    if (vs_method_name == 'vst'){
+        vs_mat <- vst(dds, blind = opt\$vs_blind, nsub = opt\$vst_nsub)
+    }else if (vs_method_name == 'rlog'){
+        vs_mat <- rlog(dds, blind = opt\$vs_blind, fitType = opt\$fit_type)
+    }
+    
     write.table(
-        format(data.frame(gene_id=rownames(counts(dds)), assay(vs_func(dds))), nsmall = 8),
+        format(data.frame(gene_id=rownames(counts(dds)), assay(vs_mat)), nsmall = 8),
         file = paste(output_prefix, vs_method_name,'tsv', sep = '.'),
         col.names = TRUE,
         row.names = FALSE,

--- a/tests/modules/nf-core/deseq2/differential/main.nf
+++ b/tests/modules/nf-core/deseq2/differential/main.nf
@@ -61,3 +61,25 @@ workflow test_deseq2_differential_csv {
         ch_contrasts.combine(ch_samples_and_matrix)
     )
 }
+
+// Test vst with modified nsub
+
+workflow test_deseq2_differential_vst_nsub {
+
+    expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true)
+    expression_matrix_file = file(params.test_data['mus_musculus']['genome']['rnaseq_matrix'], checkIfExists: true)
+    expression_contrasts = file(params.test_data['mus_musculus']['genome']['rnaseq_contrasts'], checkIfExists: true)
+
+    Channel.fromPath(expression_contrasts)
+        .splitCsv ( header:true, sep:',' )
+        .map{
+            tuple(it, expression_sample_sheet, expression_matrix_file)
+        }
+        .set{
+            input
+        }
+
+    DESEQ2_DIFFERENTIAL (
+        input
+    )
+}

--- a/tests/modules/nf-core/deseq2/differential/nextflow.config
+++ b/tests/modules/nf-core/deseq2/differential/nextflow.config
@@ -8,5 +8,8 @@ process {
     withName: 'test_deseq2_differential_csv:DESEQ2_DIFFERENTIAL' {
         ext.args = "--vs_method rlog"
     }
+    withName: 'test_deseq2_differential_vst_nsub:DESEQ2_DIFFERENTIAL' {
+        ext.args = "--vs_method vst --vst_nsub 500"
+    }
 
 }

--- a/tests/modules/nf-core/deseq2/differential/test.yml
+++ b/tests/modules/nf-core/deseq2/differential/test.yml
@@ -45,3 +45,26 @@
       md5sum: 8b674051048e826a59aec97aba752e78
     - path: output/tsv/test.csv
       md5sum: f8e51c79c9add0d07eb46aba6a09d33c
+
+- name: deseq2 differential test_deseq2_differential_vst_nsub
+  command: nextflow run ./tests/modules/nf-core/deseq2/differential -entry test_deseq2_differential_vst_nsub -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/deseq2/differential/nextflow.config
+  tags:
+    - deseq2
+    - deseq2/differential
+  files:
+    - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.results.tsv
+      md5sum: 2402bf409e0497674374528728591059
+    - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.sizefactors.tsv
+      md5sum: 6332f21889ecac387bb12eeb04f23849
+    - path: output/deseq2/treatment-mCherry-hND6-sample_number.normalised_counts.tsv
+      md5sum: 827cdf01f366d72d6e4b500e9862ba74
+    - path: output/deseq2/treatment-mCherry-hND6-sample_number.vst.tsv
+      md5sum: 53a74c2e7fd188e7236055d5e6af769a
+    - path: output/deseq2/treatment-mCherry-hND6.deseq2.results.tsv
+      md5sum: 269cdbe2b9c18393b448dd435e7f5c9a
+    - path: output/deseq2/treatment-mCherry-hND6.deseq2.sizefactors.tsv
+      md5sum: 6332f21889ecac387bb12eeb04f23849
+    - path: output/deseq2/treatment-mCherry-hND6.normalised_counts.tsv
+      md5sum: 827cdf01f366d72d6e4b500e9862ba74
+    - path: output/deseq2/treatment-mCherry-hND6.vst.tsv
+      md5sum: 53a74c2e7fd188e7236055d5e6af769a


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

As highlighted by @WackerO, we need to be able to pass some important options to e.g. `vst()` when running the DESeq2 module. I've added the passing of options, and a test to make sure VST works.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
