### PR TITLE
New subworkflow: Fastq_trim_fastp_fastqc

### DIFF
--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
@@ -1,36 +1,103 @@
-// TODO nf-core: If in doubt look at other nf-core/subworkflows to see how we are doing things! :)
-//               https://github.com/nf-core/modules/tree/master/subworkflows
-//               You can also ask for help via your pull request or on the #subworkflows channel on the nf-core Slack workspace:
-//               https://nf-co.re/join
-// TODO nf-core: A subworkflow SHOULD import at least two modules
+//
+// Read QC and trimming
+//
 
-include { SAMTOOLS_SORT      } from '../../../modules/nf-core/samtools/sort/main'
-include { SAMTOOLS_INDEX     } from '../../../modules/nf-core/samtools/index/main'
+include { FASTQC as FASTQC_RAW  } from '../../../modules/nf-core/fastqc/main'
+include { FASTQC as FASTQC_TRIM } from '../../../modules/nf-core/fastqc/main'
+include { FASTP                 } from '../../../modules/nf-core/fastp/main'
+
+//
+// Function that parses fastp json output file to get total number of reads after trimming
+//
+import groovy.json.JsonSlurper
+
+def getFastpReadsAfterFiltering(json_file) {
+    def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('summary')
+    return json['after_filtering']['total_reads'].toInteger()
+}
 
 workflow FASTQ_TRIM_FASTP_FASTQC {
-
     take:
-    // TODO nf-core: edit input (take) channels
-    ch_bam // channel: [ val(meta), [ bam ] ]
+    ch_reads              // channel: [ val(meta), [ reads ] ]
+    ch_adapter_fasta      // channel: [ path(fasta) ]
+    val_save_trimmed_fail // value: boolean
+    val_save_merged       // value: boolean
+    val_skip_fastp        // value: boolean
+    val_skip_fastqc       // value: boolean
 
     main:
 
     ch_versions = Channel.empty()
 
-    // TODO nf-core: substitute modules here for the modules of your subworkflow
+    ch_fastqc_raw_html = Channel.empty()
+    ch_fastqc_raw_zip  = Channel.empty()
+    if (!val_skip_fastqc) {
+        FASTQC_RAW (
+            ch_reads
+        )
+        fastqc_raw_html = FASTQC_RAW.out.html
+        fastqc_raw_zip  = FASTQC_RAW.out.zip
+        ch_versions     = ch_versions.mix(FASTQC_RAW.out.versions.first())
+    }
 
-    SAMTOOLS_SORT ( ch_bam )
-    ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions.first())
+    ch_trim_reads        = ch_reads
+    ch_trim_json         = Channel.empty()
+    ch_trim_html         = Channel.empty()
+    ch_trim_log          = Channel.empty()
+    ch_trim_reads_fail   = Channel.empty()
+    ch_trim_reads_merged = Channel.empty()
+    ch_fastqc_trim_html  = Channel.empty()
+    ch_fastqc_trim_zip   = Channel.empty()
+    if (!val_skip_fastp) {
+        FASTP (
+            ch_reads,
+            ch_adapter_fasta,
+            val_save_trimmed_fail,
+            val_save_merged
+        )
+        ch_trim_reads        = FASTP.out.reads
+        ch_trim_json         = FASTP.out.json
+        ch_trim_html         = FASTP.out.html
+        ch_trim_log          = FASTP.out.log
+        ch_trim_reads_fail   = FASTP.out.reads_fail
+        ch_trim_reads_merged = FASTP.out.reads_merged
+        ch_versions       = ch_versions.mix(FASTP.out.versions.first())
 
-    SAMTOOLS_INDEX ( SAMTOOLS_SORT.out.bam )
-    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
+        //
+        // Filter empty FastQ files after adapter trimming so FastQC doesn't fail
+        //
+        ch_trim_reads
+            .join(ch_trim_json)
+            .map {
+                meta, reads, json ->
+                    if (getFastpReadsAfterFiltering(json) > 0) {
+                        [ meta, reads ]
+                    }
+            }
+            .set { ch_trim_reads }
+
+        if (val_skip_fastqc) {
+            FASTQC_TRIM (
+                ch_trim_reads
+            )
+            ch_fastqc_trim_html = FASTQC_TRIM.out.html
+            ch_fastqc_trim_zip  = FASTQC_TRIM.out.zip
+            ch_versions      = ch_versions.mix(FASTQC_TRIM.out.versions.first())
+        }
+    }
 
     emit:
