### PR TITLE
Make html output optional for shinyngs static plots

### DIFF
--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICDIFFERENTIAL {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.4.2"
+    conda "bioconda::r-shinyngs=1.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.4.2--r41hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.4.2--r41hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.0--r41hdfd78af_0':
+        'quay.io/biocontainers/r-shinyngs:1.5.0--r41hdfd78af_0' }"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -5,7 +5,7 @@ process SHINYNGS_STATICDIFFERENTIAL {
     conda "bioconda::r-shinyngs=1.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.0--r41hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.5.0--r41hdfd78af_0' }"
+        'quay.io/biocontainers/r-shinyngs:1.5.0--r42hdfd78af_0' }"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -13,7 +13,7 @@ process SHINYNGS_STATICDIFFERENTIAL {
 
     output:
     tuple val(meta), path("*/png/volcano.png")      , emit: volcanos_png
-    tuple val(meta), path("*/html/volcano.html")    , emit: volcanos_html
+    tuple val(meta), path("*/html/volcano.html")    , emit: volcanos_html, optional: true
     path "versions.yml"                             , emit: versions
 
     when:

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -4,7 +4,7 @@ process SHINYNGS_STATICDIFFERENTIAL {
 
     conda "bioconda::r-shinyngs=1.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.0--r41hdfd78af_0':
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.0--r42hdfd78af_0':
         'quay.io/biocontainers/r-shinyngs:1.5.0--r42hdfd78af_0' }"
 
     input:

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -12,8 +12,9 @@ process SHINYNGS_STATICDIFFERENTIAL {
     tuple val(meta2), path(sample), path(feature_meta), path(assay_file)    // Experiment-level info
 
     output:
-    tuple val(meta), path("*/png/volcano.png"), path("*/html/volcano.html")                                 , emit: volcanos
-    path "versions.yml"                                                                                     , emit: versions
+    tuple val(meta), path("*/png/volcano.png")      , emit: volcanos_png
+    tuple val(meta), path("*/html/volcano.html")    , emit: volcanos_html
+    path "versions.yml"                             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -11,13 +11,18 @@ process SHINYNGS_STATICEXPLORATORY {
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)
 
     output:
-    tuple val(meta), path("*/png/boxplot.png"), path("*/html/boxplot.html")                 , emit: boxplots
-    tuple val(meta), path("*/png/density.png"), path("*/html/density.html")                 , emit: densities
-    tuple val(meta), path("*/png/pca2d.png"), path("*/html/pca2d.html")                     , emit: pca2d
-    tuple val(meta), path("*/png/pca3d.png"), path("*/html/pca3d.html")                     , emit: pca3d
-    tuple val(meta), path("*/png/mad_correlation.png"), path("*/html/mad_correlation.html") , emit: mad
-    tuple val(meta), path("*/png/sample_dendrogram.png")                                    , emit: dendro
-    path "versions.yml"                                                                     , emit: versions
+    tuple val(meta), path("*/png/boxplot.png")                  , emit: boxplots_png
+    tuple val(meta), path("*/png/boxplot.html")                 , emit: boxplots_html, optional: true
+    tuple val(meta), path("*/png/density.png")                  , emit: densities_png
+    tuple val(meta), path("*/html/density.html")                , emit: densities_html, optional: true
+    tuple val(meta), path("*/png/pca2d.png")                    , emit: pca2d_png
+    tuple val(meta), path("*/html/pca2d.html")                  , emit: pca2d_html, optional: true
+    tuple val(meta), path("*/png/pca3d.png")                    , emit: pca3d_png
+    tuple val(meta), path("*/png/pca3d.html")                   , emit: pca3d_html, optional: true
+    tuple val(meta), path("*/png/mad_correlation.png")          , emit: mad_png
+    tuple val(meta), path("*/html/mad_correlation.html")        , emit: mad_html, optional: true
+    tuple val(meta), path("*/png/sample_dendrogram.png")        , emit: dendro
+    path "versions.yml"                                         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -5,7 +5,7 @@ process SHINYNGS_STATICEXPLORATORY {
     conda "bioconda::r-shinyngs=1.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.0--r41hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.5.0--r41hdfd78af_0' }"
+        'quay.io/biocontainers/r-shinyngs:1.5.0--r42hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -12,13 +12,13 @@ process SHINYNGS_STATICEXPLORATORY {
 
     output:
     tuple val(meta), path("*/png/boxplot.png")                  , emit: boxplots_png
-    tuple val(meta), path("*/png/boxplot.html")                 , emit: boxplots_html, optional: true
+    tuple val(meta), path("*/html/boxplot.html")                , emit: boxplots_html, optional: true
     tuple val(meta), path("*/png/density.png")                  , emit: densities_png
     tuple val(meta), path("*/html/density.html")                , emit: densities_html, optional: true
     tuple val(meta), path("*/png/pca2d.png")                    , emit: pca2d_png
     tuple val(meta), path("*/html/pca2d.html")                  , emit: pca2d_html, optional: true
     tuple val(meta), path("*/png/pca3d.png")                    , emit: pca3d_png
-    tuple val(meta), path("*/png/pca3d.html")                   , emit: pca3d_html, optional: true
+    tuple val(meta), path("*/html/pca3d.html")                  , emit: pca3d_html, optional: true
     tuple val(meta), path("*/png/mad_correlation.png")          , emit: mad_png
     tuple val(meta), path("*/html/mad_correlation.html")        , emit: mad_html, optional: true
     tuple val(meta), path("*/png/sample_dendrogram.png")        , emit: dendro

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -4,7 +4,7 @@ process SHINYNGS_STATICEXPLORATORY {
 
     conda "bioconda::r-shinyngs=1.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.0--r41hdfd78af_0':
+        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.0--r42hdfd78af_0':
         'quay.io/biocontainers/r-shinyngs:1.5.0--r42hdfd78af_0' }"
 
     input:

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICEXPLORATORY {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.4.2"
+    conda "bioconda::r-shinyngs=1.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.4.2--r41hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.4.2--r41hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.0--r41hdfd78af_0':
+        'quay.io/biocontainers/r-shinyngs:1.5.0--r41hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)

--- a/tests/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/tests/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -19,3 +19,19 @@ workflow test_shinyngs_staticdifferential {
         ch_feature_obs_matrix
     )
 }
+
+workflow test_shinyngs_staticdifferential_html {
+
+    expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true) 
+    expression_feature_meta = file(params.test_data['mus_musculus']['genome']['rnaseq_genemeta'], checkIfExists: true) 
+    expression_matrix_file = file(params.test_data['mus_musculus']['genome']['rnaseq_matrix'], checkIfExists: true) 
+    expression_differential = file(params.test_data['mus_musculus']['genome']['deseq_results'], checkIfExists: true) 
+
+    ch_differential = [ [ "id":"hND6_vs_mCherry", "reference":"mCherry", "target":"hND6" ],  expression_differential ]
+    ch_feature_obs_matrix = [ [ "id":"SRP254919" ], expression_sample_sheet, expression_feature_meta, expression_matrix_file ]
+
+    SHINYNGS_STATICDIFFERENTIAL (
+        ch_differential,
+        ch_feature_obs_matrix
+    )
+}

--- a/tests/modules/nf-core/shinyngs/staticdifferential/nextflow.config
+++ b/tests/modules/nf-core/shinyngs/staticdifferential/nextflow.config
@@ -6,4 +6,8 @@ process {
         ext.prefix = { "${meta.id}_test" }
         ext.args = { "--reference_level $meta.reference --treatment_level $meta.target" }
     }
+    withName: 'test_shinyngs_staticdifferential_html:SHINYNGS_STATICDIFFERENTIAL' {
+        ext.prefix = { "${meta.id}_test" }
+        ext.args = { "--reference_level $meta.reference --treatment_level $meta.target --write_html" }
+    }
 }

