### PR TITLE
Fix subworkflows based on json schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,11 @@ repos:
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.21.0
     hooks:
-      - id: check-jsonschema
+      - id: check-modules-metajsonschema
         # match meta.ymls in one of the subdirectories of modules/nf-core
         files: ^modules/nf-core/.*/meta\.yml$
-        args: ["--schemafile", "yaml-schema.json"]
+        args: ["--schemafile", "modules/yaml-schema.json"]
+      - id: check-subworkflows-metajsonschema
+        # match meta.ymls in one of the subdirectories of subworkflows/nf-core
+        files: ^subworkflows/nf-core/.*/meta\.yml$
+        args: ["--schemafile", "subworkflows/yaml-schema.json"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.21.0
+    rev: 0.22.0
     hooks:
-      - id: check-modules-metajsonschema
+      - id: check-jsonschema
         # match meta.ymls in one of the subdirectories of modules/nf-core
         files: ^modules/nf-core/.*/meta\.yml$
         args: ["--schemafile", "modules/yaml-schema.json"]
-      - id: check-subworkflows-metajsonschema
+      - id: check-jsonschema
         # match meta.ymls in one of the subdirectories of subworkflows/nf-core
         files: ^subworkflows/nf-core/.*/meta\.yml$
         args: ["--schemafile", "subworkflows/yaml-schema.json"]

--- a/modules/nf-core/fqtk/meta.yml
+++ b/modules/nf-core/fqtk/meta.yml
@@ -45,10 +45,10 @@ output:
         Demultiplexing summary stats; sample_id, barcode templates, frac_templates, ratio_to_mean, ratio_to_best
       pattern: "output/demux-metrics.txt"
   - most_frequent_unmatched:
-    type: file
-    description: |
-      File containing unmatched fastq records
-    pattern: "output/unmatched*.fq.gz"
+      type: file
+      description: |
+        File containing unmatched fastq records
+      pattern: "output/unmatched*.fq.gz"
 
 authors:
   - "Samantha White @sam-white04"

--- a/modules/nf-core/vsearch/sort/meta.yml
+++ b/modules/nf-core/vsearch/sort/meta.yml
@@ -28,7 +28,7 @@ input:
   - sort_arg:
       type: string
       description: Argument to provide to sort algorithm. Sort by abundance with --sortbysize or by sequence length with --sortbylength.
-      enums: ["--sortbysize", "--sortbylength"]
+      enum: ["--sortbysize", "--sortbylength"]
 
 output:
   - meta:

--- a/modules/yaml-schema.json
+++ b/modules/yaml-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "Meta yaml",
-    "description": "Validate the meta yaml file for an nf-core module",
+    "description": "Validate the meta yaml file for an nf-core module or subworkflow",
     "type": "object",
     "properties": {
         "name": {

--- a/modules/yaml-schema.json
+++ b/modules/yaml-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "Meta yaml",
-    "description": "Validate the meta yaml file for an nf-core module or subworkflow",
+    "description": "Validate the meta yaml file for an nf-core module",
     "type": "object",
     "properties": {
         "name": {

--- a/modules/yaml-schema.json
+++ b/modules/yaml-schema.json
@@ -53,13 +53,22 @@
                             "default": {
                                 "type": ["string", "number", "boolean", "array", "object"],
                                 "description": "Default value for the input channel"
-                            }
-                        },
-                        "required": ["type", "description"]
+                            },
+                            "enum": {
+                                "type": "array",
+                                "description": "List of allowed values for the input channel",
+                                "items": {
+                                    "type": ["string", "number", "boolean", "array", "object"]
+                                },
+                                "uniqueItems": true
+                            },
+                            "required": ["type", "description"]
+                        }
                     }
                 }
             }
         },
+
         "output": {
             "type": "array",
             "description": "Output channels for the module",
@@ -81,6 +90,14 @@
                             "pattern": {
                                 "type": "string",
                                 "description": "Pattern of the input channel, given in Java glob syntax"
+                            },
+                            "enum": {
+                                "type": "array",
+                                "description": "List of allowed values for the output channel",
+                                "items": {
+                                    "type": ["string", "number", "boolean", "array", "object"]
+                                },
+                                "uniqueItems": true
                             }
                         },
                         "required": ["type", "description"]

