### PR TITLE
Windowmasker version fix

### DIFF
--- a/modules/nf-core/windowmasker/mk_counts/main.nf
+++ b/modules/nf-core/windowmasker/mk_counts/main.nf
@@ -37,7 +37,7 @@ process WINDOWMASKER_MKCOUNTS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        windowmasker: \$(windowmasker -version-full | head -n 1)
+        windowmasker: \$(windowmasker -version-full | head -n 1 | sed 's/^.*windowmasker: //; s/ .*\$//')
     END_VERSIONS
     """
 
@@ -49,7 +49,7 @@ process WINDOWMASKER_MKCOUNTS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        windowmasker: \$(windowmasker -version-full | head -n 1)
+        windowmasker: \$(windowmasker -version-full | head -n 1 | sed 's/^.*windowmasker: //; s/ .*\$//')
     END_VERSIONS
     """
 }

--- a/modules/nf-core/windowmasker/ustat/main.nf
+++ b/modules/nf-core/windowmasker/ustat/main.nf
@@ -41,7 +41,7 @@ process WINDOWMASKER_USTAT {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        windowmasker: \$(windowmasker -version-full | head -n 1)
+        windowmasker: \$(windowmasker -version-full | head -n 1 | sed 's/^.*windowmasker: //; s/ .*\$//')
     END_VERSIONS
     """
 

--- a/modules/nf-core/windowmasker/ustat/main.nf
+++ b/modules/nf-core/windowmasker/ustat/main.nf
@@ -63,7 +63,7 @@ process WINDOWMASKER_USTAT {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        windowmasker: \$(windowmasker -version-full | head -n 1)
+        windowmasker: \$(windowmasker -version-full | head -n 1 | sed 's/^.*windowmasker: //; s/ .*\$//')
     END_VERSIONS
     """
 }


### PR DESCRIPTION
Closes ##3236

This pr addresses an issue with the version currently being pulled from windowmasker causing pipelines to crash. Currently, the version is `windowmasker : 1.0.0` rather than `1.0.0`