### PR TITLE
fix tests for kallistobustools, universc

### DIFF
--- a/modules/nf-core/kallistobustools/count/meta.yml
+++ b/modules/nf-core/kallistobustools/count/meta.yml
@@ -3,13 +3,15 @@ description: quantifies scRNA-seq data from fastq files using kb-python.
 keywords:
   - scRNA-seq
   - count
+  - single-cell
+  - kallisto
+  - bustools
 tools:
   - kb:
       description: kallisto and bustools are wrapped in an easy-to-use program called kb
       homepage: https://www.kallistobus.tools/
       documentation: https://kb-python.readthedocs.io/en/latest/index.html
       tool_dev_url: https://github.com/pachterlab/kb_python
-
       licence: MIT License
 
 input:
@@ -40,11 +42,11 @@ input:
       description: kb ref's c2 unspliced_t2c file
       pattern: "*.{introns_t2c.txt}"
   - workflow_mode:
-      type: value
+      type: string
       description: String value defining workflow to use, can be one of "standard", "lamanno", "nucleus"
       pattern: "{standard,lamanno,nucleus,kite}"
   - technology:
-      type: value
+      type: string
       description: String value defining the sequencing technology used.
       pattern: "{10XV1,10XV2,10XV3,CELSEQ,CELSEQ2,DROPSEQ,INDROPSV1,INDROPSV2,INDROPSV3,SCRUBSEQ,SURECELL,SMARTSEQ}"
 

