### PR TITLE
Fix yml structure info in fastq_align_chromap subworkflow

### DIFF
--- a/subworkflows/nf-core/fastq_align_chromap/meta.yml
+++ b/subworkflows/nf-core/fastq_align_chromap/meta.yml
@@ -25,9 +25,9 @@ input:
   - ch_reads:
       type: file
       description: |
+        Structure: [val(meta), path(reads)]
         List of input FastQ files of size 1 and 2 for single-end and paired-end data,
         respectively.
-      structure: [val(meta), path(reads)]
   - meta2:
       type: map
       description: |
@@ -36,35 +36,35 @@ input:
   - ch_index:
       type: file
       description: |
+        Structure: [val(meta2), path(index)]
         Chromap genome index files
-      structure: [val(meta2), path(index)]
       pattern: "*.index"
   - ch_fasta:
       type: file
       description: |
+        Structure: [val(meta2), path(fasta)]
         Reference fasta file
-      structure: [val(meta2), path(fasta)]
       pattern: "*.{fasta,fa}"
   - ch_barcodes:
       type: file
       description: |
+        Structure: [path(barcodes)]
         Cell barcode files
-      structure: [path(barcodes)]
   - ch_whitelist:
       type: file
       description: |
+        Structure: [path(whitelist)]
         Cell barcode whitelist file
-      structure: [path(whitelist)]
   - ch_chr_order:
       type: file
       description: |
+        Structure: [path(chr_order)]
         Custom chromosome order
-      structure: [path(chr_order)]
   - ch_pairs_chr_order:
       type: file
       description: |
+        Structure: [path(pairs_chr_order)]
         Natural chromosome order for pairs flipping
-      structure: [path(pairs_chr_order)]
 output:
   - meta:
       type: map


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!
See this comment: https://github.com/nf-core/modules/pull/2426/files#r1012600269
By the moment I revert it to be consistent with the rest of subworkflows.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Follow the naming conventions.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
