### PR TITLE
Fix tiara/tiara

### DIFF
--- a/modules/nf-core/tiara/tiara/main.nf
+++ b/modules/nf-core/tiara/tiara/main.nf
@@ -12,8 +12,8 @@ process TIARA_TIARA {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path("${prefix}.out.{txt,txt.gz}")  , emit: classifications
-    tuple val(meta), path("log_*.out.{txt,txt.gz}")      , emit: log
+    tuple val(meta), path("${prefix}.{txt,txt.gz}")  , emit: classifications
+    tuple val(meta), path("log_*.{txt,txt.gz}")      , emit: log
     tuple val(meta), path("*.{fasta,fasta.gz}")          , emit: fasta, optional: true
     path "versions.yml"                                  , emit: versions
 
@@ -26,13 +26,13 @@ process TIARA_TIARA {
     def VERSION = '1.0.3' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     tiara -i ${fasta} \
-        -o ${prefix}.out.txt \
+        -o ${prefix}.txt \
         --threads ${task.cpus} \
         ${args}
 
     ## fix gzip flag weirdness and ensure consistent .fasta filename output
     ## check if fasta files are being output
-    if echo "${args}" | grep -q "tf\|to-fasta"; then
+    if echo "${args}" | grep -qE "tf|to-fasta"; then
         ## check if we've asked for gzip output, then rename files consistently
         if echo "${args}" | grep -q "gz"; then
             find . -name "*_${fasta}*" -exec sh -c 'file=`basename {}`; mv "\$file" "\${file%%_*}_${prefix}.fasta.gz"' \\;

--- a/modules/nf-core/tiara/tiara/meta.yml
+++ b/modules/nf-core/tiara/tiara/meta.yml
@@ -33,11 +33,11 @@ output:
   - classifications:
       type: file
       description: TSV file containing per-contig classification probabilities and overall classifications. Gzipped if flag --gz is set.
-      pattern: "classification_*.out.{txt,txt.gz}"
+      pattern: "*.{txt,txt.gz}"
   - log:
       type: file
       description: Log file containing tiara model parameters. Gzipped if flag --gz is set.
-      pattern: "log_*.out.{txt,txt.gz}"
+      pattern: "log_*.{txt,txt.gz}"
   - fasta:
       type: file
       description: |

--- a/tests/modules/nf-core/tiara/tiara/test.yml
+++ b/tests/modules/nf-core/tiara/tiara/test.yml
@@ -1,16 +1,16 @@
 - name: tiara tiara test_tiara_tiara
   command: nextflow run ./tests/modules/nf-core/tiara/tiara -entry test_tiara_tiara -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/tiara/tiara/nextflow.config
   tags:
-    - tiara/tiara
     - tiara
+    - tiara/tiara
   files:
     - path: output/tiara/bacteria_test.fasta
       md5sum: d46834f0b781bc0277269f79226f5001
-    - path: output/tiara/test.out.txt
-      md5sum: 1e4a4d8081c20b2540316fb9fafb5ad3
-    - path: output/tiara/log_test.out.txt
+    - path: output/tiara/log_test.txt
       contains:
         - "hidden_1: 2048"
         - "hidden_2: 1024"
         - "prob_cutoff: 0.65"
+    - path: output/tiara/test.txt
+      md5sum: 1e4a4d8081c20b2540316fb9fafb5ad3
     - path: output/tiara/versions.yml


### PR DESCRIPTION
tiara/tiara was throwing a Groovy warning that I had put down to Gitpod playing up, due to a poorly escaped \ in the script:

`unknown recognition error type: groovyjarjarantlr4.v4.runtime.LexerNoViableAltException`

Fixed by using extended grep to avoid the backslash entirely. Also updated the output filenames so that they just take $prefix and don't have an arbitrary '.out'. in the filename.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
