### PR TITLE
added custom/splitfastqbylane module

### DIFF
--- a/modules/nf-core/custom/splitfastqbylane/main.nf
+++ b/modules/nf-core/custom/splitfastqbylane/main.nf
@@ -1,0 +1,35 @@
+process CUSTOM_SPLITFASTQBYLANE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "anaconda::gawk=5.1.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gawk:5.1.0':
+        'quay.io/biocontainers/gawk:5.1.0' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*.split.fastq.gz"), emit: reads
+    path "versions.yml"                      , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    shell:
+    args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    read1 = [reads].flatten()[0]
+    read2 = [reads].flatten().size() > 1 ? reads[1] : null
+    template 'split_lanes_awk.sh'
+
+    stub:
+    """
+    touch out.split.fastq.gz
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gawk: \$(awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/custom/splitfastqbylane/meta.yml
+++ b/modules/nf-core/custom/splitfastqbylane/meta.yml
@@ -1,0 +1,43 @@
+name: "custom_splitfastqbylane"
+description: |
+  Splits fastq files with multiple or unknown number of merged flowcell+lane sources into separate fastq files, each with single flowcell+line sources.
+keywords:
+  - splitlanesbyfastq
+  - awk
+tools:
+  - "gawk":
+      description: "The awk utility interprets a special-purpose programming language that makes it easy to handle simple data-reformatting jobs."
+      homepage: "https://www.gnu.org/software/gawk/manual/gawk.html"
+      documentation: "https://www.gnu.org/software/gawk/manual/gawk.html"
+      tool_dev_url: "http://savannah.gnu.org/projects/gawk/"
+      doi: ""
+      licence: "['GPL v3']"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: List of input FastQ files of size 1 and 2 for single-end and paired-end data, respectively.
+      pattern: "*.{fastq,fastq.gz}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - reads:
+      type: file
+      description: List of output FastQ files of size of multiples of 1 and 2, for single-end and paired-end data, respectively.
+      pattern: "*.split.fastq.gz"
+
+authors:
+  - "@anoronh4"

--- a/modules/nf-core/custom/splitfastqbylane/templates/split_lanes_awk.sh
+++ b/modules/nf-core/custom/splitfastqbylane/templates/split_lanes_awk.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if [[ "!{read1}" == *gz ]] ; then  
+   cat_="zcat"
+else 
+   cat_="cat"
+fi
+
+function a() {
+    awk \
+	-v prefix=!{prefix} \
+	-v readnumber=$1 \
+	'
+        BEGIN {FS = ":"}
+        {
+            lane=$(NF-3)
+            flowcell=$(NF-4)
+            outfastq=prefix"@"flowcell"_L00"lane"_R"readnumber".split.fastq.gz"
+            print | "gzip > "outfastq
+            for (i = 1; i <= 3; i++) {
+                getline
+                print | "gzip > "outfastq
+            }
+        }
+        ' <( eval "$cat_ $2")
+}
+
+a 1 !{read1} 
+if [ ! -z !{read2} ] ; then 
+    a 2 !{read2}
+fi
+
+cat <<-END_VERSIONS > versions.yml
+"!{task.process}":
+    gawk: $(awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//')
+END_VERSIONS

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -715,6 +715,10 @@ custom/matrixfilter:
   - modules/nf-core/custom/matrixfilter/**
   - tests/modules/nf-core/custom/matrixfilter/**
 
+custom/splitfastqbylane:
+  - modules/nf-core/custom/splitfastqbylane/**
+  - tests/modules/nf-core/custom/splitfastqbylane/**
+
 custom/sratoolsncbisettings:
   - modules/nf-core/custom/sratoolsncbisettings/**
   - tests/modules/nf-core/custom/sratoolsncbisettings/**

--- a/tests/modules/nf-core/custom/splitfastqbylane/main.nf
+++ b/tests/modules/nf-core/custom/splitfastqbylane/main.nf
@@ -1,0 +1,27 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { CUSTOM_SPLITFASTQBYLANE } from '../../../../../modules/nf-core/custom/splitfastqbylane/main.nf'
+
+workflow test_custom_splitfastqbylane {
+    
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        [
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+	]
+    ]
+
+    CUSTOM_SPLITFASTQBYLANE ( input )
+}
+
+workflow test_custom_splitfastqbylane_single_end { 
+
+    input = [
+         [ id:'test', single_end:true ],
+	 file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+    ]
+    CUSTOM_SPLITFASTQBYLANE ( input )
+}

--- a/tests/modules/nf-core/custom/splitfastqbylane/nextflow.config
+++ b/tests/modules/nf-core/custom/splitfastqbylane/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    
+}

--- a/tests/modules/nf-core/custom/splitfastqbylane/test.yml
+++ b/tests/modules/nf-core/custom/splitfastqbylane/test.yml
@@ -1,0 +1,31 @@
+- name: custom splitfastqbylane test_custom_splitfastqbylane
+  command: nextflow run ./tests/modules/nf-core/custom/splitfastqbylane -entry test_custom_splitfastqbylane -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/custom/splitfastqbylane/nextflow.config
+  tags:
+    - custom
+    - custom/splitfastqbylane
+  files:
+    - path: output/custom/test@HK3MMAFX2_L001_R1.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L001_R2.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L002_R1.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L002_R2.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L003_R1.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L003_R2.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L004_R1.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L004_R2.split.fastq.gz
+    - path: output/custom/versions.yml
+      contains:
+        - "gawk"
+
+- name: custom splitfastqbylane test_custom_splitfastqbylane_single_end
+  command: nextflow run ./tests/modules/nf-core/custom/splitfastqbylane -entry test_custom_splitfastqbylane_single_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/custom/splitfastqbylane/nextflow.config
+  tags:
+    - custom
+    - custom/splitfastqbylane
+  files:
+    - path: output/custom/test@HK3MMAFX2_L001_R1.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L002_R1.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L003_R1.split.fastq.gz
+    - path: output/custom/test@HK3MMAFX2_L004_R1.split.fastq.gz
+    - path: output/custom/versions.yml
+      contains:
+        - "gawk"


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

This is a custom module using awk to split a single fastq or fastq pair into multiple fastqs or fastq pairs, where each comes from a single lane+flowcell source. This is for when the raw data input is merged. This tool uses an awk statement to read the input file and direct the output to different files based on the content of the fastq header.

## PR checklist

Closes #2836  <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
