### PR TITLE
Make MAD plots optional in shinyngs

### DIFF
--- a/modules/nf-core/shinyngs/app/meta.yml
+++ b/modules/nf-core/shinyngs/app/meta.yml
@@ -34,7 +34,7 @@ input:
       description: |
         TSV-format feature (e.g. gene) metadata
   - assay_files:
-      type: list
+      type: file
       description: |
         List of TSV-format matrix files representing different measures for the same samples (e.g. raw and normalised).
   - contrasts:
@@ -42,7 +42,7 @@ input:
       description: |
         CSV-format file with four columns identifying the sample sheet variable, reference level, treatment level, and optionally a comma-separated list of covariates used as blocking factors.
   - differential_results:
-      type: list
+      type: file
       description: |
         List of TSV-format differential analysis outputs, one per row of the contrasts file
 

--- a/modules/nf-core/shinyngs/staticdifferential/meta.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/meta.yml
@@ -27,7 +27,7 @@ input:
         features and samples, at a minimum an id.
         e.g. [ id:'test' ]
   - differential_results:
-      type: list
+      type: file
       description: |
         CSV or TSV-format tabular file with differential analysis outputs
   - sample:
@@ -39,7 +39,7 @@ input:
       description: |
         CSV or TSV-format feature (e.g. gene) metadata
   - assay_file:
-      type: list
+      type: file
       description: |
         CSV or TSV matrix file to use alongside differential statistics in
         interpretation. Usually a normalised form.

--- a/modules/nf-core/shinyngs/staticdifferential/meta.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/meta.yml
@@ -50,11 +50,16 @@ output:
       description: |
         Groovy Map containing contrast information
         e.g. [ variable:'treatment', reference:'treated', control:'saline', blocking:'' ]
-  - volcanos:
-      type: tuple
+  - volcanos_png:
+      type: file
       description: |
