### PR TITLE
Remove quay.io prefix from mulled containers

### DIFF
--- a/modules/nf-core/ascat/main.nf
+++ b/modules/nf-core/ascat/main.nf
@@ -5,7 +5,7 @@ process ASCAT {
     conda "bioconda::ascat=3.1.1 bioconda::cancerit-allelecount=4.3.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-c278c7398beb73294d78639a864352abef2931ce:ba3e6d2157eac2d38d22e62ec87675e12adb1010-0':
-        'quay.io/biocontainers/mulled-v2-c278c7398beb73294d78639a864352abef2931ce:ba3e6d2157eac2d38d22e62ec87675e12adb1010-0' }"
+        'biocontainers/mulled-v2-c278c7398beb73294d78639a864352abef2931ce:ba3e6d2157eac2d38d22e62ec87675e12adb1010-0' }"
 
     input:
     tuple val(meta), path(input_normal), path(index_normal), path(input_tumor), path(index_tumor)

--- a/modules/nf-core/bbmap/align/main.nf
+++ b/modules/nf-core/bbmap/align/main.nf
@@ -5,7 +5,7 @@ process BBMAP_ALIGN {
     conda "bioconda::bbmap=39.01 bioconda::samtools=1.16.1 pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0' :
-        'quay.io/biocontainers/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0' }"
+        'biocontainers/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0' }"
 
     input:
     tuple val(meta), path(fastq)

--- a/modules/nf-core/bbmap/bbnorm/main.nf
+++ b/modules/nf-core/bbmap/bbnorm/main.nf
@@ -5,7 +5,7 @@ process BBMAP_BBNORM {
     conda "bioconda::bbmap=39.01 pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0':
-        'quay.io/biocontainers/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0' }"
+        'biocontainers/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0' }"
 
     input:
     tuple val(meta), path(fastq)

--- a/modules/nf-core/bbmap/bbnorm/meta.yml
+++ b/modules/nf-core/bbmap/bbnorm/meta.yml
@@ -1,16 +1,15 @@
-name: "bbmap_bbnorm"
+name: bbmap_bbnorm
 description: BBNorm is designed to normalize coverage by down-sampling reads over high-depth areas of a genome, to result in a flat coverage distribution.
 keywords:
   - normalization
   - assembly
-
+  - coverage
 tools:
-  - "bbmap":
+  - bbmap:
       description: "BBMap is a short read aligner, as well as various other bioinformatic tools."
       homepage: "https://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/"
       documentation: "https://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/"
       tool_dev_url: "https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/bbnorm-guide/"
-      doi: ""
       licence: "BBMap - Bushnell B. - sourceforge.net/projects/bbmap/"
 
 input:

