### PR TITLE
Added the MD5 checksums for the delly/call tests

### DIFF
--- a/tests/modules/nf-core/delly/call/test.yml
+++ b/tests/modules/nf-core/delly/call/test.yml
@@ -4,7 +4,7 @@
     - delly
     - delly/call
   files:
-    - path: output/delly/test.bcf
+    - path: output/delly/test.bcf # No md5sum because the file includes a timestamp
     - path: output/delly/test.bcf.csi
       md5sum: 66545c77fc791a02dadc7fc252d04635
     - path: output/delly/versions.yml
@@ -15,7 +15,7 @@
     - delly
     - delly/call
   files:
-    - path: output/delly/test.vcf.gz
+    - path: output/delly/test.vcf.gz # No md5sum because the file includes a timestamp
     - path: output/delly/test.vcf.gz.tbi
       md5sum: e7180bb953d2bd657c420a5f76a7164d
     - path: output/delly/versions.yml
@@ -26,7 +26,7 @@
     - delly
     - delly/call
   files:
-    - path: output/delly/test.bcf
+    - path: output/delly/test.bcf # No md5sum because the file includes a timestamp
     - path: output/delly/test.bcf.csi
       md5sum: a2ba4f0b32a6ea857ec8a5b3068f168f
     - path: output/delly/versions.yml
@@ -37,7 +37,7 @@
     - delly
     - delly/call
   files:
-    - path: output/delly/test.vcf.gz
+    - path: output/delly/test.vcf.gz # No md5sum because the file includes a timestamp
     - path: output/delly/test.vcf.gz.tbi
       md5sum: e7180bb953d2bd657c420a5f76a7164d
     - path: output/delly/versions.yml


### PR DESCRIPTION
I looked into this to cover the `delly/call` part of #2154 . All the tests are in fact now passing since #2909 but the MD5 checksums of the VCF and BCF outputs have been removed. Why ? As you can see here, the tests pass on Docker + Singularity + Conda

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
