### PR TITLE
Ciriquant

### DIFF
--- a/modules/nf-core/ciriquant/main.nf
+++ b/modules/nf-core/ciriquant/main.nf
@@ -1,0 +1,57 @@
+process CIRIQUANT {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "bioconda::ciriquant=1.1.2"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ciriquant:1.1.2--pyhdfd78af_2' :
+        'quay.io/biocontainers/ciriquant:1.1.2--pyhdfd78af_2' }"
+
+    input:
+    tuple val(meta), path(reads)
+    path gtf
+    path fasta
+    path bwa
+    path hisat2
+
+    output:
+    tuple val(meta), path("${prefix}/${prefix}.gtf"), emit: gtf
+    path("${prefix}")                               , optional: true, emit: intermediates_directory
+    path "versions.yml"                             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    bwa_prefix = fasta.toString() == 'genome.fa' ? fasta.toString() : fasta.toString() - ~/.(fa|fasta)$/
+    hisat2_prefix = fasta.toString() - ~/.(fa|fasta)$/
+    fasta_path = fasta.toRealPath()
+    gtf_path = gtf.toRealPath()
+    bwa_path = bwa.toRealPath()
+    hisat2_path = hisat2.toRealPath()
+    """
+    BWA=`which bwa`
+    HISAT2=`which hisat2`
+    STRINGTIE=`which stringtie`
+    SAMTOOLS=`which samtools`
+
+    touch travis.yml
+    printf "name: ciriquant\ntools:\n  bwa: \$BWA\n  hisat2: \$HISAT2\n  stringtie: \$STRINGTIE\n  samtools: \$SAMTOOLS\n\nreference:\n  fasta: ${fasta_path}\n  gtf: ${gtf_path}\n  bwa_index: ${bwa_path}/${bwa_prefix}\n  hisat_index: ${hisat2_path}/${hisat2_prefix}" >> travis.yml
+
+    CIRIquant \\
+        -t ${task.cpus} \\
+        -1 ${reads[0]} \\
+        -2 ${reads[1]} \\
+        --config travis.yml \\
+        -o ${prefix} \\
+        -p ${prefix} \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        ciriquant : \$(echo \$(CIRIquant --version 2>&1) | sed 's/CIRIquant //g' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/ciriquant/meta.yml
+++ b/modules/nf-core/ciriquant/meta.yml
@@ -1,0 +1,59 @@
+name: "ciriquant"
+description: circRNA quantification using CIRIquant
+keywords:
+  - circRNA
+  - quantification
+tools:
+  - "ciriquant":
+      description: "circular RNA quantification tool"
+      homepage: "https://github.com/bioinfo-biols/CIRIquant"
+      documentation: "https://ciri-cookbook.readthedocs.io/en/latest/CIRIquant_0_home.html#"
+      doi: "https://doi.org/10.1038/s41467-019-13840-9"
+      licence: "['MIT']"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: paired-end FASTQ files (single-end not supported!)
+      pattern: "*.{fastq.gz,fq.gz}"
+  - gtf:
+      type: file
+      description: Reference GTF file used for circRNA annotation.
+      pattern: "*.gtf"
+  - fasta:
+      type: file
+      description: Reference FASTA file used for RNA-Seq alignment.
+      pattern: "*.{fasta,fa}"
+  - bwa:
+      type: path
+      description: Path to directory containing BWA indices (do not use collect() operator)
+  - hisat2:
+      type: path
+      description: Path to directory containing HISAT2 indices (do not use collect() operator)
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - gtf:
+      type: file
+      description: Quantified circRNAs in GTF format with genomic annotations
+  - intermediates_directory:
+      type: directory
+      description: |
+        Directory containing reads mapped to reference using bwa,
+        reconstructed circular reference (bwa) index files, bam files
+        and CIRI2 output.
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@BarryDigby"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -611,6 +611,10 @@ circexplorer2/parse:
   - modules/nf-core/circexplorer2/parse/**
   - tests/modules/nf-core/circexplorer2/parse/**
 
+ciriquant:
+  - modules/nf-core/ciriquant/**
+  - tests/modules/nf-core/ciriquant/**
+
 clonalframeml:
   - modules/nf-core/clonalframeml/**
   - tests/modules/nf-core/clonalframeml/**

--- a/tests/modules/nf-core/ciriquant/main.nf
+++ b/tests/modules/nf-core/ciriquant/main.nf
@@ -1,0 +1,25 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { CIRIQUANT } from '../../../../modules/nf-core/ciriquant/main.nf'
+
+workflow test_ciriquant {
+
+    reads = [
+        [ id:'fust1_1', single_end:false ],
+        file("https://raw.githubusercontent.com/nf-core/test-datasets/circrna/fastq/fust1_rep1_1.fastq.gz"),
+        file("https://raw.githubusercontent.com/nf-core/test-datasets/circrna/fastq/fust1_rep1_2.fastq.gz")
+    ]
+
+    gtf = [ file("https://raw.githubusercontent.com/nf-core/test-datasets/circrna/reference/chrI.gtf") ]
+
+    fasta = [ file("https://raw.githubusercontent.com/nf-core/test-datasets/circrna/reference/chrI.fa") ]
+
+    bwa = [ file("https://raw.githubusercontent.com/nf-core/test-datasets/circrna/bwa") ]
+
+    hisat2 = [ file("https://raw.githubusercontent.com/nf-core/test-datasets/circrna/hisat2") ]
+
+
+    CIRIQUANT ( reads, gtf, fasta, bwa, hisat2 )
+}

--- a/tests/modules/nf-core/ciriquant/nextflow.config
+++ b/tests/modules/nf-core/ciriquant/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    
+}

--- a/tests/modules/nf-core/ciriquant/test.yml
+++ b/tests/modules/nf-core/ciriquant/test.yml
@@ -1,11 +1,5 @@
-## TODO nf-core: Please run the following command to build this file:
-#                nf-core modules create-test-yml ciriquant
 - name: "ciriquant"
   command: nextflow run ./tests/modules/nf-core/ciriquant -entry test_ciriquant -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/ciriquant/nextflow.config
   tags:
     - "ciriquant"
-  files:
-    - path: "output/ciriquant/test.bam"
-      md5sum: e667c7caad0bc4b7ac383fd023c654fc
-    - path: "output/ciriquant/versions.yml"
-      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b
+

--- a/tests/modules/nf-core/ciriquant/test.yml
+++ b/tests/modules/nf-core/ciriquant/test.yml
@@ -1,0 +1,11 @@
+## TODO nf-core: Please run the following command to build this file:
+#                nf-core modules create-test-yml ciriquant
+- name: "ciriquant"
+  command: nextflow run ./tests/modules/nf-core/ciriquant -entry test_ciriquant -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/ciriquant/nextflow.config
+  tags:
+    - "ciriquant"
+  files:
+    - path: "output/ciriquant/test.bam"
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc
+    - path: "output/ciriquant/versions.yml"
+      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b


### PR DESCRIPTION
I added CIRIquant to bioconda late last year, so it makes sense to follow up and add the nf-core module.

- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
