### PR TITLE
Update jupyternotebook

### DIFF
--- a/modules/nf-core/jupyternotebook/main.nf
+++ b/modules/nf-core/jupyternotebook/main.nf
@@ -71,7 +71,7 @@ process JUPYTERNOTEBOOK {
     export OMP_NUM_THREADS="$task.cpus"
     export NUMBA_NUM_THREADS="$task.cpus"
 
-     # Convert notebook to ipynb using jupytext, execute using papermill, convert using nbconvert
+    # Convert notebook to ipynb using jupytext, execute using papermill, convert using nbconvert
     jupytext --to notebook --output - --set-kernel ${kernel} ${notebook} > ${notebook}.ipynb
     ${render_cmd} ${notebook}.ipynb ${notebook}.executed.ipynb
     jupyter nbconvert --stdin --to html --output ${prefix}.html < ${notebook}.executed.ipynb

--- a/modules/nf-core/jupyternotebook/main.nf
+++ b/modules/nf-core/jupyternotebook/main.nf
@@ -31,6 +31,7 @@ process JUPYTERNOTEBOOK {
     def parametrize = (task.ext.parametrize == null) ?  true : task.ext.parametrize
     def implicit_params = (task.ext.implicit_params == null) ? true : task.ext.implicit_params
     def meta_params = (task.ext.meta_params == null) ? true : task.ext.meta_params
+    def kernel   = task.ext.kernel ?: '-'
 
     // Dump parameters to yaml file.
     // Using a yaml file over using the CLI params because
@@ -70,10 +71,10 @@ process JUPYTERNOTEBOOK {
     export OMP_NUM_THREADS="$task.cpus"
     export NUMBA_NUM_THREADS="$task.cpus"
 
-    # Convert notebook to ipynb using jupytext, execute using papermill, convert using nbconvert
-    jupytext --to notebook --output - --set-kernel - ${notebook}  \\
-        | ${render_cmd} \\
-        | jupyter nbconvert --stdin --to html --output ${prefix}.html
+     # Convert notebook to ipynb using jupytext, execute using papermill, convert using nbconvert
+    jupytext --to notebook --output - --set-kernel ${kernel} ${notebook} > ${notebook}.ipynb
+    ${render_cmd} ${notebook}.ipynb ${notebook}.executed.ipynb
+    jupyter nbconvert --stdin --to html --output ${prefix}.html < ${notebook}.executed.ipynb
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
This update entails two minor changes:
 * split up the shell pipeline into multiple subcommands -- this makes
   debugging a lot easier should rendering the notebook fail
 * allow to override the notebook kernel via `task.ext.kernel` --
   sometimes the kernel stored in the notebook is not available in the
   environment used to execute the notebook as part of the workflow.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
