### PR TITLE
_files directories not needed for plots in shinyngs modules

### DIFF
--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -12,7 +12,7 @@ process SHINYNGS_STATICDIFFERENTIAL {
     tuple val(meta2), path(sample), path(feature_meta), path(assay_file)    // Experiment-level info
 
     output:
-    tuple val(meta), path("*/png/volcano.png"), path("*/html/volcano.html"), path("*/html/volcano_files")   , emit: volcanos
+    tuple val(meta), path("*/png/volcano.png"), path("*/html/volcano.html")                                 , emit: volcanos
     path "versions.yml"                                                                                     , emit: versions
 
     when:

--- a/modules/nf-core/shinyngs/staticdifferential/meta.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/meta.yml
@@ -53,8 +53,8 @@ output:
   - volcanos:
       type: tuple
       description: |
-        Meta-keyed tuple containing a PNG, HTML, and HTML files directory for
-        a volcano plot built from the differential result table.
+        Meta-keyed tuple containing a PNG and HTML plot for a volcano plot
+        built from the differential result table.
   - versions:
       type: file
       description: File containing software versions

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -11,13 +11,13 @@ process SHINYNGS_STATICEXPLORATORY {
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)
 
     output:
-    tuple val(meta), path("*/png/boxplot.png"), path("*/html/boxplot.html"), path("*/html/boxplot_files")                         , emit: boxplots
-    tuple val(meta), path("*/png/density.png"), path("*/html/density.html"), path("*/html/density_files")                         , emit: densities
-    tuple val(meta), path("*/png/pca2d.png"), path("*/html/pca2d.html"), path("*/html/pca2d_files")                               , emit: pca2d
-    tuple val(meta), path("*/png/pca3d.png"), path("*/html/pca3d.html"), path("*/html/pca3d_files")                               , emit: pca3d
-    tuple val(meta), path("*/png/mad_correlation.png"), path("*/html/mad_correlation.html"), path("*/html/mad_correlation_files") , emit: mad
-    tuple val(meta), path("*/png/sample_dendrogram.png")                                                                          , emit: dendro
-    path "versions.yml"                                                                                                           , emit: versions
+    tuple val(meta), path("*/png/boxplot.png"), path("*/html/boxplot.html")                 , emit: boxplots
+    tuple val(meta), path("*/png/density.png"), path("*/html/density.html")                 , emit: densities
+    tuple val(meta), path("*/png/pca2d.png"), path("*/html/pca2d.html")                     , emit: pca2d
+    tuple val(meta), path("*/png/pca3d.png"), path("*/html/pca3d.html"),                    , emit: pca3d
+    tuple val(meta), path("*/png/mad_correlation.png"), path("*/html/mad_correlation.html") , emit: mad
+    tuple val(meta), path("*/png/sample_dendrogram.png")                                    , emit: dendro
+    path "versions.yml"                                                                     , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -14,7 +14,7 @@ process SHINYNGS_STATICEXPLORATORY {
     tuple val(meta), path("*/png/boxplot.png"), path("*/html/boxplot.html")                 , emit: boxplots
     tuple val(meta), path("*/png/density.png"), path("*/html/density.html")                 , emit: densities
     tuple val(meta), path("*/png/pca2d.png"), path("*/html/pca2d.html")                     , emit: pca2d
-    tuple val(meta), path("*/png/pca3d.png"), path("*/html/pca3d.html"),                    , emit: pca3d
+    tuple val(meta), path("*/png/pca3d.png"), path("*/html/pca3d.html")                     , emit: pca3d
     tuple val(meta), path("*/png/mad_correlation.png"), path("*/html/mad_correlation.html") , emit: mad
     tuple val(meta), path("*/png/sample_dendrogram.png")                                    , emit: dendro
     path "versions.yml"                                                                     , emit: versions

--- a/modules/nf-core/shinyngs/staticexploratory/meta.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/meta.yml
@@ -37,31 +37,31 @@ output:
   - boxplots:
       type: tuple
       description: |
-        Meta-keyed tuple containing a PNG, HTML, and HTML files directory for
-        box plots covering input matrices.
+        Meta-keyed tuple containing a PNG and HTML output for box plots
+        covering input matrices.
   - densities:
       type: tuple
       description: |
-        Meta-keyed tuple containing a PNG, HTML, and HTML files directory for
-        density plots covering input matrices.
+        Meta-keyed tuple containing a PNG and HTML output for density plots
+        covering input matrices.
   - pca2d:
       type: tuple
       description: |
-        Meta-keyed tuple containing a PNG, HTML, and HTML files directory for
-        2D PCA plots covering specified input matrix (by default the last one
-        in the input list.
+        Meta-keyed tuple containing a PNG and HTML plot for 2D PCA plots
+        covering specified input matrix (by default the last one in the input
+        list.
   - pca3d:
       type: tuple
       description: |
-        Meta-keyed tuple containing a PNG, HTML, and HTML files directory for
-        3D PCA plots covering specified input matrix (by default the last one
-        in the input list.
+        Meta-keyed tuple containing a PNG and HTML plot for 3D PCA plots
+        covering specified input matrix (by default the last one in the input
+        list.
   - mad:
       type: tuple
       description: |
-        Meta-keyed tuple containing a PNG, HTML, and HTML files directory for
-        MAD correlation plots covering specified input matrix (by default the
-        last one in the input list.
+        Meta-keyed tuple containing a PNG and  HTML plot for MAD correlation
+        plots covering specified input matrix (by default the last one in the
+        input list.
   - dendro:
       type: tuple
       description: |


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This PR removes consideration of `_files` folders from the htmlwidgets-exported plots I generating from the shinyngs module. The exports are 'self contained', and while I thought the bug was in that self-containment such that folders would still be required, in fact the bug is just in deletion of the _files directories. 

TL;DR: I included some folders in the plot output which are only there due to an [upstream bug](https://github.com/ramnathv/htmlwidgets/issues/296), and can reliably be ignored. 

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
