### PR TITLE
fix: krakenuniq correctly handle read pairs

### DIFF
--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -30,89 +30,195 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args ?: ''
 
-    def paired       = meta.single_end ? "" : "--paired"
-    def classified   = meta.single_end ? '"\$PREFIX".classified.fastq'   : '"\$PREFIX".classified#.fastq'
-    def unclassified = meta.single_end ? '"\$PREFIX".unclassified.fastq' : '"\$PREFIX".unclassified#.fastq'
-    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ""
-    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ""
-    def output_option = save_output ? '--output "\$PREFIX".krakenuniq.classified.txt' : ""
-    def report = report_file ? '--report-file "\$PREFIX".krakenuniq.report.txt' : ""
-    def compress_reads_command = save_output_fastqs ? "gzip --no-name *.fastq" : ""
-
-    """
-    krakenuniq \\
-        $args \\
-        --db $db \\
-        --preload $ram_chunk_size \\
-        --threads $task.cpus
-
-    for fastq in ${fastqs.join(' ')}; do \\
-        PREFIX=\$(echo \$fastq)
+    def classified   = meta.single_end ? '"\${PREFIX}.classified.fastq"'   : '"\${PREFIX}.classified#.fastq"'
+    def unclassified = meta.single_end ? '"\${PREFIX}.unclassified.fastq"' : '"\${PREFIX}.unclassified#.fastq"'
+    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ''
+    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ''
+    def output_option = save_output ? '--output "\${PREFIX}.krakenuniq.classified.txt"' : ''
+    def report = report_file ? '--report-file "\${PREFIX}.krakenuniq.report.txt"' : ''
+    def compress_reads_command = save_output_fastqs ? 'gzip --no-name *.fastq' : ''
+    if (meta.single_end) {
+        """
         krakenuniq \\
             --db $db \\
+            --preload \\
+            --preload-size $ram_chunk_size \\
             --threads $task.cpus \\
-            $report \\
-            $output_option \\
-            $unclassified_option \\
-            $classified_option \\
-            $output_option \\
-            $paired \\
-            $args2 \\
-            \$fastq
-    done
+            $args
 
-    $compress_reads_command
+        strip_suffix() {
+            local result=\$1
+            # Strip any file extensions.
+            echo "\${result%%.*}"
+        }
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
-    END_VERSIONS
-    """
+        printf "%s\\n" ${fastqs} | while read FASTQ; do \\
+            PREFIX="\$(strip_suffix "\${FASTQ}")"
+
+            krakenuniq \\
+                --db $db \\
+                --threads $task.cpus \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
+                $output_option \\
+                $args2 \\
+                "\${FASTQ}"
+        done
+
+        $compress_reads_command
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
+        END_VERSIONS
+        """
+    } else {
+        """
+        krakenuniq \\
+            --db $db \\
+            --preload \\
+            --preload-size $ram_chunk_size \\
+            --threads $task.cpus \\
+            $args
+
+        strip_suffix() {
+            local result
+            read result
+            # Strip any trailing dot or underscore.
+            result="\${result%_}"
+            echo "\${result%.}"
+        }
+
+        printf "%s %s\\n" ${fastqs} | while read FASTQ; do \\
+            read -r -a FASTQ <<< "\${FASTQ}"
+            PREFIX="\$(printf "%s\\n" "\${FASTQ[@]}" |  sed -e 'N;s/^\\(.*\\).*\\n\\1.*\$/\\1\\n\\1/;D' | strip_suffix)"
+
+            krakenuniq \\
+                --db $db \\
+                --threads $task.cpus \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
+                $output_option \\
+                --paired \\
+                $args2 \\
+                "\${FASTQ[@]}"
+        done
+
+        $compress_reads_command
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
+        END_VERSIONS
+        """
+    }
 
     stub:
     def args = task.ext.args ?: ''
     def args2 = task.ext.args ?: ''
 