--- a/modules/nf-core/bbmap/pileup/main.nf
+++ b/modules/nf-core/bbmap/pileup/main.nf
@@ -5,7 +5,7 @@ process BBMAP_PILEUP {
     conda "bioconda::bbmap=39.01 bioconda::samtools=1.16.1 pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0' :
-        'quay.io/biocontainers/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0' }"
+        'biocontainers/mulled-v2-008daec56b7aaf3f162d7866758142b9f889d690:e8a286b2e789c091bac0a57302cdc78aa0112353-0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/biscuit/align/main.nf
+++ b/modules/nf-core/biscuit/align/main.nf
@@ -5,7 +5,7 @@ process BISCUIT_ALIGN {
     conda "bioconda::biscuit=1.1.0.20220707 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0':
-        'quay.io/biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
+        'biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/biscuit/align/meta.yml
+++ b/modules/nf-core/biscuit/align/meta.yml
@@ -29,7 +29,7 @@ input:
         List of input fastq files of size 1 and 2 for single-end and paired-end data,
         respectively.
   - index:
-      type: dir
+      type: directory
       description: Biscuit genome index directory (generated with 'biscuit index')
       pattern: "BiscuitIndex"
 

--- a/modules/nf-core/biscuit/biscuitblaster/main.nf
+++ b/modules/nf-core/biscuit/biscuitblaster/main.nf
@@ -5,7 +5,7 @@ process BISCUIT_BLASTER {
     conda "bioconda::biscuit=1.1.0.20220707 bioconda::samblaster=0.1.26 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0':
-        'quay.io/biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
+        'biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/biscuit/biscuitblaster/meta.yml
+++ b/modules/nf-core/biscuit/biscuitblaster/meta.yml
@@ -51,7 +51,7 @@ input:
         List of input fastq files of size 1 and 2 for single-end and paired-end data,
         respectively.
   - index:
-      type: dir
+      type: directory
       description: Biscuit genome index directory (generated with 'biscuit index')
       pattern: "BiscuitIndex"
 

--- a/modules/nf-core/biscuit/epiread/main.nf
+++ b/modules/nf-core/biscuit/epiread/main.nf
@@ -5,7 +5,7 @@ process BISCUIT_EPIREAD {
     conda "bioconda::biscuit=1.1.0.20220707 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0':
-        'quay.io/biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
+        'biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
 
     input:
     tuple val(meta), path(bam), path(bai), path(snp_bed)

--- a/modules/nf-core/biscuit/epiread/meta.yml
+++ b/modules/nf-core/biscuit/epiread/meta.yml
@@ -35,7 +35,7 @@ input:
       type: file
       description: BED file containing SNP information (optional)
   - index:
-      type: dir
+      type: directory
       description: Biscuit genome index directory (generated with 'biscuit index')
       pattern: "BiscuitIndex"
 

--- a/modules/nf-core/biscuit/mergecg/main.nf
+++ b/modules/nf-core/biscuit/mergecg/main.nf
@@ -5,7 +5,7 @@ process BISCUIT_MERGECG {
     conda "bioconda::biscuit=1.1.0.20220707 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0':
-        'quay.io/biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
+        'biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
 
 
     input:

--- a/modules/nf-core/biscuit/mergecg/meta.yml
+++ b/modules/nf-core/biscuit/mergecg/meta.yml
@@ -28,7 +28,7 @@ input:
       description: |
         Biscuit BED file (output of biscuit vcf2bed)
   - index:
-      type: dir
+      type: directory
       description: Biscuit genome index directory (generated with 'biscuit index')
       pattern: "BiscuitIndex"
 

--- a/modules/nf-core/biscuit/pileup/main.nf
+++ b/modules/nf-core/biscuit/pileup/main.nf
@@ -5,7 +5,7 @@ process BISCUIT_PILEUP {
     conda "bioconda::biscuit=1.1.0.20220707 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0':
-        'quay.io/biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
+        'biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
 
     input:
     tuple val(meta), path(normal_bams), path(normal_bais), path(tumor_bam), path(tumor_bai)

--- a/modules/nf-core/biscuit/pileup/meta.yml
+++ b/modules/nf-core/biscuit/pileup/meta.yml
@@ -25,29 +25,29 @@ input:
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
   - normal_bams:
-      type: file(s)
+      type: file
       description: |
         BAM files to be analyzed. If no tumor_bam file is provided, any number of "normal" BAMs may be provided
         ("normal" here is just a semantic issue, these BAMs could be from tumor or any other kind of tissue). If a
         tumor BAM file is provided, exactly one normal (germline) BAM must be provided.
       pattern: "*.{bam}"
   - normal_bais:
-      type: file(s)
+      type: file
       description: BAM index file or files corresponding to the provided normal_bams
       pattern: "*.{bai}"
   - tumor_bam:
-      type: file(s)
+      type: file
       description: |
         Optional. If a tumor BAM file is provided, pileup will run in "somatic" mode and will annotate variants with
         their somatic state (present in tumor only, present in normal only, present in both, etc). Note that if a
         tumor BAM file is provided, exactly one normal BAM must be provided.
       pattern: "*.{bam}"
   - tumor_bai:
-      type: file(s)
+      type: file
       description: Optional. BAM index file corresponding to provided tumor_bam
       pattern: "*.{bai}"
   - index:
-      type: dir
+      type: directory
       description: Biscuit genome index directory (generated with 'biscuit index')
       pattern: "BiscuitIndex"
 

--- a/modules/nf-core/biscuit/vcf2bed/main.nf
+++ b/modules/nf-core/biscuit/vcf2bed/main.nf
@@ -5,7 +5,7 @@ process BISCUIT_VCF2BED {
     conda "bioconda::biscuit=1.1.0.20220707 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0':
-        'quay.io/biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
+        'biocontainers/mulled-v2-d94f582b04a3edcede1215189c0d881506640fd9:6519548ea4f3d6a526c78ad0350c58f867f28574-0' }"
 
     input:
     tuple val(meta), path(vcf)

--- a/modules/nf-core/bowtie/align/main.nf
+++ b/modules/nf-core/bowtie/align/main.nf
@@ -5,7 +5,7 @@ process BOWTIE_ALIGN {
     conda "bioconda::bowtie=1.3.0 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:c84c7c55c45af231883d9ff4fe706ac44c479c36-0' :
-        'quay.io/biocontainers/mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:c84c7c55c45af231883d9ff4fe706ac44c479c36-0' }"
+        'biocontainers/mulled-v2-ffbf83a6b0ab6ec567a336cf349b80637135bca3:c84c7c55c45af231883d9ff4fe706ac44c479c36-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -5,7 +5,7 @@ process BOWTIE2_ALIGN {
     conda "bioconda::bowtie2=2.4.4 bioconda::samtools=1.16.1 conda-forge::pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-ac74a7f02cebcfcc07d8e8d1d750af9c83b4d45a:a0ffedb52808e102887f6ce600d092675bf3528a-0' :
-        'quay.io/biocontainers/mulled-v2-ac74a7f02cebcfcc07d8e8d1d750af9c83b4d45a:a0ffedb52808e102887f6ce600d092675bf3528a-0' }"
+        'biocontainers/mulled-v2-ac74a7f02cebcfcc07d8e8d1d750af9c83b4d45a:a0ffedb52808e102887f6ce600d092675bf3528a-0' }"
 
     input:
     tuple val(meta) , path(reads)

--- a/modules/nf-core/bwa/mem/main.nf
+++ b/modules/nf-core/bwa/mem/main.nf
@@ -5,7 +5,7 @@ process BWA_MEM {
     conda "bioconda::bwa=0.7.17 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' :
-        'quay.io/biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' }"
+        'biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/bwa/sampe/main.nf
+++ b/modules/nf-core/bwa/sampe/main.nf
@@ -5,7 +5,7 @@ process BWA_SAMPE {
     conda "bioconda::bwa=0.7.17 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' :
-        'quay.io/biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' }"
+        'biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' }"
 
     input:
     tuple val(meta), path(reads), path(sai)

--- a/modules/nf-core/bwa/samse/main.nf
+++ b/modules/nf-core/bwa/samse/main.nf
@@ -5,7 +5,7 @@ process BWA_SAMSE {
     conda "bioconda::bwa=0.7.17 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' :
-        'quay.io/biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' }"
+        'biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:219b6c272b25e7e642ae3ff0bf0c5c81a5135ab4-0' }"
 
     input:
     tuple val(meta), path(reads), path(sai)

--- a/modules/nf-core/bwamem2/mem/main.nf
+++ b/modules/nf-core/bwamem2/mem/main.nf
@@ -5,7 +5,7 @@ process BWAMEM2_MEM {
     conda "bioconda::bwa-mem2=2.2.1 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2cdf6bf1e92acbeb9b2834b1c58754167173a410-0' :
-        'quay.io/biocontainers/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2cdf6bf1e92acbeb9b2834b1c58754167173a410-0' }"
+        'biocontainers/mulled-v2-e5d375990341c5aef3c9aff74f96f66f65375ef6:2cdf6bf1e92acbeb9b2834b1c58754167173a410-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/cadd/main.nf
+++ b/modules/nf-core/cadd/main.nf
@@ -5,7 +5,7 @@ process CADD {
     conda "bioconda::cadd-scripts=1.6 anaconda::conda=4.14.0 conda-forge::mamba=1.4.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-8d145e7b16a8ca4bf920e6ca464763df6f0a56a2:d4e457a2edecb2b10e915c01d8f46e29e236b648-0':
-        'quay.io/biocontainers/mulled-v2-8d145e7b16a8ca4bf920e6ca464763df6f0a56a2:d4e457a2edecb2b10e915c01d8f46e29e236b648-0' }"
+        'biocontainers/mulled-v2-8d145e7b16a8ca4bf920e6ca464763df6f0a56a2:d4e457a2edecb2b10e915c01d8f46e29e236b648-0' }"
 
     containerOptions {
         (workflow.containerEngine == 'singularity') ?

--- a/modules/nf-core/cadd/meta.yml
+++ b/modules/nf-core/cadd/meta.yml
@@ -3,6 +3,7 @@ description: CADD is a tool for scoring the deleteriousness of single nucleotide
 keywords:
   - cadd
   - annotate
+  - variants
 tools:
   - "cadd":
       description: "CADD scripts release for offline scoring"

--- a/modules/nf-core/chromap/chromap/main.nf
+++ b/modules/nf-core/chromap/chromap/main.nf
@@ -5,7 +5,7 @@ process CHROMAP_CHROMAP {
     conda "bioconda::chromap=0.2.4 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:5b2e433ab8b3d1ef098fc944b567fd98caa23f56-0' :
-        'quay.io/biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:5b2e433ab8b3d1ef098fc944b567fd98caa23f56-0' }"
+        'biocontainers/mulled-v2-1f09f39f20b1c4ee36581dc81cc323c70e661633:5b2e433ab8b3d1ef098fc944b567fd98caa23f56-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/cnvkit/batch/main.nf
+++ b/modules/nf-core/cnvkit/batch/main.nf
@@ -5,7 +5,7 @@ process CNVKIT_BATCH {
     conda "bioconda::cnvkit=0.9.9 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-780d630a9bb6a0ff2e7b6f730906fd703e40e98f:3bdd798e4b9aed6d3e1aaa1596c913a3eeb865cb-0' :
-        'quay.io/biocontainers/mulled-v2-780d630a9bb6a0ff2e7b6f730906fd703e40e98f:3bdd798e4b9aed6d3e1aaa1596c913a3eeb865cb-0' }"
+        'biocontainers/mulled-v2-780d630a9bb6a0ff2e7b6f730906fd703e40e98f:3bdd798e4b9aed6d3e1aaa1596c913a3eeb865cb-0' }"
 
     input:
     tuple val(meta), path(tumor), path(normal)

