### PR TITLE
Update antismash-lite tests: pin the versions to allow retro-active testing

### DIFF
--- a/tests/modules/nf-core/antismash/antismashlitedownloaddatabases/main.nf
+++ b/tests/modules/nf-core/antismash/antismashlitedownloaddatabases/main.nf
@@ -8,17 +8,18 @@ include { UNTAR as UNTAR3 } from '../../../../../modules/nf-core/untar/main.nf'
 include { ANTISMASH_ANTISMASHLITEDOWNLOADDATABASES } from '../../../../../modules/nf-core/antismash/antismashlitedownloaddatabases/main.nf'
 
 workflow test_antismash_antismashlitedownloaddatabases {
+    // hash 9d816b1327c5f73cd0113af0966197db1956c840 is additional files for for antismash-lite 6.0.1
     input1 = [
         [],
-        file('https://github.com/nf-core/test-datasets/raw/modules/data/delete_me/antismash/css.tar.gz', checkIfExists: true)
+        file('https://github.com/nf-core/test-datasets/raw/9d816b1327c5f73cd0113af0966197db1956c840/data/delete_me/antismash/css.tar.gz', checkIfExists: true)
     ]
     input2 = [
         [],
-        file('https://github.com/nf-core/test-datasets/raw/modules/data/delete_me/antismash/detection.tar.gz', checkIfExists: true)
+        file('https://github.com/nf-core/test-datasets/raw/9d816b1327c5f73cd0113af0966197db1956c840/data/delete_me/antismash/detection.tar.gz', checkIfExists: true)
     ]
     input3 = [
         [],
-        file('https://github.com/nf-core/test-datasets/raw/modules/data/delete_me/antismash/modules.tar.gz', checkIfExists: true)
+        file('https://github.com/nf-core/test-datasets/raw/9d816b1327c5f73cd0113af0966197db1956c840/data/delete_me/antismash/modules.tar.gz', checkIfExists: true)
     ]
 
     UNTAR1 ( input1 )


### PR DESCRIPTION
pin the versions to allow retro-active testing

as next version 6.1.1 needs updated TARs with different scripts

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
