### PR TITLE
Add org path to .nf-core.yml

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,4 +1,5 @@
 repository_type: modules
+org_path: nf-core
 bump-versions:
   rseqc/junctionannotation: False
   rseqc/bamstat: False


### PR DESCRIPTION
In anticipation of new tooling code add the `org_path` value to the `.nf-core.yml`.
This value defines the path under which modules/subworkflows are stored i.e. `modules/<org_path>` which here is `nf-core`

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