--- a/tests/modules/nf-core/shinyngs/staticdifferential/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticdifferential/test.yml
@@ -4,6 +4,14 @@
     - shinyngs/staticdifferential
     - shinyngs
   files:
+    - path: output/shinyngs/hND6_vs_mCherry_test/png/volcano.png
+
+- name: shinyngs staticdifferential test_shinyngs_staticdifferential_html
+  command: nextflow run ./tests/modules/nf-core/shinyngs/staticdifferential -entry test_shinyngs_staticdifferential_html -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/shinyngs/staticdifferential/nextflow.config
+  tags:
+    - shinyngs/staticdifferential
+    - shinyngs
+  files:
     - path: output/shinyngs/hND6_vs_mCherry_test/html/volcano.html
       contains: ["-4.0303380084,-0.0628302706,-0.3602268157", "higher in mCherry"]
     - path: output/shinyngs/hND6_vs_mCherry_test/png/volcano.png

--- a/tests/modules/nf-core/shinyngs/staticdifferential/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticdifferential/test.yml
@@ -13,5 +13,5 @@
     - shinyngs
   files:
     - path: output/shinyngs/hND6_vs_mCherry_test/html/volcano.html
-      contains: ["-4.0303380084,-0.0628302706,-0.3602268157", "higher in mCherry"]
+      contains: ["-4.03005359258353,-3.03040865173003,null", "higher in mCherry"]
     - path: output/shinyngs/hND6_vs_mCherry_test/png/volcano.png

