### PR TITLE
update, unify cellranger module metadata

### DIFF
--- a/modules/nf-core/cellranger/mkfastq/meta.yml
+++ b/modules/nf-core/cellranger/mkfastq/meta.yml
@@ -1,5 +1,5 @@
 name: cellranger_mkfastq
-description: Module to create fastqs needed by the 10x Genomics Cell Ranger tool. Uses the cellranger mkfastq command.
+description: Module to create FastQs needed by the 10x Genomics Cell Ranger tool. Uses the cellranger mkfastq command.
 keywords:
   - reference
   - mkfastq

--- a/modules/nf-core/cellranger/mkfastq/meta.yml
+++ b/modules/nf-core/cellranger/mkfastq/meta.yml
@@ -1,5 +1,5 @@
 name: cellranger_mkfastq
-description: Module to create FastQs needed by the 10x Genomics Cell Ranger tool. Uses the cellranger mkfastq command.
+description: Module to create FASTQs needed by the 10x Genomics Cell Ranger tool. Uses the cellranger mkfastq command.
 keywords:
   - reference
   - mkfastq

--- a/modules/nf-core/cellranger/mkgtf/meta.yml
+++ b/modules/nf-core/cellranger/mkgtf/meta.yml
@@ -1,5 +1,5 @@
 name: cellranger_mkgtf
-description: Module to build a filtered gtf needed by the 10x Genomics Cell Ranger tool. Uses the cellranger mkgtf command.
+description: Module to build a filtered GTF needed by the 10x Genomics Cell Ranger tool. Uses the cellranger mkgtf command.
 keywords:
   - reference
   - mkref
@@ -15,12 +15,12 @@ tools:
 input:
   - gtf:
       type: file
-      description:
+      description: The reference GTF transcriptome file
       pattern: "*.gtf"
 output:
   - gtf:
       type: folder
-      description: gtf transcriptome file
+      description: The filtered GTF transcriptome file
       pattern: "*.filtered.gtf"
   - versions:
       type: file

--- a/modules/nf-core/cellranger/mkref/meta.yml
+++ b/modules/nf-core/cellranger/mkref/meta.yml
@@ -15,7 +15,7 @@ tools:
 input:
   - fasta:
       type: file
-      description: Reference genome FastA file
+      description: Reference genome FASTA file
       pattern: "*.{fasta,fa}"
   - gtf:
       type: file

--- a/modules/nf-core/cellranger/mkref/meta.yml
+++ b/modules/nf-core/cellranger/mkref/meta.yml
@@ -15,15 +15,15 @@ tools:
 input:
   - fasta:
       type: file
-      description: fasta genome file
+      description: Reference genome FastA file
       pattern: "*.{fasta,fa}"
   - gtf:
       type: file
-      description: gtf transcriptome file
+      description: Reference transcriptome GTF file
       pattern: "*.gtf"
   - reference_name:
       type: val
-      description: name to give the reference folder
+      description: The name to give the new reference folder
       pattern: str
 output:
   - reference:


### PR DESCRIPTION
## PR checklist

Fixes missing `cellranger` module metadata from #2914. Slightly harmonizes the text between `cellranger` submodules.