-    // TODO nf-core: edit emitted channels
-    bam      = SAMTOOLS_SORT.out.bam           // channel: [ val(meta), [ bam ] ]
-    bai      = SAMTOOLS_INDEX.out.bai          // channel: [ val(meta), [ bai ] ]
-    csi      = SAMTOOLS_INDEX.out.csi          // channel: [ val(meta), [ csi ] ]
+    reads             = ch_trim_reads         // channel: [ val(meta), [ reads ] ]
+    trim_json         = ch_trim_json          // channel: [ val(meta), [ json ] ]
+    trim_html         = ch_trim_html          // channel: [ val(meta), [ html ] ]
+    trim_log          = ch_trim_log           // channel: [ val(meta), [ log ] ]
+    trim_reads_fail   = ch_trim_reads_fail    // channel: [ val(meta), [ fastq.gz ] ]
+    trim_reads_merged = ch_trim_reads_merged  // channel: [ val(meta), [ fastq.gz ] ]
 
-    versions = ch_versions                     // channel: [ versions.yml ]
+    fastqc_raw_html  = ch_fastqc_raw_html    // channel: [ val(meta), [ html ] ]
+    fastqc_raw_zip   = ch_fastqc_raw_zip     // channel: [ val(meta), [ zip ] ]
+    fastqc_trim_html = ch_fastqc_trim_html   // channel: [ val(meta), [ html ] ]
+    fastqc_trim_zip  = ch_fastqc_trim_zip    // channel: [ val(meta), [ zip ] ]
+
+    versions = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
 }
-

--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
@@ -76,7 +76,7 @@ workflow FASTQ_TRIM_FASTP_FASTQC {
             }
             .set { ch_trim_reads }
 
