### PR TITLE
Fixed the conda syntax because params.enable_conda is deprecated

### DIFF
--- a/modules/nf-core/gatk4/determinegermlinecontigploidy/main.nf
+++ b/modules/nf-core/gatk4/determinegermlinecontigploidy/main.nf
@@ -3,9 +3,6 @@ process GATK4_DETERMINEGERMLINECONTIGPLOIDY {
     label 'process_single'
 
 
-    if(params.enable_conda){
-        error "Conda environments cannot be used for GATK4/DetermineGermlineContigPloidy at the moment. Please use docker or singularity containers."
-    }
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'broadinstitute/gatk:4.3.0.0':
         'broadinstitute/gatk:4.3.0.0' }"

--- a/modules/nf-core/graphtyper/genotype/main.nf
+++ b/modules/nf-core/graphtyper/genotype/main.nf
@@ -2,7 +2,7 @@ process GRAPHTYPER_GENOTYPE {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::graphtyper=2.7.2" : null)
+    conda "bioconda::graphtyper=2.7.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/graphtyper:2.7.2--h7d7f7ad_0':
         'quay.io/biocontainers/graphtyper:2.7.2--h7d7f7ad_0' }"

--- a/modules/nf-core/platypus/main.nf
+++ b/modules/nf-core/platypus/main.nf
@@ -6,7 +6,7 @@ process PLATYPUS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::platypus-variant=0.8.1" : null)
+    conda "bioconda::platypus-variant=0.8.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/platypus-variant:0.8.1--py27_1':
         'quay.io/biocontainers/platypus-variant:0.8.1--py27_1' }"

--- a/modules/nf-core/plink/recode/main.nf
+++ b/modules/nf-core/plink/recode/main.nf
@@ -2,7 +2,7 @@ process PLINK_RECODE {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::plink=1.90b6.21" : null)
+    conda "bioconda::plink=1.90b6.21"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/plink:1.90b6.21--h779adbc_1':
         'quay.io/biocontainers/plink:1.90b6.21--h779adbc_1' }"

--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -2,7 +2,7 @@ process SMNCOPYNUMBERCALLER {
     tag "$meta.id"
     label 'process_low'
 
-    conda (params.enable_conda ? "bioconda::smncopynumbercaller=1.1.2" : null)
+    conda "bioconda::smncopynumbercaller=1.1.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/smncopynumbercaller:1.1.2--py310h7cba7a3_0' :
         'quay.io/biocontainers/smncopynumbercaller:1.1.2--py310h7cba7a3_0' }"

--- a/modules/nf-core/trinity/main.nf
+++ b/modules/nf-core/trinity/main.nf
@@ -2,7 +2,7 @@ process TRINITY {
     tag "$meta.id"
     label 'process_high_memory'
 
-    conda (params.enable_conda ? "bioconda::trinity=2.13.2" : null)
+    conda "bioconda::trinity=2.13.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/trinity:2.13.2--h00214ad_1':
         'quay.io/biocontainers/trinity:2.13.2--h00214ad_1' }"

--- a/tests/modules/nf-core/graphtyper/genotype/main.nf
+++ b/tests/modules/nf-core/graphtyper/genotype/main.nf
@@ -1,7 +1,6 @@
 #!/usr/bin/env nextflow
 
 nextflow.enable.dsl = 2
-params.enable_conda = true
 
 include { GRAPHTYPER_GENOTYPE                               } from '../../../../../modules/nf-core/graphtyper/genotype/main.nf'
 include { GRAPHTYPER_GENOTYPE as GRAPHTYPER_GENOTYPE_REGION } from '../../../../../modules/nf-core/graphtyper/genotype/main.nf'

--- a/tests/modules/nf-core/platypus/test.yml
+++ b/tests/modules/nf-core/platypus/test.yml
@@ -5,7 +5,7 @@
   files:
     - path: output/platypus/test.log
     - path: output/platypus/test.vcf.gz
-      md5sum: b657e4e48a332615a3fb30ee08a29f14
+      md5sum: 11d29ac732a9db4e597ade1d74812200
     - path: output/platypus/test.vcf.gz.tbi
       md5sum: 92107b23b1b8b4b725fc02e347fefc3d
     - path: output/platypus/versions.yml
@@ -17,7 +17,7 @@
   files:
     - path: output/platypus/test.log
     - path: output/platypus/test.vcf.gz
-      md5sum: 34d678c4ebfc4e17ee45aa75e9e85977
+      md5sum: c7ceda051a1ade58e85125c34faf7997
     - path: output/platypus/test.vcf.gz.tbi
       md5sum: cc7168158eb6e1df88b27b41cb4e8c47
     - path: output/platypus/versions.yml
@@ -29,7 +29,7 @@
   files:
     - path: output/platypus/test.log
     - path: output/platypus/test.vcf.gz
-      md5sum: 47f548e70d339fa480f521746c2ec01a
+      md5sum: 41c06991d5b5ecd3fa3004805f37345c
     - path: output/platypus/test.vcf.gz.tbi
       md5sum: 4cb176febbc8c26d717a6c6e67b9c905
     - path: output/platypus/versions.yml


### PR DESCRIPTION
These modules were probably in progress when the overall of the conda syntax happened.

I also fixed the MD5s of the `platypus` tests, that somehow didn't match the current output.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
