### PR TITLE
copy fix for gridss

### DIFF
--- a/modules/nf-core/gridss/gridss/main.nf
+++ b/modules/nf-core/gridss/gridss/main.nf
@@ -27,7 +27,7 @@ process GRIDSS_GRIDSS {
     def VERSION = '2.13.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
     def assembly_bam = assembly ? "--assembly ${assembly}" : ""
-    def bwa = bwa_index ? "cp -l ${bwa_index}/* ." : ""
+    def bwa = bwa_index ? "cp -s ${bwa_index}/* ." : ""
 
     """
     ${bwa}

--- a/modules/nf-core/gridss/gridss/main.nf
+++ b/modules/nf-core/gridss/gridss/main.nf
@@ -37,7 +37,7 @@ process GRIDSS_GRIDSS {
         --reference ${fasta} \\
         --threads ${task.cpus} \\
         ${assembly} \\
-        --jvmheap ${task.memory.toGiga()}g \\
+        --jvmheap ${task.memory.toGiga() - 1}g \\
         --otherjvmheap ${task.memory.toGiga() - 1}g \\
         ${inputs}
 


### PR DESCRIPTION
Soft link copy of files from the BWA index (would give an error if the index was on another file system)
