### PR TITLE
smncopynumbercaller change echo newline character

### DIFF
--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -19,18 +19,19 @@ process SMNCOPYNUMBERCALLER {
     task.ext.when == null || task.ext.when
 
     script:
-    manifest_text = bam.join("\n")
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = "1.1.2" // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     """
-    printf '%s' "$manifest_text" >manifest.txt
+    echo $bam | tr ' ' '
+    ' > manifest.txt
     smn_caller.py \\
         $args \\
         --manifest manifest.txt \\
         --prefix $prefix \\
         --outDir "out" \\
         --threads $task.cpus
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         SMNCopyNumberCaller: $VERSION
@@ -44,6 +45,7 @@ process SMNCOPYNUMBERCALLER {
     mkdir out
     touch out/${prefix}.tsv
     touch out/${prefix}.json
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         SMNCopyNumberCaller: $VERSION

--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -24,7 +24,7 @@ process SMNCOPYNUMBERCALLER {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = "1.1.2" // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     """
-    echo "$manifest_text" >manifest.txt
+    printf '%s' "$manifest_text" >manifest.txt
     smn_caller.py \\
         $args \\
         --manifest manifest.txt \\


### PR DESCRIPTION
There is a problem in this module where using a newline character in the main.nf document `/n` causes the versions.yml file to not interpret END_VERSIONS correctly, and subsequently it includes the END_VERSIONS line into versions.yml. The changed code here uses an actual newline (by pressing enter in the code), and it now properly outputs the requested data in the correct format.


Problem:
<img width="817" alt="image" src="https://user-images.githubusercontent.com/57712924/221539300-2371b8bc-2f75-4917-9415-61a5b7323680.png">

With the new code:
<img width="815" alt="image" src="https://user-images.githubusercontent.com/57712924/221539477-f3ad12f5-6290-4c14-825b-8511a3c3b707.png">

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
