### PR TITLE
Fix smncaller stub

### DIFF
--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -44,7 +44,6 @@ process SMNCOPYNUMBERCALLER {
     mkdir out
     touch out/${prefix}.tsv
     touch out/${prefix}.json
-    
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         SMNCopyNumberCaller: $VERSION

--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -39,11 +39,12 @@ process SMNCOPYNUMBERCALLER {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = "1.1.2" // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
+    def VERSION = "1.1.2"
     """
     mkdir out
     touch out/${prefix}.tsv
     touch out/${prefix}.json
+    
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         SMNCopyNumberCaller: $VERSION

--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -22,7 +22,7 @@ process SMNCOPYNUMBERCALLER {
     manifest_text = bam.join("\n")
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = "1.1.2" // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
+    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     """
     echo "$manifest_text" >manifest.txt
     smn_caller.py \\
@@ -34,19 +34,19 @@ process SMNCOPYNUMBERCALLER {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        SMNCopyNumberCaller: $VERSION
+        SMNCopyNumberCaller: "1.1.2"
     END_VERSIONS
     """
 
     stub:
     """
     mkdir out
-    touch out/${prefix}.tsv
-    touch out/${prefix}.json
+    touch out/smnstub.tsv
+    touch out/smnstub.json
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        SMNCopyNumberCaller: $VERSION
+        SMNCopyNumberCaller: "1.1.2"
     END_VERSIONS
     """
 }

--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -22,7 +22,7 @@ process SMNCOPYNUMBERCALLER {
     manifest_text = bam.join("\n")
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
+    def VERSION = "1.1.2" // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     """
     echo "$manifest_text" >manifest.txt
     smn_caller.py \\
@@ -31,22 +31,22 @@ process SMNCOPYNUMBERCALLER {
         --prefix $prefix \\
         --outDir "out" \\
         --threads $task.cpus
-
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        SMNCopyNumberCaller: "1.1.2"
+        SMNCopyNumberCaller: $VERSION
     END_VERSIONS
     """
 
     stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION = "1.1.2" // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     """
     mkdir out
-    touch out/smnstub.tsv
-    touch out/smnstub.json
-
+    touch out/${prefix}.tsv
+    touch out/${prefix}.json
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        SMNCopyNumberCaller: "1.1.2"
+        SMNCopyNumberCaller: $VERSION
     END_VERSIONS
     """
 }


### PR DESCRIPTION
The SMNcopynumbercaller stub gives an error when running stub tests, because prefix and version were not defined in the stubs section.

I had identified the problem wrongly in the previous PR, which I closed, but now I understand the real error. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
