### PR TITLE
Stage inputs in directory for shorter script

### DIFF
--- a/modules/nf-core/ataqv/mkarv/main.nf
+++ b/modules/nf-core/ataqv/mkarv/main.nf
@@ -7,7 +7,7 @@ process ATAQV_MKARV {
         'quay.io/biocontainers/ataqv:1.3.0--py39hccc85d7_2' }"
 
     input:
-    path json
+    path "jsons/*"
 
     output:
     path "html"        , emit: html
@@ -24,7 +24,7 @@ process ATAQV_MKARV {
         --concurrency $task.cpus \\
         --force \\
         ./html/ \\
-        ${json.join(' ')}
+        jsons/*
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Using the groovy join operator to explicitly print all json filenames can become extremely verbose when hundreds of json files are passed to the ATAQV_MKARV process. By staging all inputs into a known directory, we can use shell globs rather than writing all filenames.

## PR checklist


- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