--- a/modules/yaml-schema.json
+++ b/modules/yaml-schema.json
@@ -61,9 +61,9 @@
                                     "type": ["string", "number", "boolean", "array", "object"]
                                 },
                                 "uniqueItems": true
-                            },
-                            "required": ["type", "description"]
-                        }
+                            }
+                        },
+                        "required": ["type", "description"]
                     }
                 }
             }

--- a/subworkflows/nf-core/bam_create_som_pon_gatk/meta.yml
+++ b/subworkflows/nf-core/bam_create_som_pon_gatk/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: bam_create_som_pon_gatk
 description: Perform variant calling on a set of normal samples using mutect2 panel of normals mode. Group them into a genomicsdbworkspace using genomicsdbimport, then use this to create a panel of normals using createsomaticpanelofnormals.
 keywords:
@@ -14,6 +15,7 @@ modules:
   - gatk4/createsomaticpanelofnormals
 input:
   - ch_mutect2_in:
+      type: list
       description: |
         An input channel containing the following files:
         - input: One or more BAM/CRAM files

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/meta.yml
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bam_dedup_stats_samtools_umitools"
 description: UMI-tools dedup, index BAM file and run samtools stats, flagstat and idxstats
 keywords:

--- a/subworkflows/nf-core/bam_docounts_contamination_angsd/meta.yml
+++ b/subworkflows/nf-core/bam_docounts_contamination_angsd/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bam_docounts_contamination_angsd"
 description: Calculate contamination of the X-chromosome with ANGSD
 keywords:

--- a/subworkflows/nf-core/bam_docounts_contamination_angsd/meta.yml
+++ b/subworkflows/nf-core/bam_docounts_contamination_angsd/meta.yml
@@ -23,7 +23,8 @@ input:
       description: BAM/SAM samtools index
       pattern: "*.{bai,csi}"
   - hapmap_file:
-      type:
+      type: file
+      description: Hapmap file
 output:
   - meta:
       type: map

--- a/subworkflows/nf-core/bam_markduplicates_picard/meta.yml
+++ b/subworkflows/nf-core/bam_markduplicates_picard/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bam_markduplicates_picard"
 description: Picard MarkDuplicates, index BAM file and run samtools stats, flagstat and idxstats
 keywords:

--- a/subworkflows/nf-core/bam_ngscheckmate/meta.yml
+++ b/subworkflows/nf-core/bam_ngscheckmate/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bam_ngscheckmate"
 description: Take a set of bam files and run NGSCheckMate to determine whether samples match with each other, using a set of SNPs.
 keywords:

--- a/subworkflows/nf-core/bam_ngscheckmate/meta.yml
+++ b/subworkflows/nf-core/bam_ngscheckmate/meta.yml
@@ -4,6 +4,8 @@ description: Take a set of bam files and run NGSCheckMate to determine whether s
 keywords:
   - ngscheckmate
   - qc
+  - bam
+  - snp
 modules:
   - bcftools/mpileup
   - ngscheckmate/ncm

--- a/subworkflows/nf-core/bam_qc_picard/meta.yml
+++ b/subworkflows/nf-core/bam_qc_picard/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: bam_qc
 description: Produces comprehensive statistics from BAM file
 keywords:

--- a/subworkflows/nf-core/bam_rseqc/meta.yml
+++ b/subworkflows/nf-core/bam_rseqc/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: bam_rseqc
 description: Subworkflow to run multiple commands in the RSeqC package
 keywords:

--- a/subworkflows/nf-core/bam_rseqc/meta.yml
+++ b/subworkflows/nf-core/bam_rseqc/meta.yml
@@ -12,15 +12,8 @@ keywords:
   - readdistribution
   - readduplication
   - tin
-tools:
-  - rseqc:
-      description: |
-        RSeQC package provides a number of useful modules that can comprehensively evaluate
-        high throughput sequence data especially RNA-seq data.
-      homepage: http://rseqc.sourceforge.net/
-      documentation: http://rseqc.sourceforge.net/
-      doi: 10.1093/bioinformatics/bts356
-      licence: ["GPL-3.0-or-later"]
+modules:
+  - rseqc
 input:
   - meta:
       type: map

