### PR TITLE
Rename spatialomics to imaging in test_data.config

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -577,8 +577,8 @@ params {
            'ome-tiff' {
                 cycif_tonsil_channels       = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-channels.csv" 
                 cycif_tonsil_cycle1     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle1.ome.tif" 
-                cycif_tonsil-cycle2     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle2.ome.tif"    
-                cycif_tonsil-cycle3     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle3.ome.tif"    
+                cycif_tonsil_cycle2     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle2.ome.tif"    
+                cycif_tonsil_cycle3     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle3.ome.tif"    
             }
         }
     }

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -575,10 +575,10 @@ params {
                 mouse_heart_wga                 = "${params.test_data_base}/data/imaging/tiff/mindagap.mouse_heart.wga.tiff"    
             }
            'ome-tiff' {
-                cycif_tonsil_channels.csv       = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-channels.csv" 
-                cycif_tonsil_cycle1.ome.tif     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle1.ome.tif" 
-                cycif_tonsil-cycle2.ome.tif     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle2.ome.tif"    
-                cycif_tonsil-cycle3.ome.tif     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle3.ome.tif"    
+                cycif_tonsil_channels       = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-channels.csv" 
+                cycif_tonsil_cycle1     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle1.ome.tif" 
+                cycif_tonsil-cycle2     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle2.ome.tif"    
+                cycif_tonsil-cycle3     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle3.ome.tif"    
             }
         }
     }

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -571,6 +571,15 @@ params {
                 plant_wga_multicut              = "${params.test_data_base}/data/imaging/ilp/plant_wga.multicut.ilp"
                 plant_wga_pixel_class           = "${params.test_data_base}/data/imaging/ilp/plant_wga.pixel_prob.ilp"
             }
+           'tiff' {
+                mouse_heart_wga                 = "${params.test_data_base}/data/imaging/tiff/mindagap.mouse_heart.wga.tiff"    
+            }
+           'ome-tiff' {
+                cycif_tonsil_channels.csv       = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-channels.csv" 
+                cycif_tonsil_cycle1.ome.tif     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle1.ome.tif" 
+                cycif_tonsil-cycle2.ome.tif     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle2.ome.tif"    
+                cycif_tonsil-cycle3.ome.tif     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle3.ome.tif"    
+            }
         }
     }
 }

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -562,14 +562,14 @@ params {
                 pretext = "${params.test_data_base}/data/genomics/eukaryotes/galaxea_fascicularis/hic/jaGalFasc40_2.pretext"
             }
         }
-        'spatialomics' {
+        'imaging' {
             'h5' {
-                plant_wga                       = "${params.test_data_base}/data/spatialomics/h5/plant_wga.h5"
-                plant_wga_prob                  = "${params.test_data_base}/data/spatialomics/h5/plant_wga_probabilities.h5"
+                plant_wga                       = "${params.test_data_base}/data/imaging/h5/plant_wga.h5"
+                plant_wga_prob                  = "${params.test_data_base}/data/imaging/h5/plant_wga_probabilities.h5"
             }
             'ilp' {
-                plant_wga_multicut              = "${params.test_data_base}/data/spatialomics/ilp/plant_wga.multicut.ilp"
-                plant_wga_pixel_class           = "${params.test_data_base}/data/spatialomics/ilp/plant_wga.pixel_prob.ilp"
+                plant_wga_multicut              = "${params.test_data_base}/data/imaging/ilp/plant_wga.multicut.ilp"
+                plant_wga_pixel_class           = "${params.test_data_base}/data/imaging/ilp/plant_wga.pixel_prob.ilp"
             }
         }
     }

