### PR TITLE
Use nf-core quay.io for ubuntu image

### DIFF
--- a/modules/nf-core/cat/fastq/main.nf
+++ b/modules/nf-core/cat/fastq/main.nf
@@ -5,7 +5,7 @@ process CAT_FASTQ {
     conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(reads, stageAs: "input*/*")

--- a/modules/nf-core/custom/tabulartogseacls/main.nf
+++ b/modules/nf-core/custom/tabulartogseacls/main.nf
@@ -5,7 +5,7 @@ process CUSTOM_TABULARTOGSEACLS {
     conda "conda-forge::coreutils=9.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(samples)

--- a/modules/nf-core/custom/tabulartogseagct/main.nf
+++ b/modules/nf-core/custom/tabulartogseagct/main.nf
@@ -5,7 +5,7 @@ process CUSTOM_TABULARTOGSEAGCT {
     conda "conda-forge::coreutils=9.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(tabular)

--- a/modules/nf-core/gunzip/main.nf
+++ b/modules/nf-core/gunzip/main.nf
@@ -5,7 +5,7 @@ process GUNZIP {
     conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(archive)

--- a/modules/nf-core/igv/js/main.nf
+++ b/modules/nf-core/igv/js/main.nf
@@ -6,7 +6,7 @@ process IGV_JS {
     conda "conda-forge::sed=4.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(alignment), path(index)

--- a/modules/nf-core/md5sum/main.nf
+++ b/modules/nf-core/md5sum/main.nf
@@ -5,7 +5,7 @@ process MD5SUM {
     conda "conda-forge::coreutils=9.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(file)

--- a/modules/nf-core/shasum/main.nf
+++ b/modules/nf-core/shasum/main.nf
@@ -5,7 +5,7 @@ process SHASUM {
     conda "conda-forge::coreutils=9.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(file)

--- a/modules/nf-core/untar/main.nf
+++ b/modules/nf-core/untar/main.nf
@@ -5,7 +5,7 @@ process UNTAR {
     conda "conda-forge::sed=4.7 bioconda::grep=3.4 conda-forge::tar=1.34"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(archive)

--- a/modules/nf-core/untarfiles/main.nf
+++ b/modules/nf-core/untarfiles/main.nf
@@ -5,7 +5,7 @@ process UNTARFILES {
     conda "conda-forge::sed=4.7 bioconda::grep=3.4 conda-forge::tar=1.34"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
-        'docker.io/library/ubuntu:20.04' }"
+        'nf-core/ubuntu:20.04' }"
 
     input:
     tuple val(meta), path(archive)


### PR DESCRIPTION
Given the recent changes in https://github.com/nf-core/modules/pull/3380 and in nf-core/tools v.2.8 where we specify a default registry to `quay.io`, I have now created a mirror of the ubuntu base image in the nf-core quay.io account:
https://quay.io/repository/nf-core/ubuntu?tab=tags

This will make it easier to override `docker.registry` for all containers in the pipeline if we can slowly transition to copying all active containers in use on the nf-core Dockerhub account to quay.io instead.