-    def paired       = meta.single_end ? "" : "--paired"
-    def classified   = meta.single_end ? '"\$PREFIX".classified.fastq'   : '"\$PREFIX".classified#.fastq'
-    def unclassified = meta.single_end ? '"\$PREFIX".unclassified.fastq' : '"\$PREFIX".unclassified#.fastq'
-    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ""
-    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ""
-    def output_option = save_output ? '--output "\$PREFIX".krakenuniq.classified.txt' : ""
-    def report = report_file ? '--report-file "\$PREFIX".krakenuniq.report.txt' : ""
-    def compress_reads_command = save_output_fastqs ? "echo 'gzip --no-name *.fastq'" : ""
-    """
-    echo "krakenuniq \\
-        $args \\
-        --db $db \\
-        --preload $ram_chunk_size \\
-        --threads $task.cpus"
-
-    for fastq in ${fastqs.join(' ')}; do \\
-        PREFIX=\$(echo \$fastq)
-        echo "krakenuniq \\
+    def classified   = meta.single_end ? '"\${PREFIX}.classified.fastq"'   : '"\${PREFIX}.classified#.fastq"'
+    def unclassified = meta.single_end ? '"\${PREFIX}.unclassified.fastq"' : '"\${PREFIX}.unclassified#.fastq"'
+    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ''
+    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ''
+    def output_option = save_output ? '--output "\${PREFIX}.krakenuniq.classified.txt"' : ''
+    def report = report_file ? '--report-file "\${PREFIX}.krakenuniq.report.txt"' : ''
+    def compress_reads_command = save_output_fastqs ? 'gzip --no-name *.fastq' : ''
+    if (meta.single_end) {
+        """
+        echo krakenuniq \\
             --db $db \\
+            --preload \\
+            --preload-size $ram_chunk_size \\
             --threads $task.cpus \\
-            $report \\
-            $output_option \\
-            $unclassified_option \\
-            $classified_option \\
-            $output_option \\
-            $paired \\
-            $args2 \\
-            \$fastq"
+            $args
 
-        touch "\$PREFIX".classified.fastq.gz
-        touch "\$PREFIX".krakenuniq.classified.txt
-        touch "\$PREFIX".krakenuniq.report.txt
-        touch "\$PREFIX".unclassified.fastq.gz
-    done
+        strip_suffix() {
+            local result=\$1
+            # Strip any file extensions.
+            echo "\${result%%.*}"
+        }
 
-    $compress_reads_command
+        printf "%s\\n" ${fastqs} | while read FASTQ; do \\
+            echo "\${FASTQ}"
+            PREFIX="\$(strip_suffix "\${FASTQ}")"
+            echo "\${PREFIX}"
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
-    END_VERSIONS
-    """
+            echo krakenuniq \\
+                --db $db \\
+                --threads $task.cpus \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
+                $output_option \\
+                $args2 \\
+                "\${FASTQ}"
+
+            touch "\${PREFIX}.classified.fastq.gz"
+            touch "\${PREFIX}.krakenuniq.classified.txt"
+            touch "\${PREFIX}.krakenuniq.report.txt"
+            touch "\${PREFIX}.unclassified.fastq.gz"
+        done
+
+        echo $compress_reads_command
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
+        END_VERSIONS
+        """
+    } else {
+        """
+        echo krakenuniq \\
+            --db $db \\
+            --preload \\
+            --preload-size $ram_chunk_size \\
+            --threads $task.cpus \\
+            $args
+
+        strip_suffix() {
+            local result
+            read result
+            # Strip any trailing dot or underscore.
+            result="\${result%_}"
+            echo "\${result%.}"
+        }
+
+        printf "%s %s\\n" ${fastqs} | while read FASTQ; do \\
+            read -r -a FASTQ <<< "\${FASTQ}"
+            echo "\${FASTQ[@]}"
+            PREFIX="\$(printf "%s\\n" "\${FASTQ[@]}" |  sed -e 'N;s/^\\(.*\\).*\\n\\1.*\$/\\1\\n\\1/;D' | strip_suffix)"
+            echo "\${PREFIX}"
+
+            echo krakenuniq \\
+                --db $db \\
+                --threads $task.cpus \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
+                $output_option \\
+                --paired \\
+                $args2 \\
+                "\${FASTQ[@]}"
+
+            touch "\${PREFIX}.classified_1.fastq.gz" "\${PREFIX}.classified_2.fastq.gz"
+            touch "\${PREFIX}.krakenuniq.classified.txt"
+            touch "\${PREFIX}.krakenuniq.report.txt"
+            touch "\${PREFIX}.unclassified_1.fastq.gz" "\${PREFIX}.unclassified_2.fastq.gz"
+        done
+
+        echo $compress_reads_command
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            krakenuniq: \$(echo \$(krakenuniq --version 2>&1) | sed 's/^.*KrakenUniq version //; s/ .*\$//')
+        END_VERSIONS
+        """
+    }
 }

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/meta.yml
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/meta.yml
@@ -51,13 +51,13 @@ output:
       description: |
         Reads classified as belonging to any of the taxa
         on the KrakenUniq database.
-      pattern: "*{fastq.gz}"
+      pattern: "*.fastq.gz"
   - unclassified_reads_fastq:
       type: file
       description: |
         Reads not classified to any of the taxa
         on the KrakenUniq database.
-      pattern: "*{fastq.gz}"
+      pattern: "*.fastq.gz"
   - classified_assignment:
       type: file
       description: |
