### PR TITLE
Fix seg-faults introduced in STAR 2.7.10a

### DIFF
--- a/modules/nf-core/star/align/main.nf
+++ b/modules/nf-core/star/align/main.nf
@@ -2,7 +2,7 @@ process STAR_ALIGN {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::star=2.7.10a bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
+    conda "bioconda::star=2.7.10b bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' :
         'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"

--- a/modules/nf-core/star/align/main.nf
+++ b/modules/nf-core/star/align/main.nf
@@ -4,8 +4,8 @@ process STAR_ALIGN {
 
     conda "bioconda::star=2.7.10b bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' :
-        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:a53b7c56addcc8233531e25d69b320bc56964994-0' :
+        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:a53b7c56addcc8233531e25d69b320bc56964994-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/star/genomegenerate/main.nf
+++ b/modules/nf-core/star/genomegenerate/main.nf
@@ -2,7 +2,7 @@ process STAR_GENOMEGENERATE {
     tag "$fasta"
     label 'process_high'
 
-    conda "bioconda::star=2.7.10a bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
+    conda "bioconda::star=2.7.10b bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' :
         'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"

--- a/modules/nf-core/star/genomegenerate/main.nf
+++ b/modules/nf-core/star/genomegenerate/main.nf
@@ -4,8 +4,8 @@ process STAR_GENOMEGENERATE {
 
     conda "bioconda::star=2.7.10b bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' :
-        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:a53b7c56addcc8233531e25d69b320bc56964994-0' :
+        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:a53b7c56addcc8233531e25d69b320bc56964994-0' }"
 
     input:
     path fasta

--- a/tests/modules/nf-core/star/align/test.yml
+++ b/tests/modules/nf-core/star/align/test.yml
@@ -36,7 +36,7 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
     - path: output/star/test.Aligned.out.bam
-      md5sum: 323a87955bd440647c772e4b4b730319
+      md5sum: 26300b1375e912062695e10f5e91d4e5
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
@@ -80,7 +80,7 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
     - path: output/star/test.Aligned.out.bam
-      md5sum: 6563f632eac2b6efc4cf61eda5ac42c4
+      md5sum: 46b29f9d844e96567525a3f43b0efdd6
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
@@ -124,7 +124,7 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
     - path: output/star/test.Aligned.out.bam
-      md5sum: 05b91996707202d7225c29dac3a7c87f
+      md5sum: 1d299d7c898952f76568233380cadfae
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out
@@ -168,9 +168,9 @@
     - path: output/star/star/transcriptInfo.tab
       md5sum: 0c3a5adb49d15e5feff81db8e29f2e36
     - path: output/star/test.Aligned.out.bam
-      md5sum: 856cc7fbdffbbb7b3f39a8b1945f042d
+      md5sum: 6a157162b2be2edccf296f2d81487cfe
     - path: output/star/test.Chimeric.out.junction
-      md5sum: 08f9d705e995d06bedaaf7a6afab883a
+      md5sum: 60ebd9c83a94b719e224053257d377f2
     - path: output/star/test.Log.final.out
     - path: output/star/test.Log.out
     - path: output/star/test.Log.progress.out

--- a/tests/subworkflows/nf-core/fastq_align_star/test.yml
+++ b/tests/subworkflows/nf-core/fastq_align_star/test.yml
@@ -56,9 +56,9 @@
     - path: ./output/samtools/test.sorted.bam.bai
       # samtools stats
     - path: ./output/samtools/test.sorted.bam.flagstat
-      md5sum: 924ce391c186068f996231fdefa42442
+      md5sum: c6b56420e8a30bff3487dbd6ec13ba5f
     - path: ./output/samtools/test.sorted.bam.idxstats
-      md5sum: c23c978974e8568a2b2959e6a5965cf2
+      md5sum: 3f1385e59e45555d2aff101b3d6de896
     - path: ./output/samtools/test.sorted.bam.stats
 
 - name: fastq_align_star fastq_align_star_paired_end


### PR DESCRIPTION
STAR version 2.7.10b fixes segmentation faults introduced in 2.7.10a. See [here](https://github.com/alexdobin/STAR/releases/tag/2.7.10b).

- [x] This comment contains a description of changes (with reason).