### PR TITLE
Fix output argument in test in kmcp/compute

### DIFF
--- a/tests/modules/nf-core/kmcp/compute/nextflow.config
+++ b/tests/modules/nf-core/kmcp/compute/nextflow.config
@@ -4,6 +4,5 @@ process {
 
     withName: KMCP_COMPUTE {
         ext.prefix = { "${meta.id}_" }
-        ext.args = { "--out-dir ${task.ext.prefix}" }
     }
 }

--- a/tests/modules/nf-core/kmcp/compute/test.yml
+++ b/tests/modules/nf-core/kmcp/compute/test.yml
@@ -5,6 +5,7 @@
     - kmcp/compute
   files:
     - path: output/kmcp/test_/_info.txt
+      contains: ["#path	name	chunkIdx	idxNum	genomeSize	kmers"]
     - path: output/kmcp/test_/genome.fasta.unik
     - path: output/kmcp/versions.yml
 
@@ -15,7 +16,7 @@
     - kmcp/compute
   files:
     - path: output/kmcp/test_/_info.txt
+      contains: ["#path	name	chunkIdx	idxNum	genomeSize	kmers"]
     - path: output/kmcp/test_/genome.fasta.unik
     - path: output/kmcp/test_/transcriptome.fasta.unik
-      md5sum: 1c81408c27fee27a2a7e28ba61bbe122
     - path: output/kmcp/versions.yml

--- a/tests/modules/nf-core/kmcp/compute/test.yml
+++ b/tests/modules/nf-core/kmcp/compute/test.yml
@@ -1,25 +1,21 @@
 - name: kmcp compute test_kmcp_compute
   command: nextflow run ./tests/modules/nf-core/kmcp/compute -entry test_kmcp_compute -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/kmcp/compute/nextflow.config
   tags:
-    - kmcp/compute
     - kmcp
+    - kmcp/compute
   files:
     - path: output/kmcp/test_/_info.txt
-      contains: ["#path	name	chunkIdx	idxNum	genomeSize	kmers"]
     - path: output/kmcp/test_/genome.fasta.unik
     - path: output/kmcp/versions.yml
 
 - name: kmcp compute test_kmcp_compute_directory
   command: nextflow run ./tests/modules/nf-core/kmcp/compute -entry test_kmcp_compute_directory -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/kmcp/compute/nextflow.config
   tags:
-    - kmcp/compute
     - kmcp
+    - kmcp/compute
   files:
     - path: output/kmcp/test_/_info.txt
-      contains: ["#path	name	chunkIdx	idxNum	genomeSize	kmers"]
     - path: output/kmcp/test_/genome.fasta.unik
     - path: output/kmcp/test_/transcriptome.fasta.unik
+      md5sum: 1c81408c27fee27a2a7e28ba61bbe122
     - path: output/kmcp/versions.yml
-    - path: output/untar/test/genome.fasta
-    - path: output/untar/test/transcriptome.fasta
-    - path: output/untar/versions.yml


### PR DESCRIPTION
## PR checklist
This PR fixes a the output file in tests for kmcp/compute module.


- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
