### PR TITLE
Fix KRAKEN_SCREEN output channel definition

### DIFF
--- a/subworkflows/nf-core/fastq_contam_seqtk_kraken/main.nf
+++ b/subworkflows/nf-core/fastq_contam_seqtk_kraken/main.nf
@@ -38,7 +38,7 @@ workflow FASTQ_CONTAM_SEQTK_KRAKEN {
                 false
         )
         ch_versions = ch_versions.mix(KRAKEN2.out.versions.first())
-        ch_reports.mix(KRAKEN2.out.report)
+        ch_reports  = ch_reports.mix(KRAKEN2.out.report)
 
     emit:
         reports  = ch_reports     // channel: [ [meta], log  ]


### PR DESCRIPTION
### Description of the bug

When running the `KRAKEN_SCREEN` sub-workflow the output channels from it, `KRAKEN_SCREEN.out.reports` are all empty. Related to issue #2516 

I checked and the fix is having:

```groovy
ch_versions = ch_versions.mix(KRAKEN2.out.versions.first())
ch_reports  = ch_reports.mix(KRAKEN2.out.report)
```

Instead of:

https://github.com/nf-core/modules/blob/master/subworkflows/nf-core/fastq_contam_seqtk_kraken/main.nf#L40-L41