### PR TITLE
Fix variable sanitisation for differential modules

### DIFF
--- a/modules/nf-core/deseq2/differential/templates/deseq_de.R
+++ b/modules/nf-core/deseq2/differential/templates/deseq_de.R
@@ -31,7 +31,7 @@ parse_args <- function(x){
 #'
 #' @return output Data frame
 
-read_delim_flexible <- function(file, header = TRUE, row.names = NULL){
+read_delim_flexible <- function(file, header = TRUE, row.names = NULL, check.names = TRUE){
 
     ext <- tolower(tail(strsplit(basename(file), split = "\\\\.")[[1]], 1))
 
@@ -48,7 +48,7 @@ read_delim_flexible <- function(file, header = TRUE, row.names = NULL){
         sep = separator,
         header = header,
         row.names = row.names,
-        check.names = FALSE
+        check.names = check.names
     )
 }
 
@@ -178,7 +178,8 @@ count.table <-
     read_delim_flexible(
         file = opt\$count_file,
         header = TRUE,
-        row.names = opt\$gene_id_col
+        row.names = opt\$gene_id_col,
+        check.names = FALSE
     )
 sample.sheet <- read_delim_flexible(file = opt\$sample_file)
 

--- a/modules/nf-core/limma/differential/templates/limma_de.R
+++ b/modules/nf-core/limma/differential/templates/limma_de.R
@@ -31,7 +31,7 @@ parse_args <- function(x){
 #'
 #' @return output Data frame
 
-read_delim_flexible <- function(file, header = TRUE, row.names = NULL){
+read_delim_flexible <- function(file, header = TRUE, row.names = NULL, check.names = TRUE){
 
     ext <- tolower(tail(strsplit(basename(file), split = "\\\\.")[[1]], 1))
 
@@ -48,7 +48,7 @@ read_delim_flexible <- function(file, header = TRUE, row.names = NULL){
         sep = separator,
         header = header,
         row.names = row.names,
-        check.names = FALSE
+        check.names = check.names
     )
 }
 
@@ -149,7 +149,8 @@ intensities.table <-
     read_delim_flexible(
         file = opt\$count_file,
         header = TRUE,
-        row.names = opt\$probe_id_col
+        row.names = opt\$probe_id_col,
+        check.names = FALSE
     )
 sample.sheet <- read_delim_flexible(file = opt\$sample_file)
 


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

This PR fixes issues caused by me getting carried away in https://github.com/nf-core/modules/pull/2911. We don't want to have `check.names` active on the input matrices, but it's actively helpful on the sample metadata table we use to construct models. 

This is actually breaking the full size tests on #differentialabundance, which has spaces in sample metadata columns.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
