### PR TITLE
Move read filtering based on number of trimmed reads into subworkflow.

### DIFF
--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -23,20 +23,21 @@ def getTrimGaloreReadsAfterFiltering(log_file) {
 
 workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
     take:
-    reads            // channel: [ val(meta), [ reads ] ]
-    skip_fastqc      // boolean: true/false
-    with_umi         // boolean: true/false
-    skip_umi_extract // boolean: true/false
-    skip_trimming    // boolean: true/false
-    umi_discard_read // integer: 0, 1 or 2
+    reads             // channel: [ val(meta), [ reads ] ]
+    skip_fastqc       // boolean: true/false
+    with_umi          // boolean: true/false
+    skip_umi_extract  // boolean: true/false
+    skip_trimming     // boolean: true/false
+    umi_discard_read  // integer: 0, 1 or 2
+    min_trimmed_reads // integer: > 0
 
     main:
-
     ch_versions = Channel.empty()
     fastqc_html = Channel.empty()
     fastqc_zip  = Channel.empty()
     if (!skip_fastqc) {
-        FASTQC ( reads ).html.set { fastqc_html }
+        FASTQC (reads)
+        fastqc_html = FASTQC.out.html
         fastqc_zip  = FASTQC.out.zip
         ch_versions = ch_versions.mix(FASTQC.out.versions.first())
     }
@@ -44,34 +45,32 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
     umi_reads = reads
     umi_log   = Channel.empty()
     if (with_umi && !skip_umi_extract) {
-
-            UMITOOLS_EXTRACT ( reads ).reads.set { umi_reads }
+            UMITOOLS_EXTRACT (reads)
+            umi_reads   = UMITOOLS_EXTRACT.out.reads
             umi_log     = UMITOOLS_EXTRACT.out.log
             ch_versions = ch_versions.mix(UMITOOLS_EXTRACT.out.versions.first())
 
             // Discard R1 / R2 if required
             if (umi_discard_read in [1,2]) {
-                UMITOOLS_EXTRACT
-                    .out
-                    .reads
+                UMITOOLS_EXTRACT.out.reads
                     .map { meta, reads ->
-                        if (!meta.single_end) {
-                            meta['single_end'] = true
-                            reads = reads[umi_discard_read % 2]
-                        }
-                        return [ meta, reads ]
+                        meta.single_end ?
+                            [ meta, reads ] :
+                            [ meta + ['single_end': true], reads[umi_discard_read % 2] ]
                     }
                     .set { umi_reads }
             }
     }
 
-    trim_reads    = umi_reads
-    trim_unpaired = Channel.empty()
-    trim_html     = Channel.empty()
-    trim_zip      = Channel.empty()
-    trim_log      = Channel.empty()
+    trim_reads      = umi_reads
+    trim_unpaired   = Channel.empty()
+    trim_html       = Channel.empty()
+    trim_zip        = Channel.empty()
+    trim_log        = Channel.empty()
+    trim_read_count = Channel.empty()
+
     if (!skip_trimming) {
-        TRIMGALORE ( umi_reads ).reads.set { trim_reads }
+        TRIMGALORE (umi_reads)
         trim_unpaired = TRIMGALORE.out.unpaired
         trim_html     = TRIMGALORE.out.html
         trim_zip      = TRIMGALORE.out.zip
@@ -79,24 +78,30 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
         ch_versions   = ch_versions.mix(TRIMGALORE.out.versions.first())
 
         //
-        // Filter empty FastQ files after adapter trimming
+        // Filter FastQ files based on minimum trimmed read count after adapter trimming
         //
-        trim_reads
+        TRIMGALORE.out.reads
             .join(trim_log, remainder: true)
-            .map {
-                meta, reads, trim_log ->
+            .map { meta, reads, trim_log ->
                     if (trim_log) {
-                        if (!meta.single_end) {
-                            trim_log = trim_log[-1]
-                        }
-                        if (getTrimGaloreReadsAfterFiltering(trim_log) > 0) {
-                            [ meta, reads ]
-                        }
+                        num_reads = getTrimGaloreReadsAfterFiltering(
+                            meta.single_end ? trim_log : trim_log[-1]
+                        )
+                        [ meta, reads, num_reads ]
                     } else {
-                        [ meta, reads ]
+                        [ meta, reads, min_trimmed_reads.toFloat() + 1 ]
                     }
             }
+            .set { ch_num_trimmed_reads }
+
+        ch_num_trimmed_reads
+            .filter { meta, reads, num_reads -> num_reads >= min_trimmed_reads.toFloat() }
+            .map { meta, reads, num_reads -> [ meta, num_reads ] }
             .set { trim_reads }
+
+        ch_num_trimmed_reads
+            .map { meta, reads, num_reads -> [ meta, num_reads ] }
+            .set { trim_read_count }
     }
 
     emit:
@@ -111,6 +116,7 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
     trim_html          // channel: [ val(meta), [ html ] ]
     trim_zip           // channel: [ val(meta), [ zip ] ]
     trim_log           // channel: [ val(meta), [ txt ] ]
+    trim_read_count    // channel: [ val(meta), val(count) ]
 
     versions = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/meta.yml
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/meta.yml
@@ -42,6 +42,10 @@ input:
       type: integer
       description: |
         Discard R1 / R2 if required
+  - min_trimmed_reads:
+      type: integer
+      description: |
+        Inputs with fewer than this reads will be filtered out of the "reads" output channel
 
 output:
   - reads:
@@ -80,6 +84,9 @@ output:
       type: file
       description: Trim Galore! trimming report
       pattern: "*_{report.txt}"
+  - trim_read_count:
+      type: integer
+      description: Number of reads remaining after trimming for all input samples
   - versions:
       type: file
       description: File containing software versions

--- a/tests/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/tests/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -12,13 +12,14 @@ workflow test_fastq_fastqc_umitools_trimgalore_single {
                 [ id:'test', single_end:true ], // meta map
                 [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
             ]
-    skip_fastqc      = false
-    with_umi         = true
-    skip_umi_extract = false
-    skip_trimming    = false
-    umi_discard_read = 1
+    skip_fastqc       = false
+    with_umi          = true
+    skip_umi_extract  = false
+    skip_trimming     = false
+    umi_discard_read  = 1
+    min_trimmed_reads = 1
 
-    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read)
+    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read, min_trimmed_reads)
 }
 
 workflow test_fastq_fastqc_umitools_trimgalore_paired {
@@ -29,13 +30,14 @@ workflow test_fastq_fastqc_umitools_trimgalore_paired {
                     file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
                 ]
             ]