--- a/subworkflows/nf-core/bam_sort_stats_samtools/meta.yml
+++ b/subworkflows/nf-core/bam_sort_stats_samtools/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: bam_sort_stats_samtools
 description: Sort SAM/BAM/CRAM file
 keywords:

--- a/subworkflows/nf-core/bam_split_by_region/meta.yml
+++ b/subworkflows/nf-core/bam_split_by_region/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bam_split_by_region"
 description: Split the reads in the input bam by specified genomic region.
 keywords:

--- a/subworkflows/nf-core/bam_stats_samtools/meta.yml
+++ b/subworkflows/nf-core/bam_stats_samtools/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: bam_stats_samtools
 description: Produces comprehensive statistics from SAM/BAM/CRAM file
 keywords:

--- a/subworkflows/nf-core/bam_tumor_normal_somatic_variant_calling_gatk/meta.yml
+++ b/subworkflows/nf-core/bam_tumor_normal_somatic_variant_calling_gatk/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: bam_tumor_normal_somatic_variant_calling_gatk
 description: |
   Perform variant calling on a paired tumor normal set of samples using mutect2 tumor normal mode.

--- a/subworkflows/nf-core/bam_variant_calling_sort_freebayes_bcftools/meta.yml
+++ b/subworkflows/nf-core/bam_variant_calling_sort_freebayes_bcftools/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bam_variant_calling_sort_freebayes_bcftools"
 description: Call variants using freebayes, then sort and index
 keywords:

--- a/subworkflows/nf-core/bam_variant_demix_boot_freyja/meta.yml
+++ b/subworkflows/nf-core/bam_variant_demix_boot_freyja/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bam_variant_demix_boot_freyja"
 description: Recover relative lineage abundances from mixed SARS-CoV-2 samples from a sequencing dataset (BAM aligned to the Hu-1 reference)
 keywords:

--- a/subworkflows/nf-core/bcl_demultiplex/meta.yml
+++ b/subworkflows/nf-core/bcl_demultiplex/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bcl_demultiplex"
 description: Demultiplex Illumina BCL data using bcl-convert or bcl2fastq
 keywords:

--- a/subworkflows/nf-core/bed_scatter_bedtools/meta.yml
+++ b/subworkflows/nf-core/bed_scatter_bedtools/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bed_scatter_bedtools"
 description: |
   Scatters inputted BED files by the amount specified.

--- a/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/meta.yml
+++ b/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/meta.yml
@@ -1,19 +1,22 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "bedgraph_bedclip_bedgraphtobigwig"
-description: Convert gedgraph to bigwig with clip
+description: Convert bedgraph to bigwig with clip
 keywords:
   - bedgraph
   - bigwig
+  - clip
+  - conversion
 modules:
   - ucsc/bedclip
   - ucsc/bedgraphtobigwig
 input:
   - bedgraph:
       type: file
-      description: bedGraph file whoch should be converted
+      description: bedGraph file which should be converted
       pattern: "*.bedGraph"
   - sizes:
       type: file
-      description: File with chromosom sizes
+      description: File with chromosome sizes
       pattern: "*.sizes"
 output:
   - bigwig:

--- a/subworkflows/nf-core/fasta_binning_concoct/meta.yml
+++ b/subworkflows/nf-core/fasta_binning_concoct/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fasta_binning_concoct"
 description: Runs the CONCOCT workflow of contig binning
 keywords:

--- a/subworkflows/nf-core/fasta_index_dna/meta.yml
+++ b/subworkflows/nf-core/fasta_index_dna/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fasta_index_dna"
 description: |
   Generate aligner index for a reference genome.

--- a/subworkflows/nf-core/fasta_newick_epang_gappa/meta.yml
+++ b/subworkflows/nf-core/fasta_newick_epang_gappa/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fasta_newick_epang_gappa"
 description: Run phylogenetic placement with a number of query sequences plus a reference alignment and phylogeny. Used in nf-core/phyloplace.
 keywords:
@@ -19,19 +20,19 @@ modules:
   - gappa/examineheattree
 input:
   - ch_pp_data:
