### PR TITLE
Add imaging test data in config

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -598,7 +598,7 @@ params {
             }
             'background_subtraction' {
                 markers                 = "${params.test_data_base}/data/imaging/background_subtraction/markers.csv"
-                image      = "${params.test_data_base}/data/imaging/background_subtraction/cycif_tonsil_registered.ome.tif"
+                image                   = "${params.test_data_base}/data/imaging/background_subtraction/cycif_tonsil_registered.ome.tif"
             }
         }
     }

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -596,6 +596,10 @@ params {
                 markers                 = "${params.test_data_base}/data/imaging/downstream/markers.csv"
                 cell_feature_array      = "${params.test_data_base}/data/imaging/downstream/cycif_tonsil_cell.csv"
             }
+            'background_subtraction' {
+                markers                 = "${params.test_data_base}/data/imaging/background_subtraction/markers.csv"
+                image      = "${params.test_data_base}/data/imaging/background_subtraction/cycif_tonsil_registered.ome.tif"
+            }
         }
     }
 }

--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -560,14 +560,41 @@ params {
                 pretext = "${params.test_data_base}/data/genomics/eukaryotes/galaxea_fascicularis/hic/jaGalFasc40_2.pretext"
             }
         }
-        'spatialomics' {
+        'imaging' {
             'h5' {
-                plant_wga                       = "${params.test_data_base}/data/spatialomics/h5/plant_wga.h5"
-                plant_wga_prob                  = "${params.test_data_base}/data/spatialomics/h5/plant_wga_probabilities.h5"
+                plant_wga                       = "${params.test_data_base}/data/imaging/h5/plant_wga.h5"
+                plant_wga_prob                  = "${params.test_data_base}/data/imaging/h5/plant_wga_probabilities.h5"
             }
             'ilp' {
-                plant_wga_multicut              = "${params.test_data_base}/data/spatialomics/ilp/plant_wga.multicut.ilp"
-                plant_wga_pixel_class           = "${params.test_data_base}/data/spatialomics/ilp/plant_wga.pixel_prob.ilp"
+                plant_wga_multicut              = "${params.test_data_base}/data/imaging/ilp/plant_wga.multicut.ilp"
+                plant_wga_pixel_class           = "${params.test_data_base}/data/imaging/ilp/plant_wga.pixel_prob.ilp"
+            }
+           'tiff' {
+                mouse_heart_wga                 = "${params.test_data_base}/data/imaging/tiff/mindagap.mouse_heart.wga.tiff"    
+            }
+           'ome-tiff' {
+                cycif_tonsil_channels   = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-channels.csv" 
+                cycif_tonsil_cycle1     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle1.ome.tif" 
+                cycif_tonsil_cycle2     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle2.ome.tif"    
+                cycif_tonsil_cycle3     = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle3.ome.tif"    
+            }
+            'registration' {
+                markers                 = "${params.test_data_base}/data/imaging/registration/markers.csv" 
+                cycle1                  = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle1.ome.tif" 
+                cycle2                  = "${params.test_data_base}/data/imaging/ome-tiff/cycif-tonsil-cycle2.ome.tif"                
+            }
+            'segmentation' {
+                markers                 = "${params.test_data_base}/data/imaging/segmentation/markers.csv" 
+                image                   = "${params.test_data_base}/data/imaging/segmentation/cycif_tonsil_registered.ome.tif" 
+            }
+            'quantification' {
+                markers                 = "${params.test_data_base}/data/imaging/quantification/markers.csv"
+                image                   = "${params.test_data_base}/data/imaging/quantification/cycif_tonsil_registered.ome.tif"
+                mask                    = "${params.test_data_base}/data/imaging/quantification/cell.ome.tif"                
+            }
+            'downstream' {
+                markers                 = "${params.test_data_base}/data/imaging/downstream/markers.csv"
+                cell_feature_array      = "${params.test_data_base}/data/imaging/downstream/cycif_tonsil_cell.csv"
             }
         }
     }


### PR DESCRIPTION
This PR contributes to https://github.com/nf-core/test-datasets/issues/822, in which we add and re-organise test datasets for imaging data

Existing test datasets are left in place to avoid causing issues for existing modules.
Module tests will be transitioned in separate PRs, so this PR should not break any modules.

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
