### PR TITLE
Add support for SRA Lite files in sratools/prefetch.

### DIFF
--- a/modules/nf-core/sratools/prefetch/templates/retry_with_backoff.sh
+++ b/modules/nf-core/sratools/prefetch/templates/retry_with_backoff.sh
@@ -47,6 +47,8 @@ retry_with_backoff !{args2} \
     !{args} \
     !{id}
 
+[ -f !{id}.sralite ] && { mkdir -p !{id}; mv "!{id}.sralite" !{id}/; }
+
 vdb-validate !{id}
 
 cat <<-END_VERSIONS > versions.yml

--- a/tests/modules/nf-core/sratools/prefetch/main.nf
+++ b/tests/modules/nf-core/sratools/prefetch/main.nf
@@ -13,3 +13,13 @@ workflow test_sratools_prefetch {
 
     SRATOOLS_PREFETCH(input, file(params.test_data['generic']['config']['ncbi_user_settings'], checkIfExists: true))
 }
+
+workflow test_sratools_prefetch_with_sralite {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        'SRR1170046'
+    ]
+
+    SRATOOLS_PREFETCH(input, file(params.test_data['generic']['config']['ncbi_user_settings'], checkIfExists: true))
+}

--- a/tests/modules/nf-core/sratools/prefetch/test.yml
+++ b/tests/modules/nf-core/sratools/prefetch/test.yml
@@ -9,3 +9,15 @@
     - path: output/sratools/versions.yml
       contains:
         - "sratools: 2.11.0"
+
+- name: sratools prefetch test_sratools_prefetch_with_sralite
+  command: nextflow run ./tests/modules/nf-core/sratools/prefetch -entry test_sratools_prefetch_with_sralite -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/sratools/prefetch/nextflow.config
+  tags:
+    - sratools/prefetch
+    - sratools
+  files:
+    - path: output/sratools/SRR1170046/SRR1170046.sralite
+      md5sum: 7acfce556ca0951aff49d780899c105b
+    - path: output/sratools/versions.yml
+      contains:
+        - "sratools: 2.11.0"


### PR DESCRIPTION
Not all SRA runs are available in the "SRA Normalized" format. In cases
where only the "SRA Lite" format is available, the behavior or prefetch
changes - writing files in the current directory rather than a directory
named by the sample ID.

This update moves the ./${id}.sralite to ./${id}/${id}.sralite to match
the location when pulling a run where the "SRA Normalized" format is
available.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [X] Remove all TODO statements.
- [X] Emit the `versions.yml` file.
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [X] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [X] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
