### PR TITLE
Fixed the `bamcmp`module tests

### DIFF
--- a/tests/modules/nf-core/bamcmp/main.nf
+++ b/tests/modules/nf-core/bamcmp/main.nf
@@ -19,8 +19,14 @@ workflow test_bamcmp {
         [ file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
     ]
 
-    fasta1 = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
-    fasta2 = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta1 = [
+        [ id:'homo_sapiens_genome'], // meta map
+        file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+    fasta2 = [
+        [ id:'sarscov2_genome'], // meta map
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
 
     BWA_INDEX ( fasta1 )
     BWA_MEM ( input, BWA_INDEX.out.index, false )

--- a/tests/modules/nf-core/bamcmp/test.yml
+++ b/tests/modules/nf-core/bamcmp/test.yml
@@ -4,8 +4,8 @@
     - bamcmp
   files:
     - path: output/bamcmp/test_contamination.bam
-      md5sum: 1fe730936d489c637479c1e51dd8ca55
+      md5sum: 5379655d8befef5a3c4b4e56c20de15f
     - path: output/bamcmp/test_primary.bam
-      md5sum: 80b9abd8ef83e63548a9b8b82be2a034
+      md5sum: e267741b9549068cd6f5fc98d8ff529d
     - path: output/bamcmp/versions.yml
       md5sum: 34d569665ff0459e84114e966dd3483b


### PR DESCRIPTION
Fixed the `bamcmp` module tests, as identified in #2154.

1. The module interface of `BWA_INDEX` had changed and now requires a meta map
2. The MD5 checksums were wrong

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
