### PR TITLE
fix bam_rseqc meta indentation

### DIFF
--- a/subworkflows/nf-core/bam_rseqc/meta.yml
+++ b/subworkflows/nf-core/bam_rseqc/meta.yml
@@ -31,9 +31,9 @@ input:
       description: BAM file to calculate statistics
       pattern: "*.{bam}"
   - bai:
-    type: file
-    description: Index for input BAM file
-    pattern: "*.{bai}"
+      type: file
+      description: Index for input BAM file
+      pattern: "*.{bai}"
   - bed:
       type: file
       description: BED file for the reference gene model


### PR DESCRIPTION
Fix the indentation in `meta.yml` from `bam_rseqc` subworklfow

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
