### PR TITLE
update aligner postalign step

### DIFF
--- a/modules/nf-core/bowtie/align/main.nf
+++ b/modules/nf-core/bowtie/align/main.nf
@@ -37,7 +37,7 @@ process BOWTIE_ALIGN {
         $args \\
         $endedness \\
         2> ${prefix}.out \\
-        | samtools view $args2 -@ $task.cpus -bS -o ${prefix}.bam -
+        | samtools view $args2 -@ $task.cpus -bS -o ${prefix}.bam
 
     if [ -f ${prefix}.unmapped.fastq ]; then
         gzip ${prefix}.unmapped.fastq

--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -51,7 +51,7 @@ process BOWTIE2_ALIGN {
         $unaligned \\
         $args \\
         2> ${prefix}.bowtie2.log \\
-        | samtools $samtools_command $args2 --threads $task.cpus -o ${prefix}.bam -
+        | samtools $samtools_command $args2 --threads $task.cpus -o ${prefix}.bam
 
     if [ -f ${prefix}.unmapped.fastq.1.gz ]; then
         mv ${prefix}.unmapped.fastq.1.gz ${prefix}.unmapped_1.fastq.gz

--- a/modules/nf-core/bwa/mem/main.nf
+++ b/modules/nf-core/bwa/mem/main.nf
@@ -32,7 +32,7 @@ process BWA_MEM {
         -t $task.cpus \\
         \$INDEX \\
         $reads \\
-        | samtools $samtools_command $args2 --threads $task.cpus -o ${prefix}.bam -
+        | samtools $samtools_command $args2 --threads $task.cpus -o ${prefix}.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bwa/sampe/main.nf
+++ b/modules/nf-core/bwa/sampe/main.nf
@@ -31,7 +31,7 @@ process BWA_SAMPE {
         $read_group \\
         \$INDEX \\
         $sai \\
-        $reads | samtools sort -@ ${task.cpus - 1} -O bam - > ${prefix}.bam
+        $reads | samtools sort -@ ${task.cpus - 1} -O bam > ${prefix}.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bwa/samse/main.nf
+++ b/modules/nf-core/bwa/samse/main.nf
@@ -31,7 +31,7 @@ process BWA_SAMSE {
         $read_group \\
         \$INDEX \\
         $sai \\
-        $reads | samtools sort -@ ${task.cpus - 1} -O bam - > ${prefix}.bam
+        $reads | samtools sort -@ ${task.cpus - 1} -O bam > ${prefix}.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bwamem2/mem/main.nf
+++ b/modules/nf-core/bwamem2/mem/main.nf
@@ -33,7 +33,7 @@ process BWAMEM2_MEM {
         -t $task.cpus \\
         \$INDEX \\
         $reads \\
-        | samtools $samtools_command $args2 -@ $task.cpus -o ${prefix}.bam -
+        | samtools $samtools_command $args2 -@ $task.cpus -o ${prefix}.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bwameth/align/main.nf
+++ b/modules/nf-core/bwameth/align/main.nf
@@ -36,7 +36,7 @@ process BWAMETH_ALIGN {
         -t $task.cpus \\
         --reference \$INDEX \\
         $reads \\
-        | samtools view $args2 -@ $task.cpus -bhS -o ${prefix}.bam -
+        | samtools view $args2 -@ $task.cpus -bhS -o ${prefix}.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/dragmap/align/main.nf
+++ b/modules/nf-core/dragmap/align/main.nf
@@ -34,7 +34,7 @@ process DRAGMAP_ALIGN {
         --num-threads $task.cpus \\
         $reads_command \\
         2> ${prefix}.dragmap.log \\
-        | samtools $samtools_command $args2 --threads $task.cpus -o ${prefix}.bam -
+        | samtools $samtools_command $args2 --threads $task.cpus -o ${prefix}.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
This PR edits the `samtools` call that's run post alignment and omit the explicit stdin (`- `).

I've got no idea how or why, but when using `-` the process gets an OOM and by omitting it runs fine.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
