### PR TITLE
Miniprot index and align

### DIFF
--- a/modules/nf-core/bwamem2/index/meta.yml
+++ b/modules/nf-core/bwamem2/index/meta.yml
@@ -6,7 +6,7 @@ keywords:
   - genome
   - reference
 tools:
-  - bwa:
+  - bwamem2:
       description: |
         BWA-mem2 is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.

--- a/modules/nf-core/minimap2/index/meta.yml
+++ b/modules/nf-core/minimap2/index/meta.yml
@@ -27,7 +27,7 @@ output:
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  - mmi:
+  - index:
       type: file
       description: Minimap2 fasta index.
       pattern: "*.mmi"

--- a/modules/nf-core/miniprot/align/main.nf
+++ b/modules/nf-core/miniprot/align/main.nf
@@ -1,0 +1,44 @@
+
+process MINIPROT_ALIGN {
+
+    tag "$meta.id"
+    label 'process_medium'
+
+    def version = '0.5-c2'
+    if (params.enable_conda) {
+        exit 1, "Conda environments cannot be used when using the miniprot process. Please use docker or singularity containers."
+    }
+    container "quay.io/sanger-tol/miniprot:${version}"
+
+    input:
+    tuple val(meta), path(ref)
+    path pep
+
+
+    output:
+    tuple val(meta), path("*.paf"), optional: true, emit: paf
+    tuple val(meta), path("*.gff"), optional: true, emit: gff
+    path "versions.yml"                           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = args.contains("--gff") ? "gff" : "paf"
+    """
+    miniprot \\
+        $args \\
+        -t $task.cpus \\
+        ${ref} \\
+        ${pep} \\
+        > ${prefix}.${extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        miniprot: $version
+    END_VERSIONS
+    """
+}
+

