### PR TITLE
Add space to fix singularity download error on shinyngs modules

### DIFF
--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -15,7 +15,7 @@ process SHINYNGS_APP {
 
     conda "bioconda::r-shinyngs=1.7.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0':
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0' :
         'quay.io/biocontainers/r-shinyngs:1.7.2--r42hdfd78af_0' }"
 
     input:

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -4,7 +4,7 @@ process SHINYNGS_STATICDIFFERENTIAL {
 
     conda "bioconda::r-shinyngs=1.7.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0':
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0' :
         'quay.io/biocontainers/r-shinyngs:1.7.2--r42hdfd78af_0' }"
 
     input:

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -4,7 +4,7 @@ process SHINYNGS_STATICEXPLORATORY {
 
     conda "bioconda::r-shinyngs=1.7.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0':
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0' :
         'quay.io/biocontainers/r-shinyngs:1.7.2--r42hdfd78af_0' }"
 
     input:

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -4,7 +4,7 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
 
     conda "bioconda::r-shinyngs=1.7.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0':
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0' :
         'quay.io/biocontainers/r-shinyngs:1.7.2--r42hdfd78af_0' }"
 
     input:


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

Adds a missing space to address issues with `nf-core download` associated with these modules. 

## PR checklist

Working to address https://github.com/nf-core/differentialabundance/issues/122

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