-    skip_fastqc      = false
-    with_umi         = true
-    skip_umi_extract = false
-    skip_trimming    = false
-    umi_discard_read = 1
+    skip_fastqc       = false
+    with_umi          = true
+    skip_umi_extract  = false
+    skip_trimming     = false
+    umi_discard_read  = 1
+    min_trimmed_reads = 1
 
-    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read)
+    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read, min_trimmed_reads)
 }
 
 workflow test_fastq_fastqc_umitools_trimgalore_ {
@@ -46,13 +48,14 @@ workflow test_fastq_fastqc_umitools_trimgalore_ {
                     file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
                 ]
             ]
-    skip_fastqc      = false
-    with_umi         = false
-    skip_umi_extract = false
-    skip_trimming    = false
-    umi_discard_read = 1
+    skip_fastqc       = false
+    with_umi          = false
+    skip_umi_extract  = false
+    skip_trimming     = false
+    umi_discard_read  = 1
+    min_trimmed_reads = 1
 
-    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read)
+    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read, min_trimmed_reads)
 }
 
 workflow test_fastq_fastqc_umitools_trimgalore_umi {
@@ -63,13 +66,14 @@ workflow test_fastq_fastqc_umitools_trimgalore_umi {
                     file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
                 ]
             ]
-    skip_fastqc      = false
-    with_umi         = false
-    skip_umi_extract = false
-    skip_trimming    = false
-    umi_discard_read = 1
+    skip_fastqc       = false
+    with_umi          = false
+    skip_umi_extract  = false
+    skip_trimming     = false
+    umi_discard_read  = 1
+    min_trimmed_reads = 1
 
-    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read)
+    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read, min_trimmed_reads)
 }
 workflow test_fastq_fastqc_umitools_trimgalore_skip {
     input = [
@@ -79,11 +83,12 @@ workflow test_fastq_fastqc_umitools_trimgalore_skip {
                     file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
                 ]
             ]
-    skip_fastqc      = true
-    with_umi         = true
-    skip_umi_extract = true
-    skip_trimming    = true
-    umi_discard_read = 0
+    skip_fastqc       = true
+    with_umi          = true
+    skip_umi_extract  = true
+    skip_trimming     = true
+    umi_discard_read  = 0
+    min_trimmed_reads = 1
 
-    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read)
+    FASTQ_FASTQC_UMITOOLS_TRIMGALORE ( input, skip_fastqc, with_umi, skip_umi_extract, skip_trimming, umi_discard_read, min_trimmed_reads)
 }


### PR DESCRIPTION
This moves a lot of the logic about filtering out samples with fewer
than "min_trimmed_reads". The "reads" output channel now only emits
fastqs for those samples that pass this basic QC. The new output channel
"trim_read_count" contains the number of reads after trimming for all
samples.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
