### PR TITLE
Fix mismatch between conda and container versions for GTDBTK/CLASSIFY

### DIFF
--- a/modules/nf-core/gtdbtk/classifywf/main.nf
+++ b/modules/nf-core/gtdbtk/classifywf/main.nf
@@ -3,7 +3,7 @@ process GTDBTK_CLASSIFYWF {
     label 'process_medium'
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
-    conda "bioconda::gtdbtk=1.5.0"
+    conda "bioconda::gtdbtk=2.1.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/gtdbtk:2.1.1--pyhdfd78af_1' :
         'biocontainers/gtdbtk:2.1.1--pyhdfd78af_1' }"

--- a/modules/nf-core/gtdbtk/classifywf/meta.yml
+++ b/modules/nf-core/gtdbtk/classifywf/meta.yml
@@ -3,6 +3,11 @@ description: GTDB-Tk is a software toolkit for assigning objective taxonomic cla
 keywords:
   - GTDB taxonomy
   - taxonomic classification
+  - metagenomics
+  - classification
+  - genome taxonomy database
+  - bacteria
+  - archaea
 tools:
   - gtdbtk:
       description: GTDB-Tk is a software toolkit for assigning objective taxonomic classifications to bacterial and archaeal genomes based on the Genome Database Taxonomy GTDB.

--- a/modules/nf-core/gtdbtk/classifywf/meta.yml
+++ b/modules/nf-core/gtdbtk/classifywf/meta.yml
@@ -25,11 +25,11 @@ input:
         e.g. [ id:'test', single_end:false,  assembler:'spades' ]
   - bins:
       type: file
-      description:  The binned fasta files from the assembler
+      description: The binned fasta files from the assembler
       pattern: "*.{fasta,fa}"
   - database:
-      type: The local copy of the taxonomic database used by GTDB-tk
-      description: The unzipped copy of the database
+      type: file
+      description: The local copy of the taxonomic database used by GTDB-tk (unzipped copy)
       pattern: "*"
 
 output:

--- a/modules/nf-core/gtdbtk/classifywf/meta.yml
+++ b/modules/nf-core/gtdbtk/classifywf/meta.yml
@@ -24,8 +24,8 @@ input:
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false,  assembler:'spades' ]
   - bins:
-      type: The binned fasta files from the assembler
-      description: Fasta files
+      type: file
+      description:  The binned fasta files from the assembler
       pattern: "*.{fasta,fa}"
   - database:
       type: The local copy of the taxonomic database used by GTDB-tk


### PR DESCRIPTION
Just noticed when looking at it on #mag.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
