### PR TITLE
Bump MALT/RUN and MALT/BUILD to 0.61

### DIFF
--- a/modules/nf-core/malt/build/main.nf
+++ b/modules/nf-core/malt/build/main.nf
@@ -2,17 +2,15 @@ process MALT_BUILD {
 
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::malt=0.41" : null)
+    conda (params.enable_conda ? "bioconda::malt=0.61" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/malt:0.41--1' :
-        'quay.io/biocontainers/malt:0.41--1' }"
+        'https://depot.galaxyproject.org/singularity/malt:0.61--hdfd78af_0' :
+        'quay.io/biocontainers/malt:0.61--hdfd78af_0' }"
 
     input:
     path fastas
-    val seq_type
-    path mapping_file
-    val mapping_type
-    val mapping_db
+    path gff
+    path mapping_db
 
     output:
     path "malt_index/"   , emit: index
@@ -31,35 +29,17 @@ process MALT_BUILD {
         avail_mem = task.memory.giga
     }
 
-    def valid_db = ['eggnog', 'interpro2go', 'kegg', 'seed', 'taxonomy']
-    if ( !valid_db.contains(mapping_db) )  { error "Unrecognised mapping database value for MALT_BUILD. Options: eggnog, interpro2go, kegg, seed, taxonomy" }
-
-    switch ( "${mapping_type}" ) {
-        case "gi":
-        mapping_prefix = "-g"; break
-        case "ref":
-        if ( mapping_db == "taxonomy" ) {
-            mapping_prefix = '-a'
-        } else {
-            mapping_prefix = "-r"
-        };break
-        case "syn":
-        mapping_prefix = "-s"; break
-        default:
-        error '[MALT_BUILD] Mapping type not recognised. Options: gi, ref, syn'; break
-    }
-
-    type_flag = mapping_prefix + '2' + mapping_db + " " + mapping_file
+    def igff = gff ? "-igff ${gff}" : ""
 
     """
     malt-build \\
         -v \\
         --input ${fastas.join(' ')} \\
-        -s $seq_type \\
+        $igff \\
         -d 'malt_index/' \\
         -t $task.cpus \\
         $args \\
-        $type_flag |&tee malt-build.log
+        -mdb ${mapping_db}/*.db |&tee malt-build.log
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/malt/build/meta.yml
+++ b/modules/nf-core/malt/build/meta.yml
@@ -24,22 +24,14 @@ input:
       type: file
       description: Directory of, or list of FASTA reference files for indexing
       pattern: "*/|*.fasta"
-  - seq_type:
-      type: string
-      description: Type of input data
-      pattern: "DNA|Protein"
-  - mapping_file:
+  - gff:
       type: file
-      description: An unzipped MEGAN mapping file in .abin format (pre-2020), downloadable from https://software-ab.informatik.uni-tuebingen.de/download/megan6/old.html
-      pattern: "*.abin"
-  - mapping_type:
-      type: value
-      description: What type of accession to use for database construction.
-      pattern: "gi|ref|syn"
-  - mapping_type:
-      type: value
-      description: Which database the mapping file is derived from.
-      pattern: "eggnog|interpro2go|kegg|seed|taxonomy"
+      description: Directory of, or GFF3 files of input FASTA files
+      pattern: "*/|*.gff|*.gff3"
+  - mapping_db:
+      type: file
+      description: MEGAN .db file from https://software-ab.informatik.uni-tuebingen.de/download/megan6/welcome.html
+      pattern: "*.db"
 
 output:
   - versions:

--- a/modules/nf-core/malt/run/main.nf
+++ b/modules/nf-core/malt/run/main.nf
@@ -2,14 +2,13 @@ process MALT_RUN {
     tag "$meta.id"
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::malt=0.41" : null)
+    conda (params.enable_conda ? "bioconda::malt=0.61" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/malt:0.41--1' :
-        'quay.io/biocontainers/malt:0.41--1' }"
+        'https://depot.galaxyproject.org/singularity/malt:0.61--hdfd78af_0' :
+        'quay.io/biocontainers/malt:0.61--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(fastqs)
-    val mode
     path index
 
     output:
@@ -38,7 +37,6 @@ process MALT_RUN {
         -o . \\
         $args \\
         --inFile ${fastqs.join(' ')} \\
-        -m $mode \\
         --index $index/ |&tee ${prefix}-malt-run.log
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/malt/run/meta.yml
+++ b/modules/nf-core/malt/run/meta.yml
@@ -28,10 +28,6 @@ input:
       type: file
       description: Input FASTQ files
       pattern: "*.{fastq.gz,fq.gz}"
-  - mode:
-      type: string
-      description: Program mode
-      pattern: "Unknown|BlastN|BlastP|BlastX|Classifier"
   - index:
       type: directory
       description: Index/database directory from malt-build

--- a/tests/modules/nf-core/malt/build_test/main.nf
+++ b/tests/modules/nf-core/malt/build_test/main.nf
@@ -6,12 +6,11 @@ include { UNZIP } from '../../../../../modules/nf-core/unzip/main.nf'
 include { MALT_BUILD } from '../../../../../modules/nf-core/malt/build/main.nf'
 
 workflow test_malt_build {
-    fastas        = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-    seq_type      = "DNA"
-    map_accession = [ [], file("http://software-ab.cs.uni-tuebingen.de/download/megan6/nucl_acc2tax-Jul2019.abin.zip", checkIfExists: true) ]
-    mapping_type  = 'ref'
-    mapping_db    = 'taxonomy'
 
-    UNZIP ( map_accession )
-    MALT_BUILD ( fastas, seq_type, UNZIP.out.unzipped_archive.map{ it[1] }, "ref", "taxonomy" )
+    fastas = file(params.test_data['candidatus_portiera_aleyrodidarum']['genome']['genome_fasta'], checkIfExists: true)
+    gff = file(params.test_data['candidatus_portiera_aleyrodidarum']['genome']['test1_gff'], checkIfExists: true)
+    mapping_db = [ [], file("https://software-ab.cs.uni-tuebingen.de/download/megan6/megan-nucl-Feb2022.db.zip", checkIfExists: true) ]
+
+    UNZIP ( mapping_db )
+    MALT_BUILD ( fastas, gff, UNZIP.out.unzipped_archive.map { it[1] } )
 }

--- a/tests/modules/nf-core/malt/build_test/nextflow.config
+++ b/tests/modules/nf-core/malt/build_test/nextflow.config
@@ -2,4 +2,8 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    withName: MALT_BUILD {
+        ext.args = "--sequenceType DNA"
+    }
+
 }

--- a/tests/modules/nf-core/malt/build_test/test.yml
+++ b/tests/modules/nf-core/malt/build_test/test.yml
@@ -1,27 +1,28 @@
 - name: malt build test_malt_build
-  command: nextflow run ./tests/modules/nf-core/malt/build -entry test_malt_build -c ./tests/config/nextflow.config  -c ./tests/modules/nf-core/malt/build/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/malt/build -entry test_malt_build -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/malt/build/nextflow.config
   tags:
-    - malt
-    - malt/build
+  - malt
+  - malt/build
   files:
-    - path: output/malt/malt-build.log
-      contains:
-        - "Peak memory"
-    - path: output/malt/malt_index/index0.idx
-      md5sum: 1954f2c00b418d00112829b0a6adb8ce
-    - path: output/malt/malt_index/ref.db
-      md5sum: 1fb74eccd5400fb23454454da1bd4c0c
-    - path: output/malt/malt_index/ref.idx
-      md5sum: 7dea362b3fac8e00956a4952a3d4f474
-    - path: output/malt/malt_index/ref.inf
-      md5sum: b146842067cf278ef1d23e6c2e7c0c35
-    - path: output/malt/malt_index/table0.db
-    - path: output/malt/malt_index/table0.idx
-    - path: output/malt/malt_index/taxonomy.idx
-      md5sum: 13aa81314892b5537319fca2a63a2c31
-    - path: output/malt/malt_index/taxonomy.map
-      md5sum: 1e972302ae6d705b8abb377cfafd380a
-    - path: output/malt/malt_index/taxonomy.tre
-      md5sum: 79c2322475a8eebc57607ff36c1e4728
-    - path: output/unzip/nucl_acc2tax-Jul2019.abin/nucl_acc2tax-Jul2019.abin
-      md5sum: b2deb1df50ebcec4de71a6beec6226d7
+  - path: output/malt/malt-build.log
+      contains: ["Peak memory"]
+  - path: output/malt/malt_index/aadd.dbx
+    md5sum: 4e2ed57e713d5372bd09350f447cdf53
+  - path: output/malt/malt_index/aadd.idx
+    md5sum: 4c9ce6fff248a692a656d259fefc1f74
+  - path: output/malt/malt_index/index0.idx
+    md5sum: 8552744159e67b12ec48f4d8b2edfc41
+  - path: output/malt/malt_index/ref.db
+    md5sum: 6bf54bed57f87abe307f50ed701e35a3
+  - path: output/malt/malt_index/ref.idx
+    md5sum: 7dea362b3fac8e00956a4952a3d4f474
+  - path: output/malt/malt_index/ref.inf
+    md5sum: 592bfd4340eafef0d2afc833424524b1
+  - path: output/malt/malt_index/table0.db
+  - path: output/malt/malt_index/table0.idx
+  - path: output/malt/malt_index/taxonomy.idx
+    md5sum: b0b009bc324fd27f7875eeadf7e38fef
+  - path: output/malt/malt_index/taxonomy.map
+    md5sum: 5bb3f2192e925bca2e61e4b54f1671e0
+  - path: output/malt/malt_index/taxonomy.tre
+    md5sum: f76fb2d5aa9b0d637234d48175841e0e

--- a/tests/modules/nf-core/malt/build_test/test.yml
+++ b/tests/modules/nf-core/malt/build_test/test.yml
@@ -1,28 +1,28 @@
 - name: malt build test_malt_build
   command: nextflow run ./tests/modules/nf-core/malt/build -entry test_malt_build -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/malt/build/nextflow.config
   tags:
-  - malt
-  - malt/build
+    - malt
+    - malt/build
   files:
-  - path: output/malt/malt-build.log
+    - path: output/malt/malt-build.log
       contains: ["Peak memory"]
-  - path: output/malt/malt_index/aadd.dbx
-    md5sum: 4e2ed57e713d5372bd09350f447cdf53
-  - path: output/malt/malt_index/aadd.idx
-    md5sum: 4c9ce6fff248a692a656d259fefc1f74
-  - path: output/malt/malt_index/index0.idx
-    md5sum: 8552744159e67b12ec48f4d8b2edfc41
-  - path: output/malt/malt_index/ref.db
-    md5sum: 6bf54bed57f87abe307f50ed701e35a3
-  - path: output/malt/malt_index/ref.idx
-    md5sum: 7dea362b3fac8e00956a4952a3d4f474
-  - path: output/malt/malt_index/ref.inf
-    md5sum: 592bfd4340eafef0d2afc833424524b1
-  - path: output/malt/malt_index/table0.db
-  - path: output/malt/malt_index/table0.idx
-  - path: output/malt/malt_index/taxonomy.idx
-    md5sum: b0b009bc324fd27f7875eeadf7e38fef
-  - path: output/malt/malt_index/taxonomy.map
-    md5sum: 5bb3f2192e925bca2e61e4b54f1671e0
-  - path: output/malt/malt_index/taxonomy.tre
-    md5sum: f76fb2d5aa9b0d637234d48175841e0e
+    - path: output/malt/malt_index/aadd.dbx
+      md5sum: 4e2ed57e713d5372bd09350f447cdf53
+    - path: output/malt/malt_index/aadd.idx
+      md5sum: 4c9ce6fff248a692a656d259fefc1f74
+    - path: output/malt/malt_index/index0.idx
+      md5sum: 8552744159e67b12ec48f4d8b2edfc41
+    - path: output/malt/malt_index/ref.db
+      md5sum: 6bf54bed57f87abe307f50ed701e35a3
+    - path: output/malt/malt_index/ref.idx
+      md5sum: 7dea362b3fac8e00956a4952a3d4f474
+    - path: output/malt/malt_index/ref.inf
+      md5sum: 592bfd4340eafef0d2afc833424524b1
+    - path: output/malt/malt_index/table0.db
+    - path: output/malt/malt_index/table0.idx
+    - path: output/malt/malt_index/taxonomy.idx
+      md5sum: b0b009bc324fd27f7875eeadf7e38fef
+    - path: output/malt/malt_index/taxonomy.map
+      md5sum: 5bb3f2192e925bca2e61e4b54f1671e0
+    - path: output/malt/malt_index/taxonomy.tre
+      md5sum: f76fb2d5aa9b0d637234d48175841e0e

--- a/tests/modules/nf-core/malt/run/main.nf
+++ b/tests/modules/nf-core/malt/run/main.nf
@@ -8,19 +8,17 @@ include { MALT_RUN   } from '../../../../../modules/nf-core/malt/run/main.nf'
 
 workflow test_malt_run {
 
-    fastas        = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-    seq_type      = "DNA"
-    map_accession = [ [], file("http://software-ab.cs.uni-tuebingen.de/download/megan6/nucl_acc2tax-Jul2019.abin.zip", checkIfExists: true) ]
-    mapping_type  = 'ref'
-    mapping_db    = 'taxonomy'
+    fastas = file(params.test_data['candidatus_portiera_aleyrodidarum']['genome']['genome_fasta'], checkIfExists: true)
+    gff = [] // file(params.test_data['candidatus_portiera_aleyrodidarum']['genome']['test1_gff'], checkIfExists: true)
+    mapping_db = [ [], file("https://software-ab.cs.uni-tuebingen.de/download/megan6/megan-nucl-Feb2022.db.zip", checkIfExists: true) ]
+
     input = [
         [ id:'test', single_end:false ], // meta map
-        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+        file(params.test_data['candidatus_portiera_aleyrodidarum']['illumina']['test_se_fastq_gz'], checkIfExists: true)
     ]
-    mode = "BlastN"
 
-    UNZIP ( map_accession )
-    MALT_BUILD ( fastas, seq_type, UNZIP.out.unzipped_archive.map{ it[1] }, "ref", "taxonomy" )
-    MALT_RUN ( input, mode, MALT_BUILD.out.index )
+    UNZIP ( mapping_db )
+    MALT_BUILD ( fastas, gff, UNZIP.out.unzipped_archive.map { it[1] } )
+    MALT_RUN ( input, MALT_BUILD.out.index )
 }
 

--- a/tests/modules/nf-core/malt/run/nextflow.config
+++ b/tests/modules/nf-core/malt/run/nextflow.config
@@ -2,4 +2,12 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    withName: MALT_RUN {
+        ext.args = "-m BlastN"
+    }
+
+    withName: MALT_BUILD {
+        ext.args = "--sequenceType DNA"
+    }
+
 }

--- a/tests/modules/nf-core/malt/run/nextflow.config
+++ b/tests/modules/nf-core/malt/run/nextflow.config
@@ -3,7 +3,7 @@ process {
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
     withName: MALT_RUN {
-        ext.args = "-m BlastN"
+        ext.args = "-m BlastN -J-Xmx8G"
     }
 
     withName: MALT_BUILD {

--- a/tests/modules/nf-core/malt/run/test.yml
+++ b/tests/modules/nf-core/malt/run/test.yml
@@ -1,10 +1,9 @@
 - name: malt run test_malt_run
-  command: nextflow run ./tests/modules/nf-core/malt/run -entry test_malt_run -c ./tests/config/nextflow.config  -c ./tests/modules/nf-core/malt/run/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/malt/run -entry test_malt_run -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/malt/run/nextflow.config
   tags:
     - malt/run
     - malt
   files:
     - path: output/malt/test-malt-run.log
-      contains:
-        - "Peak memory"
-    - path: output/malt/test_1.rma6
+      contains: ["Peak memory"]
+    - path: output/malt/test_se.rma6


### PR DESCRIPTION
Joining these in one because they are required for each other.

This is reverting the version 'revert' I did a while ago, as the latest version fixes the bug in 0.53.

I've also removed a few `val` channels which are for mandatory parameters, but are non-files, as per the most recent guidelines

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
