### PR TITLE
Add --hardtrim* files as output for TrimGalore

### DIFF
--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -11,13 +11,12 @@ process TRIMGALORE {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*{trimmed,val}*.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt")          , emit: log
-    path "versions.yml"                           , emit: versions
-
-    tuple val(meta), path("*unpaired*.fq.gz")     , emit: unpaired, optional: true
-    tuple val(meta), path("*.html")               , emit: html    , optional: true
-    tuple val(meta), path("*.zip")                , emit: zip     , optional: true
+    tuple val(meta), path("*{3prime,5prime,trimmed,val}*.fq.gz"), emit: reads
+    tuple val(meta), path("*report.txt")                        , emit: log     , optional: true
+    tuple val(meta), path("*unpaired*.fq.gz")                   , emit: unpaired, optional: true
+    tuple val(meta), path("*.html")                             , emit: html    , optional: true
+    tuple val(meta), path("*.zip")                              , emit: zip     , optional: true
+    path "versions.yml"                                         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/trimgalore/meta.yml
+++ b/modules/nf-core/trimgalore/meta.yml
@@ -36,7 +36,7 @@ output:
       description: |
         List of input adapter trimmed FastQ files of size 1 and 2 for
         single-end and paired-end data, respectively.
-      pattern: "*.{fq.gz}"
+      pattern: "*{3prime,5prime,trimmed,val}*.fq.gz"
   - unpaired:
       type: file
       description: |

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -82,13 +82,17 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
         // Filter empty FastQ files after adapter trimming
         //
         trim_reads
-            .join(trim_log)
+            .join(trim_log, remainder: true)
             .map {
                 meta, reads, trim_log ->
-                    if (!meta.single_end) {
-                        trim_log = trim_log[-1]
-                    }
-                    if (getTrimGaloreReadsAfterFiltering(trim_log) > 0) {
+                    if (trim_log) {
+                        if (!meta.single_end) {
+                            trim_log = trim_log[-1]
+                        }
+                        if (getTrimGaloreReadsAfterFiltering(trim_log) > 0) {
+                            [ meta, reads ]
+                        }
+                    } else {
                         [ meta, reads ]
                     }
             }


### PR DESCRIPTION
Partially closes https://github.com/nf-core/rnaseq/issues/922

`*report.txt` aren't produced by TrimGalore when `--hardtrim 3` or `--hardtrim 5` are set which means we can't get the read stats info. So I had to refactor the logic that filters channels if the FastQ files are empty after trimming.