--- a/modules/nf-core/deeptools/bamcoverage/main.nf
+++ b/modules/nf-core/deeptools/bamcoverage/main.nf
@@ -5,7 +5,7 @@ process DEEPTOOLS_BAMCOVERAGE {
     conda "bioconda::deeptools=3.5.1 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:62d1ebe2d3a2a9d1a7ad31e0b902983fa7c25fa7-0':
-        'quay.io/biocontainers/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:62d1ebe2d3a2a9d1a7ad31e0b902983fa7c25fa7-0' }"
+        'biocontainers/mulled-v2-eb9e7907c7a753917c1e4d7a64384c047429618a:62d1ebe2d3a2a9d1a7ad31e0b902983fa7c25fa7-0' }"
 
     input:
     tuple val(meta), path(input), path(input_index)

--- a/modules/nf-core/deeptools/bamcoverage/meta.yml
+++ b/modules/nf-core/deeptools/bamcoverage/meta.yml
@@ -1,7 +1,9 @@
 name: deeptools_bamcoverage
 description: This tool takes an alignment of reads or fragments as input (BAM file) and generates a coverage track (bigWig or bedGraph) as output.
 keywords:
-  - sort
+  - coverage
+  - depth
+  - track
 tools:
   - deeptools:
       description: A set of user-friendly tools for normalization and visualzation of deep-sequencing data

--- a/modules/nf-core/dragmap/align/main.nf
+++ b/modules/nf-core/dragmap/align/main.nf
@@ -5,7 +5,7 @@ process DRAGMAP_ALIGN {
     conda "bioconda::dragmap=1.2.1 bioconda::samtools=1.15.1 conda-forge::pigz=2.3.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:5ebebbc128cd624282eaa37d2c7fe01505a91a69-0':
-        'quay.io/biocontainers/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:5ebebbc128cd624282eaa37d2c7fe01505a91a69-0' }"
+        'biocontainers/mulled-v2-580d344d9d4a496cd403932da8765f9e0187774d:5ebebbc128cd624282eaa37d2c7fe01505a91a69-0' }"
 
     input:
     tuple val(meta) , path(reads)

--- a/modules/nf-core/hisat2/align/main.nf
+++ b/modules/nf-core/hisat2/align/main.nf
@@ -6,7 +6,7 @@ process HISAT2_ALIGN {
     conda "bioconda::hisat2=2.2.1 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2cdf6bf1e92acbeb9b2834b1c58754167173a410-0' :
-        'quay.io/biocontainers/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2cdf6bf1e92acbeb9b2834b1c58754167173a410-0' }"
+        'biocontainers/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2cdf6bf1e92acbeb9b2834b1c58754167173a410-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/homer/findpeaks/meta.yml
+++ b/modules/nf-core/homer/findpeaks/meta.yml
@@ -1,8 +1,9 @@
 name: homer_findpeaks
 description: Find peaks with HOMER suite
 keywords:
