### PR TITLE
Bump version of umi-tools to 1.14

### DIFF
--- a/modules/nf-core/umitools/dedup/main.nf
+++ b/modules/nf-core/umitools/dedup/main.nf
@@ -1,11 +1,13 @@
 process UMITOOLS_DEDUP {
     tag "$meta.id"
-    label "process_medium"
+    label "process_single"
+    label "process_long"
 
-    conda "bioconda::umi_tools=1.1.2"
+
+    conda "bioconda::umi_tools=1.1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/umi_tools:1.1.2--py38h4a8c8d9_0' :
-        'quay.io/biocontainers/umi_tools:1.1.2--py38h4a8c8d9_0' }"
+        'https://depot.galaxyproject.org/singularity/umi_tools:1.1.4--py38hbff2b2d_1' :
+        'quay.io/biocontainers/umi_tools:1.1.4--py38hbff2b2d_1' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/umitools/dedup/main.nf
+++ b/modules/nf-core/umitools/dedup/main.nf
@@ -1,8 +1,6 @@
 process UMITOOLS_DEDUP {
     tag "$meta.id"
     label "process_single"
-    label "process_long"
-
 
     conda "bioconda::umi_tools=1.1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/umitools/extract/main.nf
+++ b/modules/nf-core/umitools/extract/main.nf
@@ -1,11 +1,12 @@
 process UMITOOLS_EXTRACT {
     tag "$meta.id"
-    label "process_low"
+    label "process_single"
+    label "process_long"
 
-    conda "bioconda::umi_tools=1.1.2"
+    conda "bioconda::umi_tools=1.1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/umi_tools:1.1.2--py38h4a8c8d9_0' :
-        'quay.io/biocontainers/umi_tools:1.1.2--py38h4a8c8d9_0' }"
+        'https://depot.galaxyproject.org/singularity/umi_tools:1.1.4--py38hbff2b2d_1' :
+        'quay.io/biocontainers/umi_tools:1.1.4--py38hbff2b2d_1' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/umitools/extract/main.nf
+++ b/modules/nf-core/umitools/extract/main.nf
@@ -1,7 +1,6 @@
 process UMITOOLS_EXTRACT {
     tag "$meta.id"
     label "process_single"
-    label "process_long"
 
     conda "bioconda::umi_tools=1.1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/tests/modules/nf-core/umitools/dedup/main.nf
+++ b/tests/modules/nf-core/umitools/dedup/main.nf
@@ -30,7 +30,10 @@ workflow test_umitools_dedup_single_end_no_stats {
         [ id:'test', single_end:true ], // meta map
         file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = [
+        [ id:'sarscov2'], 
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
     get_output_stats = false
 
     UMITOOLS_EXTRACT ( input )
@@ -51,7 +54,10 @@ workflow test_umitools_dedup_paired_end_no_stats {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) 
         ]
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = [
+        [ id:'sarscov2'], 
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
     get_output_stats = false
 
     UMITOOLS_EXTRACT ( input )
@@ -72,7 +78,10 @@ workflow test_umitools_dedup_paired_end_stats {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) 
         ]
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta = [
+        [ id:'sarscov2'], 
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
     get_output_stats = true
 
     UMITOOLS_EXTRACT ( input )

--- a/tests/modules/nf-core/umitools/dedup/test.yml
+++ b/tests/modules/nf-core/umitools/dedup/test.yml
@@ -1,13 +1,15 @@
 - name: umitools dedup test_umitools_dedup_no_umi
-  command: nextflow run ./tests/modules/nf-core/umitools/dedup -entry test_umitools_dedup_no_umi -c ./tests/config/nextflow.config  -c ./tests/modules/nf-core/umitools/dedup/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/umitools/dedup -entry test_umitools_dedup_no_umi -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/umitools/dedup/nextflow.config
   tags:
     - umitools/dedup
     - umitools
   files:
     - path: output/umitools/test.dedup.bam
+      md5sum: 350e942a0d45e8356fa24bc8c47dc1ed
+    - path: output/umitools/versions.yml
 
 - name: umitools dedup test_umitools_dedup_single_end_no_stats
-  command: nextflow run ./tests/modules/nf-core/umitools/dedup -entry test_umitools_dedup_single_end_no_stats -c ./tests/config/nextflow.config  -c ./tests/modules/nf-core/umitools/dedup/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/umitools/dedup -entry test_umitools_dedup_single_end_no_stats -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/umitools/dedup/nextflow.config
   tags:
     - umitools/dedup
     - umitools
@@ -24,14 +26,18 @@
       md5sum: ab3952cabf026b48cd3eb5bccbb636d1
     - path: output/bwa/test.bam
       md5sum: af925e0019ce03eb8716ad3f8471311d
+    - path: output/bwa/versions.yml
     - path: output/samtools/test.bam.bai
       md5sum: 4db1993dbd1ad8bbe3c5eea6d7ee6136
+    - path: output/samtools/versions.yml
     - path: output/umitools/test.dedup.bam
-    - path: output/umitools/test.umi_extract.fastq.gz
+      md5sum: 9541c6ac00eea9064786244be9d8738f
     - path: output/umitools/test.umi_extract.log
+      contains: "Starting barcode extraction"
+    - path: output/umitools/versions.yml
 
 - name: umitools dedup test_umitools_dedup_paired_end_no_stats
-  command: nextflow run ./tests/modules/nf-core/umitools/dedup -entry test_umitools_dedup_paired_end_no_stats -c ./tests/config/nextflow.config  -c ./tests/modules/nf-core/umitools/dedup/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/umitools/dedup -entry test_umitools_dedup_paired_end_no_stats -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/umitools/dedup/nextflow.config
   tags:
     - umitools/dedup
     - umitools
@@ -48,15 +54,18 @@
       md5sum: ab3952cabf026b48cd3eb5bccbb636d1
     - path: output/bwa/test.bam
       md5sum: 82063366bc9e8935f3c10d863b03f719
+    - path: output/bwa/versions.yml
     - path: output/samtools/test.bam.bai
       md5sum: b63b387c59f0fa8fbc24c9faf613240a
+    - path: output/samtools/versions.yml
     - path: output/umitools/test.dedup.bam
+      md5sum: 1bf0f4849aa8b488f1f1a86135e25a16
     - path: output/umitools/test.umi_extract.log
-    - path: output/umitools/test.umi_extract_1.fastq.gz
-    - path: output/umitools/test.umi_extract_2.fastq.gz
+      contains: "Starting barcode extraction"
+    - path: output/umitools/versions.yml
 
 - name: umitools dedup test_umitools_dedup_paired_end_stats
-  command: nextflow run ./tests/modules/nf-core/umitools/dedup -entry test_umitools_dedup_paired_end_stats -c ./tests/config/nextflow.config  -c ./tests/modules/nf-core/umitools/dedup/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/umitools/dedup -entry test_umitools_dedup_paired_end_stats -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/umitools/dedup/nextflow.config
   tags:
     - umitools/dedup
     - umitools
@@ -73,9 +82,12 @@
       md5sum: ab3952cabf026b48cd3eb5bccbb636d1
     - path: output/bwa/test.bam
       md5sum: 82063366bc9e8935f3c10d863b03f719
+    - path: output/bwa/versions.yml
     - path: output/samtools/test.bam.bai
       md5sum: b63b387c59f0fa8fbc24c9faf613240a
+    - path: output/samtools/versions.yml
     - path: output/umitools/test.dedup.bam
+      md5sum: 1bf0f4849aa8b488f1f1a86135e25a16
     - path: output/umitools/test.dedup_edit_distance.tsv
       md5sum: c247a49b58768e6e2e86a6c08483e612
     - path: output/umitools/test.dedup_per_umi.tsv
@@ -83,5 +95,5 @@
     - path: output/umitools/test.dedup_per_umi_per_position.tsv
       md5sum: 2e1a12e6f720510880068deddeefe063
     - path: output/umitools/test.umi_extract.log
-    - path: output/umitools/test.umi_extract_1.fastq.gz
-    - path: output/umitools/test.umi_extract_2.fastq.gz
+      contains: "Starting barcode extraction"
+    - path: output/umitools/versions.yml

--- a/tests/modules/nf-core/umitools/dedup/test.yml
+++ b/tests/modules/nf-core/umitools/dedup/test.yml
@@ -23,9 +23,9 @@
     - path: output/bwa/bwa/genome.sa
       md5sum: ab3952cabf026b48cd3eb5bccbb636d1
     - path: output/bwa/test.bam
-      md5sum: 3ecbe569cadb9b6c881917ce60779f75
+      md5sum: af925e0019ce03eb8716ad3f8471311d
     - path: output/samtools/test.bam.bai
-      md5sum: 095af0ad3921212597ffd7c342ecd5a0
+      md5sum: 4db1993dbd1ad8bbe3c5eea6d7ee6136
     - path: output/umitools/test.dedup.bam
     - path: output/umitools/test.umi_extract.fastq.gz
     - path: output/umitools/test.umi_extract.log
@@ -47,9 +47,9 @@
     - path: output/bwa/bwa/genome.sa
       md5sum: ab3952cabf026b48cd3eb5bccbb636d1
     - path: output/bwa/test.bam
-      md5sum: e7dcbac1825bf210409b762dbb4fec8f
+      md5sum: 82063366bc9e8935f3c10d863b03f719
     - path: output/samtools/test.bam.bai
-      md5sum: f75780d1de7860329b7fb4afeadc4bed
+      md5sum: b63b387c59f0fa8fbc24c9faf613240a
     - path: output/umitools/test.dedup.bam
     - path: output/umitools/test.umi_extract.log
     - path: output/umitools/test.umi_extract_1.fastq.gz
@@ -72,9 +72,9 @@
     - path: output/bwa/bwa/genome.sa
       md5sum: ab3952cabf026b48cd3eb5bccbb636d1
     - path: output/bwa/test.bam
-      md5sum: e7dcbac1825bf210409b762dbb4fec8f
+      md5sum: 82063366bc9e8935f3c10d863b03f719
     - path: output/samtools/test.bam.bai
-      md5sum: f75780d1de7860329b7fb4afeadc4bed
+      md5sum: b63b387c59f0fa8fbc24c9faf613240a
     - path: output/umitools/test.dedup.bam
     - path: output/umitools/test.dedup_edit_distance.tsv
       md5sum: c247a49b58768e6e2e86a6c08483e612

--- a/tests/modules/nf-core/umitools/dedup/test.yml
+++ b/tests/modules/nf-core/umitools/dedup/test.yml
@@ -33,7 +33,7 @@
     - path: output/umitools/test.dedup.bam
       md5sum: 9541c6ac00eea9064786244be9d8738f
     - path: output/umitools/test.umi_extract.log
-      contains: "Starting barcode extraction"
+      contains: ["Starting barcode extraction"]
     - path: output/umitools/versions.yml
 
 - name: umitools dedup test_umitools_dedup_paired_end_no_stats
@@ -61,7 +61,7 @@
     - path: output/umitools/test.dedup.bam
       md5sum: 1bf0f4849aa8b488f1f1a86135e25a16
     - path: output/umitools/test.umi_extract.log
-      contains: "Starting barcode extraction"
+      contains: ["Starting barcode extraction"]
     - path: output/umitools/versions.yml
 
 - name: umitools dedup test_umitools_dedup_paired_end_stats
@@ -95,5 +95,5 @@
     - path: output/umitools/test.dedup_per_umi_per_position.tsv
       md5sum: 2e1a12e6f720510880068deddeefe063
     - path: output/umitools/test.umi_extract.log
-      contains: "Starting barcode extraction"
+      contains: ["Starting barcode extraction"]
     - path: output/umitools/versions.yml

--- a/tests/modules/nf-core/umitools/extract/test.yml
+++ b/tests/modules/nf-core/umitools/extract/test.yml
@@ -5,11 +5,12 @@
     - umitools
   files:
     - path: output/umitools/test.umi_extract.fastq.gz
-      contains:
-        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+      should_exist: true
+
     - path: output/umitools/test.umi_extract.log
       contains:
-        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - ["job finished in"]
+
     - path: output/umitools/versions.yml
 
 - name: umitools extract test_umitools_extract_paired_end
@@ -20,11 +21,11 @@
   files:
     - path: output/umitools/test.umi_extract.log
       contains:
-        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - ["job finished in"]
     - path: output/umitools/test.umi_extract_1.fastq.gz
-      contains:
-        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+      should_exist: true
+
     - path: output/umitools/test.umi_extract_2.fastq.gz
-      contains:
-        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+      should_exist: true
+
     - path: output/umitools/versions.yml

--- a/tests/modules/nf-core/umitools/extract/test.yml
+++ b/tests/modules/nf-core/umitools/extract/test.yml
@@ -9,7 +9,7 @@
 
     - path: output/umitools/test.umi_extract.log
       contains:
-        - ["job finished in"]
+        - "job finished in"
 
     - path: output/umitools/versions.yml
 
@@ -21,7 +21,7 @@
   files:
     - path: output/umitools/test.umi_extract.log
       contains:
-        - ["job finished in"]
+        - "job finished in"
     - path: output/umitools/test.umi_extract_1.fastq.gz
       should_exist: true
 

--- a/tests/modules/nf-core/umitools/extract/test.yml
+++ b/tests/modules/nf-core/umitools/extract/test.yml
@@ -1,27 +1,30 @@
 - name: umitools extract test_umitools_extract_single_end
-  command: nextflow run ./tests/modules/nf-core/umitools/extract -entry test_umitools_extract_single_end -c ./tests/config/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/umitools/extract -entry test_umitools_extract_single_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/umitools/extract/nextflow.config
   tags:
     - umitools/extract
     - umitools
   files:
     - path: output/umitools/test.umi_extract.fastq.gz
-      should_exist: true
+      contains:
+        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/umitools/test.umi_extract.log
-      contains: ["job finished in"]
+      contains:
+        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/umitools/versions.yml
-      md5sum: 397e6972343f9d7b8eae387fc18c12c7
 
 - name: umitools extract test_umitools_extract_paired_end
-  command: nextflow run ./tests/modules/nf-core/umitools/extract -entry test_umitools_extract_paired_end -c ./tests/config/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/umitools/extract -entry test_umitools_extract_paired_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/umitools/extract/nextflow.config
   tags:
     - umitools/extract
     - umitools
   files:
     - path: output/umitools/test.umi_extract.log
-      contains: ["job finished in"]
+      contains:
+        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/umitools/test.umi_extract_1.fastq.gz
-      should_exist: true
+      contains:
+        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/umitools/test.umi_extract_2.fastq.gz
-      should_exist: true
+      contains:
+        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/umitools/versions.yml
-      md5sum: 0aec6f919d62b7b79f6d0c5d79411464


### PR DESCRIPTION
After almost two years without updates, [versions 1.13 and 1.14 of umi-tools were released early March 2023](https://github.com/CGATOxford/UMI-tools/releases). 

Those new versions comprise for example [a speed-up for read pair mate writing](https://github.com/CGATOxford/UMI-tools/pull/543). This improves performance for transcriptome alignments greatly (Time to run is reduced from 5 hours to 4 minutes) and is thus most anticipated for the RNA-seq pipeline.

Accordingly, I have also changed the process labels. Since `umi-tools` is not multithreaded, in particular _process medium_ seemed like a waste of CPU. 

Also, the new `--umi-separator` command to `umi-tools extract` will be beneficial. So far only available for `umi-tools dedup`, so we had to stick to underscores as separator, although Illumina's bclconvert imposes a semicolon.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
