### PR TITLE
Fix pyrodigal input

### DIFF
--- a/modules/nf-core/pyrodigal/main.nf
+++ b/modules/nf-core/pyrodigal/main.nf
@@ -25,7 +25,7 @@ process PYRODIGAL {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     pigz -cdf ${fasta} > pigz_fasta.fna
-    
+
     pyrodigal \\
         $args \\
         -i pigz_fasta.fna \\

--- a/modules/nf-core/pyrodigal/main.nf
+++ b/modules/nf-core/pyrodigal/main.nf
@@ -24,9 +24,11 @@ process PYRODIGAL {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    pigz -cdf ${fasta} | pyrodigal \\
+    pigz -cdf ${fasta} > pigz_fasta.fna
+    
+    pyrodigal \\
         $args \\
-        -i ${fasta} \\
+        -i pigz_fasta.fna \\
         -o ${prefix}.gff \\
         -d ${prefix}.fna \\
         -a ${prefix}.faa \\

--- a/modules/nf-core/pyrodigal/meta.yml
+++ b/modules/nf-core/pyrodigal/meta.yml
@@ -23,7 +23,7 @@ input:
   - fasta:
       type: file
       description: FASTA file
-      pattern: "*.{fasta,fa,fna}"
+      pattern: "*.{fasta.gz,fa.gz,fna.gz}"
 
 output:
   - meta:


### PR DESCRIPTION
PR to fix the previous [PR](https://github.com/nf-core/modules/pull/3414): The uncompressed fasta file from pigz was not caught by pyrodigal.
And updated the meta.yml.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