-  - annotations
+  - annotation
   - peaks
+  - enrichment
 tools:
   - homer:
       description: |

--- a/modules/nf-core/homer/maketagdirectory/main.nf
+++ b/modules/nf-core/homer/maketagdirectory/main.nf
@@ -7,7 +7,7 @@ process HOMER_MAKETAGDIRECTORY {
     conda "bioconda::homer=4.11 bioconda::samtools=1.11 conda-forge::r-base=4.0.2 bioconda::bioconductor-deseq2=1.30.0 bioconda::bioconductor-edger=3.32.0 anaconda::perl=5.26.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-29293b111ffe5b4c1d1e14c711264aaed6b97b4a:594338b771cacf1623bd27772b5e12825f8835f2-0' :
-        'quay.io/biocontainers/mulled-v2-29293b111ffe5b4c1d1e14c711264aaed6b97b4a:594338b771cacf1623bd27772b5e12825f8835f2-0' }"
+        'biocontainers/mulled-v2-29293b111ffe5b4c1d1e14c711264aaed6b97b4a:594338b771cacf1623bd27772b5e12825f8835f2-0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/homer/pos2bed/meta.yml
+++ b/modules/nf-core/homer/pos2bed/meta.yml
@@ -2,6 +2,8 @@ name: "homer_pos2bed"
 description: Coverting from HOMER peak to BED file formats
 keywords:
   - peaks
+  - bed
+  - pos
 tools:
   - "homer":
       description: |

--- a/modules/nf-core/jupyternotebook/main.nf
+++ b/modules/nf-core/jupyternotebook/main.nf
@@ -10,7 +10,7 @@ process JUPYTERNOTEBOOK {
     conda "conda-forge::ipykernel=6.0.3 conda-forge::jupytext=1.11.4 conda-forge::nbconvert=6.1.0 conda-forge::papermill=2.3.3 conda-forge::matplotlib=3.4.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-514b1a5d280c7043110b2a8d0a87b57ba392a963:879972fc8bdc81ee92f2bce3b4805d89a772bf84-0' :
-        'quay.io/biocontainers/mulled-v2-514b1a5d280c7043110b2a8d0a87b57ba392a963:879972fc8bdc81ee92f2bce3b4805d89a772bf84-0' }"
+        'biocontainers/mulled-v2-514b1a5d280c7043110b2a8d0a87b57ba392a963:879972fc8bdc81ee92f2bce3b4805d89a772bf84-0' }"
 
     input:
     tuple val(meta), path(notebook)

--- a/modules/nf-core/jupyternotebook/meta.yml
+++ b/modules/nf-core/jupyternotebook/meta.yml
@@ -45,7 +45,7 @@ input:
         Groovy map with notebook parameters which will be passed
         to papermill in order to create parametrized reports.
   - input_files:
-      type: path
+      type: file
       description: One or multiple files serving as input data for the notebook.
       pattern: "*"
 

--- a/modules/nf-core/kraken2/kraken2/main.nf
+++ b/modules/nf-core/kraken2/kraken2/main.nf
@@ -5,7 +5,7 @@ process KRAKEN2_KRAKEN2 {
     conda "bioconda::kraken2=2.1.2 conda-forge::pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-5799ab18b5fc681e75923b2450abaa969907ec98:87fc08d11968d081f3e8a37131c1f1f6715b6542-0' :
-        'quay.io/biocontainers/mulled-v2-5799ab18b5fc681e75923b2450abaa969907ec98:87fc08d11968d081f3e8a37131c1f1f6715b6542-0' }"
+        'biocontainers/mulled-v2-5799ab18b5fc681e75923b2450abaa969907ec98:87fc08d11968d081f3e8a37131c1f1f6715b6542-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/manta/convertinversion/main.nf
+++ b/modules/nf-core/manta/convertinversion/main.nf
@@ -5,7 +5,7 @@ process MANTA_CONVERTINVERSION {
     conda "bioconda::manta=1.6.0 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-40295ae41112676b05b649e513fe7000675e9b84:a0332aa38645fbb8969567731ce68cfb7f830ec4-0':
-        'quay.io/biocontainers/mulled-v2-40295ae41112676b05b649e513fe7000675e9b84:a0332aa38645fbb8969567731ce68cfb7f830ec4-0' }"
+        'biocontainers/mulled-v2-40295ae41112676b05b649e513fe7000675e9b84:a0332aa38645fbb8969567731ce68cfb7f830ec4-0' }"
 
     input:
     tuple val(meta), path(vcf)

--- a/modules/nf-core/manta/convertinversion/meta.yml
+++ b/modules/nf-core/manta/convertinversion/meta.yml
@@ -3,6 +3,7 @@ description: Manta calls structural variants (SVs) and indels from mapped paired
 keywords:
   - structural variants
   - conversion
+  - indels
 tools:
   - manta:
       description: Structural variant and indel caller for mapped sequencing data

--- a/modules/nf-core/megahit/main.nf
+++ b/modules/nf-core/megahit/main.nf
@@ -5,7 +5,7 @@ process MEGAHIT {
     conda "bioconda::megahit=1.2.9 conda-forge::pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0' :
-        'quay.io/biocontainers/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0' }"
+        'biocontainers/mulled-v2-0f92c152b180c7cd39d9b0e6822f8c89ccb59c99:8ec213d21e5d03f9db54898a2baeaf8ec729b447-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/minimap2/align/main.nf
+++ b/modules/nf-core/minimap2/align/main.nf
@@ -6,7 +6,7 @@ process MINIMAP2_ALIGN {
     conda "bioconda::minimap2=2.24 bioconda::samtools=1.14"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0' :
-        'quay.io/biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0' }"
+        'biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/paftools/sam2paf/main.nf
+++ b/modules/nf-core/paftools/sam2paf/main.nf
@@ -6,7 +6,7 @@ process PAFTOOLS_SAM2PAF {
     conda "bioconda::minimap2=2.24 bioconda::samtools=1.14"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0' :
-        'quay.io/biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0' }"
+        'biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/pretextmap/main.nf
+++ b/modules/nf-core/pretextmap/main.nf
@@ -6,7 +6,7 @@ process PRETEXTMAP {
     conda "bioconda::pretextmap=0.1.9 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:c6242a6c1a522137de7a9e9ff90779ede11cf5c5-0':
-        'quay.io/biocontainers/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:c6242a6c1a522137de7a9e9ff90779ede11cf5c5-0' }"
+        'biocontainers/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:c6242a6c1a522137de7a9e9ff90779ede11cf5c5-0' }"
 
     input:
     tuple val(meta), path(input)

