### PR TITLE
fix: missing 'stub' option

### DIFF
--- a/modules/nf-core/bowtie2/build/main.nf
+++ b/modules/nf-core/bowtie2/build/main.nf
@@ -27,4 +27,16 @@ process BOWTIE2_BUILD {
         bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
     END_VERSIONS
     """
+
+    stub:
+    """
+    mkdir bowtie2
+    touch bowtie2/${fasta.baseName}.{1..4}.bt2
+    touch bowtie2/${fasta.baseName}.rev.{1,2}.bt2
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
+    END_VERSIONS
+    """
 }


### PR DESCRIPTION
## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

Missing stub for the `bowtie2/build`

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
