### PR TITLE
vep: bump version and force compressed output

### DIFF
--- a/modules/nf-core/ensemblvep/Dockerfile
+++ b/modules/nf-core/ensemblvep/Dockerfile
@@ -11,8 +11,8 @@ RUN conda env create -f /environment.yml && conda clean -a
 # Setup default ARG variables
 ARG GENOME=GRCh38
 ARG SPECIES=homo_sapiens
-ARG VEP_CACHE_VERSION=106
-ARG VEP_VERSION=106.1
+ARG VEP_CACHE_VERSION=108
+ARG VEP_VERSION=108.2
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
 ENV PATH /opt/conda/envs/nf-core-vep-${VEP_VERSION}/bin:$PATH

--- a/modules/nf-core/ensemblvep/build.sh
+++ b/modules/nf-core/ensemblvep/build.sh
@@ -20,11 +20,11 @@ build_push() {
     docker push nfcore/vep:${VEP_VERSION}.${GENOME}
 }
 
-build_push "CanFam3.1" "canis_lupus_familiaris"   "104" "106.1"
-build_push "GRCh37"    "homo_sapiens"             "106" "106.1"
-build_push "GRCh38"    "homo_sapiens"             "106" "106.1"
-build_push "GRCm38"    "mus_musculus"             "102" "106.1"
-build_push "GRCm39"    "mus_musculus"             "106" "106.1"
-build_push "R64-1-1"   "saccharomyces_cerevisiae" "106" "106.1"
-build_push "UMD3.1"    "bos_taurus"               "94"  "106.1"
-build_push "WBcel235"  "caenorhabditis_elegans"   "106" "106.1"
+build_push "CanFam3.1" "canis_lupus_familiaris"   "104" "108.2"
+build_push "GRCh37"    "homo_sapiens"             "108" "108.2"
+build_push "GRCh38"    "homo_sapiens"             "108" "108.2"
+build_push "GRCm38"    "mus_musculus"             "102" "108.2"
+build_push "GRCm39"    "mus_musculus"             "108" "108.2"
+build_push "R64-1-1"   "saccharomyces_cerevisiae" "108" "108.2"
+build_push "UMD3.1"    "bos_taurus"               "94"  "108.2"
+build_push "WBcel235"  "caenorhabditis_elegans"   "108" "108.2"

--- a/modules/nf-core/ensemblvep/environment.yml
+++ b/modules/nf-core/ensemblvep/environment.yml
@@ -1,10 +1,10 @@
 # You can use this file to create a conda environment for this module:
 #   conda env create -f environment.yml
-name: nf-core-vep-106.1
+name: nf-core-vep-108.2
 channels:
   - conda-forge
   - bioconda
   - defaults
 
 dependencies:
-  - bioconda::ensembl-vep=106.1
+  - bioconda::ensembl-vep=108.2

--- a/modules/nf-core/ensemblvep/main.nf
+++ b/modules/nf-core/ensemblvep/main.nf
@@ -2,10 +2,10 @@ process ENSEMBLVEP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::ensembl-vep=106.1" : null)
+    conda (params.enable_conda ? "bioconda::ensembl-vep=108.2" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ensembl-vep:106.1--pl5321h4a94de4_0' :
-        'quay.io/biocontainers/ensembl-vep:106.1--pl5321h4a94de4_0' }"
+        'https://depot.galaxyproject.org/singularity/ensembl-vep:108.2--pl5321h4a94de4_0' :
+        'quay.io/biocontainers/ensembl-vep:108.2--pl5321h4a94de4_0' }"
 
     input:
     tuple val(meta), path(vcf)