--- a/modules/nf-core/pretextmap/meta.yml
+++ b/modules/nf-core/pretextmap/meta.yml
@@ -1,7 +1,9 @@
 name: "pretextmap"
 description: converts sam/bam/cram/pairs into genome contact map
 keywords:
-  - genome contact map
+  - contact
+  - bam
+  - map
 tools:
   - "pretextmap":
       description: "Paired REad TEXTure Mapper. Converts SAM formatted read pairs into genome contact maps."

--- a/modules/nf-core/prodigal/main.nf
+++ b/modules/nf-core/prodigal/main.nf
@@ -5,7 +5,7 @@ process PRODIGAL {
     conda "bioconda::prodigal=2.6.3 conda-forge::pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-2e442ba7b07bfa102b9cf8fac6221263cd746ab8:57f05cfa73f769d6ed6d54144cb3aa2a6a6b17e0-0' :
-        'quay.io/biocontainers/mulled-v2-2e442ba7b07bfa102b9cf8fac6221263cd746ab8:57f05cfa73f769d6ed6d54144cb3aa2a6a6b17e0-0' }"
+        'biocontainers/mulled-v2-2e442ba7b07bfa102b9cf8fac6221263cd746ab8:57f05cfa73f769d6ed6d54144cb3aa2a6a6b17e0-0' }"
 
     input:
     tuple val(meta), path(genome)

--- a/modules/nf-core/prodigal/meta.yml
+++ b/modules/nf-core/prodigal/meta.yml
@@ -1,7 +1,9 @@
 name: prodigal
 description: Prodigal (Prokaryotic Dynamic Programming Genefinding Algorithm) is a microbial (bacterial and archaeal) gene finding program
 keywords:
-  - sort
+  - prokaryotes
+  - gene finding
+  - microbial
 tools:
   - prodigal:
       description: Prodigal (Prokaryotic Dynamic Programming Genefinding Algorithm) is a microbial (bacterial and archaeal) gene finding program

--- a/modules/nf-core/purecn/intervalfile/main.nf
+++ b/modules/nf-core/purecn/intervalfile/main.nf
@@ -6,7 +6,7 @@ process PURECN_INTERVALFILE {
     conda "bioconda::bioconductor-purecn=2.4.0 bioconda::bioconductor-txdb.hsapiens.ucsc.hg38.knowngene=3.16.0 bioconductor-txdb.hsapiens.ucsc.hg19.knowngene=3.2.2 bioconda::bioconductor-org.hs.eg.db=3.16.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0':
-        'quay.io/biocontainers/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0' }"
+        'biocontainers/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0' }"
 
     input:
     tuple val(meta), path(target_bed)

--- a/modules/nf-core/qualimap/bamqccram/main.nf
+++ b/modules/nf-core/qualimap/bamqccram/main.nf
@@ -5,7 +5,7 @@ process QUALIMAP_BAMQCCRAM {
     conda "bioconda::qualimap=2.2.2d bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-d3934ca6bb4e61334891ffa2e9a4c87a530e3188:00d3c18496ddf07ea580fd00d1dd203cf31ab630-0' :
-        'quay.io/biocontainers/mulled-v2-d3934ca6bb4e61334891ffa2e9a4c87a530e3188:00d3c18496ddf07ea580fd00d1dd203cf31ab630-0' }"
+        'biocontainers/mulled-v2-d3934ca6bb4e61334891ffa2e9a4c87a530e3188:00d3c18496ddf07ea580fd00d1dd203cf31ab630-0' }"
 
     input:
     tuple val(meta), path(cram), path(crai)

--- a/modules/nf-core/qualimap/bamqccram/meta.yml
+++ b/modules/nf-core/qualimap/bamqccram/meta.yml
@@ -40,7 +40,7 @@ output:
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
   - results:
-      type: dir
+      type: directory
       description: Qualimap results dir
       pattern: "*/*"
   - versions:

--- a/modules/nf-core/rapidnj/main.nf
+++ b/modules/nf-core/rapidnj/main.nf
@@ -5,7 +5,7 @@ process RAPIDNJ {
     conda "bioconda::rapidnj=2.3.2 conda-forge::biopython=1.78"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-805c6e0f138f952f9c61cdd57c632a1a263ea990:3c52e4c8da6b3e4d69b9ca83fa4d366168898179-0' :
-        'quay.io/biocontainers/mulled-v2-805c6e0f138f952f9c61cdd57c632a1a263ea990:3c52e4c8da6b3e4d69b9ca83fa4d366168898179-0' }"
+        'biocontainers/mulled-v2-805c6e0f138f952f9c61cdd57c632a1a263ea990:3c52e4c8da6b3e4d69b9ca83fa4d366168898179-0' }"
 
     input:
     path alignment

