### PR TITLE
Add default retry strategy to flaky bbsplit module

### DIFF
--- a/modules/nf-core/bbmap/bbsplit/main.nf
+++ b/modules/nf-core/bbmap/bbsplit/main.nf
@@ -1,5 +1,6 @@
 process BBMAP_BBSPLIT {
     label 'process_high'
+    label 'error_retry'
 
     conda "bioconda::bbmap=39.01"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/bbmap/bbsplit/meta.yml
+++ b/modules/nf-core/bbmap/bbsplit/meta.yml
@@ -30,7 +30,7 @@ input:
       description: Directory to place generated index
       pattern: "*"
   - primary_ref:
-      type: path
+      type: file
       description: Path to the primary reference
       pattern: "*"
   - other_ref_names:

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/main.nf
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/main.nf
@@ -39,7 +39,7 @@ workflow BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS {
                 }
         }
 
-    BAM_STATS_SAMTOOLS ( ch_bam_bai_dedup, [[],[]] )
+    BAM_STATS_SAMTOOLS ( ch_bam_bai_dedup, [ [:], [] ] )
     ch_versions = ch_versions.mix(BAM_STATS_SAMTOOLS.out.versions)
 
     emit:


### PR DESCRIPTION
BBSplit fails intermittently in daily tests we run and retrying seems to fix the issue. Added a label by default to retry.