### PR TITLE
MultiQC does not use quay.io prefix in container specification

### DIFF
--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -4,7 +4,7 @@ process MULTIQC {
     conda "bioconda::multiqc=1.14"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/multiqc:1.14--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0' }"
+        'biocontainers/multiqc:1.14--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"


### PR DESCRIPTION
A little canary check for multiqc to confirm everything is working.