--- a/modules/nf-core/rmarkdownnotebook/main.nf
+++ b/modules/nf-core/rmarkdownnotebook/main.nf
@@ -10,7 +10,7 @@ process RMARKDOWNNOTEBOOK {
     conda "conda-forge::r-base=4.1.0 conda-forge::r-rmarkdown=2.9 conda-forge::r-yaml=2.2.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-31ad840d814d356e5f98030a4ee308a16db64ec5:0e852a1e4063fdcbe3f254ac2c7469747a60e361-0' :
-        'quay.io/biocontainers/mulled-v2-31ad840d814d356e5f98030a4ee308a16db64ec5:0e852a1e4063fdcbe3f254ac2c7469747a60e361-0' }"
+        'biocontainers/mulled-v2-31ad840d814d356e5f98030a4ee308a16db64ec5:0e852a1e4063fdcbe3f254ac2c7469747a60e361-0' }"
 
     input:
     tuple val(meta), path(notebook)

--- a/modules/nf-core/rmarkdownnotebook/meta.yml
+++ b/modules/nf-core/rmarkdownnotebook/meta.yml
@@ -46,7 +46,7 @@ input:
         Groovy map with notebook parameters which will be passed to
         rmarkdown to generate parametrized reports.
   - input_files:
-      type: path
+      type: file
       description: One or multiple files serving as input data for the notebook.
       pattern: "*"
 

--- a/modules/nf-core/rsem/calculateexpression/main.nf
+++ b/modules/nf-core/rsem/calculateexpression/main.nf
@@ -5,7 +5,7 @@ process RSEM_CALCULATEEXPRESSION {
     conda "bioconda::rsem=1.3.3 bioconda::star=2.7.10a"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:64aad4a4e144878400649e71f42105311be7ed87-0' :
-        'quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:64aad4a4e144878400649e71f42105311be7ed87-0' }"
+        'biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:64aad4a4e144878400649e71f42105311be7ed87-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/rsem/preparereference/main.nf
+++ b/modules/nf-core/rsem/preparereference/main.nf
@@ -5,7 +5,7 @@ process RSEM_PREPAREREFERENCE {
     conda "bioconda::rsem=1.3.3 bioconda::star=2.7.10a"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:64aad4a4e144878400649e71f42105311be7ed87-0' :
-        'quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:64aad4a4e144878400649e71f42105311be7ed87-0' }"
+        'biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:64aad4a4e144878400649e71f42105311be7ed87-0' }"
 
     input:
     path fasta, stageAs: "rsem/*"

--- a/modules/nf-core/rsem/preparereference/meta.yml
+++ b/modules/nf-core/rsem/preparereference/meta.yml
@@ -2,7 +2,8 @@ name: rsem_preparereference
 description: Prepare a reference genome for RSEM
 keywords:
   - rsem
-  - reference
+  - genome
+  - index
 tools:
   - rseqc:
       description: |

--- a/modules/nf-core/samblaster/main.nf
+++ b/modules/nf-core/samblaster/main.nf
@@ -5,7 +5,7 @@ process SAMBLASTER {
     conda "bioconda::samblaster=0.1.26 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-19fa9f1a5c3966b63a24166365e81da35738c5ab:cee56b506ceb753d4bbef7e05b81e1bfc25d937f-0' :
-        'quay.io/biocontainers/mulled-v2-19fa9f1a5c3966b63a24166365e81da35738c5ab:cee56b506ceb753d4bbef7e05b81e1bfc25d937f-0' }"
+        'biocontainers/mulled-v2-19fa9f1a5c3966b63a24166365e81da35738c5ab:cee56b506ceb753d4bbef7e05b81e1bfc25d937f-0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/samblaster/meta.yml
+++ b/modules/nf-core/samblaster/meta.yml
@@ -10,6 +10,8 @@ description: |
   options.args3 for the output bam file
 keywords:
   - sort
+  - duplicate marking
+  - bam
 tools:
   - samblaster:
       description: |

--- a/modules/nf-core/seacr/callpeak/main.nf
+++ b/modules/nf-core/seacr/callpeak/main.nf
@@ -6,7 +6,7 @@ process SEACR_CALLPEAK {
     conda "bioconda::seacr=1.3 conda-forge::r-base=4.0.2 bioconda::bedtools=2.30.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-03bfeb32fe80910c231f630d4262b83677c8c0f4:f4bb19b68e66de27e4c64306f951d5ff11919931-0' :
-        'quay.io/biocontainers/mulled-v2-03bfeb32fe80910c231f630d4262b83677c8c0f4:f4bb19b68e66de27e4c64306f951d5ff11919931-0' }"
+        'biocontainers/mulled-v2-03bfeb32fe80910c231f630d4262b83677c8c0f4:f4bb19b68e66de27e4c64306f951d5ff11919931-0' }"
 
     input:
     tuple val(meta), path(bedgraph), path(ctrlbedgraph)

--- a/modules/nf-core/seacr/callpeak/meta.yml
+++ b/modules/nf-core/seacr/callpeak/meta.yml
@@ -32,7 +32,7 @@ input:
       description: |
         Control (IgG) data bedgraph file to generate an empirical threshold for peak calling.
   - threshold:
-      type: value
+      type: integer
       description: |
         Threshold value used to call peaks if the ctrlbedgraph input is set to []. Set to 1 if using a control bedgraph
 output:

--- a/modules/nf-core/sratools/fasterqdump/main.nf
+++ b/modules/nf-core/sratools/fasterqdump/main.nf
@@ -5,7 +5,7 @@ process SRATOOLS_FASTERQDUMP {
     conda "bioconda::sra-tools=2.11.0 conda-forge::pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' :
-        'quay.io/biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' }"
+        'biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' }"
 
     input:
     tuple val(meta), path(sra)

