### PR TITLE
Change meta2 to meta3 for the index

### DIFF
--- a/modules/nf-core/chromap/chromap/main.nf
+++ b/modules/nf-core/chromap/chromap/main.nf
@@ -10,7 +10,7 @@ process CHROMAP_CHROMAP {
     input:
     tuple val(meta), path(reads)
     tuple val(meta2), path(fasta)
-    tuple val(meta2), path(index)
+    tuple val(meta3), path(index)
     path barcodes
     path whitelist
     path chr_order

--- a/modules/nf-core/chromap/chromap/meta.yml
+++ b/modules/nf-core/chromap/chromap/meta.yml
@@ -36,12 +36,17 @@ input:
   - meta2:
       type: map
       description: |
-        Groovy Map containing sample information
+        Groovy Map containing information for the fasta
         e.g. [ id:'test' ]
   - fasta:
       type: file
       description: |
         The fasta reference file.
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing information for the index
+        e.g. [ id:'test' ]
   - index:
       type: file
       description: |


### PR DESCRIPTION
`meta2` was use both for the fasta and the index. Change to `meta3` for the index.

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
