### PR TITLE
Sentieon docker image

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -107,14 +107,6 @@ jobs:
           - profile: "conda"
             tags: scimap/mcmicro
           - profile: "conda"
-            tags: sentieon/bwaindex
-          - profile: "conda"
-            tags: sentieon/bwamem
-          - profile: "conda"
-            tags: sentieon/dedup
-          - profile: "conda"
-            tags: sentieon/haplotyper
-          - profile: "conda"
             tags: universc
           - profile: "singularity"
             tags: universc

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -110,6 +110,14 @@ jobs:
             tags: universc
           - profile: "singularity"
             tags: universc
+          - profile: "singularity"
+            tags: sentieon/bwaindex
+          - profile: "singularity"
+            tags: sentieon/bwamem
+          - profile: "singularity"
+            tags: sentieon/dedup
+          - profile: "singularity"
+            tags: sentieon/haplotyper
           - profile: "conda"
             tags: subworkflows/bcl_demultiplex
           - profile: "conda"

--- a/modules/nf-core/sentieon/bwaindex/main.nf
+++ b/modules/nf-core/sentieon/bwaindex/main.nf
@@ -3,12 +3,10 @@ process SENTIEON_BWAINDEX {
     label 'process_high'
     label 'sentieon'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "Sentieon modules does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
-    container 'nfcore/sentieon:202112.06'
+    conda "bioconda::sentieon=202112.06"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sentieon:202112.06--h5b5514e_1' :
+        'quay.io/biocontainers/sentieon:202112.06--h5b5514e_1' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/sentieon/bwamem/main.nf
+++ b/modules/nf-core/sentieon/bwamem/main.nf
@@ -5,12 +5,10 @@ process SENTIEON_BWAMEM {
 
     secret 'SENTIEON_LICENSE_BASE64'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "Sentieon modules does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
-    container 'nfcore/sentieon:202112.06'
+    conda "bioconda::sentieon=202112.06"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sentieon:202112.06--h5b5514e_1' :
+        'quay.io/biocontainers/sentieon:202112.06--h5b5514e_1' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/sentieon/bwamem/meta.yml
+++ b/modules/nf-core/sentieon/bwamem/meta.yml
@@ -15,6 +15,7 @@ tools:
         Our software improves upon BWA, STAR, Minimap2, GATK, HaplotypeCaller, Mutect, and Mutect2 based pipelines and is deployable on any generic-CPU-based computing system.
       homepage: https://www.sentieon.com/
       documentation: https://www.sentieon.com/
+
 input:
   - meta:
       type: map
@@ -41,6 +42,7 @@ input:
       type: file
       description: The index of the FASTA reference.
       pattern: "*.fai"
+
 output:
   - meta:
       type: map
@@ -52,11 +54,13 @@ output:
       description: BAM file.
       pattern: "*.bam"
   - bai:
+      type: file
       description: BAI file
       pattern: "*.bai"
   - versions:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
+
 authors:
   - "@asp8200"

--- a/modules/nf-core/sentieon/dedup/main.nf
+++ b/modules/nf-core/sentieon/dedup/main.nf
@@ -4,7 +4,7 @@ process SENTIEON_DEDUP {
     label 'sentieon'
 
     secret 'SENTIEON_LICENSE_BASE64'
-    
+
     conda "bioconda::sentieon=202112.06"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/sentieon:202112.06--h5b5514e_1' :

--- a/modules/nf-core/sentieon/dedup/main.nf
+++ b/modules/nf-core/sentieon/dedup/main.nf
@@ -4,13 +4,11 @@ process SENTIEON_DEDUP {
     label 'sentieon'
 
     secret 'SENTIEON_LICENSE_BASE64'
-
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "Sentieon modules does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
-    container 'nfcore/sentieon:202112.06'
+    
+    conda "bioconda::sentieon=202112.06"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sentieon:202112.06--h5b5514e_1' :
+        'quay.io/biocontainers/sentieon:202112.06--h5b5514e_1' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/sentieon/dedup/meta.yml
+++ b/modules/nf-core/sentieon/dedup/meta.yml
@@ -14,6 +14,7 @@ tools:
         Our software improves upon BWA, STAR, Minimap2, GATK, HaplotypeCaller, Mutect, and Mutect2 based pipelines and is deployable on any generic-CPU-based computing system.
       homepage: https://www.sentieon.com/
       documentation: https://www.sentieon.com/
+
 input:
   - meta:
       type: map
@@ -25,6 +26,7 @@ input:
       description: BAM file.
       pattern: "*.bam"
   - bai:
+      type: file
       description: BAI file
       pattern: "*.bai"
   - fasta:
@@ -35,6 +37,7 @@ input:
       type: file
       description: The index of the FASTA reference.
       pattern: "*.fai"
+
 output:
   - meta:
       type: map
@@ -54,6 +57,7 @@ output:
       description: BAM file.
       pattern: "*.bam"
   - bai:
+      type: file
       description: BAI file
       pattern: "*.bai"
   - score:
@@ -68,5 +72,6 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
+
 authors:
   - "@asp8200"

--- a/modules/nf-core/sentieon/haplotyper/main.nf
+++ b/modules/nf-core/sentieon/haplotyper/main.nf
@@ -5,12 +5,10 @@ process SENTIEON_HAPLOTYPER {
 
     secret 'SENTIEON_LICENSE_BASE64'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "Sentieon modules does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
-    container 'nfcore/sentieon:202112.06'
+    conda "bioconda::sentieon=202112.06"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sentieon:202112.06--h5b5514e_1' :
+        'quay.io/biocontainers/sentieon:202112.06--h5b5514e_1' }"
 
     input:
     val(emit_mode)

--- a/tests/modules/nf-core/sentieon/dedup/test.yml
+++ b/tests/modules/nf-core/sentieon/dedup/test.yml
@@ -5,11 +5,11 @@
     - sentieon/dedup
   files:
     - path: ./output/sentieon/test.cram
-      md5sum: 22e6ed2be1f2a1725d27f0c9c8e20f37
+      md5sum: 5045e22db0fd1c69731466748020947e
     - path: ./output/sentieon/test.cram.crai
-      md5sum: 99594ee9725d4cc2023ecbbd7d5b8e05
+      md5sum: ed8b18e2221ff35e761eccba4b62cb44
     - path: ./output/sentieon/test.cram.metrics
-      md5sum: b9026573bc740e93d8d6a2186010eb34
+      md5sum: c64e371590f96d5bd2d60cbd533cec02
     - path: ./output/sentieon/test.score
       md5sum: 4a36fe59dc6865cd5ee9e7ecd936106e
     - path: ./output/sentieon/versions.yml
@@ -20,11 +20,11 @@
     - sentieon/dedup
   files:
     - path: ./output/sentieon/test.cram
-      md5sum: 2aeaf710f5d7d5057cd2e40b0cb16a21
+      md5sum: 7367ed6a7e32f05fd8ad408c003cd4e9
     - path: ./output/sentieon/test.cram.crai
-      md5sum: 8273946b2eb2fe4410657496afd719e2
+      md5sum: 4ed9a4d82c3d4f989591fff2a4a13c6b
     - path: ./output/sentieon/test.cram.metrics
-      md5sum: 8608759432f5d91819f199a76d00703d
+      md5sum: dfa078a95f53941eab5c06e023989c0d
     - path: ./output/sentieon/test.score
       md5sum: 4a36fe59dc6865cd5ee9e7ecd936106e
     - path: ./output/sentieon/versions.yml

--- a/tests/modules/nf-core/sentieon/dedup/test.yml
+++ b/tests/modules/nf-core/sentieon/dedup/test.yml
@@ -5,14 +5,12 @@
     - sentieon/dedup
   files:
     - path: ./output/sentieon/test.cram
-      md5sum: 5045e22db0fd1c69731466748020947e
     - path: ./output/sentieon/test.cram.crai
-      md5sum: ed8b18e2221ff35e761eccba4b62cb44
     - path: ./output/sentieon/test.cram.metrics
-      md5sum: c64e371590f96d5bd2d60cbd533cec02
     - path: ./output/sentieon/test.score
       md5sum: 4a36fe59dc6865cd5ee9e7ecd936106e
     - path: ./output/sentieon/versions.yml
+
 - name: sentieon test_dedup_remove_duplicate_reads
   command: nextflow run ./tests/modules/nf-core/sentieon/dedup -entry test_dedup_remove_duplicate_reads -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/sentieon/dedup/nextflow.config
   tags:
@@ -20,11 +18,8 @@
     - sentieon/dedup
   files:
     - path: ./output/sentieon/test.cram
-      md5sum: 7367ed6a7e32f05fd8ad408c003cd4e9
     - path: ./output/sentieon/test.cram.crai
-      md5sum: 4ed9a4d82c3d4f989591fff2a4a13c6b
     - path: ./output/sentieon/test.cram.metrics
-      md5sum: dfa078a95f53941eab5c06e023989c0d
     - path: ./output/sentieon/test.score
       md5sum: 4a36fe59dc6865cd5ee9e7ecd936106e
     - path: ./output/sentieon/versions.yml


### PR DESCRIPTION
Replace Sentieon Docker image with one from Quay.io

There might be a good reason for not using quay.io, but it's worth a try.

- Turns off Singularity tests because they don't work because of LD_PRELOAD (not sure why not) but Conda and Docker seem to work.