### PR TITLE
Turn off name checking in DESeq2 script

### DIFF
--- a/modules/nf-core/deseq2/differential/templates/deseq_de.R
+++ b/modules/nf-core/deseq2/differential/templates/deseq_de.R
@@ -47,7 +47,8 @@ read_delim_flexible <- function(file, header = TRUE, row.names = NULL){
         file,
         sep = separator,
         header = header,
-        row.names = row.names
+        row.names = row.names,
+        check.names = FALSE
     )
 }
 
@@ -65,7 +66,10 @@ round_dataframe_columns <- function(df, columns = NULL, digits = 8){
         columns <- colnames(df)
     }
 
-    df[,columns] <- format(data.frame(df[, columns]), nsmall = digits)
+    df[,columns] <- format(
+        data.frame(df[, columns], check.names = FALSE), 
+        nsmall = digits
+    )
 
     # Convert columns back to numeric
 
@@ -347,7 +351,8 @@ cat("Saving results for ", contrast.name, " ...\n", sep = "")
 write.table(
     data.frame(
         gene_id = rownames(comp.results),
-        round_dataframe_columns(data.frame(comp.results))
+        round_dataframe_columns(data.frame(comp.results, check.names = FALSE)),
+        check.names = FALSE
     ),
     file = paste(output_prefix, 'deseq2.results.tsv', sep = '.'),
     col.names = TRUE,
@@ -372,7 +377,11 @@ saveRDS(dds, file = paste(output_prefix, 'dds.rld.rds', sep = '.'))
 
 # Size factors
 
-sf_df = data.frame(sample = names(sizeFactors(dds)), data.frame(sizeFactors(dds)))
+sf_df = data.frame(
+    sample = names(sizeFactors(dds)), 
+    data.frame(sizeFactors(dds), check.names = FALSE),
+    check.names = FALSE
+)
 colnames(sf_df) <- c('sample', 'sizeFactor')
 write.table(
     sf_df,
@@ -386,7 +395,11 @@ write.table(
 # Write specified matrices
 
 write.table(
-    data.frame(gene_id=rownames(counts(dds)), counts(dds, normalized = TRUE)),
+    data.frame(
+        gene_id=rownames(counts(dds)), 
+        counts(dds, normalized = TRUE),
+        check.names = FALSE
+    ),
     file = paste(output_prefix, 'normalised_counts.tsv', sep = '.'),
     col.names = TRUE,
     row.names = FALSE,
@@ -408,7 +421,10 @@ for (vs_method_name in strsplit(opt\$vs_method, ',')){
     write.table(
         data.frame(
             gene_id=rownames(counts(dds)),
-            round_dataframe_columns(data.frame(assay(vs_mat)))
+            round_dataframe_columns(
+                data.frame(assay(vs_mat), check.names = FALSE)
+            ),
+            check.names = FALSE
         ),
         file = paste(output_prefix, vs_method_name,'tsv', sep = '.'),
         col.names = TRUE,

--- a/modules/nf-core/deseq2/differential/templates/deseq_de.R
+++ b/modules/nf-core/deseq2/differential/templates/deseq_de.R
@@ -67,7 +67,7 @@ round_dataframe_columns <- function(df, columns = NULL, digits = 8){
     }
 
     df[,columns] <- format(
-        data.frame(df[, columns], check.names = FALSE), 
+        data.frame(df[, columns], check.names = FALSE),
         nsmall = digits
     )
 
@@ -378,7 +378,7 @@ saveRDS(dds, file = paste(output_prefix, 'dds.rld.rds', sep = '.'))
 # Size factors
 
 sf_df = data.frame(
-    sample = names(sizeFactors(dds)), 
+    sample = names(sizeFactors(dds)),
     data.frame(sizeFactors(dds), check.names = FALSE),
     check.names = FALSE
 )
@@ -396,7 +396,7 @@ write.table(
 
 write.table(
     data.frame(
-        gene_id=rownames(counts(dds)), 
+        gene_id=rownames(counts(dds)),
         counts(dds, normalized = TRUE),
         check.names = FALSE
     ),


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

This PR turns of R's default name checking, which can mangle some things (e.g. column names starting with numbers).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