--- a/tests/modules/nf-core/kallistobustools/count/main.nf
+++ b/tests/modules/nf-core/kallistobustools/count/main.nf
@@ -10,8 +10,8 @@ workflow test_kallistobustools_count {
     input   = [
         [id:'test'], // meta map
         [ 
-          file(params.test_data['homo_sapiens']['illumina']['test_10x_1_fastq_gz'], checkIfExists: true),
-          file(params.test_data['homo_sapiens']['illumina']['test_10x_2_fastq_gz'], checkIfExists: true)
+          file(params.test_data['homo_sapiens']['10xgenomics']['cellranger']['test_10x_10k_pbmc_cmo_gex1_fastq_1_gz'], checkIfExists: true),
+          file(params.test_data['homo_sapiens']['10xgenomics']['cellranger']['test_10x_10k_pbmc_cmo_gex1_fastq_2_gz'], checkIfExists: true)
         ]
     ]
 

--- a/tests/modules/nf-core/kallistobustools/count/test.yml
+++ b/tests/modules/nf-core/kallistobustools/count/test.yml
@@ -1,5 +1,5 @@
 - name: kallistobustools count test_kallistobustools_count
-  command: nextflow run ./tests/modules/nf-core/kallistobustools/count -entry test_kallistobustools_count -c ./tests/config/nextflow.config  -c ./tests/modules/nf-core/kallistobustools/count/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/kallistobustools/count -entry test_kallistobustools_count -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/kallistobustools/count/nextflow.config
   tags:
     - kallistobustools/count
     - kallistobustools
@@ -10,24 +10,23 @@
     - path: output/kallistobustools/test.count/10x_version3_whitelist.txt
       md5sum: 3d36d0a4021fd292b265e2b5e72aaaf3
     - path: output/kallistobustools/test.count/counts_unfiltered/cellranger/barcodes.tsv
-      md5sum: 8a41142de30df61fbb9551b29dd05a83
+      md5sum: 2889825ad9c096ca567e057d8ddea098
     - path: output/kallistobustools/test.count/counts_unfiltered/cellranger/genes.tsv
       md5sum: 1b31f05f9b20a4c0ac3e07b9e3ff3a14
     - path: output/kallistobustools/test.count/counts_unfiltered/cellranger/matrix.mtx
-      md5sum: 5b7bff2d19fc90168733f4ac812c7d7b
+      md5sum: b167312e8269d6bbfd609e9cdde837c7
     - path: output/kallistobustools/test.count/counts_unfiltered/cells_x_genes.barcodes.txt
-      md5sum: 8d7ef602416818a598f5680a707756a7
+      md5sum: cf482bc1373075aff0fda0365dfaf3c8
     - path: output/kallistobustools/test.count/counts_unfiltered/cells_x_genes.genes.txt
       md5sum: fe6d5501923867b514a0447aa4b4995f
     - path: output/kallistobustools/test.count/counts_unfiltered/cells_x_genes.mtx
-      md5sum: 0a84dc5a7570b5821da4eef6b5769a0c
+      md5sum: fc1fe0cbc931e084546d8cb897e50ecc
     - path: output/kallistobustools/test.count/inspect.json
-      md5sum: b853330f160e06fc8af170a837384ef5
+      md5sum: 0bfebc754e0be8aac2b50bacb52a2541
     - path: output/kallistobustools/test.count/kb_info.json
     - path: output/kallistobustools/test.count/matrix.ec
     - path: output/kallistobustools/test.count/output.bus
-      md5sum: f5d8efa83f107826824292cbbdb4e37b
     - path: output/kallistobustools/test.count/output.unfiltered.bus
-      md5sum: dcbc651dc64eb38ae14e0b90795b30d2
     - path: output/kallistobustools/test.count/run_info.json
     - path: output/kallistobustools/test.count/transcripts.txt
+    - path: output/kallistobustools/versions.yml

--- a/tests/modules/nf-core/universc/main.nf
+++ b/tests/modules/nf-core/universc/main.nf
@@ -9,8 +9,8 @@ include { UNIVERSC } from '../../../../modules/nf-core/universc//main.nf'
 workflow test_universc_10x {
     
     input = [ [ id:'123', technology:'10x', chemistry:'SC3Pv3', single_end:false, strandedness:'forward', samples: ["test_10x"] ], // meta map
-             [ file(params.test_data['homo_sapiens']['illumina']['test_10x_1_fastq_gz'], checkIfExists: true),
-              file(params.test_data['homo_sapiens']['illumina']['test_10x_2_fastq_gz'], checkIfExists: true)
+             [ file(params.test_data['homo_sapiens']['10xgenomics']['cellranger']['test_10x_10k_pbmc_cmo_gex1_fastq_1_gz'], checkIfExists: true),
+              file(params.test_data['homo_sapiens']['10xgenomics']['cellranger']['test_10x_10k_pbmc_cmo_gex1_fastq_2_gz'], checkIfExists: true)
         ]
     ]
 

--- a/tests/modules/nf-core/universc/test.yml
+++ b/tests/modules/nf-core/universc/test.yml
@@ -45,7 +45,6 @@
       md5sum: 6fa11b4d34f4680a1c23dbcea2e050d5
     - path: output/cellranger/versions.yml
     - path: output/universc/sample-123/outs/_err
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: output/universc/sample-123/outs/_invocation
       md5sum: adbbbc1027756be9fdeebabf979863e5
     - path: output/universc/sample-123/outs/_log

--- a/tests/modules/nf-core/universc/test.yml
+++ b/tests/modules/nf-core/universc/test.yml
@@ -9,6 +9,8 @@
       md5sum: f315020d899597c1b57e5fe9f60f4c3e
     - path: output/cellranger/homo_sapiens_chr22_reference/fasta/genome.fa.fai
       md5sum: 3520cd30e1b100e55f578db9c855f685
+    - path: output/cellranger/homo_sapiens_chr22_reference/genes/genes.gtf
+      md5sum: c37539d5bdae419bae799165d3f80c53
     - path: output/cellranger/homo_sapiens_chr22_reference/reference.json
       md5sum: 1f7bf05454cc908bf70cd232ae70b02d
     - path: output/cellranger/homo_sapiens_chr22_reference/star/Genome
@@ -33,11 +35,35 @@
       md5sum: a20c70b081f5d83649c48ebbd951cb77
     - path: output/cellranger/homo_sapiens_chr22_reference/star/genomeParameters.txt
       contains: ["genomeGenerate"]
+    - path: output/cellranger/homo_sapiens_chr22_reference/star/sjdbInfo.txt
+      md5sum: 5690ea9d9f09f7ff85b7fd47bd234903
+    - path: output/cellranger/homo_sapiens_chr22_reference/star/sjdbList.fromGTF.out.tab
+      md5sum: 9e4f991abbbfeb3935a2bb21b9e258f1
+    - path: output/cellranger/homo_sapiens_chr22_reference/star/sjdbList.out.tab
+      md5sum: 9e4f991abbbfeb3935a2bb21b9e258f1
     - path: output/cellranger/homo_sapiens_chr22_reference/star/transcriptInfo.tab
       md5sum: 6fa11b4d34f4680a1c23dbcea2e050d5
+    - path: output/cellranger/versions.yml
+    - path: output/universc/sample-123/outs/_err
+      md5sum: d41d8cd98f00b204e9800998ecf8427e
+    - path: output/universc/sample-123/outs/_invocation
+      md5sum: adbbbc1027756be9fdeebabf979863e5
+    - path: output/universc/sample-123/outs/_log
     - path: output/universc/sample-123/outs/basic_stats.txt
-      md5sum: 6ce8341506150f0b1add1800b0a11cdd
+      md5sum: 90004df04ec7b65a0dd8d26a08e55fd2
+    - path: output/universc/sample-123/outs/filtered_feature_bc_matrix.h5
+    - path: output/universc/sample-123/outs/filtered_feature_bc_matrix/barcodes.tsv.gz
+    - path: output/universc/sample-123/outs/filtered_feature_bc_matrix/features.tsv.gz
+    - path: output/universc/sample-123/outs/filtered_feature_bc_matrix/matrix.mtx.gz
     - path: output/universc/sample-123/outs/metrics_summary.csv
-      md5sum: edfa1a0dc666c38f9740167c045fb3c8
+      md5sum: bba1b122b15698d97a034af61e3fcd59
+    - path: output/universc/sample-123/outs/molecule_info.h5
+    - path: output/universc/sample-123/outs/possorted_genome_bam.bam
+    - path: output/universc/sample-123/outs/possorted_genome_bam.bam.bai
+    - path: output/universc/sample-123/outs/raw_feature_bc_matrix.h5
+    - path: output/universc/sample-123/outs/raw_feature_bc_matrix/barcodes.tsv.gz
+    - path: output/universc/sample-123/outs/raw_feature_bc_matrix/features.tsv.gz
+    - path: output/universc/sample-123/outs/raw_feature_bc_matrix/matrix.mtx.gz
     - path: output/universc/sample-123/outs/web_summary.html
-      contains: ["      <td>sample-123</td>"]
+      contains: ["sample-123"]
+    - path: output/universc/versions.yml


### PR DESCRIPTION
## PR checklist

Closes https://github.com/nf-core/test-datasets/issues/917

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!

tests for kallistobustools/count and universc were broken during a large reorganization of 10X Genomics data (https://github.com/nf-core/test-datasets/pull/878)

the original gene expression FASTQs were purged in favor of new data compatible with cellranger/multi

this PR fixes the broken tests by pointing to replacement 10X Genomics single cell gene expression FASTQs using the 3' version 3 chemistry