--- a/modules/nf-core/star/align/main.nf
+++ b/modules/nf-core/star/align/main.nf
@@ -5,7 +5,7 @@ process STAR_ALIGN {
     conda "bioconda::star=2.7.10a bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' :
-        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"
+        'biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/star/genomegenerate/main.nf
+++ b/modules/nf-core/star/genomegenerate/main.nf
@@ -5,7 +5,7 @@ process STAR_GENOMEGENERATE {
     conda "bioconda::star=2.7.10a bioconda::samtools=1.16.1 conda-forge::gawk=5.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' :
-        'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"
+        'biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0' }"
 
     input:
     path fasta

--- a/modules/nf-core/svdb/merge/main.nf
+++ b/modules/nf-core/svdb/merge/main.nf
@@ -4,7 +4,7 @@ process SVDB_MERGE {
     conda "bioconda::svdb=2.8.1 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-c8daa8f9d69d3c5a1a4ff08283a166c18edb0000:af6f8534cd538a85ff43a2eae1b52b143e7abd05-0':
-        'quay.io/biocontainers/mulled-v2-c8daa8f9d69d3c5a1a4ff08283a166c18edb0000:af6f8534cd538a85ff43a2eae1b52b143e7abd05-0' }"
+        'biocontainers/mulled-v2-c8daa8f9d69d3c5a1a4ff08283a166c18edb0000:af6f8534cd538a85ff43a2eae1b52b143e7abd05-0' }"
 
     input:
     tuple val(meta), path(vcfs)

--- a/modules/nf-core/svdb/merge/meta.yml
+++ b/modules/nf-core/svdb/merge/meta.yml
@@ -2,6 +2,8 @@ name: svdb_merge
 description: The merge module merges structural variants within one or more vcf files.
 keywords:
   - structural variants
+  - vcf
+  - merge
 tools:
   - svdb:
       description: structural variant database software

--- a/modules/nf-core/tailfindr/main.nf
+++ b/modules/nf-core/tailfindr/main.nf
@@ -5,7 +5,7 @@ process TAILFINDR {
     conda "bioconda::ont-fast5-api=0.4.1 bioconda::r-tailfindr=1.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-f24f1399a77784f913670cbb36a0f17b78e0631b:80e40d512cd5a71665e3e00e8d0ad1462fc58f76-0':
-        'quay.io/biocontainers/mulled-v2-f24f1399a77784f913670cbb36a0f17b78e0631b:80e40d512cd5a71665e3e00e8d0ad1462fc58f76-0' }"
+        'biocontainers/mulled-v2-f24f1399a77784f913670cbb36a0f17b78e0631b:80e40d512cd5a71665e3e00e8d0ad1462fc58f76-0' }"
 
     input:
     tuple val(meta), path(fast5)

--- a/modules/nf-core/tailfindr/meta.yml
+++ b/modules/nf-core/tailfindr/meta.yml
@@ -1,8 +1,9 @@
 name: "tailfindr"
 description: Estimating poly(A)-tail lengths from basecalled fast5 files produced by Nanopore sequencing of RNA and DNA
 keywords:
-  - polyA
+  - polya tail
   - fast5
+  - nanopore
 tools:
   - "tailfindr":
       description: "An R package for estimating poly(A)-tail lengths in Oxford Nanopore RNA and DNA reads."

--- a/modules/nf-core/ultra/align/main.nf
+++ b/modules/nf-core/ultra/align/main.nf
@@ -5,7 +5,7 @@ process ULTRA_ALIGN {
     conda "bioconda::ultra_bioinformatics=0.0.4.2 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-4b749ef583d6de806ddbf51c2d235ac8c14763c6:bda5f599c82caf73ec2e2fe0133ce3eb53f1c724-0':
-        'quay.io/biocontainers/mulled-v2-4b749ef583d6de806ddbf51c2d235ac8c14763c6:bda5f599c82caf73ec2e2fe0133ce3eb53f1c724-0' }"
+        'biocontainers/mulled-v2-4b749ef583d6de806ddbf51c2d235ac8c14763c6:bda5f599c82caf73ec2e2fe0133ce3eb53f1c724-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/vcf2maf/main.nf
+++ b/modules/nf-core/vcf2maf/main.nf
@@ -7,7 +7,7 @@ process VCF2MAF {
     conda "bioconda::vcf2maf=1.6.21 bioconda::ensembl-vep=106.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-b6fc09bed47d0dc4d8384ce9e04af5806f2cc91b:305092c6f8420acd17377d2cc8b96e1c3ccb7d26-0':
-        'quay.io/biocontainers/mulled-v2-b6fc09bed47d0dc4d8384ce9e04af5806f2cc91b:305092c6f8420acd17377d2cc8b96e1c3ccb7d26-0' }"
+        'biocontainers/mulled-v2-b6fc09bed47d0dc4d8384ce9e04af5806f2cc91b:305092c6f8420acd17377d2cc8b96e1c3ccb7d26-0' }"
 
     input:
     tuple val(meta), path(vcf) // Use an uncompressed VCF file!

--- a/modules/nf-core/vcf2maf/meta.yml
+++ b/modules/nf-core/vcf2maf/meta.yml
@@ -1,7 +1,8 @@
 name: "vcf2maf"
 description: vcf2maf
 keywords:
-  - "vcf2maf"
+  - vcf
+  - maf
   - annotation
 tools:
   - "vcf2maf":

--- a/modules/nf-core/vsearch/cluster/main.nf
+++ b/modules/nf-core/vsearch/cluster/main.nf
@@ -5,7 +5,7 @@ process VSEARCH_CLUSTER {
     conda "bioconda::vsearch=2.21.1 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-53dae514294fca7b44842b784ed85a5303ac2d80:7b3365d778c690ca79bc85aaaeb86bb39a2dec69-0':
-        'quay.io/biocontainers/mulled-v2-53dae514294fca7b44842b784ed85a5303ac2d80:7b3365d778c690ca79bc85aaaeb86bb39a2dec69-0' }"
+        'biocontainers/mulled-v2-53dae514294fca7b44842b784ed85a5303ac2d80:7b3365d778c690ca79bc85aaaeb86bb39a2dec69-0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/vsearch/cluster/meta.yml
+++ b/modules/nf-core/vsearch/cluster/meta.yml
@@ -3,6 +3,7 @@ description: Cluster sequences using a single-pass, greedy centroid-based cluste
 keywords:
   - vsearch
   - clustering
