### PR TITLE
Add purecn/normaldb test data to config and fix paths in tests

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -457,6 +457,10 @@ params {
                 purecn_ex1_bam                                          = "${params.test_data_base}/data/genomics/homo_sapiens/illumina/purecn/purecn_ex1.bam"
                 purecn_ex1_bai                                          = "${params.test_data_base}/data/genomics/homo_sapiens/illumina/purecn/purecn_ex1.bam.bai"
                 purecn_ex1_interval                                     = "${params.test_data_base}/data/genomics/homo_sapiens/illumina/purecn/purecn_ex1_intervals.txt"
+                purecn_ex1_normal                                       = "${params.test_data_base}/data/genomics/homo_sapiens/illumina/purecn/purecn_ex1_normal.txt.gz"
+                purecn_ex2_normal                                       = "${params.test_data_base}/data/genomics/homo_sapiens/illumina/purecn/purecn_ex2_normal.txt.gz"
+                purecn_normalpanel_vcf                                  = "${params.test_data_base}/data/genomics/homo_sapiens/illumina/purecn/purecn_normalpanel.vcf.gz"
+                purecn_normalpanel_tbi                                  = "${params.test_data_base}/data/genomics/homo_sapiens/illumina/purecn/purecn_normalpanel.vcf.gz.tbi"
             }
             'pacbio' {
                 primers                         = "${params.test_data_base}/data/genomics/homo_sapiens/pacbio/fasta/primers.fasta"

--- a/tests/modules/nf-core/purecn/normaldb/main.nf
+++ b/tests/modules/nf-core/purecn/normaldb/main.nf
@@ -25,7 +25,7 @@ workflow test_purecn_normaldb_normalvcf {
         [file(params.test_data['homo_sapiens']['illumina']['purecn_ex1_normal'], checkIfExists: true),
         file(params.test_data['homo_sapiens']['illumina']['purecn_ex2_normal'], checkIfExists: true)],
         [file(params.test_data['homo_sapiens']['illumina']['purecn_normalpanel_vcf'], checkIfExists: true)],
-        [file(params.test_data['homo_sapiens']['illumina']['purecn_normalpanel_vcf_tbi'], checkIfExists: true)]
+        [file(params.test_data['homo_sapiens']['illumina']['purecn_normalpanel_tbi'], checkIfExists: true)]
     ]
     genome = 'hg38'
     assay  = 'illumina'

--- a/tests/modules/nf-core/purecn/normaldb/main.nf
+++ b/tests/modules/nf-core/purecn/normaldb/main.nf
@@ -8,8 +8,8 @@ workflow test_purecn_normaldb {
 
     input  = [
         [ id:'test' ],
-        [file('https://raw.githubusercontent.com/lima1/PureCN/master/inst/extdata/example_normal.txt.gz', checkIfExists: true),
-        file('https://raw.githubusercontent.com/lima1/PureCN/master/inst/extdata/example_normal2.txt.gz', checkIfExists: true)],
+        [file(params.test_data['homo_sapiens']['illumina']['purecn_ex1_normal'], checkIfExists: true),
+        file(params.test_data['homo_sapiens']['illumina']['purecn_ex2_normal'], checkIfExists: true)],
         [], []
     ]
     genome = 'hg38'
@@ -22,10 +22,10 @@ workflow test_purecn_normaldb_normalvcf {
 
     input  = [
         [ id:'test' ],
-        [file('https://raw.githubusercontent.com/lima1/PureCN/master/inst/extdata/example_normal.txt.gz', checkIfExists: true),
-        file('https://raw.githubusercontent.com/lima1/PureCN/master/inst/extdata/example_normal2.txt.gz', checkIfExists: true)],
-        [file('https://raw.githubusercontent.com/lima1/PureCN/master/inst/extdata/normalpanel.vcf.gz', checkIfExists: true)],
-        [file('https://raw.githubusercontent.com/lima1/PureCN/master/inst/extdata/normalpanel.vcf.gz.tbi', checkIfExists: true)]
+        [file(params.test_data['homo_sapiens']['illumina']['purecn_ex1_normal'], checkIfExists: true),
+        file(params.test_data['homo_sapiens']['illumina']['purecn_ex2_normal'], checkIfExists: true)],
+        [file(params.test_data['homo_sapiens']['illumina']['purecn_normalpanel_vcf'], checkIfExists: true)],
+        [file(params.test_data['homo_sapiens']['illumina']['purecn_normalpanel_vcf_tbi'], checkIfExists: true)]
     ]
     genome = 'hg38'
     assay  = 'illumina'


### PR DESCRIPTION
As discussed with @nvnieuwk , this PR completes https://github.com/nf-core/modules/pull/3129 addressing the absence of the new purecn/normaldb test in the config file. Additionally, it modifies the paths of the test data within the tests.

@lbeltrame 
