### PR TITLE
Enforce numeric on formatted tabular outputs from DESeq2

### DIFF
--- a/tests/modules/nf-core/deseq2/differential/test.yml
+++ b/tests/modules/nf-core/deseq2/differential/test.yml
@@ -5,21 +5,21 @@
     - deseq2/differential
   files:
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.results.tsv
-      md5sum: 2402bf409e0497674374528728591059
+      md5sum: 86f0312a4691dfb4d7c15643059d8fb8
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.sizefactors.tsv
       md5sum: 6332f21889ecac387bb12eeb04f23849
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.normalised_counts.tsv
       md5sum: 827cdf01f366d72d6e4b500e9862ba74
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.rlog.tsv
-      md5sum: 8b674051048e826a59aec97aba752e78
+      md5sum: 1077cf03a8c6a155932eaaed7415b74c
     - path: output/deseq2/treatment-mCherry-hND6.deseq2.results.tsv
-      md5sum: 269cdbe2b9c18393b448dd435e7f5c9a
+      md5sum: 4034522732d975951c79731acc1c9731
     - path: output/deseq2/treatment-mCherry-hND6.deseq2.sizefactors.tsv
       md5sum: 6332f21889ecac387bb12eeb04f23849
     - path: output/deseq2/treatment-mCherry-hND6.normalised_counts.tsv
       md5sum: 827cdf01f366d72d6e4b500e9862ba74
     - path: output/deseq2/treatment-mCherry-hND6.rlog.tsv
-      md5sum: 8b674051048e826a59aec97aba752e78
+      md5sum: 1077cf03a8c6a155932eaaed7415b74c
 
 - name: deseq2 differential test_deseq2_differential_csv
   command: nextflow run ./tests/modules/nf-core/deseq2/differential -entry test_deseq2_differential_csv -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/deseq2/differential/nextflow.config
@@ -28,21 +28,21 @@
     - deseq2/differential
   files:
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.results.tsv
-      md5sum: 2402bf409e0497674374528728591059
+      md5sum: 86f0312a4691dfb4d7c15643059d8fb8
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.sizefactors.tsv
       md5sum: 6332f21889ecac387bb12eeb04f23849
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.normalised_counts.tsv
       md5sum: 827cdf01f366d72d6e4b500e9862ba74
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.rlog.tsv
-      md5sum: 8b674051048e826a59aec97aba752e78
+      md5sum: 1077cf03a8c6a155932eaaed7415b74c
     - path: output/deseq2/treatment-mCherry-hND6.deseq2.results.tsv
-      md5sum: 269cdbe2b9c18393b448dd435e7f5c9a
+      md5sum: 4034522732d975951c79731acc1c9731
     - path: output/deseq2/treatment-mCherry-hND6.deseq2.sizefactors.tsv
       md5sum: 6332f21889ecac387bb12eeb04f23849
     - path: output/deseq2/treatment-mCherry-hND6.normalised_counts.tsv
       md5sum: 827cdf01f366d72d6e4b500e9862ba74
     - path: output/deseq2/treatment-mCherry-hND6.rlog.tsv
-      md5sum: 8b674051048e826a59aec97aba752e78
+      md5sum: 1077cf03a8c6a155932eaaed7415b74c
     - path: output/tsv/test.csv
       md5sum: f8e51c79c9add0d07eb46aba6a09d33c
 
@@ -53,18 +53,18 @@
     - deseq2/differential
   files:
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.results.tsv
-      md5sum: 2402bf409e0497674374528728591059
+      md5sum: 86f0312a4691dfb4d7c15643059d8fb8
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.deseq2.sizefactors.tsv
       md5sum: 6332f21889ecac387bb12eeb04f23849
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.normalised_counts.tsv
       md5sum: 827cdf01f366d72d6e4b500e9862ba74
     - path: output/deseq2/treatment-mCherry-hND6-sample_number.vst.tsv
-      md5sum: 53a74c2e7fd188e7236055d5e6af769a
+      md5sum: 0960df48c0116a626289960284148fbb
     - path: output/deseq2/treatment-mCherry-hND6.deseq2.results.tsv
-      md5sum: 269cdbe2b9c18393b448dd435e7f5c9a
+      md5sum: 4034522732d975951c79731acc1c9731
     - path: output/deseq2/treatment-mCherry-hND6.deseq2.sizefactors.tsv
       md5sum: 6332f21889ecac387bb12eeb04f23849
     - path: output/deseq2/treatment-mCherry-hND6.normalised_counts.tsv
       md5sum: 827cdf01f366d72d6e4b500e9862ba74
     - path: output/deseq2/treatment-mCherry-hND6.vst.tsv
-      md5sum: 53a74c2e7fd188e7236055d5e6af769a
+      md5sum: 0960df48c0116a626289960284148fbb


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

When I wrote the DESeq2 module I applied some limitation to the decimal places used in certain tabular outputs, for consistency to make use of the CI easier. But that created some issues in that the outputs were strings, with NAs (for example) padded out. It's then a pain to parse these files and convert the strings back to numeric. 

This PR does that conversion back to numeric before the tables are written, including preservation of NA values.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
