### PR TITLE
Update bam_split_by_region subworkflow

### DIFF
--- a/tests/subworkflows/nf-core/bam_split_by_region/main.nf
+++ b/tests/subworkflows/nf-core/bam_split_by_region/main.nf
@@ -8,17 +8,19 @@ include { BAM_SPLIT_BY_REGION } from '../../../../subworkflows/nf-core/bam_split
 workflow test_bam_split_by_region {
 
     input = [ [ id: 'test', single_end: false ],
-        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_markduplicates_sorted_bam'],     checkIfExists: true)
+        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_markduplicates_sorted_bam'],     checkIfExists: true),
+
     ]
 
-    regions = Channel.of(
+    regions = [ [ id: 'test', single_end: false ],
         file(params.test_data['homo_sapiens']['genome']['genome_21_multi_interval_bed'],     checkIfExists: true)
-    )
+    ]
 
     SAMTOOLS_INDEX(input)
 
     ch_bam_split_input=Channel.of(input)
             .join(SAMTOOLS_INDEX.out.bai)
+            .join(Channel.of(regions))
 
-    BAM_SPLIT_BY_REGION ( ch_bam_split_input, regions )
+    BAM_SPLIT_BY_REGION ( ch_bam_split_input )
 }


### PR DESCRIPTION
Instead of providing bed files and bam files in two separate channels, now a single channel is accepted that includes the bed file to be used for that specific bam file. 

This is more flexible than the previous implementation.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist


- [x] This comment contains a description of changes (with reason).
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