--- a/modules/nf-core/miniprot/align/main.nf
+++ b/modules/nf-core/miniprot/align/main.nf
@@ -11,8 +11,8 @@ process MINIPROT_ALIGN {
     container "quay.io/sanger-tol/miniprot:${version}"
 
     input:
-    tuple val(meta), path(ref)
-    path pep
+    tuple val(meta), path(pep)
+    path ref
 
 
     output:

--- a/modules/nf-core/miniprot/align/main.nf
+++ b/modules/nf-core/miniprot/align/main.nf
@@ -4,11 +4,10 @@ process MINIPROT_ALIGN {
     tag "$meta.id"
     label 'process_medium'
 
-    def version = '0.5-c2'
-    if (params.enable_conda) {
-        exit 1, "Conda environments cannot be used when using the miniprot process. Please use docker or singularity containers."
-    }
-    container "quay.io/sanger-tol/miniprot:${version}"
+    conda (params.enable_conda ? "bioconda::miniprot=0.5" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/miniprot:0.5--h7132678_0':
+        'quay.io/biocontainers/miniprot:0.5--h7132678_0' }"
 
     input:
     tuple val(meta), path(pep)
@@ -37,7 +36,7 @@ process MINIPROT_ALIGN {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        miniprot: $version
+        miniprot: \$(miniprot --version 2>&1)
     END_VERSIONS
     """
 }

--- a/modules/nf-core/miniprot/align/main.nf
+++ b/modules/nf-core/miniprot/align/main.nf
@@ -1,6 +1,4 @@
-
 process MINIPROT_ALIGN {
-
     tag "$meta.id"
     label 'process_medium'
 
@@ -12,7 +10,6 @@ process MINIPROT_ALIGN {
     input:
     tuple val(meta), path(pep)
     path ref
-
 
     output:
     tuple val(meta), path("*.paf"), optional: true, emit: paf
@@ -40,4 +37,3 @@ process MINIPROT_ALIGN {
     END_VERSIONS
     """
 }
-

--- a/modules/nf-core/miniprot/align/main.nf
+++ b/modules/nf-core/miniprot/align/main.nf
@@ -9,7 +9,7 @@ process MINIPROT_ALIGN {
 
     input:
     tuple val(meta), path(pep)
-    path ref
+    tuple val(meta2), path(ref)
 
     output:
     tuple val(meta), path("*.paf"), optional: true, emit: paf

--- a/modules/nf-core/miniprot/align/meta.yml
+++ b/modules/nf-core/miniprot/align/meta.yml
@@ -1,0 +1,48 @@
+name: miniprot_align
+description: A versatile pairwise aligner for genomic and spliced nucleotide sequences
+keywords:
+  - align
+  - fasta
+  - protein
+  - genome
+  - paf
+  - gff
+tools:
+  - miniprot:
+      description: |
+        A versatile pairwise aligner for genomic and protein sequences.
+      homepage: https://github.com/lh3/miniprot
+      documentation: https://github.com/lh3/miniprot
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - pep:
+      type: file
+      description: a fasta file contains one or multiple protein sequences
+  - ref:
+      type: file
+      description: Reference database in FASTA format or miniprot index format.
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - paf:
+      type: file
+      description: Alignment in PAF format
+      pattern: "*.paf"
+  - gff:
+      type: file
+      description: Alignment in gff format
+      pattern: "*.gff"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@yumisims"

--- a/modules/nf-core/miniprot/align/meta.yml
+++ b/modules/nf-core/miniprot/align/meta.yml
@@ -23,6 +23,10 @@ input:
   - pep:
       type: file
       description: a fasta file contains one or multiple protein sequences
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
   - ref:
       type: file
       description: Reference database in FASTA format or miniprot index format.

--- a/modules/nf-core/miniprot/align/meta.yml
+++ b/modules/nf-core/miniprot/align/meta.yml
@@ -46,3 +46,4 @@ output:
       pattern: "versions.yml"
 authors:
   - "@yumisims"
+  - "@muffato"

--- a/modules/nf-core/miniprot/index/main.nf
+++ b/modules/nf-core/miniprot/index/main.nf
@@ -1,0 +1,35 @@
+process MINIPROT_INDEX {
+    tag "$meta.id"
+    label 'process_medium'
+    def version = '0.5-c2'
+    if (params.enable_conda) {
+        exit 1, "Conda environments cannot be used when using the miniprot process. Please use docker or singularity containers."
+    }
+    container "quay.io/sanger-tol/miniprot:${version}"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("*.mpi"), emit: index
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+
+    """
+    miniprot \\
+        -t $task.cpus \\
+        -d ${fasta.baseName}.mpi \\
+        $args \\
+        $fasta
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        miniprot: $version
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/miniprot/index/main.nf
+++ b/modules/nf-core/miniprot/index/main.nf
@@ -1,11 +1,11 @@
 process MINIPROT_INDEX {
     tag "$meta.id"
     label 'process_medium'
-    def version = '0.5-c2'
-    if (params.enable_conda) {
-        exit 1, "Conda environments cannot be used when using the miniprot process. Please use docker or singularity containers."
-    }
-    container "quay.io/sanger-tol/miniprot:${version}"
+
+    conda (params.enable_conda ? "bioconda::miniprot=0.5" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/miniprot:0.5--h7132678_0':
+        'quay.io/biocontainers/miniprot:0.5--h7132678_0' }"
 
     input:
     tuple val(meta), path(fasta)
@@ -29,7 +29,7 @@ process MINIPROT_INDEX {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        miniprot: $version
+        miniprot: \$(miniprot --version 2>&1)
     END_VERSIONS
     """
 }

--- a/modules/nf-core/miniprot/index/meta.yml
+++ b/modules/nf-core/miniprot/index/meta.yml
@@ -1,0 +1,39 @@
+name: miniprot_index
+description: Provides fasta index required by miniprot alignment.
+keywords:
+  - index
+  - fasta
+  - reference
+tools:
+  - miniprot:
+      description: |
+        A versatile pairwise aligner for genomic and protein sequences.
+      homepage: https://github.com/lh3/miniprot
+      documentation: https://github.com/lh3/miniprot
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: |
+        Reference database in FASTA format.
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - index:
+      type: file
+      description: miniprot fasta index.
+      pattern: "*.mpi"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@yumisims"

--- a/modules/nf-core/miniprot/index/meta.yml
+++ b/modules/nf-core/miniprot/index/meta.yml
@@ -37,3 +37,4 @@ output:
       pattern: "versions.yml"
 authors:
   - "@yumisims"
+  - "@muffato"

--- a/modules/nf-core/miniprot/index/meta.yml
+++ b/modules/nf-core/miniprot/index/meta.yml
@@ -3,6 +3,7 @@ description: Provides fasta index required by miniprot alignment.
 keywords:
   - index
   - fasta
+  - genome
   - reference
 tools:
   - miniprot:

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -1902,6 +1902,10 @@ miranda:
   - modules/nf-core/miranda/**
   - tests/modules/nf-core/miranda/**
 
+miniprot/align:
+  - modules/miniprot/align/**
+  - tests/modules/miniprot/align/**
+
 miniprot/index:
   - modules/nf-core/miniprot/index/**
   - tests/modules/nf-core/miniprot/index/**

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -1902,6 +1902,10 @@ miranda:
   - modules/nf-core/miranda/**
   - tests/modules/nf-core/miranda/**
 
+miniprot/index:
+  - modules/nf-core/miniprot/index/**
+  - tests/modules/nf-core/miniprot/index/**
+
 mlst:
   - modules/nf-core/mlst/**
   - tests/modules/nf-core/mlst/**

--- a/tests/modules/nf-core/miniprot/align/main.nf
+++ b/tests/modules/nf-core/miniprot/align/main.nf
@@ -1,0 +1,28 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+include { MINIPROT_INDEX } from '../../../../modules/miniprot/index/main.nf'
+include { MINIPROT_ALIGN } from '../../../../modules/miniprot/align/main.nf'
+
+workflow test_miniprot_align_gff {
+    
+    input = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+
+    input_pep = file(params.test_data['sarscov2']['genome']['proteome_fasta'], checkIfExists: true)
+
+    MINIPROT_INDEX ( [ [id:'test'], input] )
+ 
+    MINIPROT_ALIGN ( [ [id:'test'], input_pep] , MINIPROT_INDEX.out.index.map { it[1] } )
+}
+
+workflow test_miniprot_align_paf {
+    
+    input = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    
+    input_pep = file(params.test_data['sarscov2']['genome']['proteome_fasta'], checkIfExists: true)
+
+    MINIPROT_INDEX ( [ [id:'test'], input] )
+ 
+    MINIPROT_ALIGN ( [ [id:'test'], input_pep] , MINIPROT_INDEX.out.index.map { it[1] } )
+}
+

--- a/tests/modules/nf-core/miniprot/align/main.nf
+++ b/tests/modules/nf-core/miniprot/align/main.nf
@@ -12,7 +12,7 @@ workflow test_miniprot_align_gff {
 
     MINIPROT_INDEX ( [ [id:'test'], input] )
  
-    MINIPROT_ALIGN ( [ [id:'test'], input_pep] , MINIPROT_INDEX.out.index.map { it[1] } )
+    MINIPROT_ALIGN ( [ [id:'test'], input_pep] , MINIPROT_INDEX.out.index )
 }
 
 workflow test_miniprot_align_paf {
@@ -23,6 +23,6 @@ workflow test_miniprot_align_paf {
 
     MINIPROT_INDEX ( [ [id:'test'], input] )
  
-    MINIPROT_ALIGN ( [ [id:'test'], input_pep] , MINIPROT_INDEX.out.index.map { it[1] } )
+    MINIPROT_ALIGN ( [ [id:'test'], input_pep] , MINIPROT_INDEX.out.index )
 }
 

--- a/tests/modules/nf-core/miniprot/align/main.nf
+++ b/tests/modules/nf-core/miniprot/align/main.nf
@@ -1,8 +1,8 @@
 #!/usr/bin/env nextflow
 
 nextflow.enable.dsl = 2
-include { MINIPROT_INDEX } from '../../../../modules/miniprot/index/main.nf'
-include { MINIPROT_ALIGN } from '../../../../modules/miniprot/align/main.nf'
+include { MINIPROT_INDEX } from '../../../../../modules/nf-core/miniprot/index/main.nf'
+include { MINIPROT_ALIGN } from '../../../../../modules/nf-core/miniprot/align/main.nf'
 
 workflow test_miniprot_align_gff {
     

--- a/tests/modules/nf-core/miniprot/align/nextflow.config
+++ b/tests/modules/nf-core/miniprot/align/nextflow.config
@@ -1,0 +1,14 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    withName: 'test_miniprot_align_gff:MINIPROT_ALIGN' {
+        ext.args = "-u --gff"
+    }
+
+    withName: 'test_miniprot_align_paf:MINIPROT_ALIGN' {
+        ext.args = "-u"
+    }
+    
+}
+

--- a/tests/modules/nf-core/miniprot/align/test.yml
+++ b/tests/modules/nf-core/miniprot/align/test.yml
@@ -7,7 +7,7 @@
     - path: output/miniprot/genome.mpi
       md5sum: bf4f59376dc00f758b69706f38b4f650
     - path: output/miniprot/test.gff
-      md5sum: 5faabc6fb54e4021de37aa78c129fab6
+      md5sum: dc2d01ac840ee26416b5eb9cf252181d
     - path: output/miniprot/versions.yml
       md5sum: 25e86c616466985a3012658f64a9868b
 
@@ -20,6 +20,6 @@
     - path: output/miniprot/genome.mpi
       md5sum: bf4f59376dc00f758b69706f38b4f650
     - path: output/miniprot/test.paf
-      md5sum: af65a174f8d8d18ec4e1abf8d33ef3f1
+      md5sum: f2b40da6a9605df44efc9df14b255b53
     - path: output/miniprot/versions.yml
       md5sum: 80ec5877c67aaa0b86cdda26d242814c

--- a/tests/modules/nf-core/miniprot/align/test.yml
+++ b/tests/modules/nf-core/miniprot/align/test.yml
@@ -1,0 +1,25 @@
+- name: miniprot align test_miniprot_align_gff
+  command: nextflow run ./tests/modules/miniprot/align -entry test_miniprot_align_gff -c ./tests/config/nextflow.config -c ./tests/modules/miniprot/align/nextflow.config
+  tags:
+    - miniprot
+    - miniprot/align
+  files:
+    - path: output/miniprot/genome.mpi
+      md5sum: bf4f59376dc00f758b69706f38b4f650
+    - path: output/miniprot/test.gff
+      md5sum: 5faabc6fb54e4021de37aa78c129fab6
+    - path: output/miniprot/versions.yml
+      md5sum: 25e86c616466985a3012658f64a9868b
+
+- name: miniprot align test_miniprot_align_paf
+  command: nextflow run ./tests/modules/miniprot/align -entry test_miniprot_align_paf -c ./tests/config/nextflow.config -c ./tests/modules/miniprot/align/nextflow.config
+  tags:
+    - miniprot
+    - miniprot/align
+  files:
+    - path: output/miniprot/genome.mpi
+      md5sum: bf4f59376dc00f758b69706f38b4f650
+    - path: output/miniprot/test.paf
+      md5sum: af65a174f8d8d18ec4e1abf8d33ef3f1
+    - path: output/miniprot/versions.yml
+      md5sum: 80ec5877c67aaa0b86cdda26d242814c

--- a/tests/modules/nf-core/miniprot/align/test.yml
+++ b/tests/modules/nf-core/miniprot/align/test.yml
@@ -1,5 +1,5 @@
 - name: miniprot align test_miniprot_align_gff
-  command: nextflow run ./tests/modules/miniprot/align -entry test_miniprot_align_gff -c ./tests/config/nextflow.config -c ./tests/modules/miniprot/align/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/miniprot/align -entry test_miniprot_align_gff -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/miniprot/align/nextflow.config
   tags:
     - miniprot
     - miniprot/align
@@ -12,7 +12,7 @@
       md5sum: 25e86c616466985a3012658f64a9868b
 
 - name: miniprot align test_miniprot_align_paf
-  command: nextflow run ./tests/modules/miniprot/align -entry test_miniprot_align_paf -c ./tests/config/nextflow.config -c ./tests/modules/miniprot/align/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/miniprot/align -entry test_miniprot_align_paf -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/miniprot/align/nextflow.config
   tags:
     - miniprot
     - miniprot/align

--- a/tests/modules/nf-core/miniprot/align/test.yml
+++ b/tests/modules/nf-core/miniprot/align/test.yml
@@ -9,7 +9,6 @@
     - path: output/miniprot/test.gff
       md5sum: dc2d01ac840ee26416b5eb9cf252181d
     - path: output/miniprot/versions.yml
-      md5sum: 25e86c616466985a3012658f64a9868b
 
 - name: miniprot align test_miniprot_align_paf
   command: nextflow run ./tests/modules/nf-core/miniprot/align -entry test_miniprot_align_paf -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/miniprot/align/nextflow.config
@@ -22,4 +21,3 @@
     - path: output/miniprot/test.paf
       md5sum: f2b40da6a9605df44efc9df14b255b53
     - path: output/miniprot/versions.yml
-      md5sum: 80ec5877c67aaa0b86cdda26d242814c

--- a/tests/modules/nf-core/miniprot/index/main.nf
+++ b/tests/modules/nf-core/miniprot/index/main.nf
@@ -1,0 +1,10 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { MINIPROT_INDEX } from '../../../../modules/miniprot/index/main.nf'
+
+workflow test_miniprot_index {
+    fasta =file(params.tol_test_data['small_genome']['Oscheius_sp']['assembly']['assembly_fasta'],checkIfExists: true)
+    MINIPROT_INDEX ( [ [id:'test'], fasta ] )
+}

--- a/tests/modules/nf-core/miniprot/index/main.nf
+++ b/tests/modules/nf-core/miniprot/index/main.nf
@@ -2,7 +2,7 @@
 
 nextflow.enable.dsl = 2
 
-include { MINIPROT_INDEX } from '../../../../modules/miniprot/index/main.nf'
+include { MINIPROT_INDEX } from '../../../../../modules/nf-core/miniprot/index/main.nf'
 
 workflow test_miniprot_index {
     fasta =file(params.tol_test_data['small_genome']['Oscheius_sp']['assembly']['assembly_fasta'],checkIfExists: true)

--- a/tests/modules/nf-core/miniprot/index/main.nf
+++ b/tests/modules/nf-core/miniprot/index/main.nf
@@ -5,6 +5,6 @@ nextflow.enable.dsl = 2
 include { MINIPROT_INDEX } from '../../../../../modules/nf-core/miniprot/index/main.nf'
 
 workflow test_miniprot_index {
-    fasta =file(params.tol_test_data['small_genome']['Oscheius_sp']['assembly']['assembly_fasta'],checkIfExists: true)
+    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     MINIPROT_INDEX ( [ [id:'test'], fasta ] )
 }

--- a/tests/modules/nf-core/miniprot/index/nextflow.config
+++ b/tests/modules/nf-core/miniprot/index/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    
+}

--- a/tests/modules/nf-core/miniprot/index/test.yml
+++ b/tests/modules/nf-core/miniprot/index/test.yml
@@ -1,0 +1,10 @@
+- name: miniprot index
+  command: nextflow run ./tests/modules/miniprot/index -entry test_miniprot_index -c ./tests/config/nextflow.config -c ./tests/modules/miniprot/index/nextflow.config
+  tags:
+    - miniprot
+    - miniprot/index
+  files:
+    - path: output/miniprot/nxOscSpef2.mpi
+      md5sum: ec3d98dc989e73873afe5b529c84c022
+    - path: output/miniprot/versions.yml
+      md5sum: b191a09118135126e3da7080ad64983d

--- a/tests/modules/nf-core/miniprot/index/test.yml
+++ b/tests/modules/nf-core/miniprot/index/test.yml
@@ -1,5 +1,5 @@
 - name: miniprot index
-  command: nextflow run ./tests/modules/miniprot/index -entry test_miniprot_index -c ./tests/config/nextflow.config -c ./tests/modules/miniprot/index/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/miniprot/index -entry test_miniprot_index -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/miniprot/index/nextflow.config
   tags:
     - miniprot
     - miniprot/index

--- a/tests/modules/nf-core/miniprot/index/test.yml
+++ b/tests/modules/nf-core/miniprot/index/test.yml
@@ -4,7 +4,6 @@
     - miniprot
     - miniprot/index
   files:
-    - path: output/miniprot/nxOscSpef2.mpi
-      md5sum: ec3d98dc989e73873afe5b529c84c022
+    - path: output/miniprot/genome.mpi
+      md5sum: bf4f59376dc00f758b69706f38b4f650
     - path: output/miniprot/versions.yml
-      md5sum: b191a09118135126e3da7080ad64983d


### PR DESCRIPTION
Miniprot is the latest aligner, which can align protein sequences against genomic sequences: https://github.com/lh3/miniprot

This PR adds support for the `index` and `align` modes. The modules are very close to the minimap2 ones (because the CLI is almost identical) and borrow the same interface, layout, nomenclature, etc.

I also found that one of the minimap2 output channel was wrong in meta.yaml

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [/] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
