### PR TITLE
fix #3261.

### DIFF
--- a/modules/nf-core/samtools/calmd/meta.yml
+++ b/modules/nf-core/samtools/calmd/meta.yml
@@ -1,4 +1,4 @@
-name: "SAMTOOLS_CALMD"
+name: "samtools_calmd"
 description: calculates MD and NM tags
 keywords:
   - calmd


### PR DESCRIPTION
fix samtools/calmd yaml where name was all in caps.

Closes #3261

