### PR TITLE
fix bclconvert interop output

### DIFF
--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -14,12 +14,12 @@ process BCLCONVERT {
 
     output:
     tuple val(meta), path("**[!Undetermined]_S*_R?_00?.fastq.gz")   ,emit: fastq
-    tuple val(meta), path("**[!Undetermined]_S*_I?_00?.fastq.gz")   ,optional:true ,emit: fastq_idx
-    tuple val(meta), path("**Undetermined_S0*_R?_00?.fastq.gz")     ,optional:true ,emit: undetermined
+    tuple val(meta), path("**[!Undetermined]_S*_I?_00?.fastq.gz")   ,optional:true, emit: fastq_idx
+    tuple val(meta), path("**Undetermined_S0*_R?_00?.fastq.gz")     ,optional:true, emit: undetermined
     tuple val(meta), path("**Undetermined_S0*_I?_00?.fastq.gz")     ,optional:true, emit: undetermined_idx
     tuple val(meta), path("Reports")                                ,emit: reports
     tuple val(meta), path("Logs")                                   ,emit: logs
-    tuple val(meta), path("**/InterOp/*.bin")                       ,emit: interop
+    tuple val(meta), path("**/InterOp/*.bin")                       ,optional:true, emit: interop
     path("versions.yml")                                            ,emit: versions
 
     when:

--- a/tests/modules/nf-core/bclconvert/test.yml
+++ b/tests/modules/nf-core/bclconvert/test.yml
@@ -35,17 +35,17 @@
       md5sum: 0a0341e2990b4fa1d9ad4b4c603144c1
     - path: output/bclconvert/Undetermined_S0_L001_R1_001.fastq.gz
       md5sum: febef808ae5397ea4ee7ee40e5fd39e0
-    - path: output/bclconvert/flowcell/InterOp/ControlMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/ControlMetricsOut.bin
       md5sum: 6d77b38d0793a6e1ce1e85706e488953
-    - path: output/bclconvert/flowcell/InterOp/CorrectedIntMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/CorrectedIntMetricsOut.bin
       md5sum: 2bbf84d3be72734addaa2fe794711434
-    - path: output/bclconvert/flowcell/InterOp/ErrorMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/ErrorMetricsOut.bin
       md5sum: 38c88def138e9bb832539911affdb286
-    - path: output/bclconvert/flowcell/InterOp/ExtractionMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/ExtractionMetricsOut.bin
       md5sum: 7497c3178837eea8f09350b5cd252e99
-    - path: output/bclconvert/flowcell/InterOp/IndexMetricsOut.bin
-    - path: output/bclconvert/flowcell/InterOp/QMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/IndexMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/QMetricsOut.bin
       md5sum: 7e9f198d53ebdfbb699a5f94cf1ed51c
-    - path: output/bclconvert/flowcell/InterOp/TileMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/TileMetricsOut.bin
       md5sum: 83891751ec1c91a425a524b476b6ca3c
     - path: output/bclconvert/versions.yml

--- a/tests/subworkflows/nf-core/bcl_demultiplex/test.yml
+++ b/tests/subworkflows/nf-core/bcl_demultiplex/test.yml
@@ -37,18 +37,18 @@
       md5sum: 0a0341e2990b4fa1d9ad4b4c603144c1
     - path: output/bclconvert/Undetermined_S0_L001_R1_001.fastq.gz
       md5sum: febef808ae5397ea4ee7ee40e5fd39e0
-    - path: output/bclconvert/flowcell/InterOp/ControlMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/ControlMetricsOut.bin
       md5sum: 6d77b38d0793a6e1ce1e85706e488953
-    - path: output/bclconvert/flowcell/InterOp/CorrectedIntMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/CorrectedIntMetricsOut.bin
       md5sum: 2bbf84d3be72734addaa2fe794711434
-    - path: output/bclconvert/flowcell/InterOp/ErrorMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/ErrorMetricsOut.bin
       md5sum: 38c88def138e9bb832539911affdb286
-    - path: output/bclconvert/flowcell/InterOp/ExtractionMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/ExtractionMetricsOut.bin
       md5sum: 7497c3178837eea8f09350b5cd252e99
-    - path: output/bclconvert/flowcell/InterOp/IndexMetricsOut.bin
-    - path: output/bclconvert/flowcell/InterOp/QMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/IndexMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/QMetricsOut.bin
       md5sum: 7e9f198d53ebdfbb699a5f94cf1ed51c
-    - path: output/bclconvert/flowcell/InterOp/TileMetricsOut.bin
+    - path: output/bclconvert/test/InterOp/TileMetricsOut.bin
       md5sum: 83891751ec1c91a425a524b476b6ca3c
 
 - name: bcl_demultiplex test_bcl_demultiplex_bcl2fastq
@@ -72,17 +72,17 @@
       md5sum: 0c6f2d87ee183b84d1051cde9a5643d1
     - path: output/bcl2fastq/Stats/Stats.json
       md5sum: 8e5f038b8aa9e465599d3575f930e604
-    - path: output/bcl2fastq/flowcell/InterOp/ControlMetricsOut.bin
+    - path: output/bcl2fastq/test/InterOp/ControlMetricsOut.bin
       md5sum: 6d77b38d0793a6e1ce1e85706e488953
-    - path: output/bcl2fastq/flowcell/InterOp/CorrectedIntMetricsOut.bin
+    - path: output/bcl2fastq/test/InterOp/CorrectedIntMetricsOut.bin
       md5sum: 2bbf84d3be72734addaa2fe794711434
-    - path: output/bcl2fastq/flowcell/InterOp/ErrorMetricsOut.bin
+    - path: output/bcl2fastq/test/InterOp/ErrorMetricsOut.bin
       md5sum: 38c88def138e9bb832539911affdb286
-    - path: output/bcl2fastq/flowcell/InterOp/ExtractionMetricsOut.bin
+    - path: output/bcl2fastq/test/InterOp/ExtractionMetricsOut.bin
       md5sum: 7497c3178837eea8f09350b5cd252e99
-    - path: output/bcl2fastq/flowcell/InterOp/IndexMetricsOut.bin
+    - path: output/bcl2fastq/test/InterOp/IndexMetricsOut.bin
       md5sum: 9e688c58a5487b8eaf69c9e1005ad0bf
-    - path: output/bcl2fastq/flowcell/InterOp/QMetricsOut.bin
+    - path: output/bcl2fastq/test/InterOp/QMetricsOut.bin
       md5sum: 7e9f198d53ebdfbb699a5f94cf1ed51c
-    - path: output/bcl2fastq/flowcell/InterOp/TileMetricsOut.bin
+    - path: output/bcl2fastq/test/InterOp/TileMetricsOut.bin
       md5sum: 83891751ec1c91a425a524b476b6ca3c


### PR DESCRIPTION
Apparently `bcl-convert` doesn't generate any InterOp reports for the NextSeq2000. This PR sets the output to optional.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
