### PR TITLE
Bump software versions for modules used in nf-core/viralrecon

### DIFF
--- a/modules/nf-core/blast/blastn/main.nf
+++ b/modules/nf-core/blast/blastn/main.nf
@@ -2,10 +2,10 @@ process BLAST_BLASTN {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::blast=2.12.0"
+    conda "bioconda::blast=2.13.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/blast:2.12.0--pl5262h3289130_0' :
-        'quay.io/biocontainers/blast:2.12.0--pl5262h3289130_0' }"
+        'https://depot.galaxyproject.org/singularity/blast:2.13.0--hf3cf87c_0' :
+        'quay.io/biocontainers/blast:2.13.0--hf3cf87c_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/blast/makeblastdb/main.nf
+++ b/modules/nf-core/blast/makeblastdb/main.nf
@@ -2,10 +2,10 @@ process BLAST_MAKEBLASTDB {
     tag "$fasta"
     label 'process_medium'
 
-    conda "bioconda::blast=2.12.0"
+    conda "bioconda::blast=2.13.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/blast:2.12.0--pl5262h3289130_0' :
-        'quay.io/biocontainers/blast:2.12.0--pl5262h3289130_0' }"
+        'https://depot.galaxyproject.org/singularity/blast:2.13.0--hf3cf87c_0' :
+        'quay.io/biocontainers/blast:2.13.0--hf3cf87c_0' }"
 
     input:
     path fasta

--- a/modules/nf-core/blast/tblastn/main.nf
+++ b/modules/nf-core/blast/tblastn/main.nf
@@ -2,10 +2,10 @@ process BLAST_TBLASTN {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::blast=2.12.0"
+    conda "bioconda::blast=2.13.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/blast:2.12.0--pl5262h3289130_0' :
-        'quay.io/biocontainers/blast:2.12.0--pl5262h3289130_0' }"
+        'https://depot.galaxyproject.org/singularity/blast:2.13.0--hf3cf87c_0' :
+        'quay.io/biocontainers/blast:2.13.0--hf3cf87c_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/custom/dumpsoftwareversions/main.nf
+++ b/modules/nf-core/custom/dumpsoftwareversions/main.nf
@@ -2,10 +2,10 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     label 'process_single'
 
     // Requires `pyyaml` which does not have a dedicated container but is in the MultiQC container
-    conda "bioconda::multiqc=1.13"
+    conda "bioconda::multiqc=1.14"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.13--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.13--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.14--pyhdfd78af_0' :
+        'quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0' }"
 
     input:
     path versions

--- a/modules/nf-core/ivar/consensus/main.nf
+++ b/modules/nf-core/ivar/consensus/main.nf
@@ -2,10 +2,10 @@ process IVAR_CONSENSUS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::ivar=1.3.1"
+    conda "bioconda::ivar=1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ivar:1.3.1--h089eab3_0' :
-        'quay.io/biocontainers/ivar:1.3.1--h089eab3_0' }"
+        'https://depot.galaxyproject.org/singularity/ivar:1.4--h6b7c446_1' :
+        'quay.io/biocontainers/ivar:1.4--h6b7c446_1' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/ivar/trim/main.nf
+++ b/modules/nf-core/ivar/trim/main.nf
@@ -2,10 +2,10 @@ process IVAR_TRIM {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::ivar=1.3.1"
+    conda "bioconda::ivar=1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ivar:1.3.1--h089eab3_0' :
-        'quay.io/biocontainers/ivar:1.3.1--h089eab3_0' }"
+        'https://depot.galaxyproject.org/singularity/ivar:1.4--h6b7c446_1' :
+        'quay.io/biocontainers/ivar:1.4--h6b7c446_1' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/ivar/variants/main.nf
+++ b/modules/nf-core/ivar/variants/main.nf
@@ -2,10 +2,10 @@ process IVAR_VARIANTS {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::ivar=1.3.1"
+    conda "bioconda::ivar=1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ivar:1.3.1--h089eab3_0' :
-        'quay.io/biocontainers/ivar:1.3.1--h089eab3_0' }"
+        'https://depot.galaxyproject.org/singularity/ivar:1.4--h6b7c446_1' :
+        'quay.io/biocontainers/ivar:1.4--h6b7c446_1' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/nextclade/datasetget/main.nf
+++ b/modules/nf-core/nextclade/datasetget/main.nf
@@ -2,10 +2,10 @@ process NEXTCLADE_DATASETGET {
     tag "$dataset"
     label 'process_low'
 
-    conda "bioconda::nextclade=2.2.0"
+    conda "bioconda::nextclade=2.12.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nextclade:2.2.0--h9ee0642_0' :
-        'quay.io/biocontainers/nextclade:2.2.0--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/nextclade:2.12.0--h9ee0642_0' :
+        'quay.io/biocontainers/nextclade:2.12.0--h9ee0642_0' }"
 
     input:
     val dataset