-        if (val_skip_fastqc) {
+        if (!val_skip_fastqc) {
             FASTQC_TRIM (
                 ch_trim_reads
             )

--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
@@ -1,0 +1,36 @@
+// TODO nf-core: If in doubt look at other nf-core/subworkflows to see how we are doing things! :)
+//               https://github.com/nf-core/modules/tree/master/subworkflows
+//               You can also ask for help via your pull request or on the #subworkflows channel on the nf-core Slack workspace:
+//               https://nf-co.re/join
+// TODO nf-core: A subworkflow SHOULD import at least two modules
+
+include { SAMTOOLS_SORT      } from '../../../modules/nf-core/samtools/sort/main'
+include { SAMTOOLS_INDEX     } from '../../../modules/nf-core/samtools/index/main'
+
+workflow FASTQ_TRIM_FASTP_FASTQC {
+
+    take:
+    // TODO nf-core: edit input (take) channels
+    ch_bam // channel: [ val(meta), [ bam ] ]
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    // TODO nf-core: substitute modules here for the modules of your subworkflow
+
+    SAMTOOLS_SORT ( ch_bam )
+    ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions.first())
+
+    SAMTOOLS_INDEX ( SAMTOOLS_SORT.out.bam )
+    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
+
+    emit:
+    // TODO nf-core: edit emitted channels
+    bam      = SAMTOOLS_SORT.out.bam           // channel: [ val(meta), [ bam ] ]
+    bai      = SAMTOOLS_INDEX.out.bai          // channel: [ val(meta), [ bai ] ]
+    csi      = SAMTOOLS_INDEX.out.csi          // channel: [ val(meta), [ csi ] ]
+
+    versions = ch_versions                     // channel: [ versions.yml ]
+}
+

--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/meta.yml
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/meta.yml
@@ -1,0 +1,48 @@
+name: "fastq_trim_fastp_fastqc"
+## TODO nf-core: Add a description of the subworkflow and list keywords
+description: Sort SAM/BAM/CRAM file
+keywords:
+  - sort
+  - bam
+  - sam
+  - cram
+## TODO nf-core: Add a list of the modules used in the subworkflow
+modules:
+  - samtools/sort
+  - samtools/index
+## TODO nf-core: List all of the variables used as input, including their types and descriptions
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - bam:
+      type: file
+      description: BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+## TODO nf-core: List all of the variables used as output, including their types and descriptions
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - bam:
+      type: file
+      description: Sorted BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+  - bai:
+      type: file
+      description: BAM/CRAM/SAM samtools index
+      pattern: "*.{bai,crai,sai}"
+  - csi:
+      type: file
+      description: CSI samtools index
+      pattern: "*.csi"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@Joon-Klaps"

--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/meta.yml
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/meta.yml
@@ -1,45 +1,101 @@
 name: "fastq_trim_fastp_fastqc"
-## TODO nf-core: Add a description of the subworkflow and list keywords
-description: Sort SAM/BAM/CRAM file
+description: Read QC, fastp trimming and read qc
 keywords:
-  - sort
-  - bam
-  - sam
-  - cram
-## TODO nf-core: Add a list of the modules used in the subworkflow
+  - qc
+  - quality_control
+  - adapters
+  - trimming
+  - fastq
 modules:
-  - samtools/sort
-  - samtools/index
-## TODO nf-core: List all of the variables used as input, including their types and descriptions
+  - fastqc
+  - fastp
+
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test' ]
-  - bam:
+  - ch_reads:
       type: file
-      description: BAM/CRAM/SAM file
-      pattern: "*.{bam,cram,sam}"
-## TODO nf-core: List all of the variables used as output, including their types and descriptions
+      description: |
+        Structure: [ val(meta), path (reads) ]
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively. If you wish to run interleaved paired-end data,  supply as single-end data
+        but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
+  - ch_adapter_fasta:
+      type: file
+      description: |
+        Structure: path(adapter_fasta)
+        File in FASTA format containing possible adapters to remove.
+  - val_save_trimmed_fail:
+      type: boolean
+      description: |
+        Structure: val(save_trimmed_fail)
+        Specify true to save files that failed to pass trimming thresholds ending in `*.fail.fastq.gz`
+  - val_save_merged:
+      type: boolean
+      description: |
+        Structure: val(save_merged)
+        Specify true to save all merged reads to the a file ending in `*.merged.fastq.gz`
+  - val_skip_fastqc:
+    type: boolean
+    description: |
+        Structure: val(skip_fastqc)
+        skip the fastqc process if true
+  - val_skip_fastp:
+    type: boolean
+    description: |
+        Structure: val(skip_fastp)
+        skip the fastp process if true
+
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test' ]
-  - bam:
-      type: file
-      description: Sorted BAM/CRAM/SAM file
-      pattern: "*.{bam,cram,sam}"
-  - bai:
-      type: file
-      description: BAM/CRAM/SAM samtools index
-      pattern: "*.{bai,crai,sai}"
-  - csi:
-      type: file
-      description: CSI samtools index
-      pattern: "*.csi"
+  - reads:
+    type: file
+    description: |
+      Structure: [ val(meta), path(reads) ]
+      The trimmed/modified/unmerged fastq reads
+  - trim_json:
+    type: file
+    description: |
+      Structure: [ val(meta), path(trim_json) ]
+      Results in JSON format
+  - trim_html:
+    type: file
+    description: |
+      Structure: [ val(meta), path(trim_html) ]
+      Results in HTML format
+  - trim_log:
+    type: file
+    description: |
+      Structure: [ val(meta), path(trim_log) ]
+      fastq log file
+  - trim_reads_fail:
+    type: file
+    description: |
+      Structure: [ val(meta), path(trim_reads_fail) ]
+      Reads the failed the preprocessing
+  - trim_reads_merged:
+    type: file
+    description: |
+      Structure: [ val(meta), path(trim_reads_merged) ]
+      Reads that were successfully merged
+
+  - fastqc_raw_html:
+    type: file
+    description: |
+      Structure: [ val(meta), path(fastqc_raw_html) ]
+      Raw fastQC report
+  - fastqc_raw_zip:
+    type: file
+    description: |
+      Structure: [ val(meta), path(fastqc_raw_zip) ]
+      Raw fastQC report archive
+  - fastqc_trim_html:
+    type: file
+    description: |
+      Structure: [ val(meta), path(fastqc_trim_html) ]
+      Trimmed fastQC report
+  - fastqc_trim_zip:
+    type: file
+    description: |
+      Structure: [ val(meta), path(fastqc_trim_zip) ]
+      Trimmed fastQC report archive
   - versions:
       type: file
       description: File containing software versions

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -3128,6 +3128,10 @@ subworkflows/fastq_subsample_fq_salmon:
   - subworkflows/nf-core/fastq_subsample_fq_salmon/**
   - tests/subworkflows/nf-core/fastq_subsample_fq_salmon/**
 
+subworkflows/fastq_trim_fastp_fastqc:
+  - subworkflows/nf-core/fastq_trim_fastp_fastqc/**
+  - tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/**
+
 subworkflows/gatk_create_som_pon:
   - subworkflows/nf-core/gatk_create_som_pon/**
   - tests/subworkflows/nf-core/gatk_create_som_pon/**

--- a/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
+++ b/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
@@ -1,0 +1,97 @@
+include { FASTQC as FASTQC_RAW  } from '../../modules/nf-core/fastqc/main'
+include { FASTQC as FASTQC_TRIM } from '../../modules/nf-core/fastqc/main'
+include { FASTP                 } from '../../modules/nf-core/fastp/main'
+
+//
+// Function that parses fastp json output file to get total number of reads after trimming
+//
+import groovy.json.JsonSlurper
+
+def getFastpReadsAfterFiltering(json_file) {
+    def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('summary')
+    return json['after_filtering']['total_reads'].toInteger()
+}
+
+workflow FASTQ_TRIM_FASTP_FASTQC {
+    take:
+    reads             // channel: [ val(meta), [ reads ] ]
+    adapter_fasta     // file: adapter.fasta
+    save_trimmed_fail // value: boolean
+    save_merged       // value: boolean
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    fastqc_raw_html = Channel.empty()
+    fastqc_raw_zip  = Channel.empty()
+    if (!params.skip_fastqc) {
+        FASTQC_RAW (
+            reads
+        )
+        fastqc_raw_html = FASTQC_RAW.out.html
+        fastqc_raw_zip  = FASTQC_RAW.out.zip
+        ch_versions     = ch_versions.mix(FASTQC_RAW.out.versions.first())
+    }
+
+    trim_reads        = reads
+    trim_json         = Channel.empty()
+    trim_html         = Channel.empty()
+    trim_log          = Channel.empty()
+    trim_reads_fail   = Channel.empty()
+    trim_reads_merged = Channel.empty()
+    fastqc_trim_html  = Channel.empty()
+    fastqc_trim_zip   = Channel.empty()
+    if (!params.skip_fastp) {
+        FASTP (
+            reads,
+            adapter_fasta,
+            save_trimmed_fail,
+            save_merged
+        )
+        trim_reads        = FASTP.out.reads
+        trim_json         = FASTP.out.json
+        trim_html         = FASTP.out.html
+        trim_log          = FASTP.out.log
+        trim_reads_fail   = FASTP.out.reads_fail
+        trim_reads_merged = FASTP.out.reads_merged
+        ch_versions       = ch_versions.mix(FASTP.out.versions.first())
+
+        //
+        // Filter empty FastQ files after adapter trimming so FastQC doesn't fail
+        //
+        trim_reads
+            .join(trim_json)
+            .map {
+                meta, reads, json ->
+                    if (getFastpReadsAfterFiltering(json) > 0) {
+                        [ meta, reads ]
+                    }
+            }
+            .set { trim_reads }
+
+        if (!params.skip_fastqc) {
+            FASTQC_TRIM (
+                trim_reads
+            )
+            fastqc_trim_html = FASTQC_TRIM.out.html
+            fastqc_trim_zip  = FASTQC_TRIM.out.zip
+            ch_versions      = ch_versions.mix(FASTQC_TRIM.out.versions.first())
+        }
+    }
+
+    emit:
+    ch_reads = trim_reads // channel: [ val(meta), [ reads ] ]
+    ch_trim_json          // channel: [ val(meta), [ json ] ]
+    ch_trim_html          // channel: [ val(meta), [ html ] ]
+    ch_trim_log           // channel: [ val(meta), [ log ] ]
+    ch_trim_reads_fail    // channel: [ val(meta), [ fastq.gz ] ]
+    trim_reads_merged  // channel: [ val(meta), [ fastq.gz ] ]
+
+    fastqc_raw_html    // channel: [ val(meta), [ html ] ]
+    fastqc_raw_zip     // channel: [ val(meta), [ zip ] ]
+    fastqc_trim_html   // channel: [ val(meta), [ html ] ]
+    fastqc_trim_zip    // channel: [ val(meta), [ zip ] ]
+
+    versions = ch_versions.ifEmpty(null) // channel: [ versions.yml ]
+}

--- a/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/nextflow.config
+++ b/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+}

--- a/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/nextflow.config
+++ b/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/nextflow.config
@@ -5,4 +5,12 @@ process {
     withName: '.*interleaved:FASTP' {
         ext.args = "--interleaved_in"
     }
+
+    withName: '.*FASTQC_RAW' {
+        ext.prefix = { "${meta.id}_raw" }
+    }
+
+    withName: '.*FASTQC_TRIM' {
+        ext.prefix = { "${meta.id}_trim" }
+    }
 }

--- a/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/nextflow.config
+++ b/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/nextflow.config
@@ -2,4 +2,7 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    withName: '.*interleaved:FASTP' {
+        ext.args = "--interleaved_in"
+    }
 }

--- a/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/test.yml
+++ b/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/test.yml
@@ -1,0 +1,12 @@
+## TODO nf-core: Please run the following command to build this file:
+#                nf-core subworkflows create-test-yml 
+- name: "fastq_trim_fastp_fastqc"
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc -c ./tests/config/nextflow.config
+  tags:
+    - "subworkflows"
+    - "subworkflows/fastq_trim_fastp_fastqc"
+  files:
+    - path: "output/fastq_trim_fastp_fastqc/test.bam"
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc
+    - path: output/fastq_trim_fastp_fastqc/versions.yml
+      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b

--- a/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/test.yml
+++ b/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/test.yml
@@ -7,19 +7,18 @@
     - subworkflows/fastq_trim_fastp_fastqc
   files:
     - path: output/fastp/test.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test.fastp.html
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.fastp.json
       md5sum: 2616b6791fd89fb1cc2d16a73b9463b0
     - path: output/fastp/test.fastp.log
-      md5sum: 27fa23f9a0c948ed222d367ee7b34ff8
-    - path: output/fastqc/test_fastqc.html
-      md5sum: ab784b544222a900cd7d5a3ca58ea55c
-    - path: output/fastqc/test_fastqc.zip
+    - path: output/fastqc/test_raw_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - <tr><td>File type</td><td>Conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_fastqc.zip
+    - path: output/fastqc/test_trim_fastqc.html
+      contains:
+        - <tr><td>File type</td><td>Conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_fastqc.zip
 
 - name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end
   command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end -c ./tests/config/nextflow.config
@@ -30,26 +29,29 @@
     - subworkflows/fastq_trim_fastp_fastqc
   files:
     - path: output/fastp/test.fastp.html
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
     - path: output/fastp/test.fastp.json
       md5sum: cfc3e8b871b9bc770f1dc16432d64e67
     - path: output/fastp/test.fastp.log
-      md5sum: 8b1e318b1ae7b1bc23da61d4b4904bf7
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
-    - path: output/fastqc/test_1_fastqc.html
-      md5sum: 48411648e244ca956f7b62adc52cb7c4
-    - path: output/fastqc/test_1_fastqc.zip
+    - path: output/fastqc/test_raw_1_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
-    - path: output/fastqc/test_2_fastqc.html
-      md5sum: acdf96873a02ae5f153c295c92dcd11f
-    - path: output/fastqc/test_2_fastqc.zip
+        - <tr><td>File type</td><td>Conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_1_fastqc.zip
+    - path: output/fastqc/test_raw_2_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - <tr><td>File type</td><td>Conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_2_fastqc.zip
+    - path: output/fastqc/test_trim_1_fastqc.html
+      contains:
+        - <tr><td>File type</td><td>Conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_1_fastqc.zip
+    - path: output/fastqc/test_trim_2_fastqc.html
+      contains:
+        - <tr><td>File type</td><td>Conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_2_fastqc.zip
+
 
 - name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_interleaved
   command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_interleaved -c ./tests/config/nextflow.config
@@ -60,19 +62,18 @@
     - subworkflows/fastq_trim_fastp_fastqc
   files:
     - path: output/fastp/test.fastp.fastq.gz
-      md5sum: 0adfb99efed3bd9a4034260f645342e5
     - path: output/fastp/test.fastp.html
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.fastp.json
       md5sum: e08e99057ba1bcf93422a273c1ee38dc
     - path: output/fastp/test.fastp.log
-      md5sum: c9d1448f50cbe23b0c250a3726688b4a
-    - path: output/fastqc/test_fastqc.html
-      md5sum: b9a9f01a97cbae4281d5671b83387c99
-    - path: output/fastqc/test_fastqc.zip
+    - path: output/fastqc/test_raw_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - <tr><td>File type</td><td>Conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_fastqc.zip
+    - path: output/fastqc/test_trim_fastqc.html
+      contains:
+        - <tr><td>File type</td><td>Conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_fastqc.zip
 
 - name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_single_end_trim_fail
   command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_single_end_trim_fail -c ./tests/config/nextflow.config
@@ -83,21 +84,19 @@
     - subworkflows/fastq_trim_fastp_fastqc
   files:
     - path: output/fastp/test.fail.fastq.gz
-      md5sum: b57f2026eb259a0b0c0b3960c270258d
     - path: output/fastp/test.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test.fastp.html
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.fastp.json
       md5sum: 7e10b0b12fab5cff620fdeb1a32392f8
     - path: output/fastp/test.fastp.log
-      md5sum: 315e67b400836ef64e4d42f09d156342
-    - path: output/fastqc/test_fastqc.html
-      md5sum: ab784b544222a900cd7d5a3ca58ea55c
-    - path: output/fastqc/test_fastqc.zip
+    - path: output/fastqc/test_raw_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_fastqc.zip
+    - path: output/fastqc/test_trim_fastqc.html
+      contains:
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_fastqc.zip
 
 - name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_trim_fail
   command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_trim_fail -c ./tests/config/nextflow.config
@@ -108,31 +107,29 @@
     - subworkflows/fastq_trim_fastp_fastqc
   files:
     - path: output/fastp/test.fastp.html
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.fastp.json
       md5sum: 5750c4e642f2473af496cfc3387c2874
     - path: output/fastp/test.fastp.log
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test_1.fail.fastq.gz
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test_2.fail.fastq.gz
-      md5sum: 72d0002841967676ac936d08746a9128
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
-    - path: output/fastqc/test_1_fastqc.html
-      md5sum: 48411648e244ca956f7b62adc52cb7c4
-    - path: output/fastqc/test_1_fastqc.zip
+    - path: output/fastqc/test_raw_1_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
-    - path: output/fastqc/test_2_fastqc.html
-      md5sum: acdf96873a02ae5f153c295c92dcd11f
-    - path: output/fastqc/test_2_fastqc.zip
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_1_fastqc.zip
+    - path: output/fastqc/test_raw_2_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_2_fastqc.zip
+    - path: output/fastqc/test_trim_1_fastqc.html
+      contains:
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_1_fastqc.zip
+    - path: output/fastqc/test_trim_2_fastqc.html
+      contains:
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_2_fastqc.zip
 
 - name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_merged
   command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_merged -c ./tests/config/nextflow.config
@@ -143,29 +140,28 @@
     - subworkflows/fastq_trim_fastp_fastqc
   files:
     - path: output/fastp/test.fastp.html
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.fastp.json
       md5sum: 045785e81e3327920c88e6948b8e077f
     - path: output/fastp/test.fastp.log
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.merged.fastq.gz
-      md5sum: 4955ca2c899729b17bd526d2626a8d73
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 4a03721ee252b7c6e81e007550e6ab63
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 7a4ddf8485c147cd7aaf0d4f6cd57ace
-    - path: output/fastqc/test_1_fastqc.html
-      md5sum: 48411648e244ca956f7b62adc52cb7c4
-    - path: output/fastqc/test_1_fastqc.zip
+    - path: output/fastqc/test_raw_1_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
-    - path: output/fastqc/test_2_fastqc.html
-      md5sum: acdf96873a02ae5f153c295c92dcd11f
-    - path: output/fastqc/test_2_fastqc.zip
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_1_fastqc.zip
+    - path: output/fastqc/test_raw_2_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_2_fastqc.zip
+    - path: output/fastqc/test_trim_1_fastqc.html
+      contains:
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_1_fastqc.zip
+    - path: output/fastqc/test_trim_2_fastqc.html
+      contains:
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_2_fastqc.zip
 
 - name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_merged_adapterlist
   command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_merged_adapterlist -c ./tests/config/nextflow.config
@@ -176,29 +172,28 @@
     - subworkflows/fastq_trim_fastp_fastqc
   files:
     - path: output/fastp/test.fastp.html
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.fastp.json
       md5sum: 25d3b524eb752a43c781f80facabeb98
     - path: output/fastp/test.fastp.log
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.merged.fastq.gz
-      md5sum: 4955ca2c899729b17bd526d2626a8d73
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 4a03721ee252b7c6e81e007550e6ab63
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 7a4ddf8485c147cd7aaf0d4f6cd57ace
-    - path: output/fastqc/test_1_fastqc.html
-      md5sum: 48411648e244ca956f7b62adc52cb7c4
-    - path: output/fastqc/test_1_fastqc.zip
+    - path: output/fastqc/test_raw_1_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
-    - path: output/fastqc/test_2_fastqc.html
-      md5sum: acdf96873a02ae5f153c295c92dcd11f
-    - path: output/fastqc/test_2_fastqc.zip
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_1_fastqc.zip
+    - path: output/fastqc/test_raw_2_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_2_fastqc.zip
+    - path: output/fastqc/test_trim_1_fastqc.html
+      contains:
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_1_fastqc.zip
+    - path: output/fastqc/test_trim_2_fastqc.html
+      contains:
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_trim_2_fastqc.zip
 
 - name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_skip_fastqc
   command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_skip_fastqc -c ./tests/config/nextflow.config
@@ -209,26 +204,11 @@
     - subworkflows/fastq_trim_fastp_fastqc
   files:
     - path: output/fastp/test.fastp.html
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/fastp/test.fastp.json
       md5sum: cfc3e8b871b9bc770f1dc16432d64e67
     - path: output/fastp/test.fastp.log
-      md5sum: 8b1e318b1ae7b1bc23da61d4b4904bf7
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
-    - path: output/fastqc/test_1_fastqc.html
-      md5sum: 7954ade4fcd61f984a7c3e2f0fa5e63a
-    - path: output/fastqc/test_1_fastqc.zip
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
-    - path: output/fastqc/test_2_fastqc.html
-      md5sum: 7da866da90f0dc4345cfb49cb1110a1e
-    - path: output/fastqc/test_2_fastqc.zip
-      contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
 
 - name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_skip_fastp
   command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_skip_fastp -c ./tests/config/nextflow.config
@@ -238,13 +218,11 @@
     - subworkflows
     - subworkflows/fastq_trim_fastp_fastqc
   files:
-    - path: output/fastqc/test_1_fastqc.html
-      md5sum: 48411648e244ca956f7b62adc52cb7c4
-    - path: output/fastqc/test_1_fastqc.zip
+    - path: output/fastqc/test_raw_1_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
-    - path: output/fastqc/test_2_fastqc.html
-      md5sum: acdf96873a02ae5f153c295c92dcd11f
-    - path: output/fastqc/test_2_fastqc.zip
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_1_fastqc.zip
+    - path: output/fastqc/test_raw_2_fastqc.html
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - <tr><td>file type</td><td>conventional base calls</td></tr>
+    - path: output/fastqc/test_raw_2_fastqc.zip

--- a/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/test.yml
+++ b/tests/subworkflows/nf-core/fastq_trim_fastp_fastqc/test.yml
@@ -1,12 +1,250 @@
-## TODO nf-core: Please run the following command to build this file:
-#                nf-core subworkflows create-test-yml 
-- name: "fastq_trim_fastp_fastqc"
-  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc -c ./tests/config/nextflow.config
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_single_end
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_single_end -c ./tests/config/nextflow.config
   tags:
-    - "subworkflows"
-    - "subworkflows/fastq_trim_fastp_fastqc"
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
   files:
-    - path: "output/fastq_trim_fastp_fastqc/test.bam"
-      md5sum: e667c7caad0bc4b7ac383fd023c654fc
-    - path: output/fastq_trim_fastp_fastqc/versions.yml
-      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b
+    - path: output/fastp/test.fastp.fastq.gz
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
+    - path: output/fastp/test.fastp.html
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.fastp.json
+      md5sum: 2616b6791fd89fb1cc2d16a73b9463b0
+    - path: output/fastp/test.fastp.log
+      md5sum: 27fa23f9a0c948ed222d367ee7b34ff8
+    - path: output/fastqc/test_fastqc.html
+      md5sum: ab784b544222a900cd7d5a3ca58ea55c
+    - path: output/fastqc/test_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
+  files:
+    - path: output/fastp/test.fastp.html
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.fastp.json
+      md5sum: cfc3e8b871b9bc770f1dc16432d64e67
+    - path: output/fastp/test.fastp.log
+      md5sum: 8b1e318b1ae7b1bc23da61d4b4904bf7
+    - path: output/fastp/test_1.fastp.fastq.gz
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
+    - path: output/fastp/test_2.fastp.fastq.gz
+      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
+    - path: output/fastqc/test_1_fastqc.html
+      md5sum: 48411648e244ca956f7b62adc52cb7c4
+    - path: output/fastqc/test_1_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastqc/test_2_fastqc.html
+      md5sum: acdf96873a02ae5f153c295c92dcd11f
+    - path: output/fastqc/test_2_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_interleaved
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_interleaved -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
+  files:
+    - path: output/fastp/test.fastp.fastq.gz
+      md5sum: 0adfb99efed3bd9a4034260f645342e5
+    - path: output/fastp/test.fastp.html
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.fastp.json
+      md5sum: e08e99057ba1bcf93422a273c1ee38dc
+    - path: output/fastp/test.fastp.log
+      md5sum: c9d1448f50cbe23b0c250a3726688b4a
+    - path: output/fastqc/test_fastqc.html
+      md5sum: b9a9f01a97cbae4281d5671b83387c99
+    - path: output/fastqc/test_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_single_end_trim_fail
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_single_end_trim_fail -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
+  files:
+    - path: output/fastp/test.fail.fastq.gz
+      md5sum: b57f2026eb259a0b0c0b3960c270258d
+    - path: output/fastp/test.fastp.fastq.gz
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
+    - path: output/fastp/test.fastp.html
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.fastp.json
+      md5sum: 7e10b0b12fab5cff620fdeb1a32392f8
+    - path: output/fastp/test.fastp.log
+      md5sum: 315e67b400836ef64e4d42f09d156342
+    - path: output/fastqc/test_fastqc.html
+      md5sum: ab784b544222a900cd7d5a3ca58ea55c
+    - path: output/fastqc/test_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_trim_fail
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_trim_fail -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
+  files:
+    - path: output/fastp/test.fastp.html
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.fastp.json
+      md5sum: 5750c4e642f2473af496cfc3387c2874
+    - path: output/fastp/test.fastp.log
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test_1.fail.fastq.gz
+      md5sum: d41d8cd98f00b204e9800998ecf8427e
+    - path: output/fastp/test_1.fastp.fastq.gz
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
+    - path: output/fastp/test_2.fail.fastq.gz
+      md5sum: 72d0002841967676ac936d08746a9128
+    - path: output/fastp/test_2.fastp.fastq.gz
+      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
+    - path: output/fastqc/test_1_fastqc.html
+      md5sum: 48411648e244ca956f7b62adc52cb7c4
+    - path: output/fastqc/test_1_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastqc/test_2_fastqc.html
+      md5sum: acdf96873a02ae5f153c295c92dcd11f
+    - path: output/fastqc/test_2_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_merged
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_merged -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
+  files:
+    - path: output/fastp/test.fastp.html
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.fastp.json
+      md5sum: 045785e81e3327920c88e6948b8e077f
+    - path: output/fastp/test.fastp.log
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.merged.fastq.gz
+      md5sum: 4955ca2c899729b17bd526d2626a8d73
+    - path: output/fastp/test_1.fastp.fastq.gz
+      md5sum: 4a03721ee252b7c6e81e007550e6ab63
+    - path: output/fastp/test_2.fastp.fastq.gz
+      md5sum: 7a4ddf8485c147cd7aaf0d4f6cd57ace
+    - path: output/fastqc/test_1_fastqc.html
+      md5sum: 48411648e244ca956f7b62adc52cb7c4
+    - path: output/fastqc/test_1_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastqc/test_2_fastqc.html
+      md5sum: acdf96873a02ae5f153c295c92dcd11f
+    - path: output/fastqc/test_2_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_merged_adapterlist
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_merged_adapterlist -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
+  files:
+    - path: output/fastp/test.fastp.html
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.fastp.json
+      md5sum: 25d3b524eb752a43c781f80facabeb98
+    - path: output/fastp/test.fastp.log
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.merged.fastq.gz
+      md5sum: 4955ca2c899729b17bd526d2626a8d73
+    - path: output/fastp/test_1.fastp.fastq.gz
+      md5sum: 4a03721ee252b7c6e81e007550e6ab63
+    - path: output/fastp/test_2.fastp.fastq.gz
+      md5sum: 7a4ddf8485c147cd7aaf0d4f6cd57ace
+    - path: output/fastqc/test_1_fastqc.html
+      md5sum: 48411648e244ca956f7b62adc52cb7c4
+    - path: output/fastqc/test_1_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastqc/test_2_fastqc.html
+      md5sum: acdf96873a02ae5f153c295c92dcd11f
+    - path: output/fastqc/test_2_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_skip_fastqc
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_skip_fastqc -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
+  files:
+    - path: output/fastp/test.fastp.html
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastp/test.fastp.json
+      md5sum: cfc3e8b871b9bc770f1dc16432d64e67
+    - path: output/fastp/test.fastp.log
+      md5sum: 8b1e318b1ae7b1bc23da61d4b4904bf7
+    - path: output/fastp/test_1.fastp.fastq.gz
+      md5sum: 4ce5c2b4db68a743cb0635ce7da3b9a4
+    - path: output/fastp/test_2.fastp.fastq.gz
+      md5sum: 532b190fb4dc7b2277ee5cf1464e598c
+    - path: output/fastqc/test_1_fastqc.html
+      md5sum: 7954ade4fcd61f984a7c3e2f0fa5e63a
+    - path: output/fastqc/test_1_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastqc/test_2_fastqc.html
+      md5sum: 7da866da90f0dc4345cfb49cb1110a1e
+    - path: output/fastqc/test_2_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+
+- name: fastq_trim_fastp_fastqc test_fastq_trim_fastp_fastqc_paired_end_skip_fastp
+  command: nextflow run ./tests/subworkflows/nf-core/fastq_trim_fastp_fastqc -entry test_fastq_trim_fastp_fastqc_paired_end_skip_fastp -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - fastqc
+    - subworkflows
+    - subworkflows/fastq_trim_fastp_fastqc
+  files:
+    - path: output/fastqc/test_1_fastqc.html
+      md5sum: 48411648e244ca956f7b62adc52cb7c4
+    - path: output/fastqc/test_1_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/fastqc/test_2_fastqc.html
+      md5sum: acdf96873a02ae5f153c295c92dcd11f
+    - path: output/fastqc/test_2_fastqc.zip
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Addresses second bullet from https://github.com/nf-core/viralrecon/issues/371 

Adds the subworkflow Fastq_trim_fastp_fastqc used in nf-core/viralrecon to nf-core/modules

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [X] Remove all TODO statements.
- [X] Emit the `versions.yml` file.
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [X] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