-        Meta-keyed tuple containing a PNG and HTML plot for a volcano plot
-        built from the differential result table.
+        Meta-keyed tuple containing a PNG output for a volcano plot built from
+        the differential result table.
+  - volcanos_html:
+      type: file
+      description: |
+        Meta-keyed tuple containing an HTML output for a volcano plot built
+        from the differential result table.
   - versions:
       type: file
       description: File containing software versions

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -19,7 +19,7 @@ process SHINYNGS_STATICEXPLORATORY {
     tuple val(meta), path("*/html/pca2d.html")                  , emit: pca2d_html, optional: true
     tuple val(meta), path("*/png/pca3d.png")                    , emit: pca3d_png
     tuple val(meta), path("*/html/pca3d.html")                  , emit: pca3d_html, optional: true
-    tuple val(meta), path("*/png/mad_correlation.png")          , emit: mad_png
+    tuple val(meta), path("*/png/mad_correlation.png")          , emit: mad_png, optional: true
     tuple val(meta), path("*/html/mad_correlation.html")        , emit: mad_html, optional: true
     tuple val(meta), path("*/png/sample_dendrogram.png")        , emit: dendro
     path "versions.yml"                                         , emit: versions

--- a/modules/nf-core/shinyngs/staticexploratory/meta.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/meta.yml
@@ -34,34 +34,58 @@ input:
       description: |
         List of TSV-format matrix files representing different measures for the same samples (e.g. raw and normalised).
 output:
-  - boxplots:
+  - boxplots_png:
       type: file
       description: |
-        Meta-keyed tuple containing a PNG and HTML output for box plots
+        Meta-keyed tuple containing PNG output for box plots covering input
+        matrices.
+  - boxplots_html:
+      type: file
+      description: |
+        Meta-keyed tuple containing HTML output for box plots covering input
+        matrices.
+  - densities_png:
+      type: file
+      description: |
+        Meta-keyed tuple containing PNG output for density plots
         covering input matrices.
-  - densities:
+  - densities_html:
       type: file
       description: |
-        Meta-keyed tuple containing a PNG and HTML output for density plots
+        Meta-keyed tuple containing HTML output for density plots
         covering input matrices.
-  - pca2d:
+  - pca2d_png:
       type: file
       description: |
-        Meta-keyed tuple containing a PNG and HTML plot for 2D PCA plots
+        Meta-keyed tuple containing a PNG output for 2D PCA plots covering
+        specified input matrix (by default the last one in the input list.
+  - pca2d_html:
+      type: file
+      description: |
+        Meta-keyed tuple containing an HTML output for 2D PCA plots covering
+        specified input matrix (by default the last one in the input list.
+  - pca3d_png:
+      type: file
+      description: |
+        Meta-keyed tuple containing a PNG output for 3D PCA plots covering
+        specified input matrix (by default the last one in the input list.
+  - pca3d_html:
+      type: file
+      description: |
+        Meta-keyed tuple containing an HTML output for 3D PCA plots covering
+        specified input matrix (by default the last one in the input list.
+  - mad_png:
+      type: file
+      description: |
+        Meta-keyed tuple containing a PNG output for MAD correlation plots
         covering specified input matrix (by default the last one in the input
         list.
-  - pca3d:
+  - mad_dendro:
       type: file
       description: |
-        Meta-keyed tuple containing a PNG and HTML plot for 3D PCA plots
+        Meta-keyed tuple containing an HTML output for MAD correlation plots
         covering specified input matrix (by default the last one in the input
         list.
-  - mad:
-      type: file
-      description: |
-        Meta-keyed tuple containing a PNG and  HTML plot for MAD correlation
-        plots covering specified input matrix (by default the last one in the
-        input list.
   - dendro:
       type: file
       description: |

--- a/modules/nf-core/shinyngs/staticexploratory/meta.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/meta.yml
@@ -30,7 +30,7 @@ input:
       description: |
         TSV-format feature (e.g. gene) metadata
   - assay_files:
-      type: list
+      type: file
       description: |
         List of TSV-format matrix files representing different measures for the same samples (e.g. raw and normalised).
 output:

--- a/modules/nf-core/shinyngs/staticexploratory/meta.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/meta.yml
@@ -35,35 +35,35 @@ input:
         List of TSV-format matrix files representing different measures for the same samples (e.g. raw and normalised).
 output:
   - boxplots:
-      type: tuple
+      type: file
       description: |
         Meta-keyed tuple containing a PNG and HTML output for box plots
         covering input matrices.
   - densities:
-      type: tuple
+      type: file
       description: |
         Meta-keyed tuple containing a PNG and HTML output for density plots
         covering input matrices.
   - pca2d:
-      type: tuple
+      type: file
       description: |
         Meta-keyed tuple containing a PNG and HTML plot for 2D PCA plots
         covering specified input matrix (by default the last one in the input
         list.
   - pca3d:
-      type: tuple
+      type: file
       description: |
         Meta-keyed tuple containing a PNG and HTML plot for 3D PCA plots
         covering specified input matrix (by default the last one in the input
         list.
   - mad:
-      type: tuple
+      type: file
       description: |
         Meta-keyed tuple containing a PNG and  HTML plot for MAD correlation
         plots covering specified input matrix (by default the last one in the
         input list.
   - dendro:
-      type: tuple
+      type: file
       description: |
         Meta-keyed tuple containing a PNG, for a sample clustering
         dendrogramcovering specified input matrix (by default the last one in

--- a/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
@@ -3,6 +3,9 @@ description: validate consistency of feature and sample annotations with matrice
 
 keywords:
   - expression
+  - features
+  - observations
+  - validation
 
 tools:
   - "shinyngs":

--- a/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
@@ -42,7 +42,7 @@ input:
       description: |
         TSV-format feature (e.g. gene) metadata
   - assay_files:
-      type: list
+      type: file
       description: |
         List of TSV-format matrix files representing different measures for the same samples (e.g. raw and normalised).
   - contrasts:


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

In recent updates, Shinyngs will not attempt to output MAD plots for outlier detection if the replication number are too low (< 3). So the outputs need to be optional. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