@@ -17,12 +17,9 @@ process ENSEMBLVEP {
     path  extra_files
 
     output:
-    tuple val(meta), path("*.ann.vcf")     , optional:true, emit: vcf
-    tuple val(meta), path("*.ann.tab")     , optional:true, emit: tab
-    tuple val(meta), path("*.ann.json")    , optional:true, emit: json
-    tuple val(meta), path("*.ann.vcf.gz")  , optional:true, emit: vcf_gz
-    tuple val(meta), path("*.ann.tab.gz")  , optional:true, emit: tab_gz
-    tuple val(meta), path("*.ann.json.gz") , optional:true, emit: json_gz
+    tuple val(meta), path("*.ann.vcf.gz")  , optional:true, emit: vcf
+    tuple val(meta), path("*.ann.tab.gz")  , optional:true, emit: tab
+    tuple val(meta), path("*.ann.json.gz") , optional:true, emit: json
     path "*.summary.html"                  , emit: report
     path "versions.yml"                    , emit: versions
 
@@ -32,7 +29,7 @@ process ENSEMBLVEP {
     script:
     def args = task.ext.args ?: ''
     def file_extension = args.contains("--vcf") ? 'vcf' : args.contains("--json")? 'json' : args.contains("--tab")? 'tab' : 'vcf'
-    def compress_out = args.contains("--compress_output") ? '.gz' : ''
+    def compress_cmf = args.contains("--compress_output") ? '' : '--compress_output bgzip'
     def prefix = task.ext.prefix ?: "${meta.id}"
     def dir_cache = cache ? "\${PWD}/${cache}" : "/.vep"
     def reference = fasta ? "--fasta $fasta" : ""
@@ -40,7 +37,7 @@ process ENSEMBLVEP {
     """
     vep \\
         -i $vcf \\
-        -o ${prefix}.ann.${file_extension}${compress_out} \\
+        -o ${prefix}.ann.${file_extension}.gz \\
         $args \\
         $reference \\
         --assembly $genome \\
@@ -61,9 +58,6 @@ process ENSEMBLVEP {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.ann.vcf
-    touch ${prefix}.ann.tab
-    touch ${prefix}.ann.json
     touch ${prefix}.ann.vcf.gz
     touch ${prefix}.ann.tab.gz
     touch ${prefix}.ann.json.gz

--- a/modules/nf-core/ensemblvep/meta.yml
+++ b/modules/nf-core/ensemblvep/meta.yml
@@ -50,17 +50,17 @@ output:
       type: file
       description: |
         annotated vcf (optional)
-      pattern: "*.ann.vcf"
+      pattern: "*.ann.vcf.gz"
   - tab:
       type: file
       description: |
         tab file with annotated variants (optional)
-      pattern: "*.ann.tab"
+      pattern: "*.ann.tab.gz"
   - json:
       type: file
       description: |
         json file with annotated variants (optional)
-      pattern: "*.ann.json"
+      pattern: "*.ann.json.gz"
   - report:
       type: file
       description: VEP report file
@@ -71,3 +71,4 @@ output:
       pattern: "versions.yml"
 authors:
   - "@maxulysse"
+  - "@matthdsm"

--- a/tests/modules/nf-core/ensemblvep/test.yml
+++ b/tests/modules/nf-core/ensemblvep/test.yml
@@ -3,7 +3,7 @@
   tags:
     - ensemblvep
   files:
-    - path: output/ensemblvep/test.ann.json
+    - path: output/ensemblvep/test.ann.json.gz
     - path: output/ensemblvep/test.summary.html
 
 - name: ensemblvep test_ensemblvep_fasta_tab
@@ -11,7 +11,7 @@
   tags:
     - ensemblvep
   files:
-    - path: output/ensemblvep/test.ann.tab
+    - path: output/ensemblvep/test.ann.tab.gz
     - path: output/ensemblvep/test.summary.html
 
 - name: ensemblvep test_ensemblvep_fasta_vcf
@@ -19,7 +19,7 @@
   tags:
     - ensemblvep
   files:
-    - path: output/ensemblvep/test.ann.vcf
+    - path: output/ensemblvep/test.ann.vcf.gz
     - path: output/ensemblvep/test.summary.html
 
 - name: ensemblvep test_ensemblvep_fasta_vcf_bgzip
@@ -43,7 +43,7 @@
   tags:
     - ensemblvep
   files:
-    - path: output/ensemblvep/test.ann.vcf
+    - path: output/ensemblvep/test.ann.vcf.gz
     - path: output/ensemblvep/test.summary.html
 
 - name: ensemblvep test_ensemblvep_no_fasta
@@ -51,7 +51,7 @@
   tags:
     - ensemblvep
   files:
-    - path: output/ensemblvep/test.ann.vcf
+    - path: output/ensemblvep/test.ann.vcf.gz
     - path: output/ensemblvep/test.summary.html
 
 - name: ensemblvep test_ensemblvep_fasta_vcf_stub
@@ -59,5 +59,5 @@
   tags:
     - ensemblvep
   files:
-    - path: output/ensemblvep/test.ann.vcf
+    - path: output/ensemblvep/test.ann.vcf.gz
     - path: output/ensemblvep/test.summary.html


### PR DESCRIPTION
Bump VEP version and force compressed output


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