--- a/modules/nf-core/nextclade/run/main.nf
+++ b/modules/nf-core/nextclade/run/main.nf
@@ -2,10 +2,10 @@ process NEXTCLADE_RUN {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::nextclade=2.2.0"
+    conda "bioconda::nextclade=2.12.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nextclade:2.2.0--h9ee0642_0' :
-        'quay.io/biocontainers/nextclade:2.2.0--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/nextclade:2.12.0--h9ee0642_0' :
+        'quay.io/biocontainers/nextclade:2.12.0--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/pangolin/main.nf
+++ b/modules/nf-core/pangolin/main.nf
@@ -2,10 +2,10 @@ process PANGOLIN {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::pangolin=4.1.1"
+    conda "bioconda::pangolin=4.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pangolin:4.1.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/pangolin:4.1.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/pangolin:4.2--pyhdfd78af_1' :
+        'quay.io/biocontainers/pangolin:4.2--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/spades/main.nf
+++ b/modules/nf-core/spades/main.nf
@@ -2,10 +2,10 @@ process SPADES {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::spades=3.15.4"
+    conda "bioconda::spades=3.15.5"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/spades:3.15.4--h95f258a_0' :
-        'quay.io/biocontainers/spades:3.15.4--h95f258a_0' }"
+        'https://depot.galaxyproject.org/singularity/spades:3.15.5--h95f258a_1' :
+        'quay.io/biocontainers/spades:3.15.5--h95f258a_1' }"
 
     input:
     tuple val(meta), path(illumina), path(pacbio), path(nanopore)

--- a/modules/nf-core/unicycler/main.nf
+++ b/modules/nf-core/unicycler/main.nf
@@ -2,10 +2,10 @@ process UNICYCLER {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::unicycler=0.5.0"
+    conda "bioconda::unicycler=0.4.8"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/unicycler:0.5.0--py39h2add14b_2' :
-        'quay.io/biocontainers/unicycler:0.5.0--py39h2add14b_2' }"
+        'https://depot.galaxyproject.org/singularity/unicycler:0.4.8--py38h8162308_3' :
+        'quay.io/biocontainers/unicycler:0.4.8--py38h8162308_3' }"
 
     input:
     tuple val(meta), path(shortreads), path(longreads)

--- a/modules/nf-core/unicycler/main.nf
+++ b/modules/nf-core/unicycler/main.nf
@@ -2,10 +2,10 @@ process UNICYCLER {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::unicycler=0.4.8"
+    conda "bioconda::unicycler=0.5.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/unicycler:0.4.8--py38h8162308_3' :
-        'quay.io/biocontainers/unicycler:0.4.8--py38h8162308_3' }"
+        'https://depot.galaxyproject.org/singularity/unicycler:0.5.0--py39h2add14b_2' :
+        'quay.io/biocontainers/unicycler:0.5.0--py39h2add14b_2' }"
 
     input:
     tuple val(meta), path(shortreads), path(longreads)

--- a/tests/modules/nf-core/blast/tblastn/test.yml
+++ b/tests/modules/nf-core/blast/tblastn/test.yml
@@ -7,7 +7,7 @@
     - path: ./output/blast/test.tblastn.txt
       md5sum: c26ccfa5ceae82fc6affdc77f5505b62
     - path: ./output/blast/versions.yml
-      md5sum: 6d23563b8d75e2fe1e03d3fbe10098a9
+      md5sum: 63d79c4c09cfd691d6be814e7fa3efd3
     - path: ./output/blast/blast_db/genome.fasta.nsq
       md5sum: 982cbc7d9e38743b9b1037588862b9da
     - path: ./output/blast/blast_db/genome.fasta.nin

--- a/tests/modules/nf-core/ivar/consensus/test.yml
+++ b/tests/modules/nf-core/ivar/consensus/test.yml
@@ -20,4 +20,3 @@
     - path: output/ivar/test.qual.txt
       md5sum: 68b329da9893e34099c7d8ad5cb9c940
     - path: output/ivar/test.mpileup
-      md5sum: d41d8cd98f00b204e9800998ecf8427e

--- a/tests/modules/nf-core/ivar/trim/test.yml
+++ b/tests/modules/nf-core/ivar/trim/test.yml
@@ -5,4 +5,4 @@
     - ivar/trim
   files:
     - path: output/ivar/test.bam
