### PR TITLE
New subworkflow: fastq_align_bwaaln

### DIFF
--- a/subworkflows/nf-core/fastq_align_bwaaln/main.nf
+++ b/subworkflows/nf-core/fastq_align_bwaaln/main.nf
@@ -10,7 +10,7 @@ include { SAMTOOLS_INDEX     } from '../../../modules/nf-core/samtools/index/mai
 workflow FASTQ_ALIGN_BWAALN {
 
     take:
-    ch_reads // channel (mandatory): [ val(meta), [ reads ] ]. subworkImportant: meta REQUIRES singleend` entry!
+    ch_reads // channel (mandatory): [ val(meta), [ reads ] ]. subworkImportant: meta REQUIRES single_end` entry!
     ch_index // channel (mandatory): [ val(meta), [ index ] ]
 
     main:

--- a/subworkflows/nf-core/fastq_align_bwaaln/main.nf
+++ b/subworkflows/nf-core/fastq_align_bwaaln/main.nf
@@ -10,7 +10,7 @@ include { SAMTOOLS_INDEX     } from '../../../modules/nf-core/samtools/index/mai
 workflow FASTQ_ALIGN_BWAALN {
 
     take:
-    ch_reads // channel (mandatory): [ val(meta), [ reads ] ]. Important: meta REQUIRES singleend` entry!
+    ch_reads // channel (mandatory): [ val(meta), [ reads ] ]. subworkImportant: meta REQUIRES singleend` entry!
     ch_index // channel (mandatory): [ val(meta), [ index ] ]
 
     main:
@@ -21,9 +21,9 @@ workflow FASTQ_ALIGN_BWAALN {
     ch_versions = ch_versions.mix( BWA_ALN.out.versions.first() )
 
     ch_sai_for_bam = ch_reads
-                        .join( BWA_ALN.out.sai )
+                        .join ( BWA_ALN.out.sai )
                         .branch {
-                            meta, sai ->
+                            meta, reads, sai ->
                                 pe: !meta.single_end
                                 se: meta.single_end
                         }

--- a/subworkflows/nf-core/fastq_align_bwaaln/main.nf
+++ b/subworkflows/nf-core/fastq_align_bwaaln/main.nf
@@ -1,0 +1,49 @@
+//
+// Alignment with bwa aln and sort
+//
+
+include { BWA_ALN            } from '../../../modules/nf-core/bwa/aln/main'
+include { BWA_SAMSE          } from '../../../modules/nf-core/bwa/samse/main'
+include { BWA_SAMPE          } from '../../../modules/nf-core/bwa/sampe/main'
+include { SAMTOOLS_INDEX     } from '../../../modules/nf-core/samtools/index/main'
+
+workflow FASTQ_ALIGN_BWAALN {
+
+    take:
+    ch_reads // channel (mandatory): [ val(meta), [ reads ] ]. Important: meta REQUIRES singleend` entry!
+    ch_index // channel (mandatory): [ val(meta), [ index ] ]
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    BWA_ALN ( ch_reads, ch_index )
+    ch_versions = ch_versions.mix( BWA_ALN.out.versions.first() )
+
+    ch_sai_for_bam = ch_reads
+                        .join( BWA_ALN.out.sai )
+                        .branch {
+                            meta, sai ->
+                                pe: !meta.single_end
+                                se: meta.single_end
+                        }
+
+    BWA_SAMPE ( ch_sai_for_bam.pe, ch_index )
+    ch_versions = ch_versions.mix( BWA_SAMPE.out.versions.first() )
+
+    BWA_SAMSE ( ch_sai_for_bam.se, ch_index )
+    ch_versions = ch_versions.mix( BWA_SAMSE.out.versions.first() )
+
+    ch_bam_for_index = BWA_SAMPE.out.bam.mix( BWA_SAMSE.out.bam )
+
+    SAMTOOLS_INDEX ( ch_bam_for_index )
+    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
+
+    emit:
+    bam      = ch_bam_for_index           // channel: [ val(meta), [ bam ] ]
+    bai      = SAMTOOLS_INDEX.out.bai     // channel: [ val(meta), [ bai ] ]
+    csi      = SAMTOOLS_INDEX.out.csi     // channel: [ val(meta), [ csi ] ]
+
+    versions = ch_versions                     // channel: [ versions.yml ]
+}
+

--- a/subworkflows/nf-core/fastq_align_bwaaln/meta.yml
+++ b/subworkflows/nf-core/fastq_align_bwaaln/meta.yml
@@ -23,10 +23,9 @@ input:
       type: directory
       description: |
         Structure: [ val(meta), path(index/) ]
-        A directory containing bwa aln reference indicies as from `bwa index`
+        A directory containing bwa aln reference indices as from `bwa index`
         Contains files ending in extensions such as .amb, .ann, .bwt etc.
 
-      pattern: "*.{bam,cram,sam}"
 
 output:
   - meta:

--- a/subworkflows/nf-core/fastq_align_bwaaln/meta.yml
+++ b/subworkflows/nf-core/fastq_align_bwaaln/meta.yml
@@ -26,7 +26,6 @@ input:
         A directory containing bwa aln reference indices as from `bwa index`
         Contains files ending in extensions such as .amb, .ann, .bwt etc.
 
-
 output:
   - meta:
       type: map

--- a/subworkflows/nf-core/fastq_align_bwaaln/meta.yml
+++ b/subworkflows/nf-core/fastq_align_bwaaln/meta.yml
@@ -1,0 +1,60 @@
+name: "fastq_align_bwaaln_samtools"
+description: Align FASTQ files against reference genome with the bwa aln short-read aligner producing a sorted and indexed BAM files
+keywords:
+  - bwa
+  - aln
+  - fasta
+  - bwa
+  - align
+  - map
+modules:
+  - bwa/aln
+  - bwa/sampe
+  - bwa/samse
+  - samtools/index
+input:
+  - ch_reads:
+      type: file
+      description: |
+        Structure: [ val(meta), path(fastq) ]
+        One or two FASTQ files for single or paired end data respectively.
+      pattern: "*.{fastq,fq,fastq.gz,fq.gz}"
+  - ch_index:
+      type: directory
+      description: |
+        Structure: [ val(meta), path(index/) ]
+        A directory containing bwa aln reference indicies as from `bwa index`
+        Contains files ending in extensions such as .amb, .ann, .bwt etc.
+
+      pattern: "*.{bam,cram,sam}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - bam:
+      type: file
+      description: |
+        Structure: [ val(meta), path(bam) ]
+        Sorted BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+  - bai:
+      type: file
+      description: |
+        Structure: [ val(meta), path(bai) ]
+        BAM/CRAM/SAM samtools index file
+      pattern: "*.{bai,crai,sai}"
+  - csi:
+      type: file
+      description: |
+        Structure: [ val(meta), path(csi) ]
+        BAM/CRAM/SAM samtools index file for larger references
+      pattern: "*.csi"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@jfy133"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -2787,6 +2787,10 @@ subworkflows/fastq_align_hisat2:
   - subworkflows/nf-core/fastq_align_hisat2/**
   - tests/subworkflows/nf-core/fastq_align_hisat2/**
 
+subworkflows/fastq_align_bwaaln_samtools:
+  - subworkflows/nf-core/fastq_align_bwaaln/**
+  - tests/subworkflows/nf-core/fastq_align_bwaaln/**
+
 subworkflows/fastq_align_star:
   - subworkflows/nf-core/fastq_align_star/**
   - tests/subworkflows/nf-core/fastq_align_star/**

--- a/tests/subworkflows/nf-core/fastq_align_bwaaln/main.nf
+++ b/tests/subworkflows/nf-core/fastq_align_bwaaln/main.nf
@@ -16,7 +16,6 @@ workflow test_fastq_align_bwaaln_singleend {
         [id: 'test'],
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
-    sort = false
 
     BWA_INDEX ( fasta )
     FASTQ_ALIGN_BWAALN ( input, BWA_INDEX.out.index )

--- a/tests/subworkflows/nf-core/fastq_align_bwaaln/main.nf
+++ b/tests/subworkflows/nf-core/fastq_align_bwaaln/main.nf
@@ -1,0 +1,64 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { BWA_INDEX          } from '../../../../modules/nf-core/bwa/index/main.nf'
+include { FASTQ_ALIGN_BWAALN } from '../../../../subworkflows/nf-core/fastq_align_bwaaln/main.nf'
+
+
+workflow test_fastq_align_bwaaln_singleend {
+
+    input = Channel.fromList(
+        [
+            [ id:'test', single_end:true ], // meta map
+            [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
+        ]
+    )
+    fasta = [
+        [id: 'test'],
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+    sort = false
+
+    BWA_INDEX ( fasta )
+    FASTQ_ALIGN_BWAALN ( input, BWA_INDEX.out.index )
+}
+
+workflow test_fastq_align_bwaaln_paired_end {
+
+    input = Channel.fromList(
+        [
+            [ id:'test', single_end:false ], // meta map
+            [
+                file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+            ]
+        ]
+    )
+    fasta = [
+        [id: 'test'],
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+
+    BWA_INDEX ( fasta )
+    FASTQ_ALIGN_BWAALN ( input, BWA_INDEX.out.index )
+
+}
+
+workflow test_fastq_align_bwaaln_both {
+
+    input = Channel.fromList(
+        [
+            [ [ id:'test',  single_end:false ], [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true), file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ] ],
+            [ [ id:'test2', single_end:true ],  [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ] ]
+        ]
+    )
+    fasta = [
+        [id: 'test'],
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+
+    BWA_INDEX ( fasta )
+    FASTQ_ALIGN_BWAALN ( input, BWA_INDEX.out.index )
+
+}

--- a/tests/subworkflows/nf-core/fastq_align_bwaaln/main.nf
+++ b/tests/subworkflows/nf-core/fastq_align_bwaaln/main.nf
@@ -8,12 +8,10 @@ include { FASTQ_ALIGN_BWAALN } from '../../../../subworkflows/nf-core/fastq_alig
 
 workflow test_fastq_align_bwaaln_singleend {
 
-    input = Channel.fromList(
-        [
+    input = Channel.of([
             [ id:'test', single_end:true ], // meta map
             [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
-        ]
-    )
+        ])
     fasta = [
         [id: 'test'],
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
@@ -26,16 +24,14 @@ workflow test_fastq_align_bwaaln_singleend {
 
 workflow test_fastq_align_bwaaln_paired_end {
 
-    input = Channel.fromList(
-        [
-            [ id:'test', single_end:false ], // meta map
-            [
-                file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
-            ]
-        ]
-    )
-    fasta = [
+    input = Channel.of([
+                [ id:'test', single_end:false ], // meta map
+                [
+                    file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                    file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                ]
+    ])
+            fasta = [
         [id: 'test'],
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]

--- a/tests/subworkflows/nf-core/fastq_align_bwaaln/nextflow.config
+++ b/tests/subworkflows/nf-core/fastq_align_bwaaln/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+}

--- a/tests/subworkflows/nf-core/fastq_align_bwaaln/test.yml
+++ b/tests/subworkflows/nf-core/fastq_align_bwaaln/test.yml
@@ -1,0 +1,12 @@
+## TODO nf-core: Please run the following command to build this file:
+#                nf-core subworkflows create-test-yml
+- name: "fastq_align_bwaaln"
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_align_bwaaln -entry test_fastq_align_bwaaln -c ./tests/config/nextflow.config
+  tags:
+    - "subworkflows"
+    - "subworkflows/fastq_align_bwaaln"
+  files:
+    - path: "output/fastq_align_bwaaln/test.bam"
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc
+    - path: output/fastq_align_bwaaln/versions.yml
+      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b

--- a/tests/subworkflows/nf-core/fastq_align_bwaaln/test.yml
+++ b/tests/subworkflows/nf-core/fastq_align_bwaaln/test.yml
@@ -1,12 +1,66 @@
-## TODO nf-core: Please run the following command to build this file:
-#                nf-core subworkflows create-test-yml
-- name: "fastq_align_bwaaln"
-  command: nextflow run ./tests/subworkflows/nf-core/fastq_align_bwaaln -entry test_fastq_align_bwaaln -c ./tests/config/nextflow.config
+- name: fastq_align_bwaaln test_fastq_align_bwaaln_singleend
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_align_bwaaln -entry test_fastq_align_bwaaln_singleend -c ./tests/config/nextflow.config
   tags:
-    - "subworkflows"
-    - "subworkflows/fastq_align_bwaaln"
+    - bwa
+    - bwa/aln
+    - bwa/sampe
+    - bwa/samse
+    - samtools
+    - samtools/index
+    - subworkflows
+    - subworkflows/fastq_align_bwaaln
   files:
-    - path: "output/fastq_align_bwaaln/test.bam"
-      md5sum: e667c7caad0bc4b7ac383fd023c654fc
-    - path: output/fastq_align_bwaaln/versions.yml
-      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b
+    - path: output/bwa/test.bam
+      md5sum: 5cf3882480b7a7be0d7256be19807850
+    - path: output/bwa/test.sai
+      md5sum: aaaf39b6814c96ca1a5eacc662adf926
+    - path: output/samtools/test.bam.bai
+      md5sum: 0006931d17e40a4b8896ff1438bbbdcb
+
+- name: fastq_align_bwaaln test_fastq_align_bwaaln_paired_end
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_align_bwaaln -entry test_fastq_align_bwaaln_paired_end -c ./tests/config/nextflow.config
+  tags:
+    - bwa
+    - bwa/aln
+    - bwa/sampe
+    - bwa/samse
+    - samtools
+    - samtools/index
+    - subworkflows
+    - subworkflows/fastq_align_bwaaln
+  files:
+    - path: output/bwa/test.1.sai
+      md5sum: aaaf39b6814c96ca1a5eacc662adf926
+    - path: output/bwa/test.2.sai
+      md5sum: b4f185d9b4cb256dd5c377070a536124
+    - path: output/bwa/test.bam
+      md5sum: 3d650b76c7a80b5e6ff672a01e2a6bfa
+    - path: output/samtools/test.bam.bai
+      md5sum: ef100143d24336c57b66ac9a462e6373
+
+- name: fastq_align_bwaaln test_fastq_align_bwaaln_both
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_align_bwaaln -entry test_fastq_align_bwaaln_both -c ./tests/config/nextflow.config
+  tags:
+    - bwa
+    - bwa/aln
+    - bwa/sampe
+    - bwa/samse
+    - samtools
+    - samtools/index
+    - subworkflows
+    - subworkflows/fastq_align_bwaaln
+  files:
+    - path: output/bwa/test.1.sai
+      md5sum: aaaf39b6814c96ca1a5eacc662adf926
+    - path: output/bwa/test.2.sai
+      md5sum: b4f185d9b4cb256dd5c377070a536124
+    - path: output/bwa/test.bam
+      md5sum: 3d650b76c7a80b5e6ff672a01e2a6bfa
+    - path: output/bwa/test2.bam
+      md5sum: 84bac6c61a24b671fce06b841ee8cdcf
+    - path: output/bwa/test2.sai
+      md5sum: aaaf39b6814c96ca1a5eacc662adf926
+    - path: output/samtools/test.bam.bai
+      md5sum: ef100143d24336c57b66ac9a462e6373
+    - path: output/samtools/test2.bam.bai
+      md5sum: 0006931d17e40a4b8896ff1438bbbdcb


### PR DESCRIPTION
Implements the bwa aln -> samse/sampe -> index workflow.

I've not modified the excisitng `fastq_align_bwa` to maybe the more 'correct' `fastq_align_bwamem`, but maybe this is something to consider @JoseEspinosa? I'm wondering if that should also be in guidelines (full module name, if subcommands exist?)

Note that _unlike_ other alignment subworkflows, I've explicitly _not_ included the stats here. I'm wary of doing this at this step given in some cases people (i.e., me) may actually want to map per run/lane/library separately, then merge the resulting BAM files after this (of a given sample/library), upon which you generte stats (so to get stats per library or sample rather than of each lane/run separately). This helps chunk up alignment steps of pipelines into smaller/'cluster-friendly' batches of jobs and often will run faster (than one monolith - something we currently do in eager DSL1 and people complained about).

Therefore, I also wonder if this could be another guideline... 'stats' related subworkflows should be separate from 'functional' workflows?  In sense we don't want to assume too 'hard' what a pipeline developer wants to generate stats from? Although this would maybe require updating of previous subworkflows

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
