### PR TITLE
ci: Add apt-get update

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -96,7 +96,8 @@ jobs:
       - name: Output log on failure
         if: failure()
         run: |
-          sudo apt install bat > /dev/null
+          sudo apt-get update > /dev/null
+          sudo apt-get install bat > /dev/null
           batcat --decorations=always --color=always /home/runner/pytest_workflow_*/*/log.{out,err}
 
       - name: Upload logs on failure


### PR DESCRIPTION
Also switch to apt-get

Fixes

```
Run sudo apt install bat > /dev/null

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/r/rust-bat/bat_0.12.1-1ubuntu0.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
