### PR TITLE
gatk4/filtermutectcalls can take multiple contamination tables

### DIFF
--- a/modules/nf-core/gatk4/filtermutectcalls/main.nf
+++ b/modules/nf-core/gatk4/filtermutectcalls/main.nf
@@ -29,7 +29,7 @@ process GATK4_FILTERMUTECTCALLS {
     def orientationbias_command = orientationbias ? orientationbias.collect{"--orientation-bias-artifact-priors $it"}.join(' ') : ''
     def segmentation_command    = segmentation    ? segmentation.collect{"--tumor-segmentation $it"}.join(' ')                  : ''
     def estimate_command        = estimate        ? " --contamination-estimate ${estimate} "                                    : ''
-    def table_command           = table           ? " --contamination-table ${table} "                                          : ''
+    def table_command           = table           ? table.collect{"--contamination-table $it"}.join(' ')                        : ''
 
     def avail_mem = 3072
     if (!task.memory) {

--- a/modules/nf-core/gatk4/filtermutectcalls/meta.yml
+++ b/modules/nf-core/gatk4/filtermutectcalls/meta.yml
@@ -35,19 +35,19 @@ input:
       description: Stats file that pairs with output vcf file
       pattern: "*vcf.gz.stats"
   - orientationbias:
-      type: list
+      type: file
       description: files containing artifact priors for input vcf. Optional input.
       pattern: "*.artifact-prior.tar.gz"
   - segmentation:
-      type: list
+      type: file
       description: tables containing segmentation information for input vcf. Optional input.
       pattern: "*.segmentation.table"
   - table:
-      type: list
+      type: file
       description: table(s) containing contamination data for input vcf. Optional input, takes priority over estimate.
       pattern: "*.contamination.table"
   - estimate:
-      type: val
+      type: float
       description: estimation of contamination value as a double. Optional input, will only be used if table is not specified.
   - fasta:
       type: file


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- Used `table.collect` function to concatenate multiple `--contamination-table` inputs.
- Passed the existing tests. I don't think we need to add/change the tests for this.
- Also fixed linting in `meta.yml` with nf-core tools v2.8 and `pre-commit`. 
- Closes #3388 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