-    type: map
-    description: |
-      Structure: [
-        meta: val(meta),
-        data: [
-          alignmethod:  'hmmer',
-          queryseqfile: path("*.faa"),
-          refseqfile:   path("*.alnfaa"),
-          refphylogeny: path("*.newick"),
-          model:        "LG",
-          taxonomy:     path("*.tsv")
+      type: map
+      description: |
+        Structure: [
+          meta: val(meta),
+          data: [
+            alignmethod:  'hmmer',
+            queryseqfile: path("*.faa"),
+            refseqfile:   path("*.alnfaa"),
+            refphylogeny: path("*.newick"),
+            model:        "LG",
+            taxonomy:     path("*.tsv")
+          ]
         ]
-      ]
   - meta:
       type: map
       description: |

--- a/subworkflows/nf-core/fastq_align_bowtie2/meta.yml
+++ b/subworkflows/nf-core/fastq_align_bowtie2/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: fastq_align_bowtie2
 description: Align reads to a reference genome using bowtie2 then sort with samtools
 keywords:
@@ -33,9 +34,10 @@ input:
         Save reads that do not map to the reference (true) or discard them (false)
         (default: false)
   - sort_bam:
+      type: boolean
       description: |
         Save reads that do not map to the reference (true) or discard them (false)
-        (default: false)
+      default: false
   - ch_fasta:
       type: file
       description: Reference fasta file

--- a/subworkflows/nf-core/fastq_align_bwa/meta.yml
+++ b/subworkflows/nf-core/fastq_align_bwa/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: fastq_align_bwa
 description: Align reads to a reference genome using bwa then sort with samtools
 keywords:

--- a/subworkflows/nf-core/fastq_align_bwaaln/meta.yml
+++ b/subworkflows/nf-core/fastq_align_bwaaln/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fastq_align_bwaaln_samtools"
 description: Align FASTQ files against reference genome with the bwa aln short-read aligner producing a sorted and indexed BAM files
 keywords:

--- a/subworkflows/nf-core/fastq_align_chromap/meta.yml
+++ b/subworkflows/nf-core/fastq_align_chromap/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fastq_align_chromap"
 description: Align high throughput chromatin profiles using Chromap then sort with samtools
 keywords:

--- a/subworkflows/nf-core/fastq_align_dna/meta.yml
+++ b/subworkflows/nf-core/fastq_align_dna/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fastq_align_dna"
 description: Align fastq files to a reference genome
 keywords:

--- a/subworkflows/nf-core/fastq_align_hisat2/meta.yml
+++ b/subworkflows/nf-core/fastq_align_hisat2/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fastq_align_hisat2"
 description: Align reads to a reference genome using hisat2 then sort with samtools
 keywords:

--- a/subworkflows/nf-core/fastq_align_star/meta.yml
+++ b/subworkflows/nf-core/fastq_align_star/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fastq_align_star"
 description: Align reads to a reference genome using bowtie2 then sort with samtools
 keywords:

--- a/subworkflows/nf-core/fastq_contam_seqtk_kraken/meta.yml
+++ b/subworkflows/nf-core/fastq_contam_seqtk_kraken/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "FASTQ_CONTAM_SEQTK_KRAKEN"
 description: Produces a contamination report from FastQ input after subsampling
 keywords:

--- a/subworkflows/nf-core/fastq_create_umi_consensus_fgbio/meta.yml
+++ b/subworkflows/nf-core/fastq_create_umi_consensus_fgbio/meta.yml
@@ -44,7 +44,11 @@ input:
       type: string
       description: |
       Reguired argument: defines the UMI assignment strategy.
-      Must be chosen among: Identity, Edit, Adjacency, Paired.
+      enum:
+        - Identity
+        - Edit
+        - Adjacency
+        - Paired
 output:
   - versions:
       type: file

--- a/subworkflows/nf-core/fastq_create_umi_consensus_fgbio/meta.yml
+++ b/subworkflows/nf-core/fastq_create_umi_consensus_fgbio/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: fgbio_create_umi_consensus
 description: |
   This workflow uses the suite FGBIO to identify and remove UMI tags from FASTQ reads
@@ -40,10 +41,10 @@ input:
         If the read does not contain any UMI, the structure will be +T (i.e. only template of any length).
         https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures
   - groupreadsbyumi_strategy:
-    type: string
-    description: |
-    Reguired argument: defines the UMI assignment strategy.
-    Must be chosen among: Identity, Edit, Adjacency, Paired.
+      type: string
+      description: |
+      Reguired argument: defines the UMI assignment strategy.
+      Must be chosen among: Identity, Edit, Adjacency, Paired.
 output:
   - versions:
       type: file

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/meta.yml
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: fastq_download_prefetch_fasterqdump_sratools
 description: Download FASTQ sequencing reads from the NCBI's Sequence Read Archive (SRA).
 keywords:

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/meta.yml
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/meta.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
+# yaml-language-server: $schema=yaml-schema.json
 name: "fastq_fastqc_umitools_fastp"
 description: Read QC, UMI extraction and trimming
 keywords:
@@ -65,12 +67,12 @@ output:
         Groovy Map containing sample information
         e.g. [ id:'test' ]
   - reads:
-    type: file
-    description: >
-      Extracted FASTQ files. |
-      For single-end reads, pattern is \${prefix}.umi_extract.fastq.gz. |
-        For paired-end reads, pattern is \${prefix}.umi_extract_{1,2}.fastq.gz.
-    pattern: "*.{fastq.gz}"
+      type: file
+      description: >
+        Extracted FASTQ files. |
+        For single-end reads, pattern is \${prefix}.umi_extract.fastq.gz. |
+          For paired-end reads, pattern is \${prefix}.umi_extract_{1,2}.fastq.gz.
+      pattern: "*.{fastq.gz}"
   - fastqc_html:
       type: file
       description: FastQC report
@@ -96,16 +98,16 @@ output:
       description: Logfile FastP
       pattern: "*.{fastp.log}"
   - trim_reads_fail:
-    type: file
-    description: Trimmed fastq files failing QC
-    pattern: "*.{fastq.gz}"
+      type: file
+      description: Trimmed fastq files failing QC
+      pattern: "*.{fastq.gz}"
   - trim_reads_merged:
-    type: file
-    description: Trimmed and merged fastq files
-    pattern: "*.{fastq.gz}"
+      type: file
+      description: Trimmed and merged fastq files
+      pattern: "*.{fastq.gz}"
   - trim_read_count:
-    type: integer
-    description: Number of reads after trimming
+      type: integer
+      description: Number of reads after trimming
   - fastqc_trim_html:
       type: file
       description: FastQC report

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/meta.yml
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fastq_fastqc_umitools_trimgalore"
 description: Read QC, UMI extraction and trimming
 keywords:
@@ -49,12 +50,12 @@ input:
 
 output:
   - reads:
-    type: file
-    description: >
-      Extracted FASTQ files. |
-      For single-end reads, pattern is \${prefix}.umi_extract.fastq.gz. |
-        For paired-end reads, pattern is \${prefix}.umi_extract_{1,2}.fastq.gz.
-    pattern: "*.{fastq.gz}"
+      type: file
+      description: >
+        Extracted FASTQ files. |
+        For single-end reads, pattern is \${prefix}.umi_extract.fastq.gz. |
+          For paired-end reads, pattern is \${prefix}.umi_extract_{1,2}.fastq.gz.
+      pattern: "*.{fastq.gz}"
   - fastqc_html:
       type: file
       description: FastQC report

--- a/subworkflows/nf-core/fastq_subsample_fq_salmon/meta.yml
+++ b/subworkflows/nf-core/fastq_subsample_fq_salmon/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fastq_subsample_fq_salmon"
 description: Subsample fastq
 keywords:

--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/meta.yml
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "fastq_trim_fastp_fastqc"
 description: Read QC, fastp trimming and read qc
 keywords:
@@ -35,72 +36,72 @@ input:
         Structure: val(save_merged)
         Specify true to save all merged reads to the a file ending in `*.merged.fastq.gz`
   - val_skip_fastqc:
-    type: boolean
-    description: |
-      Structure: val(skip_fastqc)
-      skip the fastqc process if true
+      type: boolean
+      description: |
+        Structure: val(skip_fastqc)
+        skip the fastqc process if true
   - val_skip_fastp:
-    type: boolean
-    description: |
-      Structure: val(skip_fastp)
-      skip the fastp process if true
+      type: boolean
+      description: |
+        Structure: val(skip_fastp)
+        skip the fastp process if true
 
 output:
   - meta:
-    type: value
-    description: Groovy Map containing sample information
-      e.g. [ id:'test', single_end:false ]
+      type: value
+      description: Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
   - reads:
-    type: file
-    description: |
-      Structure: [ val(meta), path(reads) ]
-      The trimmed/modified/unmerged fastq reads
+      type: file
+      description: |
+        Structure: [ val(meta), path(reads) ]
+        The trimmed/modified/unmerged fastq reads
   - trim_json:
-    type: file
-    description: |
-      Structure: [ val(meta), path(trim_json) ]
-      Results in JSON format
+      type: file
+      description: |
+        Structure: [ val(meta), path(trim_json) ]
+        Results in JSON format
   - trim_html:
-    type: file
-    description: |
-      Structure: [ val(meta), path(trim_html) ]
-      Results in HTML format
+      type: file
+      description: |
+        Structure: [ val(meta), path(trim_html) ]
+        Results in HTML format
   - trim_log:
-    type: file
-    description: |
-      Structure: [ val(meta), path(trim_log) ]
-      fastq log file
+      type: file
+      description: |
+        Structure: [ val(meta), path(trim_log) ]
+        fastq log file
   - trim_reads_fail:
-    type: file
-    description: |
-      Structure: [ val(meta), path(trim_reads_fail) ]
-      Reads the failed the preprocessing
+      type: file
+      description: |
+        Structure: [ val(meta), path(trim_reads_fail) ]
+        Reads the failed the preprocessing
   - trim_reads_merged:
-    type: file
-    description: |
-      Structure: [ val(meta), path(trim_reads_merged) ]
-      Reads that were successfully merged
+      type: file
+      description: |
+        Structure: [ val(meta), path(trim_reads_merged) ]
+        Reads that were successfully merged
 
   - fastqc_raw_html:
-    type: file
-    description: |
-      Structure: [ val(meta), path(fastqc_raw_html) ]
-      Raw fastQC report
+      type: file
+      description: |
+        Structure: [ val(meta), path(fastqc_raw_html) ]
+        Raw fastQC report
   - fastqc_raw_zip:
-    type: file
-    description: |
-      Structure: [ val(meta), path(fastqc_raw_zip) ]
-      Raw fastQC report archive
+      type: file
+      description: |
+        Structure: [ val(meta), path(fastqc_raw_zip) ]
+        Raw fastQC report archive
   - fastqc_trim_html:
-    type: file
-    description: |
-      Structure: [ val(meta), path(fastqc_trim_html) ]
-      Trimmed fastQC report
+      type: file
+      description: |
+        Structure: [ val(meta), path(fastqc_trim_html) ]
+        Trimmed fastQC report
   - fastqc_trim_zip:
-    type: file
-    description: |
-      Structure: [ val(meta), path(fastqc_trim_zip) ]
-      Trimmed fastQC report archive
+      type: file
+      description: |
+        Structure: [ val(meta), path(fastqc_trim_zip) ]
+        Trimmed fastQC report archive
   - versions:
       type: file
       description: File containing software versions

--- a/subworkflows/nf-core/gatk_tumor_only_somatic_variant_calling/meta.yml
+++ b/subworkflows/nf-core/gatk_tumor_only_somatic_variant_calling/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: gatk_tumor_only_somatic_variant_calling
 description: |
   Perform variant calling on a single tumor sample using mutect2 tumor only mode.

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep/meta.yml
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: vcf_annotate_ensemblvep
 description: Perform annotation with ensemblvep and bgzip + tabix index the resulting VCF file
 keywords:

--- a/subworkflows/nf-core/vcf_annotate_snpeff/meta.yml
+++ b/subworkflows/nf-core/vcf_annotate_snpeff/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: vcf_annotate_snpeff
 description: Perform annotation with snpEff and bgzip + tabix index the resulting VCF file
 keywords:

--- a/subworkflows/nf-core/vcf_extract_relate_somalier/meta.yml
+++ b/subworkflows/nf-core/vcf_extract_relate_somalier/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "vcf_extract_relate_somalier"
 description: Perform somalier extraction and relate stats on input VCFs
 keywords:

--- a/subworkflows/nf-core/vcf_gather_bcftools/meta.yml
+++ b/subworkflows/nf-core/vcf_gather_bcftools/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "vcf_gather_bcftools"
 description: |
   Concatenate several VCF files using bcftools concat.

--- a/subworkflows/nf-core/vcf_impute_glimpse/meta.yml
+++ b/subworkflows/nf-core/vcf_impute_glimpse/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "vcf_imputation_glimpse"
 description: Impute VCF/BCF files with Glimpse
 keywords:

--- a/subworkflows/nf-core/vcf_phase_shapeit5/meta.yml
+++ b/subworkflows/nf-core/vcf_phase_shapeit5/meta.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://github.com/nf-core/modules/tree/master/subworkflows/yaml-schema.json
 name: "vcf_phase_shapeit5"
 description: Phase vcf panel with Shapeit5 tools
 keywords:

--- a/subworkflows/yaml-schema.json
+++ b/subworkflows/yaml-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
     "title": "Meta yaml",
-    "description": "Validate the meta yaml file for an nf-core module or subworkflow",
+    "description": "Validate the meta yaml file for an nf-core subworkflow",
     "type": "object",
     "properties": {
         "name": {

--- a/subworkflows/yaml-schema.json
+++ b/subworkflows/yaml-schema.json
@@ -54,6 +54,18 @@
                             "pattern": {
                                 "type": "string",
                                 "description": "Pattern of the input channel, given in Java glob syntax"
+                            },
+                            "default": {
+                                "type": ["string", "number", "boolean", "array", "object"],
+                                "description": "Default value for the input channel"
+                            },
+                            "enum": {
+                                "type": "array",
+                                "description": "List of allowed values for the input channel",
+                                "items": {
+                                    "type": ["string", "number", "boolean", "array", "object"]
+                                },
+                                "uniqueItems": true
                             }
                         },
                         "required": ["description"]
@@ -81,6 +93,14 @@
                             "pattern": {
                                 "type": "string",
                                 "description": "Pattern of the input channel, given in Java glob syntax"
+                            },
+                            "enum": {
+                                "type": "array",
+                                "description": "List of allowed values for the output channel",
+                                "items": {
+                                    "type": ["string", "number", "boolean", "array", "object"]
+                                },
+                                "uniqueItems": true
                             }
                         },
                         "required": ["description"]

--- a/subworkflows/yaml-schema.json
+++ b/subworkflows/yaml-schema.json
@@ -1,0 +1,93 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "title": "Meta yaml",
+    "description": "Validate the meta yaml file for an nf-core module or subworkflow",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the subworkflow"
+        },
+        "description": {
+            "type": "string",
+            "description": "Description of the subworkflow"
+        },
+        "authors": {
+            "type": "array",
+            "description": "Authors of the subworkflow",
+            "items": {
+                "type": "string"
+            }
+        },
+        "modules": {
+            "type": "array",
+            "description": "Modules used in the subworkflow",
+            "items": {
+                "type": "string"
+            }
+        },
+        "keywords": {
+            "type": "array",
+            "description": "Keywords for the module",
+            "items": {
+                "type": "string"
+            },
+            "minItems": 3
+        },
+        "input": {
+            "type": "array",
+            "description": "Input channels for the subworkflow",
+            "items": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the input channel"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the input channel"
+                            },
+                            "pattern": {
+                                "type": "string",
+                                "description": "Pattern of the input channel, given in Java glob syntax"
+                            }
+                        },
+                        "required": ["description"]
+                    }
+                }
+            }
+        },
+        "output": {
+            "type": "array",
+            "description": "Output channels for the subworkflow",
+            "items": {
+                "type": "object",
+                "patternProperties": {
+                    ".*": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the output channel"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Description of the output channel"
+                            },
+                            "pattern": {
+                                "type": "string",
+                                "description": "Pattern of the input channel, given in Java glob syntax"
+                            }
+                        },
+                        "required": ["description"]
+                    }
+                }
+            }
+        }
+    },
+    "required": ["name", "description", "keywords", "authors", "output", "modules"]
+}


### PR DESCRIPTION
Yet another json schema, this time for subworkflows (needed so they are all nicely rendered on the website).
In order for the two schemas to behave nicely, I had to split them into two files and put them into the respective subfolders. It is very similar to the schema for modules, biggest difference is that I don't require types for the input and output, because it felt like 90% was some kind of `map` (you can still give them and they will be rendered on the homepage).

I fixed the broken meta.yaml according to  this new rules.

I also added the hint for the yaml-language server, to nicely show the problems already in the editor (thanks @Emiller88 for pointing this out)