--- a/tests/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -14,3 +14,14 @@ workflow test_shinyngs_staticexploratory {
         [ [ "id":"treatment" ], expression_sample_sheet, expression_feature_meta, [ expression_matrix_file ] ],
     )
 }
+
+workflow test_shinyngs_staticexploratory_html {
+
+    expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true) 
+    expression_feature_meta = file(params.test_data['mus_musculus']['genome']['rnaseq_genemeta'], checkIfExists: true) 
+    expression_matrix_file = file(params.test_data['mus_musculus']['genome']['rnaseq_matrix'], checkIfExists: true) 
+
+    SHINYNGS_STATICEXPLORATORY ( 
+        [ [ "id":"treatment" ], expression_sample_sheet, expression_feature_meta, [ expression_matrix_file ] ],
+    )
+}

--- a/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
@@ -2,7 +2,7 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
     
-    withName: test_shinyngs_staticexploratory_html:SHINYNGS_STATICEXPLORATORY {
+    withName: 'test_shinyngs_staticexploratory_html:SHINYNGS_STATICEXPLORATORY' {
         ext.args = { "--write_html" }
     }
 }

--- a/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
@@ -2,4 +2,7 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
     
+    withName: test_shinyngs_staticexploratory_html:SHINYNGS_STATICEXPLORATORY {
+        ext.args = { "--write_html" }
+    }
 }

--- a/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
@@ -4,6 +4,19 @@
     - shinyngs/staticexploratory
     - shinyngs
   files:
+    - path: output/shinyngs/treatment/png/boxplot.png
+    - path: output/shinyngs/treatment/png/density.png
+    - path: output/shinyngs/treatment/png/mad_correlation.png
+    - path: output/shinyngs/treatment/png/pca2d.png
+    - path: output/shinyngs/treatment/png/pca3d.png
+    - path: output/shinyngs/treatment/png/sample_dendrogram.png
+
+- name: shinyngs staticexploratory test_shinyngs_staticexploratory_html
+  command: nextflow run ./tests/modules/nf-core/shinyngs/staticexploratory -entry test_shinyngs_staticexploratory_html -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
+  tags:
+    - shinyngs/staticexploratory
+    - shinyngs
+  files:
     - path: output/shinyngs/treatment/html/boxplot.html
     - path: output/shinyngs/treatment/html/density.html
     - path: output/shinyngs/treatment/html/mad_correlation.html

--- a/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
@@ -18,10 +18,15 @@
     - shinyngs
   files:
     - path: output/shinyngs/treatment/html/boxplot.html
+      contains: ["SRX8042381", ' ENSMUSG00000027456","Gm37080']
     - path: output/shinyngs/treatment/html/density.html
+      contains: ["4.34767786283394,4.38328343135943,4.41888899988492"]
     - path: output/shinyngs/treatment/html/mad_correlation.html
+      contains: ["0,-0.742952800676994,0.674490759476595,-0.674490759476595"]
     - path: output/shinyngs/treatment/html/pca2d.html
+      contains: ["32.3997993673843,13.7663278451248,-0.483622416696978"]
     - path: output/shinyngs/treatment/html/pca3d.html
+      contains: ["-13.7631950076655,-23.9333781666004,-7.98593162154611"]
     - path: output/shinyngs/treatment/png/boxplot.png
     - path: output/shinyngs/treatment/png/density.png
     - path: output/shinyngs/treatment/png/mad_correlation.png

--- a/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
@@ -24,9 +24,9 @@
     - path: output/shinyngs/treatment/html/mad_correlation.html
       contains: ["0,-0.742952800676994,0.674490759476595,-0.674490759476595"]
     - path: output/shinyngs/treatment/html/pca2d.html
-      contains: ["32.3997993673843,13.7663278451248,-0.483622416696978"]
+      contains: ['SRX8042381","SRX8042382']
     - path: output/shinyngs/treatment/html/pca3d.html
-      contains: ["-13.7631950076655,-23.9333781666004,-7.98593162154611"]
+      contains: ['SRX8042381","SRX8042382']
     - path: output/shinyngs/treatment/png/boxplot.png
     - path: output/shinyngs/treatment/png/density.png
     - path: output/shinyngs/treatment/png/mad_correlation.png


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This PR is basically pulling in https://github.com/pinin4fjords/shinyngs/pull/26, making HTML outputs optional (and by default off) for the shinyngs plotting scripts. 

I also added some missing 'contains' statements in a test.yml.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
