### PR TITLE
Add meta to fasta reference and index of chromap modules

### DIFF
--- a/modules/nf-core/chromap/chromap/main.nf
+++ b/modules/nf-core/chromap/chromap/main.nf
@@ -9,8 +9,8 @@ process CHROMAP_CHROMAP {
 
     input:
     tuple val(meta), path(reads)
-    tuple val(meta2), path (fasta)
-    tuple val(meta3), path(index)
+    path fasta
+    tuple val(meta2), path(index)
     path barcodes
     path whitelist
     path chr_order

--- a/modules/nf-core/chromap/chromap/main.nf
+++ b/modules/nf-core/chromap/chromap/main.nf
@@ -9,8 +9,8 @@ process CHROMAP_CHROMAP {
 
     input:
     tuple val(meta), path(reads)
-    path fasta
-    path index
+    tuple val(meta2), path (fasta)
+    tuple val(meta3), path(index)
     path barcodes
     path whitelist
     path chr_order

--- a/modules/nf-core/chromap/chromap/main.nf
+++ b/modules/nf-core/chromap/chromap/main.nf
@@ -9,7 +9,7 @@ process CHROMAP_CHROMAP {
 
     input:
     tuple val(meta), path(reads)
-    path fasta
+    tuple val(meta2), path(fasta)
     tuple val(meta2), path(index)
     path barcodes
     path whitelist

--- a/modules/nf-core/chromap/chromap/meta.yml
+++ b/modules/nf-core/chromap/chromap/meta.yml
@@ -33,10 +33,20 @@ input:
       description: |
         List of input FastQ files of size 1 and 2 for single-end and paired-end data,
         respectively.
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
   - fasta:
       type: file
       description: |
         The fasta reference file.
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
   - index:
       type: file
       description: |
@@ -86,3 +96,4 @@ output:
 
 authors:
   - "@mahesh-panchal"
+  - "@joseespinosa"

--- a/modules/nf-core/chromap/chromap/meta.yml
+++ b/modules/nf-core/chromap/chromap/meta.yml
@@ -33,16 +33,11 @@ input:
       description: |
         List of input FastQ files of size 1 and 2 for single-end and paired-end data,
         respectively.
-  - meta2:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test' ]
   - fasta:
       type: file
       description: |
         The fasta reference file.
-  - meta3:
+  - meta2:
       type: map
       description: |
         Groovy Map containing sample information

--- a/modules/nf-core/chromap/chromap/meta.yml
+++ b/modules/nf-core/chromap/chromap/meta.yml
@@ -33,15 +33,15 @@ input:
       description: |
         List of input FastQ files of size 1 and 2 for single-end and paired-end data,
         respectively.
-  - fasta:
-      type: file
-      description: |
-        The fasta reference file.
   - meta2:
       type: map
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test' ]
+  - fasta:
+      type: file
+      description: |
+        The fasta reference file.
   - index:
       type: file
       description: |

--- a/modules/nf-core/chromap/index/main.nf
+++ b/modules/nf-core/chromap/index/main.nf
@@ -8,11 +8,11 @@ process CHROMAP_INDEX {
         'quay.io/biocontainers/chromap:0.2.1--hd03093a_0' }"
 
     input:
-    path fasta
+    tuple val(meta), path(fasta)
 
     output:
-    path "*.index"     , emit: index
-    path "versions.yml", emit: versions
+    tuple val(meta), path ("*.index"), emit: index
+    path "versions.yml"              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/chromap/index/meta.yml
+++ b/modules/nf-core/chromap/index/meta.yml
@@ -15,6 +15,11 @@ tools:
       licence: ["GPL v3"]
 
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
   - fasta:
       type: file
       description: Fasta reference file.
@@ -24,6 +29,11 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
   - index:
       type: file
       description: Index file of the reference genome
@@ -31,3 +41,4 @@ output:
 
 authors:
   - "@mahesh-panchal"
+  - "@joseespinosa"

--- a/tests/modules/nf-core/chromap/chromap/main.nf
+++ b/tests/modules/nf-core/chromap/chromap/main.nf
@@ -15,7 +15,10 @@ workflow test_chromap_chromap_single_end {
             file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
 
     CHROMAP_INDEX ( fasta )
     CHROMAP_CHROMAP_BASE (
@@ -39,7 +42,10 @@ workflow test_chromap_chromap_paired_end {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
 
     CHROMAP_INDEX ( fasta )
     CHROMAP_CHROMAP_BASE (
@@ -63,7 +69,10 @@ workflow test_chromap_chromap_paired_bam {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
 
     CHROMAP_INDEX ( fasta )
     CHROMAP_CHROMAP_SAM (

--- a/tests/modules/nf-core/chromap/chromap/main.nf
+++ b/tests/modules/nf-core/chromap/chromap/main.nf
@@ -15,15 +15,16 @@ workflow test_chromap_chromap_single_end {
             file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta = [
+    fasta_index = [
         [ id:'test' ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
+    fasta_map = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    CHROMAP_INDEX ( fasta )
+    CHROMAP_INDEX ( fasta_index )
     CHROMAP_CHROMAP_BASE (
         input,                      // meta + read data
-        fasta,                      // reference genome
+        fasta_map,                      // reference genome
         CHROMAP_INDEX.out.index,    // reference index
         [],                         // barcode file
         [],                         // barcode whitelist
@@ -42,15 +43,16 @@ workflow test_chromap_chromap_paired_end {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta = [
+    fasta_index = [
         [ id:'test' ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
+    fasta_map = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
     CHROMAP_INDEX ( fasta )
     CHROMAP_CHROMAP_BASE (
         input,                      // meta + read data
-        fasta,                      // reference genome
+        fasta_map,                      // reference genome
         CHROMAP_INDEX.out.index,    // reference index
         [],                         // barcode file
         [],                         // barcode whitelist
@@ -69,15 +71,16 @@ workflow test_chromap_chromap_paired_bam {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta = [
+    fasta_index = [
         [ id:'test' ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
+    fasta_map = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    CHROMAP_INDEX ( fasta )
+    CHROMAP_INDEX ( fasta_index )
     CHROMAP_CHROMAP_SAM (
         input,                      // meta + read data
-        fasta,                      // reference genome
+        fasta_map,                      // reference genome
         CHROMAP_INDEX.out.index,    // reference index
         [],                         // barcode file
         [],                         // barcode whitelist

--- a/tests/modules/nf-core/chromap/chromap/main.nf
+++ b/tests/modules/nf-core/chromap/chromap/main.nf
@@ -15,16 +15,15 @@ workflow test_chromap_chromap_single_end {
             file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta_index = [
+    fasta = [
         [ id:'test' ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
-    fasta_map = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    CHROMAP_INDEX ( fasta_index )
+    CHROMAP_INDEX ( fasta )
     CHROMAP_CHROMAP_BASE (
         input,                      // meta + read data
-        fasta_map,                      // reference genome
+        fasta,                      // reference genome
         CHROMAP_INDEX.out.index,    // reference index
         [],                         // barcode file
         [],                         // barcode whitelist
@@ -43,16 +42,15 @@ workflow test_chromap_chromap_paired_end {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta_index = [
+    fasta = [
         [ id:'test' ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
-    fasta_map = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
     CHROMAP_INDEX ( fasta )
     CHROMAP_CHROMAP_BASE (
         input,                      // meta + read data
-        fasta_map,                      // reference genome
+        fasta,                      // reference genome
         CHROMAP_INDEX.out.index,    // reference index
         [],                         // barcode file
         [],                         // barcode whitelist
@@ -71,16 +69,15 @@ workflow test_chromap_chromap_paired_bam {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
-    fasta_index = [
+    fasta = [
         [ id:'test' ], // meta map
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
-    fasta_map = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
 
-    CHROMAP_INDEX ( fasta_index )
+    CHROMAP_INDEX ( fasta )
     CHROMAP_CHROMAP_SAM (
         input,                      // meta + read data
-        fasta_map,                      // reference genome
+        fasta,                      // reference genome
         CHROMAP_INDEX.out.index,    // reference index
         [],                         // barcode file
         [],                         // barcode whitelist

--- a/tests/modules/nf-core/chromap/index/main.nf
+++ b/tests/modules/nf-core/chromap/index/main.nf
@@ -6,7 +6,10 @@ include { CHROMAP_INDEX } from '../../../../../modules/nf-core/chromap/index/mai
 
 workflow test_chromap_index {
 
-    input = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    input = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
 
     CHROMAP_INDEX ( input )
 }


### PR DESCRIPTION
As requested on #2414 add meta to reference channels of chromap modules.

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