-      md5sum: 12cff17d43b1efdba8120a6bff5311e3
+      md5sum: 38b3719e6f0650e1a8f9c58c4435a93e

--- a/tests/modules/nf-core/ivar/variants/test.yml
+++ b/tests/modules/nf-core/ivar/variants/test.yml
@@ -5,7 +5,7 @@
     - ivar/variants
   files:
     - path: output/ivar/test.tsv
-      md5sum: 728f1430f2402861396d9953465ac706
+      md5sum: 76c93420121bb891fa275f716142a157
 
 - name: ivar variants no gff with mpileup
   command: nextflow run ./tests/modules/nf-core/ivar/variants -entry test_ivar_variants_no_gff_with_mpileup -c ./tests/config/nextflow.config --save_mpileup -c ./tests/modules/nf-core/ivar/variants/nextflow.config
@@ -14,9 +14,9 @@
     - ivar/variants
   files:
     - path: output/ivar/test.tsv
-      md5sum: 728f1430f2402861396d9953465ac706
+      md5sum: 76c93420121bb891fa275f716142a157
     - path: output/ivar/test.mpileup
-      md5sum: 56c4cd5a4ecb7d6364878818f46ae256
+      md5sum: 958e6bead4103d72026f80153b6b5150
 
 - name: ivar variants with gff with mpileup
   command: nextflow run ./tests/modules/nf-core/ivar/variants -entry test_ivar_variants_with_gff_with_mpileup -c ./tests/config/nextflow.config --gff tests/data/gff/sarscov2/MN908947.3.gff3 --save_mpileup -c ./tests/modules/nf-core/ivar/variants/nextflow.config
@@ -25,6 +25,6 @@
     - ivar/variants
   files:
     - path: output/ivar/test.tsv
-      md5sum: 7b59146132a60da58444bebffc3c2577
+      md5sum: 2cf6c48b55e0e81155ff310d48de94df
     - path: output/ivar/test.mpileup
-      md5sum: 56c4cd5a4ecb7d6364878818f46ae256
+      md5sum: 958e6bead4103d72026f80153b6b5150

--- a/tests/modules/nf-core/nextclade/run/test.yml
+++ b/tests/modules/nf-core/nextclade/run/test.yml
@@ -25,7 +25,7 @@
     - path: output/nextclade/test.auspice.json
       md5sum: 04d8c32f141435ca45bf430dcb59bcba
     - path: output/nextclade/test.csv
-      md5sum: 9489bab7f58c07c0b6949182789aa435
+      md5sum: 7ff4df651dd4199ec9e6b02134271fb5
     - path: output/nextclade/test.errors.csv
       md5sum: 810d1c72e1ed010a9a017afba7ce8063
     - path: output/nextclade/test.insertions.csv
@@ -33,9 +33,9 @@
     - path: output/nextclade/test.json
       contains: ["nextcladeAlgoVersion"]
     - path: output/nextclade/test.ndjson
-      md5sum: 32e3c1e733be19509faa0a45260a3d96
+      md5sum: 0aa70ebfa0c9cc262de4cfc6544cd20f
     - path: output/nextclade/test.tsv
-      md5sum: 7f4bea521bcef4d1bca02c51d11b2fe1
+      md5sum: cae39bb97064867ddf748c2f75ca0ae9
     - path: output/nextclade/test_gene_E.translation.fasta
       md5sum: 1a6d93bd7abfeb193476a86950f07202
     - path: output/nextclade/test_gene_M.translation.fasta

--- a/tests/modules/nf-core/pangolin/test.yml
+++ b/tests/modules/nf-core/pangolin/test.yml
@@ -4,4 +4,4 @@
     - pangolin
   files:
     - path: ./output/pangolin/test.pangolin.csv
-      md5sum: cae39bb97064867ddf748c2f75ca0ae9
+      md5sum: 5913b1fc7645798ab7be31e9029c5f7e

--- a/tests/modules/nf-core/pangolin/test.yml
+++ b/tests/modules/nf-core/pangolin/test.yml
@@ -4,4 +4,4 @@
     - pangolin
   files:
     - path: ./output/pangolin/test.pangolin.csv
-      md5sum: 3484156c2f2e2e638431be7934cfc5b7
+      md5sum: cae39bb97064867ddf748c2f75ca0ae9


### PR DESCRIPTION
blast: `2.12.0` -> `2.13.0`
ivar: `1.3.1` -> `1.4`
nextclade: `2.2.0` -> `2.12.0`
pangolin: `4.1.1` -> `4.2`
spades: `3.15.4` -> `3.15.5`