--- a/tests/modules/nf-core/ilastik/multicut/main.nf
+++ b/tests/modules/nf-core/ilastik/multicut/main.nf
@@ -8,15 +8,15 @@ workflow test_ilastik_multicut {
 
     input = [
         [ id:'image' ], // meta map
-        file(params.test_data['spatialomics']['h5']['plant_wga'], checkIfExists: true)
+        file(params.test_data['imaging']['h5']['plant_wga'], checkIfExists: true)
     ]
     ilp =   [
         [id:'ilastik_model'],
-        file(params.test_data['spatialomics']['ilp']['plant_wga_multicut'], checkIfExists: true)
+        file(params.test_data['imaging']['ilp']['plant_wga_multicut'], checkIfExists: true)
     ]
     probs = [
         [id:'probability_maps'],
-        file(params.test_data['spatialomics']['h5']['plant_wga_prob'], checkIfExists: true)
+        file(params.test_data['imaging']['h5']['plant_wga_prob'], checkIfExists: true)
     ]
 
     ILASTIK_MULTICUT ( input, ilp, probs )

--- a/tests/modules/nf-core/ilastik/pixelclassification/main.nf
+++ b/tests/modules/nf-core/ilastik/pixelclassification/main.nf
@@ -11,12 +11,12 @@ workflow test_ilastik_pixelclassification {
 
     input = [
         [ id:'probabilities' ], // meta map
-        file(params.test_data['spatialomics']['h5']['plant_wga'], checkIfExists: true)
+        file(params.test_data['imaging']['h5']['plant_wga'], checkIfExists: true)
     ]
 
     ilp   = [
         [id:'project'],
-        file(params.test_data['spatialomics']['ilp']['plant_wga_pixel_class'], checkIfExists: true)
+        file(params.test_data['imaging']['ilp']['plant_wga_pixel_class'], checkIfExists: true)
     ]
 
     ILASTIK_PIXELCLASSIFICATION_PROBABILITIES ( input, ilp )
@@ -26,11 +26,11 @@ workflow test_ilastik_pixelclassification_simplesegmentation {
 
     input = [
         [ id:'segmentations' ], // meta map
-        file(params.test_data['spatialomics']['h5']['plant_wga'], checkIfExists: true)
+        file(params.test_data['imaging']['h5']['plant_wga'], checkIfExists: true)
     ]
     ilp   = [
         [id:'project'],
-        file(params.test_data['spatialomics']['ilp']['plant_wga_pixel_class'], checkIfExists: true)
+        file(params.test_data['imaging']['ilp']['plant_wga_pixel_class'], checkIfExists: true)
     ]
 
     ILASTIK_PIXELCLASSIFICATION_SIMPLESEGMENTATION ( input, ilp )
@@ -40,11 +40,11 @@ workflow test_ilastik_pixelclassification_uncertainty {
 
     input = [
         [ id:'uncertainty' ], // meta map
-        file(params.test_data['spatialomics']['h5']['plant_wga'], checkIfExists: true)
+        file(params.test_data['imaging']['h5']['plant_wga'], checkIfExists: true)
     ]
     ilp   = [
         [id:'project'],
-        file(params.test_data['spatialomics']['ilp']['plant_wga_pixel_class'], checkIfExists: true)
+        file(params.test_data['imaging']['ilp']['plant_wga_pixel_class'], checkIfExists: true)
     ]
 
     ILASTIK_PIXELCLASSIFICATION_UNCERTAINTY ( input, ilp )
@@ -54,11 +54,11 @@ workflow test_ilastik_pixelclassification_features {
 
     input = [
         [ id:'features' ], // meta map
-        file(params.test_data['spatialomics']['h5']['plant_wga'], checkIfExists: true)
+        file(params.test_data['imaging']['h5']['plant_wga'], checkIfExists: true)
     ]
     ilp   = [
         [id:'project'],
-        file(params.test_data['spatialomics']['ilp']['plant_wga_pixel_class'], checkIfExists: true)
+        file(params.test_data['imaging']['ilp']['plant_wga_pixel_class'], checkIfExists: true)
     ]
 
     ILASTIK_PIXELCLASSIFICATION_FEATURES ( input, ilp )


### PR DESCRIPTION
Contributes to https://github.com/nf-core/test-datasets/issues/815 as requested in https://github.com/nf-core/test-datasets/pull/821#pullrequestreview-1360366283.

This PR renames the previous `spatialomics` test dataset directory to `imaging` for more consistency and clarity.

`tiff` and `ometiff` datasets added in  https://github.com/nf-core/test-datasets/pull/821 have also added

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
