### PR TITLE
Update: RGI_MAIN to ensure you can separate temp files from real output 

### DIFF
--- a/modules/nf-core/rgi/main/main.nf
+++ b/modules/nf-core/rgi/main/main.nf
@@ -13,6 +13,7 @@ process RGI_MAIN {
     output:
     tuple val(meta), path("*.json"), emit: json
     tuple val(meta), path("*.txt") , emit: tsv
+    tuple val(meta), path("temp/")  , emit: tmp
     env VER                        , emit: tool_version
     env DBVER                      , emit: db_version
     path "versions.yml"            , emit: versions
@@ -30,6 +31,9 @@ process RGI_MAIN {
         --num_threads $task.cpus \\
         --output_file $prefix \\
         --input_sequence $fasta
+
+    mkdir temp/
+    mv *.xml *.fsa *.{nhr,nin,nsq} *.draft *.potentialGenes *{variant,rrna,protein,predictedGenes,overexpression,homolog}.json temp/
 
     VER=\$(rgi main --version)
     DBVER=\$(rgi database --version)

--- a/modules/nf-core/rgi/main/meta.yml
+++ b/modules/nf-core/rgi/main/meta.yml
@@ -42,6 +42,10 @@ output:
       type: file
       description: Tab-delimited file with RGI results
       pattern: "*.{txt}"
+  - temp:
+      type: directory
+      description: Directory containing various intermediate files
+      pattern: "temp/"
   - tool_version:
       type: string
       description: The version of the tool in string format (useful for downstream tools such as hAMRronization)

--- a/tests/modules/nf-core/rgi/main/test.yml
+++ b/tests/modules/nf-core/rgi/main/test.yml
@@ -1,10 +1,40 @@
-- name: rgi main
+- name: rgi main test_rgi_main
   command: nextflow run ./tests/modules/nf-core/rgi/main -entry test_rgi_main -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/rgi/main/nextflow.config
   tags:
-    - rgi
     - rgi/main
+    - rgi
   files:
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa
+      md5sum: f9f0fbb922adaf3968f8edbfbafe0bd8
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.blastRes.rrna.xml
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.contig.fsa
+      md5sum: f1397f3b38e3e6c92bd1cc9109f77418
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.contig.fsa.blastRes.xml
+      md5sum: 6c89f2c1038c81c0e8d54a4054ed4619
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.contigToORF.fsa
+      md5sum: 29f63c68bc6921af726a004d308bba9c
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.db.nhr
+      md5sum: fe609718f417ed4fd6fe7c0133e11ee6
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.db.nin
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.db.nsq
+      md5sum: 4d2cb41788a29ed976b61f33648ca865
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.draft
+      md5sum: 489c853eb2f5378bb601e2d2633f2ca8
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.homolog.json
+      md5sum: 9afc2bbd09d09355d9af60444a142c9e
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.overexpression.json
+      md5sum: 99914b932bd37a50b983c5e7c90ae93b
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.potentialGenes
+      md5sum: c0036a6de024663abb227b1c9d270433
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.predictedGenes.json
+      md5sum: 34a72a154d89ff463f86e6e353b602a6
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.predictedGenes.protein.json
+      md5sum: 1bc75d8e5f5e63e28589bc001c082459
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.rrna.json
+      md5sum: 99914b932bd37a50b983c5e7c90ae93b
+    - path: output/rgi/temp/genome.fna.gz.temp.uncompressed.fsa.temp.variant.json
+      md5sum: d6cf35350328bd51b67d52cdddcba177
     - path: output/rgi/test.json
-      contains: ["NZ_LS483480", "orf_end", "perc_identity", "Pulvomycin"]
+      md5sum: 5a65dd8d206883010e8a5834e7a8121a
     - path: output/rgi/test.txt
-      contains: ["NZ_LS483480", "ORF_ID", "Model_type", "Pulvomycin"]
+      md5sum: ecee265ab7fcb352890d147dbb2700dc


### PR DESCRIPTION
As `publishDir`  patterns can't exclude (or rather globs don't :().

Moves all files with `temp` in the name to a dedicated directory

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
