### PR TITLE
Updated the MD5 checksums of all controlfreec tests

### DIFF
--- a/tests/modules/nf-core/controlfreec/assesssignificance/test.yml
+++ b/tests/modules/nf-core/controlfreec/assesssignificance/test.yml
@@ -5,7 +5,7 @@
     - controlfreec
   files:
     - path: output/controlfreec/test.p.value.txt
-      md5sum: 44e23b916535fbc1a3f47b57fad292df
+      md5sum: 94bf84d58c9696f116a9a6d8cb350e14
     - path: output/controlfreec/versions.yml
 
 - name: controlfreec assesssignificance test_controlfreec_assesssignificance_single

--- a/tests/modules/nf-core/controlfreec/freec2bed/test.yml
+++ b/tests/modules/nf-core/controlfreec/freec2bed/test.yml
@@ -5,7 +5,8 @@
     - controlfreec
   files:
     - path: output/controlfreec/test.bed
-      md5sum: abe10b7ce94ba903503e697394c17297
+      md5sum: 833920178e4f40a296d8eab029caf086
+    - path: output/controlfreec/versions.yml
 
 - name: controlfreec freec2bed test_controlfreec_freec2bed_single
   command: nextflow run ./tests/modules/nf-core/controlfreec/freec2bed -entry test_controlfreec_freec2bed_single -c ./tests/config/nextflow.config -stub-run
@@ -14,3 +15,4 @@
     - controlfreec
   files:
     - path: output/controlfreec/test.bed
+    - path: output/controlfreec/versions.yml

--- a/tests/modules/nf-core/controlfreec/freec2circos/test.yml
+++ b/tests/modules/nf-core/controlfreec/freec2circos/test.yml
@@ -5,7 +5,8 @@
     - controlfreec/freec2circos
   files:
     - path: output/controlfreec/test.circos.txt
-      md5sum: 19cf35f2c36b46f717dc8342b8a5a645
+      md5sum: 92ce5ce97b27a7214dfa9c2cb20cf854
+    - path: output/controlfreec/versions.yml
 
 - name: controlfreec freec2circos test_controlfreec_freec2circos_single
   command: nextflow run ./tests/modules/nf-core/controlfreec/freec2circos -entry test_controlfreec_freec2circos_single -c ./tests/config/nextflow.config -stub-run
@@ -14,3 +15,4 @@
     - controlfreec/freec2circos
   files:
     - path: output/controlfreec/test.circos.txt
+    - path: output/controlfreec/versions.yml

--- a/tests/modules/nf-core/controlfreec/makegraph/test.yml
+++ b/tests/modules/nf-core/controlfreec/makegraph/test.yml
@@ -5,11 +5,9 @@
     - controlfreec/makegraph
   files:
     - path: output/controlfreec/test_BAF.png
-      md5sum: f9d977839e09c7e2472d970bd4aa834c
     - path: output/controlfreec/test_ratio.log2.png
-      md5sum: b3c7916b1b4951a0cc3da20d8e9e0262
     - path: output/controlfreec/test_ratio.png
-      md5sum: 1435b29536b3b1555b4c423f8f4fb000
+    - path: output/controlfreec/versions.yml
 
 - name: controlfreec makegraph test_controlfreec_makegraph_single
   command: nextflow run ./tests/modules/nf-core/controlfreec/makegraph -entry test_controlfreec_makegraph_single -c ./tests/config/nextflow.config -stub-run
@@ -20,3 +18,4 @@
     - path: output/controlfreec/test_BAF.png
     - path: output/controlfreec/test_ratio.log2.png
     - path: output/controlfreec/test_ratio.png
+    - path: output/controlfreec/versions.yml


### PR DESCRIPTION
This comes from #2154 
I checked all `controlfreec` tests and updated the MD5 checksums. Just one issue: `controlfreec/assesssignificance` doesn't pass on Conda + GitHub, it complains of an installation issue, but it works locally (and the MD5s match).
Any idea what that could be ?


<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