+  - microbiome
 tools:
   - vsearch:
       description: VSEARCH is a versatile open-source tool for microbiome analysis, including chimera detection, clustering, dereplication and rereplication, extraction, FASTA/FASTQ/SFF file processing, masking, orienting, pair-wise alignment, restriction site cutting, searching, shuffling, sorting, subsampling, and taxonomic classification of amplicon sequences for metagenomics, genomics, and population genetics. (USEARCH alternative)

--- a/modules/nf-core/whamg/main.nf
+++ b/modules/nf-core/whamg/main.nf
@@ -5,7 +5,7 @@ process WHAMG {
     conda "bioconda::wham=1.8.0 bioconda::tabix=1.11"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-fb3127231a8f88daa68d5eb0eec49593cd98b440:e6a1c182ebdfe372b5e3cdc05a6cece64cef7274-0':
-        'quay.io/biocontainers/mulled-v2-fb3127231a8f88daa68d5eb0eec49593cd98b440:e6a1c182ebdfe372b5e3cdc05a6cece64cef7274-0' }"
+        'biocontainers/mulled-v2-fb3127231a8f88daa68d5eb0eec49593cd98b440:e6a1c182ebdfe372b5e3cdc05a6cece64cef7274-0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/yara/mapper/main.nf
+++ b/modules/nf-core/yara/mapper/main.nf
@@ -5,7 +5,7 @@ process YARA_MAPPER {
     conda "bioconda::yara=1.0.2 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-f13549097a0d1ca36f9d4f017636fb3609f6c083:de7982183b85634270540ac760c2644f16e0b6d1-0' :
-        'quay.io/biocontainers/mulled-v2-f13549097a0d1ca36f9d4f017636fb3609f6c083:de7982183b85634270540ac760c2644f16e0b6d1-0' }"
+        'biocontainers/mulled-v2-f13549097a0d1ca36f9d4f017636fb3609f6c083:de7982183b85634270540ac760c2644f16e0b6d1-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/tests/modules/nf-core/megahit/test.yml
+++ b/tests/modules/nf-core/megahit/test.yml
@@ -6,29 +6,20 @@
     - path: output/megahit/megahit_out/test.contigs.fa.gz
       md5sum: 8ed114f22130e16df3532d3f6b03e116
     - path: output/megahit/megahit_out/intermediate_contigs/k21.addi.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k21.contigs.fa.gz
       md5sum: 4221d45f238045bbdb1eea04e4ce4261
     - path: output/megahit/megahit_out/intermediate_contigs/k21.final.contigs.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k21.local.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k29.addi.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k29.contigs.fa.gz
       md5sum: c72aeb242788542af0260098b4d61204
     - path: output/megahit/megahit_out/intermediate_contigs/k29.final.contigs.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k29.local.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k39.addi.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k39.contigs.fa.gz
       md5sum: aa188f4c92e69c1a4b396e8f2991236f
     - path: output/megahit/megahit_out/intermediate_contigs/k39.final.contigs.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k39.local.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
 
 - name: megahit_single
   command: nextflow run ./tests/modules/nf-core/megahit -entry test_megahit_single -c ./tests/config/nextflow.config -process.cpus 1 -c ./tests/modules/nf-core/megahit/nextflow.config
@@ -38,34 +29,25 @@
     - path: output/megahit/megahit_out/test.contigs.fa.gz
       md5sum: f50352838b778cc67824f631197a8346
     - path: output/megahit/megahit_out/intermediate_contigs/k21.addi.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k21.contigs.fa.gz
       md5sum: 61554dc60ba8e95d9c1d9dca8d465bef
     - path: output/megahit/megahit_out/intermediate_contigs/k21.final.contigs.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k21.local.fa.gz
       md5sum: b916fc620fdf0d23ef33485352c168b3
     - path: output/megahit/megahit_out/intermediate_contigs/k29.addi.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k29.contigs.fa.gz
       md5sum: d916bc564854aa0fabaa5234035aa47b
     - path: output/megahit/megahit_out/intermediate_contigs/k29.final.contigs.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k29.local.fa.gz
       md5sum: cccf44441e65913b02fb64eb0835dcc1
     - path: output/megahit/megahit_out/intermediate_contigs/k39.addi.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k39.contigs.fa.gz
       md5sum: 4416a9e846ccbeb06b880ac2fdc02925
     - path: output/megahit/megahit_out/intermediate_contigs/k39.final.contigs.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k39.local.fa.gz
       md5sum: 590d0a08285226d24f7f984f7b3b4f65
     - path: output/megahit/megahit_out/intermediate_contigs/k59.addi.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k59.contigs.fa.gz
       md5sum: 51ef726b87a53b0cbdde762d7973a8a7
     - path: output/megahit/megahit_out/intermediate_contigs/k59.final.contigs.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a
     - path: output/megahit/megahit_out/intermediate_contigs/k59.local.fa.gz
-      md5sum: 7029066c27ac6f5ef18d660d5741979a


### PR DESCRIPTION
Currently the AWS ECR Biocontainer mirror doesn't host mulled Biocontainers. This is why we thought it might be better to leave any mulled containers to keep the full path so if the AWS registry is used to override `docker.registry` then any mulled containers would still be fetched from "quay.io". However, having thought about it a little more this should be the exception rather than the rule, especially for us to standardise container definitions. For anyone else using private registries it doesn't make sense to write custom configs every time just for mulled containers. The best case scenario is that we make the changes in this PR and mulled containers are pushed to the AWS ECR registry to solve this upstream until then a custom config will have to be created for anyone using the AWS ECR registry.