### PR TITLE
Fix SMNcaller stub

### DIFF
--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -22,7 +22,7 @@ process SMNCOPYNUMBERCALLER {
     manifest_text = bam.join("\n")
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = "1.1.2" // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
+    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     """
     echo "$manifest_text" >manifest.txt
     smn_caller.py \\
@@ -34,19 +34,19 @@ process SMNCOPYNUMBERCALLER {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        SMNCopyNumberCaller: $VERSION
+        SMNCopyNumberCaller: "1.1.2"
     END_VERSIONS
     """
 
     stub:
     """
     mkdir out
-    touch out/${prefix}.tsv
-    touch out/${prefix}.json
+    touch out/smnstub.tsv
+    touch out/smnstub.json
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        SMNCopyNumberCaller: $VERSION
+        SMNCopyNumberCaller: "1.1.2"
     END_VERSIONS
     """
 }


### PR DESCRIPTION
The SMNcopynumbercaller stub gives an error when running stub tests when the prefix is not defined. Here the output files have received a placeholder name instead, and successfully complete all tests.

Furthermore, Version has been defined in the module in quotes, as the version information is not provided by tool on CLI. A warning is present in the main.nf file to update version info when bumping program versions.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