@@ -68,10 +68,11 @@ output:
       description: |
         KrakenUniq report containing stats about classified
         and not classifed reads.
-      pattern: "*.{report.txt}"
+      pattern: "*.report.txt"
   - versions:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
 authors:
   - "@mjamy"
+  - "@Midnighter"

--- a/tests/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/tests/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -4,12 +4,32 @@ nextflow.enable.dsl = 2
 
 include { KRAKENUNIQ_PRELOADEDKRAKENUNIQ } from '../../../../../modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf'
 
-workflow test_krakenuniq_preloadedkrakenuniq {
+workflow test_krakenuniq_preloadedkrakenuniq_paired {
 
     input = [
-        [ id:'test', single_end:true ], // meta map
-        [file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)]
+        [id: 'test', single_end: false], // meta map
+        [
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+        ]
+    ]
+    db = []
+    ram_chunk_size = '8GB'
+    save_output_fastqs = true
+    report_file = true
+    save_output = true
+
+    KRAKENUNIQ_PRELOADEDKRAKENUNIQ ( input, db, ram_chunk_size, save_output_fastqs, report_file, save_output )
+}
+
+workflow test_krakenuniq_preloadedkrakenuniq_single {
+
+    input = [
+        [id:'test', single_end:true], // meta map
+        [
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+        ]
     ]
     db = []
     ram_chunk_size = '8GB'

--- a/tests/modules/nf-core/krakenuniq/preloadedkrakenuniq/test.yml
+++ b/tests/modules/nf-core/krakenuniq/preloadedkrakenuniq/test.yml
@@ -1,14 +1,27 @@
-- name: krakenuniq preloadedkrakenuniq test_krakenuniq_preloadedkrakenuniq
-  command: nextflow run ./tests/modules/nf-core/krakenuniq/preloadedkrakenuniq -entry test_krakenuniq_preloadedkrakenuniq -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/krakenuniq/preloadedkrakenuniq/nextflow.config -stub-run
+- name: krakenuniq preloadedkrakenuniq test_krakenuniq_preloadedkrakenuniq_paired
+  command: nextflow run ./tests/modules/nf-core/krakenuniq/preloadedkrakenuniq -entry test_krakenuniq_preloadedkrakenuniq_paired -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/krakenuniq/preloadedkrakenuniq/nextflow.config -stub-run
   tags:
     - krakenuniq/preloadedkrakenuniq
     - krakenuniq
   files:
-    - path: output/krakenuniq/test_1.fastq.gz.classified.fastq.gz
-    - path: output/krakenuniq/test_1.fastq.gz.krakenuniq.classified.txt
-    - path: output/krakenuniq/test_1.fastq.gz.krakenuniq.report.txt
-    - path: output/krakenuniq/test_1.fastq.gz.unclassified.fastq.gz
-    - path: output/krakenuniq/test_2.fastq.gz.classified.fastq.gz
-    - path: output/krakenuniq/test_2.fastq.gz.krakenuniq.classified.txt
-    - path: output/krakenuniq/test_2.fastq.gz.krakenuniq.report.txt
-    - path: output/krakenuniq/test_2.fastq.gz.unclassified.fastq.gz
+    - path: output/krakenuniq/test.classified_1.fastq.gz
+    - path: output/krakenuniq/test.classified_2.fastq.gz
+    - path: output/krakenuniq/test.krakenuniq.classified.txt
+    - path: output/krakenuniq/test.krakenuniq.report.txt
+    - path: output/krakenuniq/test.unclassified_1.fastq.gz
+    - path: output/krakenuniq/test.unclassified_2.fastq.gz
+
+- name: krakenuniq preloadedkrakenuniq test_krakenuniq_preloadedkrakenuniq_single
+  command: nextflow run ./tests/modules/nf-core/krakenuniq/preloadedkrakenuniq -entry test_krakenuniq_preloadedkrakenuniq_single -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/krakenuniq/preloadedkrakenuniq/nextflow.config -stub-run
+  tags:
+    - krakenuniq/preloadedkrakenuniq
+    - krakenuniq
+  files:
+    - path: output/krakenuniq/test_1.classified.fastq.gz
+    - path: output/krakenuniq/test_1.krakenuniq.classified.txt
+    - path: output/krakenuniq/test_1.krakenuniq.report.txt
+    - path: output/krakenuniq/test_1.unclassified.fastq.gz
+    - path: output/krakenuniq/test_2.classified.fastq.gz
+    - path: output/krakenuniq/test_2.krakenuniq.classified.txt
+    - path: output/krakenuniq/test_2.krakenuniq.report.txt
+    - path: output/krakenuniq/test_2.unclassified.fastq.gz


### PR DESCRIPTION
Improve prefix generation and split flows for single- and paired-end reads.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
