### PR TITLE
Add mito_name to ATAQV_ATAQV inputs

### DIFF
--- a/modules/nf-core/ataqv/ataqv/main.nf
+++ b/modules/nf-core/ataqv/ataqv/main.nf
@@ -34,6 +34,7 @@ process ATAQV_ATAQV {
     """
     ataqv \\
         $args \\
+        $mito \\
         $peak \\
         $tss \\
         $excl_regs \\

--- a/modules/nf-core/ataqv/ataqv/main.nf
+++ b/modules/nf-core/ataqv/ataqv/main.nf
@@ -10,6 +10,7 @@ process ATAQV_ATAQV {
     input:
     tuple val(meta), path(bam), path(bai), path(peak_file)
     val organism
+    val mito_name
     path tss_file
     path excl_regs_file
     path autosom_ref_file
@@ -24,6 +25,7 @@ process ATAQV_ATAQV {
 
     script:
     def args = task.ext.args ?: ''
+    def mito = mito_name ? "--mitochondrial-reference-name ${mito_name}" : ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def peak        = peak_file        ? "--peak-file $peak_file"                       : ''
     def tss         = tss_file         ? "--tss-file $tss_file"                         : ''

--- a/modules/nf-core/ataqv/ataqv/meta.yml
+++ b/modules/nf-core/ataqv/ataqv/meta.yml
@@ -32,6 +32,9 @@ input:
   - organism:
       type: string
       description: The subject of the experiment, which determines the list of autosomes (see "Reference Genome Configuration" section at https://github.com/ParkerLab/ataqv).
+  - mito_name:
+      type: string
+      description: Name of the mitochondrial sequence.
   - tss_file:
       type: file
       description: A BED file of transcription start sites for the experiment organism. If supplied, a TSS enrichment score will be calculated according to the ENCODE data standards. This calculation requires that the BAM file of alignments be indexed.

--- a/tests/modules/nf-core/ataqv/ataqv/main.nf
+++ b/tests/modules/nf-core/ataqv/ataqv/main.nf
@@ -14,7 +14,7 @@ workflow test_ataqv_ataqv {
         []
     ]
     
-    ATAQV_ATAQV ( input, 'human', [], [], [], [] )
+    ATAQV_ATAQV ( input, 'human', '', [], [], [] )
 }
 
 workflow test_ataqv_ataqv_problem_reads {
@@ -26,7 +26,7 @@ workflow test_ataqv_ataqv_problem_reads {
         []
     ]
     
-    ATAQV_ATAQV_PROBLEM_READS ( input, 'human', [], [], [], [] )
+    ATAQV_ATAQV_PROBLEM_READS ( input, 'human', '', [], [], [] )
 }
 
 workflow test_ataqv_ataqv_peak {
@@ -38,7 +38,7 @@ workflow test_ataqv_ataqv_peak {
         file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
     ]
     
-    ATAQV_ATAQV ( input, 'human', [], [], [], [] )
+    ATAQV_ATAQV ( input, 'human', '', [], [], [] )
 }
 
 workflow test_ataqv_ataqv_tss {
@@ -51,7 +51,7 @@ workflow test_ataqv_ataqv_tss {
     ] 
     tss_file = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
    
-    ATAQV_ATAQV ( input, 'human', [], tss_file, [], [] )
+    ATAQV_ATAQV ( input, 'human', '', tss_file, [], [] )
 }
 
 workflow test_ataqv_ataqv_excluded_regs {
@@ -65,5 +65,5 @@ workflow test_ataqv_ataqv_excluded_regs {
     tss_file = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
     excl_regs_file = file(params.test_data['sarscov2']['genome']['test2_bed'], checkIfExists: true)
    
-    ATAQV_ATAQV ( input, 'human', [], tss_file, excl_regs_file, [] )
+    ATAQV_ATAQV ( input, 'human', '', tss_file, excl_regs_file, [] )
 }

--- a/tests/modules/nf-core/ataqv/ataqv/main.nf
+++ b/tests/modules/nf-core/ataqv/ataqv/main.nf
@@ -14,7 +14,7 @@ workflow test_ataqv_ataqv {
         []
     ]
     
-    ATAQV_ATAQV ( input, 'human', [], [], [] )
+    ATAQV_ATAQV ( input, 'human', [], [], [], [] )
 }
 
 workflow test_ataqv_ataqv_problem_reads {
@@ -26,7 +26,7 @@ workflow test_ataqv_ataqv_problem_reads {
         []
     ]
     
-    ATAQV_ATAQV_PROBLEM_READS ( input, 'human', [], [], [] )
+    ATAQV_ATAQV_PROBLEM_READS ( input, 'human', [], [], [], [] )
 }
 
 workflow test_ataqv_ataqv_peak {
@@ -38,7 +38,7 @@ workflow test_ataqv_ataqv_peak {
         file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
     ]
     
-    ATAQV_ATAQV ( input, 'human', [], [], [] )
+    ATAQV_ATAQV ( input, 'human', [], [], [], [] )
 }
 
 workflow test_ataqv_ataqv_tss {
@@ -51,7 +51,7 @@ workflow test_ataqv_ataqv_tss {
     ] 
     tss_file = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
    
-    ATAQV_ATAQV ( input, 'human', tss_file, [], [] )
+    ATAQV_ATAQV ( input, 'human', [], tss_file, [], [] )
 }
 
 workflow test_ataqv_ataqv_excluded_regs {
@@ -65,5 +65,5 @@ workflow test_ataqv_ataqv_excluded_regs {
     tss_file = file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
     excl_regs_file = file(params.test_data['sarscov2']['genome']['test2_bed'], checkIfExists: true)
    
-    ATAQV_ATAQV ( input, 'human', tss_file, excl_regs_file, [] )
+    ATAQV_ATAQV ( input, 'human', [], tss_file, excl_regs_file, [] )
 }

--- a/tests/modules/nf-core/ataqv/mkarv/main.nf
+++ b/tests/modules/nf-core/ataqv/mkarv/main.nf
@@ -14,6 +14,6 @@ workflow test_ataqv_mkarv {
         []
     ]
 
-    ATAQV_ATAQV ( input, 'human', [], [], [], [] )
+    ATAQV_ATAQV ( input, 'human', '', [], [], [] )
     ATAQV_MKARV ( ATAQV_ATAQV.out.json.collect{ it[1]} )
 }

--- a/tests/modules/nf-core/ataqv/mkarv/main.nf
+++ b/tests/modules/nf-core/ataqv/mkarv/main.nf
@@ -14,6 +14,6 @@ workflow test_ataqv_mkarv {
         []
     ]
 
-    ATAQV_ATAQV ( input, 'human', [], [], [] )
+    ATAQV_ATAQV ( input, 'human', [], [], [], [] )
     ATAQV_MKARV ( ATAQV_ATAQV.out.json.collect{ it[1]} )
 }


### PR DESCRIPTION
# Description

This PR is required to fix an issue in nf-core/atacseq, detailed in https://github.com/nf-core/modules/issues/2502.

Essentially, we cannot rely on ext.args to supply the `--mitochondrial-reference-name` argument, as the parameter is often set *after* the ext.args are resolved.

This commit introduces the `mito_name` as a process input.