### PR TITLE
add fasta index to collectWGSmetrics

### DIFF
--- a/modules/nf-core/picard/collectwgsmetrics/main.nf
+++ b/modules/nf-core/picard/collectwgsmetrics/main.nf
@@ -10,6 +10,7 @@ process PICARD_COLLECTWGSMETRICS {
     input:
     tuple val(meta), path(bam), path(bai)
     tuple val(meta2), path(fasta)
+    tuple val(meta2), path(fai)
     path  intervallist
 
     output:

--- a/modules/nf-core/picard/collectwgsmetrics/meta.yml
+++ b/modules/nf-core/picard/collectwgsmetrics/meta.yml
@@ -35,6 +35,15 @@ input:
   - fasta:
       type: file
       description: Genome fasta file
+      pattern: "*.{fa,fasta,fna}"
+  - meta2:
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'genome' ]
+  - fai:
+      type: file
+      description: Genome fasta file index
+      pattern: "*.{fai}"
   - intervallist:
       type: file
       description: Picard Interval List. Defines which contigs to include. Can be generated from a BED file with GATK BedToIntervalList.

--- a/subworkflows/nf-core/bam_qc_picard/main.nf
+++ b/subworkflows/nf-core/bam_qc_picard/main.nf
@@ -28,7 +28,7 @@ workflow BAM_QC_PICARD {
         ch_coverage_metrics = ch_coverage_metrics.mix(PICARD_COLLECTHSMETRICS.out.metrics)
         ch_versions = ch_versions.mix(PICARD_COLLECTHSMETRICS.out.versions.first())
     } else {
-        PICARD_COLLECTWGSMETRICS( ch_bam_bai, ch_fasta, [] )
+        PICARD_COLLECTWGSMETRICS( ch_bam_bai, ch_fasta, ch_fasta_fai, [] )
         ch_versions = ch_versions.mix(PICARD_COLLECTWGSMETRICS.out.versions.first())
         ch_coverage_metrics = ch_coverage_metrics.mix(PICARD_COLLECTWGSMETRICS.out.metrics)
     }

--- a/subworkflows/nf-core/bam_qc_picard/meta.yml
+++ b/subworkflows/nf-core/bam_qc_picard/meta.yml
@@ -43,7 +43,7 @@ input:
   - fasta_fai:
       type: optional file
       description: Reference fasta file index
-      pattern: "*.{fasta,fa}.fai"
+      pattern: "*.{fasta,fa,fna}.fai"
   - bait_intervals:
       type: optional file
       description: An interval list file that contains the locations of the baits used.

--- a/tests/modules/nf-core/picard/collectwgsmetrics/main.nf
+++ b/tests/modules/nf-core/picard/collectwgsmetrics/main.nf
@@ -14,8 +14,11 @@ workflow test_picard_collectwgsmetrics {
         [id:'genome'],
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
-
-    PICARD_COLLECTWGSMETRICS ( input, fasta, [] )
+    fai = [
+        [id:'genome'],
+        file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
+    ]
+    PICARD_COLLECTWGSMETRICS ( input, fasta, fai,  [] )
 }
 
 //Test with an interval list file
@@ -28,7 +31,11 @@ workflow test_picard_collectwgsmetrics_with_interval {
         [id:'genome'],
         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
+    fai = [
+        [id:'genome'],
+        file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
+    ]
     intervallist = file(params.test_data['sarscov2']['genome']['baits_interval_list'], checkIfExists: true)
 
-    PICARD_COLLECTWGSMETRICS ( input, fasta, intervallist )
+    PICARD_COLLECTWGSMETRICS ( input, fasta, fai, intervallist )
 }


### PR DESCRIPTION
Add fasta index to picard/collectWGSMetrics for cram compatibility

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
