### PR TITLE
Use "contains" rather than the MD5 checksum (seqtk/seq)

### DIFF
--- a/tests/modules/nf-core/seqtk/seq/test.yml
+++ b/tests/modules/nf-core/seqtk/seq/test.yml
@@ -5,7 +5,8 @@
     - seqtk
   files:
     - path: output/seqtk/test.seqtk-seq.fasta.gz
-      md5sum: 50d73992c8c7e56dc095ef47ec52a754
+      contains:
+        - ">MT192765.1 Severe acute respiratory syndrome coronavirus 2 isolate SARS-CoV-2/human/USA/PC00101P/2020, complete genome"
 
 - name: seqtk seq test_seqtk_seq_fq
   command: nextflow run ./tests/modules/nf-core/seqtk/seq -entry test_seqtk_seq_fq -c ./tests/config/nextflow.config


### PR DESCRIPTION
Under conda, the `.gz` files differ, but their uncompressed form is OK, so switching to `contains`

## PR checklist

Closes #1416

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
