### PR TITLE
Updates to hmmcopy module tools to match existing structure

### DIFF
--- a/modules/nf-core/hmmcopy/gccounter/main.nf
+++ b/modules/nf-core/hmmcopy/gccounter/main.nf
@@ -8,22 +8,23 @@ process HMMCOPY_GCCOUNTER {
         'quay.io/biocontainers/hmmcopy:0.1.1--h2e03b76_7' }"
 
     input:
-    path fasta
+    tuple val(meta), path(fasta)
 
     output:
-    path "*.gc.wig"    , emit: wig
-    path "versions.yml", emit: versions
+    tuple val(meta), path("*.wig"), emit: wig
+    path "versions.yml"           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     gcCounter \\
         $args \\
-        ${fasta} > ${fasta.baseName}.gc.wig
+        ${fasta} > ${prefix}.wig
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/hmmcopy/gccounter/meta.yml
+++ b/modules/nf-core/hmmcopy/gccounter/meta.yml
@@ -14,11 +14,21 @@ tools:
       licence: ["GPL v3"]
 
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - fasta:
       type: file
       description: Input genome fasta file
 
 output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - versions:
       type: file
       description: File containing software versions
@@ -26,7 +36,8 @@ output:
   - wig:
       type: file
       description: wig file containing gc content of each window of the genome
-      pattern: "*.{gc.wig}"
+      pattern: "*.wig"
 
 authors:
   - "@sppearce"
+  - "@adamrtalbot"

--- a/modules/nf-core/hmmcopy/generatemap/main.nf
+++ b/modules/nf-core/hmmcopy/generatemap/main.nf
@@ -9,10 +9,10 @@ process HMMCOPY_GENERATEMAP {
         'quay.io/biocontainers/hmmcopy:0.1.1--h2e03b76_7' }"
 
     input:
-    path fasta
+    tuple val(meta), path(fasta)
 
     output:
-    path "*.map.bw"              , emit: bigwig
+    tuple val(meta), path("*.bw"), emit: bigwig
     path "versions.yml"          , emit: versions
 
     when:
