### PR TITLE
Fixed the `amps` test

### DIFF
--- a/modules/nf-core/malt/build/meta.yml
+++ b/modules/nf-core/malt/build/meta.yml
@@ -14,7 +14,7 @@ tools:
   - malt:
       description: A tool for mapping metagenomic data
       homepage: https://www.wsi.uni-tuebingen.de/lehrstuehle/algorithms-in-bioinformatics/software/malt/
-      documentation: https://software-ab.informatik.uni-tuebingen.de/download/malt/manual.pdf
+      documentation: https://software-ab.cs.uni-tuebingen.de/download/malt/manual.pdf
 
       doi: "10.1038/s41559-017-0446-6"
       licence: ["GPL v3"]
@@ -30,7 +30,7 @@ input:
       pattern: "*/|*.gff|*.gff3"
   - mapping_db:
       type: file
-      description: MEGAN .db file from https://software-ab.informatik.uni-tuebingen.de/download/megan6/welcome.html
+      description: MEGAN .db file from https://software-ab.cs.uni-tuebingen.de/download/megan6/welcome.html
       pattern: "*.db"
 
 output:

--- a/modules/nf-core/malt/run/meta.yml
+++ b/modules/nf-core/malt/run/meta.yml
@@ -13,7 +13,7 @@ tools:
   - malt:
       description: A tool for mapping metagenomic data
       homepage: https://www.wsi.uni-tuebingen.de/lehrstuehle/algorithms-in-bioinformatics/software/malt/
-      documentation: https://software-ab.informatik.uni-tuebingen.de/download/malt/manual.pdf
+      documentation: https://software-ab.cs.uni-tuebingen.de/download/malt/manual.pdf
 
       doi: "10.1038/s41559-017-0446-6"
       licence: ["GPL v3"]

--- a/modules/nf-core/megan/daa2info/meta.yml
+++ b/modules/nf-core/megan/daa2info/meta.yml
@@ -10,7 +10,7 @@ tools:
   - "megan":
       description: "A tool for studying the taxonomic content of a set of DNA reads"
       homepage: "https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/lehrstuehle/algorithms-in-bioinformatics/software/megan6/"
-      documentation: "https://software-ab.informatik.uni-tuebingen.de/download/megan6/welcome.html"
+      documentation: "https://software-ab.cs.uni-tuebingen.de/download/megan6/welcome.html"
       tool_dev_url: "https://github.com/husonlab/megan-ce"
       doi: "10.1371/journal.pcbi.1004957"
       licence: "['GPL >=3']"

--- a/modules/nf-core/megan/rma2info/meta.yml
+++ b/modules/nf-core/megan/rma2info/meta.yml
@@ -9,7 +9,7 @@ tools:
   - "megan":
       description: "A tool for studying the taxonomic content of a set of DNA reads"
       homepage: "https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/lehrstuehle/algorithms-in-bioinformatics/software/megan6/"
-      documentation: "https://software-ab.informatik.uni-tuebingen.de/download/megan6/welcome.html"
+      documentation: "https://software-ab.cs.uni-tuebingen.de/download/megan6/welcome.html"
       tool_dev_url: "https://github.com/husonlab/megan-ce"
       doi: "10.1371/journal.pcbi.1004957"
       licence: "['GPL >=3']"

--- a/tests/modules/nf-core/amps/main.nf
+++ b/tests/modules/nf-core/amps/main.nf
@@ -15,7 +15,7 @@ workflow test_amps {
     fastas = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     gff = []
     seq_type = "DNA"
-    map_db = [ [], file("https://software-ab.informatik.uni-tuebingen.de/download/megan6/megan-nucl-Jan2021.db.zip", checkIfExists: true) ]
+    map_db = [ [], file("https://software-ab.cs.uni-tuebingen.de/download/megan6/megan-nucl-Jan2021.db.zip", checkIfExists: true) ]
     input = [
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)

--- a/tests/modules/nf-core/amps/main.nf
+++ b/tests/modules/nf-core/amps/main.nf
@@ -14,20 +14,18 @@ workflow test_amps {
 
     fastas = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     gff = []
-    seq_type = "DNA"
     map_db = [ [], file("https://software-ab.cs.uni-tuebingen.de/download/megan6/megan-nucl-Jan2021.db.zip", checkIfExists: true) ]
     input = [
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
     ]
-    mode = "BlastN"
     taxon_list = file(params.test_data['sarscov2']['genome']['taxon_list_txt'], checkIfExists: true)
     ncbi_dir = [ [], file(params.test_data['sarscov2']['genome']['ncbi_taxmap_zip'], checkIfExists: true) ]
 
     UNZIP_MALT ( map_db )
     UNZIP_MALTEXTRACT ( ncbi_dir )
-    MALT_BUILD ( fastas, seq_type, gff, UNZIP_MALT.out.unzipped_archive.map{ it[1] } )
-    MALT_RUN ( input, mode, MALT_BUILD.out.index )
+    MALT_BUILD ( fastas, gff, UNZIP_MALT.out.unzipped_archive.map{ it[1] } )
+    MALT_RUN ( input, MALT_BUILD.out.index )
     ch_input_to_maltextract = MALT_RUN.out.rma6.map{ it[1] }
     MALTEXTRACT ( ch_input_to_maltextract, taxon_list, UNZIP_MALTEXTRACT.out.unzipped_archive.map{ it[1] })
 

--- a/tests/modules/nf-core/amps/nextflow.config
+++ b/tests/modules/nf-core/amps/nextflow.config
@@ -2,6 +2,14 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    withName: MALT_BUILD {
+        ext.args = '--sequenceType DNA'
+    }
+
+    withName: MALT_RUN {
+        ext.args = '--mode BlastN -J-Xmx3G'
+    }
+
     withName: MALTEXTRACT {
         ext.args = '-f def_anc'
     }


### PR DESCRIPTION
The `amps` module test was identified as failing in #2154. This was caused by some changes in the interface of other modules (`malt/build` and `malt/extract`) that are used in the test.

This PR fixes those tests and also updates the URL of the Tübingen university, because the old one has an expired certificate that Nextflow complains about.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
