### PR TITLE
fix: correct pon if statement, rm collect, set tumor_out to empty string

### DIFF
--- a/modules/nf-core/cnvkit/batch/main.nf
+++ b/modules/nf-core/cnvkit/batch/main.nf
@@ -67,9 +67,10 @@ process CNVKIT_BATCH {
     // generation of panel of normals
     def generate_pon = panel_of_normals ? true : false
 
-    if (generate_pon && !tumor_exists && normal_bam){
-        def pon_input = normal.collect("$it").join(' ')
+    if (generate_pon && !tumor_exists){
+        def pon_input = normal.join(' ')
         normal_args = "--normal $pon_input"
+        tumor_out = ""
     }
 
     def target_args = targets ? "--targets $targets" : ""


### PR DESCRIPTION
## PR checklist

this module did not create a PON even when specified - bug fixed.

Closes #2705

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
