### PR TITLE
Bump shinyngs to address palette issues

### DIFF
--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICDIFFERENTIAL {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.5.1"
+    conda "bioconda::r-shinyngs=1.5.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.1--r42hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.5.1--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.4--r42hdfd78af_0':
+        'quay.io/biocontainers/r-shinyngs:1.5.4--r42hdfd78af_0' }"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -4,7 +4,7 @@ process SHINYNGS_STATICEXPLORATORY {
 
     conda "bioconda::r-shinyngs=1.5.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.4--r42hdfd78af_0':
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.4--r42hdfd78af_0':
         'quay.io/biocontainers/r-shinyngs:1.5.4--r42hdfd78af_0' }"
 
     input:

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICEXPLORATORY {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.5.1"
+    conda "bioconda::r-shinyngs=1.5.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.1--r42hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.5.1--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.4--r42hdfd78af_0':
+        'quay.io/biocontainers/r-shinyngs:1.5.4--r42hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
     tag "$sample"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.5.1"
+    conda "bioconda::r-shinyngs=1.5.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.1--r42hdfd78af_0':
-        'quay.io/biocontainers/r-shinyngs:1.5.1--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.4--r42hdfd78af_0':
+        'quay.io/biocontainers/r-shinyngs:1.5.4--r42hdfd78af_0' }"
 
     input:
     tuple val(meta),  path(sample), path(assay_files)

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -4,7 +4,7 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
 
     conda "bioconda::r-shinyngs=1.5.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs%3A1.5.4--r42hdfd78af_0':
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.5.4--r42hdfd78af_0':
         'quay.io/biocontainers/r-shinyngs:1.5.4--r42hdfd78af_0' }"
 
     input:


### PR DESCRIPTION
This PR incorporates upstream fixes for https://github.com/nf-core/differentialabundance/issues/56. 

There appears to be something going on with the singularity CI. The change should have got to the galaxy servers by now, but hasn't. Docker is fine.

I'll leave this overnight and see what happens then.


<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
