### PR TITLE
Nanoplot: make png output optional to enable using --no-static

### DIFF
--- a/modules/nf-core/nanoplot/main.nf
+++ b/modules/nf-core/nanoplot/main.nf
@@ -11,11 +11,11 @@ process NANOPLOT {
     tuple val(meta), path(ontfile)
 
     output:
-    tuple val(meta), path("*.html"), emit: html
-    tuple val(meta), path("*.png") , emit: png
-    tuple val(meta), path("*.txt") , emit: txt
-    tuple val(meta), path("*.log") , emit: log
-    path  "versions.yml"           , emit: versions
+    tuple val(meta), path("*.html")                , emit: html
+    tuple val(meta), path("*.png") , optional: true, emit: png
+    tuple val(meta), path("*.txt")                 , emit: txt
+    tuple val(meta), path("*.log")                 , emit: log
+    path  "versions.yml"                           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when


### PR DESCRIPTION
Nanoplot has a `--no-static` option which disables generation of the static png plots. In order to be able to use this with the nextflow module, `png` output needs to be marked as optional. 

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
