### PR TITLE
Add core detection test data to config

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -600,6 +600,9 @@ params {
                 markers                 = "${params.test_data_base}/data/imaging/background_subtraction/markers.csv"
                 image                   = "${params.test_data_base}/data/imaging/background_subtraction/cycif_tonsil_registered.ome.tif"
             }
+            'core_detection' {
+                image                   = "${params.test_data_base}/data/imaging/core_detection/single_core_dapi.tif"
+            }
         }
     }
 }


### PR DESCRIPTION
This PR contributes to https://github.com/nf-core/test-datasets/issues/822 by exposing test data sets for TMA core detection modules in the `test_data.config` file

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
