### PR TITLE
Update angsd/docounts main.nf

### DIFF
--- a/modules/nf-core/angsd/docounts/main.nf
+++ b/modules/nf-core/angsd/docounts/main.nf
@@ -5,7 +5,7 @@ process ANGSD_DOCOUNTS {
     conda "bioconda::angsd=0.939"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/angsd:0.939--h468462d_0':
-        'biocontainers/angsd:0.939--h468462d_0' }"
+        'quay.io/biocontainers/angsd:0.939--h468462d_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai), path(minqfile)


### PR DESCRIPTION
Updated angsd/docounts main.nf to include quay.io to be able to pull docker image

## PR checklist

Closes #3410 

- [x] This comment contains a description of changes (with reason).

- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