@@ -20,6 +20,7 @@ process HMMCOPY_GENERATEMAP {
 
     script:
     def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     # build required indexes

--- a/modules/nf-core/hmmcopy/generatemap/meta.yml
+++ b/modules/nf-core/hmmcopy/generatemap/meta.yml
@@ -14,11 +14,21 @@ tools:
       licence: ["GPL v3"]
 
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - fasta:
       type: file
       description: Input genome fasta file
 
 output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - versions:
       type: file
       description: File containing software versions
@@ -26,7 +36,8 @@ output:
   - bigwig:
       type: file
       description: bigwig file containing the mappability of the genome
-      pattern: "*.{map.bw}"
+      pattern: "*.bw"
 
 authors:
   - "@sppearce"
+  - "@adamrtalbot"

--- a/modules/nf-core/hmmcopy/mapcounter/main.nf
+++ b/modules/nf-core/hmmcopy/mapcounter/main.nf
@@ -1,5 +1,5 @@
 process HMMCOPY_MAPCOUNTER {
-    label 'process_medium'
+    label 'process_single'
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "bioconda::hmmcopy=0.1.1"
@@ -8,22 +8,23 @@ process HMMCOPY_MAPCOUNTER {
         'quay.io/biocontainers/hmmcopy:0.1.1--h2e03b76_7' }"
 
     input:
-    path bigwig
+    tuple val(meta), path(bigwig)
 
     output:
-    path "*.map.wig"              , emit: wig
-    path "versions.yml"           , emit: versions
+    tuple val(meta), path("*.wig"), emit: wig
+    path "versions.yml"               , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     mapCounter \\
         $args \\
-        $bigwig > ${bigwig.baseName}.map.wig
+        $bigwig > ${prefix}.wig
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/hmmcopy/mapcounter/meta.yml
+++ b/modules/nf-core/hmmcopy/mapcounter/meta.yml
@@ -14,12 +14,22 @@ tools:
       licence: ["GPL v3"]
 
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - bigwig:
       type: file
       description: BigWig file with the mappability score of the genome, for instance made with generateMap function.
       pattern: "*.wig"
 
 output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - versions:
       type: file
       description: File containing software versions
@@ -28,7 +38,7 @@ output:
   - wig:
       type: file
       description: wig file containing mappability of each window of the genome
-      pattern: "*.map.wig"
+      pattern: "*.wig"
 
 authors:
   - "@sppearce"

--- a/tests/modules/nf-core/hmmcopy/gccounter/main.nf
+++ b/tests/modules/nf-core/hmmcopy/gccounter/main.nf
@@ -5,7 +5,12 @@ nextflow.enable.dsl = 2
 include { HMMCOPY_GCCOUNTER } from '../../../../../modules/nf-core/hmmcopy/gccounter/main.nf'
 
 workflow test_hmmcopy_gccounter {
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = Channel.of(
+        tuple(
+            [id: "test"],
+            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+        )
+    )
 
     HMMCOPY_GCCOUNTER (fasta)
 }

--- a/tests/modules/nf-core/hmmcopy/gccounter/test.yml
+++ b/tests/modules/nf-core/hmmcopy/gccounter/test.yml
@@ -1,8 +1,8 @@
 - name: hmmcopy gccounter test_hmmcopy_gccounter
   command: nextflow run ./tests/modules/nf-core/hmmcopy/gccounter -entry test_hmmcopy_gccounter -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hmmcopy/gccounter/nextflow.config
   tags:
-    - hmmcopy
     - hmmcopy/gccounter
+    - hmmcopy
   files:
-    - path: output/hmmcopy/genome.gc.wig
+    - path: output/hmmcopy/test.wig
       md5sum: 59ad14bc5aaa903187d7b248c9490deb

--- a/tests/modules/nf-core/hmmcopy/gccounter/test.yml
+++ b/tests/modules/nf-core/hmmcopy/gccounter/test.yml
@@ -1,8 +1,9 @@
 - name: hmmcopy gccounter test_hmmcopy_gccounter
   command: nextflow run ./tests/modules/nf-core/hmmcopy/gccounter -entry test_hmmcopy_gccounter -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hmmcopy/gccounter/nextflow.config
   tags:
-    - hmmcopy/gccounter
     - hmmcopy
+    - hmmcopy/gccounter
   files:
     - path: output/hmmcopy/test.wig
       md5sum: 59ad14bc5aaa903187d7b248c9490deb
+    - path: output/hmmcopy/versions.yml

--- a/tests/modules/nf-core/hmmcopy/generatemap/main.nf
+++ b/tests/modules/nf-core/hmmcopy/generatemap/main.nf
@@ -6,7 +6,12 @@ include { HMMCOPY_GENERATEMAP } from '../../../../../modules/nf-core/hmmcopy/gen
 
 workflow test_hmmcopy_generatemap {
 
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = Channel.of(
+        tuple(
+            [id: "test"],
+            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+        )
+    )
 
     HMMCOPY_GENERATEMAP ( fasta )
 }

--- a/tests/modules/nf-core/hmmcopy/generatemap/test.yml
+++ b/tests/modules/nf-core/hmmcopy/generatemap/test.yml
@@ -1,10 +1,8 @@
 - name: hmmcopy generatemap test_hmmcopy_generatemap
-  command: nextflow run ./tests/modules/nf-core/hmmcopy/generatemap -entry test_hmmcopy_generatemap -c ./tests/config/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/hmmcopy/generatemap -entry test_hmmcopy_generatemap -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hmmcopy/generatemap/nextflow.config
   tags:
     - hmmcopy
     - hmmcopy/generatemap
   files:
     - path: output/hmmcopy/genome.fasta.map.bw
       md5sum: 7ad68224a1e40287978284c387e8eb70
-    - path: output/hmmcopy/versions.yml
-      md5sum: f950580f94d8a2d88332c477972cb9f0

--- a/tests/modules/nf-core/hmmcopy/generatemap/test.yml
+++ b/tests/modules/nf-core/hmmcopy/generatemap/test.yml
@@ -1,8 +1,9 @@
 - name: hmmcopy generatemap test_hmmcopy_generatemap
   command: nextflow run ./tests/modules/nf-core/hmmcopy/generatemap -entry test_hmmcopy_generatemap -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hmmcopy/generatemap/nextflow.config
   tags:
-    - hmmcopy
     - hmmcopy/generatemap
+    - hmmcopy
   files:
     - path: output/hmmcopy/genome.fasta.map.bw
       md5sum: 7ad68224a1e40287978284c387e8eb70
+    - path: output/hmmcopy/versions.yml

--- a/tests/modules/nf-core/hmmcopy/mapcounter/main.nf
+++ b/tests/modules/nf-core/hmmcopy/mapcounter/main.nf
@@ -6,7 +6,12 @@ include { HMMCOPY_MAPCOUNTER } from '../../../../../modules/nf-core/hmmcopy/mapc
 include { HMMCOPY_GENERATEMAP } from '../../../../../modules/nf-core/hmmcopy/generatemap/main.nf'
 workflow test_hmmcopy_mapcounter {
 
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = Channel.of(
+        tuple(
+            [id: "test"],
+            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+        )
+    )
 
     HMMCOPY_GENERATEMAP( fasta )
 

--- a/tests/modules/nf-core/hmmcopy/mapcounter/test.yml
+++ b/tests/modules/nf-core/hmmcopy/mapcounter/test.yml
@@ -1,12 +1,10 @@
 - name: hmmcopy mapcounter test_hmmcopy_mapcounter
-  command: nextflow run ./tests/modules/nf-core/hmmcopy/mapcounter -entry test_hmmcopy_mapcounter -c ./tests/config/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/hmmcopy/mapcounter -entry test_hmmcopy_mapcounter -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hmmcopy/mapcounter/nextflow.config
   tags:
     - hmmcopy/mapcounter
     - hmmcopy
   files:
     - path: output/hmmcopy/genome.fasta.map.bw
       md5sum: 7ad68224a1e40287978284c387e8eb70
-    - path: output/hmmcopy/genome.fasta.map.map.wig
+    - path: output/hmmcopy/test.wig
       md5sum: e2d39dc204ed31c1ce372d633a42560f
-    - path: output/hmmcopy/versions.yml
-      md5sum: 8361e3c0f8b96cf84834678cf988a209

--- a/tests/modules/nf-core/hmmcopy/mapcounter/test.yml
+++ b/tests/modules/nf-core/hmmcopy/mapcounter/test.yml
@@ -1,10 +1,11 @@
 - name: hmmcopy mapcounter test_hmmcopy_mapcounter
   command: nextflow run ./tests/modules/nf-core/hmmcopy/mapcounter -entry test_hmmcopy_mapcounter -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hmmcopy/mapcounter/nextflow.config
   tags:
-    - hmmcopy/mapcounter
     - hmmcopy
+    - hmmcopy/mapcounter
   files:
     - path: output/hmmcopy/genome.fasta.map.bw
       md5sum: 7ad68224a1e40287978284c387e8eb70
     - path: output/hmmcopy/test.wig
       md5sum: e2d39dc204ed31c1ce372d633a42560f
+    - path: output/hmmcopy/versions.yml


### PR DESCRIPTION
Update existing hmmcopy tools to match existing module tooling.

Changes:
  - add meta map to all channels
  - add prefix variable to all output filenames
  - remove extra suffixes from file extensions (use prefix in place)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
