### PR TITLE
Bismark summary - BAM filenames, not files

### DIFF
--- a/modules/nf-core/bismark/summary/main.nf
+++ b/modules/nf-core/bismark/summary/main.nf
@@ -7,7 +7,7 @@ process BISMARK_SUMMARY {
         'quay.io/biocontainers/bismark:0.24.0--hdfd78af_0' }"
 
     input:
-    path(bam)
+    val(bam)
     path(align_report)
     path(dedup_report)
     path(splitting_report)
@@ -23,7 +23,7 @@ process BISMARK_SUMMARY {
     script:
     def args = task.ext.args ?: ''
     """
-    bismark2summary
+    bismark2summary $bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bismark/summary/main.nf
+++ b/modules/nf-core/bismark/summary/main.nf
@@ -23,7 +23,7 @@ process BISMARK_SUMMARY {
     script:
     def args = task.ext.args ?: ''
     """
-    bismark2summary $bam
+    bismark2summary ${bam.join(' ')}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bismark/summary/meta.yml
+++ b/modules/nf-core/bismark/summary/meta.yml
@@ -24,7 +24,7 @@ tools:
 input:
   - bam:
       type: value
-      description: Bismark alignment BAM filenames (not files)
+      description: Array of Bismark alignment BAM filenames
       pattern: "*.bam"
   - align_report:
       type: file

--- a/modules/nf-core/bismark/summary/meta.yml
+++ b/modules/nf-core/bismark/summary/meta.yml
@@ -23,25 +23,25 @@ tools:
       licence: ["GPL-3.0-or-later"]
 input:
   - bam:
-      type: file
-      description: Bismark alignment
-      pattern: "*.{bam}"
+      type: value
+      description: Bismark alignment BAM filenames (not files)
+      pattern: "*.bam"
   - align_report:
       type: file
       description: Bismark alignment reports
-      pattern: "*{report.txt}"
+      pattern: "*report.txt"
   - dedup_report:
       type: file
       description: Bismark deduplication reports
-      pattern: "*.{deduplication_report.txt}"
+      pattern: "*.deduplication_report.txt"
   - splitting_report:
       type: file
       description: Bismark splitting reports
-      pattern: "*{splitting_report.txt}"
+      pattern: "*splitting_report.txt"
   - mbias:
       type: file
       description: Text file containing methylation bias information
-      pattern: "*.{txt}"
+      pattern: "*.txt"
 output:
   - summary:
       type: file

--- a/tests/modules/nf-core/bismark/summary/main.nf
+++ b/tests/modules/nf-core/bismark/summary/main.nf
@@ -20,10 +20,10 @@ workflow test_bismark_summary {
     BISMARK_DEDUPLICATE ( BISMARK_ALIGN.out.bam )
     BISMARK_METHYLATIONEXTRACTOR ( BISMARK_DEDUPLICATE.out.bam, BISMARK_GENOMEPREPARATION.out.index )
     BISMARK_SUMMARY (
-        BISMARK_ALIGN.out.bam.collect{ meta, bam -> bam },
-        BISMARK_ALIGN.out.report.collect{ meta, report -> report },
-        BISMARK_DEDUPLICATE.out.report.collect{ meta, bam -> bam },
-        BISMARK_METHYLATIONEXTRACTOR.out.report.collect{ meta, report -> report },
-        BISMARK_METHYLATIONEXTRACTOR.out.mbias.collect{ meta, mbias -> mbias }
+        BISMARK_ALIGN.out.bam.collect{ it[1].name }.ifEmpty([]),
+        BISMARK_ALIGN.out.report.collect{ it[1] }.ifEmpty([]),
+        BISMARK_DEDUPLICATE.out.report.collect{ it[1] }.ifEmpty([]),
+        BISMARK_METHYLATIONEXTRACTOR.out.report.collect{ it[1] }.ifEmpty([]),
+        BISMARK_METHYLATIONEXTRACTOR.out.mbias.collect{ it[1] }.ifEmpty([]),
     )
 }


### PR DESCRIPTION
This bismark/summary module pulled in all BAM files to run. This staged them in the work directory and `bismark2summary` used these to guess the report filenames. That's all 😅  Quite an expensive strategy when staging files on the cloud.

Changed to instead accept a list of BAM _filenames_ instead, without staging the files.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
