### PR TITLE
Fixed the layout of the dictionary

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -486,7 +486,7 @@ params {
                 ipython_ipynb                   = "${test_data_dir}/generic/notebooks/jupyter/ipython_notebook.ipynb"
             }
             'tar' {
-                tar_gz                           = "${test_data_dir}/generic/tar/hello.tar.gz"
+                tar_gz                          = "${test_data_dir}/generic/tar/hello.tar.gz"
             }
             'tsv' {
                 test_tsv                        = "${test_data_dir}/generic/tsv/test.tsv"
@@ -509,34 +509,33 @@ params {
                 ncbi_user_settings              = "${test_data_dir}/generic/config/ncbi_user_settings.mkfg"
             }
         }
-	'proteomics' {
-	    'msspectra' {
-	        ups_file1                       = "${test_data_dir}/proteomics/msspectra/OVEMB150205_12.raw"
-	        ups_file2                       = "${test_data_dir}/proteomics/msspectra/OVEMB150205_14.raw"
-	    }
-	    'database' {
-            yeast_ups                       = "${test_data_dir}/proteomics/database/yeast_UPS.fasta"
-        }
-	    'parameter' {
-	        maxquant                        = "${test_data_dir}/proteomics/parameter/mqpar.xml"
-	    }
-        'idfile' {
-            openms_idxml                    = "${test_data_dir}/proteomics/openms_idxml/BSA_QC_file.idXML"
-        }
-	}
-    'mus_musculus' {
-        'illumina' {
-            test_1_fastq_gz                                = "${test_data_dir}/genomics/mus_musculus/mageck/ERR376998.small.fastq.gz"
-            test_2_fastq_gz                                = "${test_data_dir}/genomics/mus_musculus/mageck/ERR376999.small.fastq.gz"
-        }
-        'csv' {
-            count_table                                    = "${test_data_dir}/genomics/mus_musculus/mageck/count_table.csv"
-            library                                        = "${test_data_dir}/genomics/mus_musculus/mageck/yusa_library.csv"
+        'proteomics' {
+            'msspectra' {
+                ups_file1                       = "${test_data_dir}/proteomics/msspectra/OVEMB150205_12.raw"
+                ups_file2                       = "${test_data_dir}/proteomics/msspectra/OVEMB150205_14.raw"
             }
-        'txt' {
-            design_matrix                                  = "${test_data_dir}/genomics/mus_musculus/mageck/design_matrix.txt"
+            'database' {
+                yeast_ups                       = "${test_data_dir}/proteomics/database/yeast_UPS.fasta"
             }
-
-    }
+            'parameter' {
+                maxquant                        = "${test_data_dir}/proteomics/parameter/mqpar.xml"
+            }
+            'idfile' {
+                openms_idxml                    = "${test_data_dir}/proteomics/openms_idxml/BSA_QC_file.idXML"
+            }
+        }
+        'mus_musculus' {
+            'illumina' {
+                test_1_fastq_gz                 = "${test_data_dir}/genomics/mus_musculus/mageck/ERR376998.small.fastq.gz"
+                test_2_fastq_gz                 = "${test_data_dir}/genomics/mus_musculus/mageck/ERR376999.small.fastq.gz"
+            }
+            'csv' {
+                count_table                     = "${test_data_dir}/genomics/mus_musculus/mageck/count_table.csv"
+                library                         = "${test_data_dir}/genomics/mus_musculus/mageck/yusa_library.csv"
+            }
+            'txt' {
+                design_matrix                   = "${test_data_dir}/genomics/mus_musculus/mageck/design_matrix.txt"
+            }
+        }
     }
 }


### PR DESCRIPTION
When making a new module, I realised that the layout of test_data.config was corrupted:
 - it had some tabulations
 - some hashes were wrongly indented
 - some `=` were not aligned

This PR fixes all three issues.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
