### PR TITLE
Add rna paired-end chr6 test data

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -246,6 +246,8 @@ params {
                 test_paired_end_hla                                     = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/example_hla_pe.bam"
                 test_paired_end_hla_sorted_bam                          = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/example_hla_pe.sorted.bam"
                 test_paired_end_hla_sorted_bam_bai                      = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/example_hla_pe.sorted.bam.bai"
+                test_rna_paired_end_sorted_chr6_bam                     = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/test.rna.paired_end.sorted.chr6.bam"
+                test_rna_paired_end_sorted_chr6_bam_bai                 = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/test.rna.paired_end.sorted.chr6.bam.bai"
                 test2_paired_end_sorted_bam                     = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/test2.paired_end.sorted.bam"
                 test2_paired_end_sorted_bam_bai                 = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/test2.paired_end.sorted.bam.bai"
                 test2_paired_end_name_sorted_bam                = "${test_data_dir}/genomics/homo_sapiens/illumina/bam/test2.paired_end.name.sorted.bam"


### PR DESCRIPTION
This adds RNA paired-end test data from chromosome 6 that can e.g. be used by HLA genotyping modules.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
