### PR TITLE
zip pyrodigal output

### DIFF
--- a/modules/nf-core/pyrodigal/main.nf
+++ b/modules/nf-core/pyrodigal/main.nf
@@ -5,7 +5,7 @@ process PYRODIGAL {
     conda "bioconda::pyrodigal=2.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-2fe9a8ce513c91df34b43a6610df94c3a2eb3bd0:697b3838b186fac6a9ceec198b09d4032162a079-0':
-        'quay.io/biocontainers/mulled-v2-2fe9a8ce513c91df34b43a6610df94c3a2eb3bd0:697b3838b186fac6a9ceec198b09d4032162a079-0' }"
+        'biocontainers/mulled-v2-2fe9a8ce513c91df34b43a6610df94c3a2eb3bd0:697b3838b186fac6a9ceec198b09d4032162a079-0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/pyrodigal/main.nf
+++ b/modules/nf-core/pyrodigal/main.nf
@@ -4,17 +4,17 @@ process PYRODIGAL {
 
     conda "bioconda::pyrodigal=2.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pyrodigal:2.1.0--py310h1425a21_0':
-        'biocontainers/pyrodigal:2.1.0--py310h1425a21_0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-2fe9a8ce513c91df34b43a6610df94c3a2eb3bd0:697b3838b186fac6a9ceec198b09d4032162a079-0':
+        'quay.io/biocontainers/mulled-v2-2fe9a8ce513c91df34b43a6610df94c3a2eb3bd0:697b3838b186fac6a9ceec198b09d4032162a079-0' }"
 
     input:
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path("*.gff")      , emit: gff
-    tuple val(meta), path("*.fna")      , emit: fna
-    tuple val(meta), path("*.faa")      , emit: faa
-    tuple val(meta), path("*.score")    , emit: score
+    tuple val(meta), path("*.gff.gz")      , emit: gff
+    tuple val(meta), path("*.fna.gz")      , emit: fna
+    tuple val(meta), path("*.faa.gz")      , emit: faa
+    tuple val(meta), path("*.score.gz")    , emit: score
     path "versions.yml"                 , emit: versions
 
     when:
@@ -24,13 +24,15 @@ process PYRODIGAL {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    pyrodigal \\
+    pigz -cdf ${fasta} | pyrodigal \\
         $args \\
         -i ${fasta} \\
         -o ${prefix}.gff \\
         -d ${prefix}.fna \\
         -a ${prefix}.faa \\
         -s ${prefix}.score
+
+    pigz -nm ${prefix}*
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/pyrodigal/meta.yml
+++ b/modules/nf-core/pyrodigal/meta.yml
@@ -38,19 +38,19 @@ output:
   - gff:
       type: file
       description: gene annotations in gff format
-      pattern: "*.{gff}"
+      pattern: "*.{gff.gz}"
   - faa:
       type: file
       description: protein translations file
-      pattern: "*.{faa}"
+      pattern: "*.{faa.gz}"
   - fna:
       type: file
       description: nucleotide sequences file
-      pattern: "*.{fna}"
+      pattern: "*.{fna.gz}"
   - score:
       type: file
       description: all potential genes (with scores)
-      pattern: "*.{score}"
+      pattern: "*.{score.gz}"
 
 authors:
   - "@louperelo"

--- a/tests/modules/nf-core/pyrodigal/main.nf
+++ b/tests/modules/nf-core/pyrodigal/main.nf
@@ -2,16 +2,14 @@
 
 nextflow.enable.dsl = 2
 
-include { GUNZIP    } from '../../../../modules/nf-core/gunzip/main.nf'
 include { PYRODIGAL } from '../../../../modules/nf-core/pyrodigal/main.nf'
 
 workflow test_pyrodigal {
 
     input = [
         [ id:'test', single_end:false ], // meta map
-        file(params.test_data['haemophilus_influenzae']['genome']['genome_fna_gz'], checkIfExists: true)
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
     ]
 
-    GUNZIP( input )
-    PYRODIGAL ( GUNZIP.out.gunzip )
+    PYRODIGAL ( input )
 }

--- a/tests/modules/nf-core/pyrodigal/test.yml
+++ b/tests/modules/nf-core/pyrodigal/test.yml
@@ -1,14 +1,14 @@
-- name: "pyrodigal"
+- name: pyrodigal test_pyrodigal
   command: nextflow run ./tests/modules/nf-core/pyrodigal -entry test_pyrodigal -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/pyrodigal/nextflow.config
   tags:
-    - "pyrodigal"
+    - pyrodigal
   files:
-    - path: output/pyrodigal/test.faa
-      md5sum: 0a953d0a9efd550fdcad0631b1161788
-    - path: output/pyrodigal/test.fna
-      md5sum: 37ea9c18dac656f72377b7518b21af9b
-    - path: output/pyrodigal/test.gff
-      md5sum: 8b2265db2d29a6fd33d2759c123dfe20
-    - path: output/pyrodigal/test.score
-      md5sum: 270fd600ee19526d619b76688f08c8ad
+    - path: output/pyrodigal/test.faa.gz
+      md5sum: 7524e6583836529618b9b7469e7248ff
+    - path: output/pyrodigal/test.fna.gz
+      md5sum: e5978af4ef6535146bc92a701e23129f
+    - path: output/pyrodigal/test.gff.gz
+      md5sum: 4d95a2c1ceb35252f23e20b34b9382d0
+    - path: output/pyrodigal/test.score.gz
+      md5sum: 169cfd95a0eb36f89b9edf6d3e760caa
     - path: output/pyrodigal/versions.yml


### PR DESCRIPTION
Update of the `Pyrodigal` module including `pigz` to unzip input and zip output files. This was done like before in the `Prodigal` module.
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #3395  <!-- If this PR fixes an issue, please link it here! -->

- [x ] This comment contains a description of changes (with reason).
- [ x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x ] Remove all TODO statements.
- [x ] Emit the `versions.yml` file.
- [ x] Follow the naming conventions.
- [x ] Follow the parameters requirements.
- [x ] Follow the input/output options guidelines.
- [x ] Add a resource `label`
- [x ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
