### PR TITLE
Move containers for sarek, demultiplex and scrnaseq to quay.io

### DIFF
--- a/modules/nf-core/bases2fastq/main.nf
+++ b/modules/nf-core/bases2fastq/main.nf
@@ -2,7 +2,7 @@ process BASES2FASTQ {
     tag "$meta.id"
     label 'process_high'
 
-    container "docker.io/elembio/bases2fastq:1.1.0"
+    container "nf-core/bases2fastq:1.1.0"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/bcl2fastq/main.nf
+++ b/modules/nf-core/bcl2fastq/main.nf
@@ -2,7 +2,7 @@ process BCL2FASTQ {
     tag {"$meta.lane" ? "$meta.id"+"."+"$meta.lane" : "$meta.id" }
     label 'process_high'
 
-    container "docker.io/nfcore/bcl2fastq:2.20.0.422"
+    container "nf-core/bcl2fastq:2.20.0.422"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -2,7 +2,7 @@ process BCLCONVERT {
     tag {"$meta.lane" ? "$meta.id"+"."+"$meta.lane" : "$meta.id" }
     label 'process_high'
 
-    container "docker.io/nfcore/bclconvert:4.0.3"
+    container "nf-core/bclconvert:4.0.3"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/cellranger/count/main.nf
+++ b/modules/nf-core/cellranger/count/main.nf
@@ -2,7 +2,7 @@ process CELLRANGER_COUNT {
     tag "$meta.id"
     label 'process_high'
 
-    container "docker.io/nfcore/cellranger:7.1.0"
+    container "nf-core/cellranger:7.1.0"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/cellranger/mkgtf/main.nf
+++ b/modules/nf-core/cellranger/mkgtf/main.nf
@@ -2,7 +2,7 @@ process CELLRANGER_MKGTF {
     tag "$gtf"
     label 'process_low'
 
-    container "docker.io/nfcore/cellranger:7.1.0"
+    container "nf-core/cellranger:7.1.0"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/cellranger/mkref/main.nf
+++ b/modules/nf-core/cellranger/mkref/main.nf
@@ -2,7 +2,7 @@ process CELLRANGER_MKREF {
     tag "$fasta"
     label 'process_high'
 
-    container "docker.io/nfcore/cellranger:7.1.0"
+    container "nf-core/cellranger:7.1.0"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/cellranger/mkvdjref/main.nf
+++ b/modules/nf-core/cellranger/mkvdjref/main.nf
@@ -2,7 +2,7 @@ process CELLRANGER_MKVDJREF {
     tag "$fasta"
     label 'process_high'
 
-    container "docker.io/nfcore/cellranger:7.1.0"
+    container "nf-core/cellranger:7.1.0"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/cellranger/multi/main.nf
+++ b/modules/nf-core/cellranger/multi/main.nf
@@ -2,7 +2,7 @@ process CELLRANGER_MULTI {
     tag "$meta.id"
     label 'process_high'
 
-    container "docker.io/nfcore/cellranger:7.1.0"
+    container "nf-core/cellranger:7.1.0"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/cellranger/vdj/main.nf
+++ b/modules/nf-core/cellranger/vdj/main.nf
@@ -2,7 +2,7 @@ process CELLRANGER_VDJ {
     tag "${meta.id}"
     label 'process_high'
 
-    container "docker.io/nfcore/cellranger:7.1.0"
+    container "nf-core/cellranger:7.1.0"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/deepvariant/main.nf
+++ b/modules/nf-core/deepvariant/main.nf
@@ -2,7 +2,7 @@ process DEEPVARIANT {
     tag "$meta.id"
     label 'process_high'
 
-    container "docker.io/google/deepvariant:1.5.0"
+    container "nf-core/deepvariant:1.5.0"
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/gatk4/applybqsrspark/main.nf
+++ b/modules/nf-core/gatk4/applybqsrspark/main.nf
@@ -3,7 +3,7 @@ process GATK4_APPLYBQSR_SPARK {
     label 'process_low'
 
     conda "bioconda::gatk4=4.3.0.0 conda-forge::openjdk=8.0.312"
-    container 'nf-core/gatk:4.4.0.0'
+    container "nf-core/gatk:4.4.0.0"
 
     input:
     tuple val(meta), path(input), path(input_index), path(bqsr_table), path(intervals)

--- a/modules/nf-core/gatk4/applybqsrspark/main.nf
+++ b/modules/nf-core/gatk4/applybqsrspark/main.nf
@@ -3,7 +3,7 @@ process GATK4_APPLYBQSR_SPARK {
     label 'process_low'
 
     conda "bioconda::gatk4=4.3.0.0 conda-forge::openjdk=8.0.312"
-    container 'docker.io/broadinstitute/gatk:4.4.0.0'
+    container 'nf-core/gatk:4.4.0.0'
 
     input:
     tuple val(meta), path(input), path(input_index), path(bqsr_table), path(intervals)

--- a/modules/nf-core/gatk4/baserecalibratorspark/main.nf
+++ b/modules/nf-core/gatk4/baserecalibratorspark/main.nf
@@ -3,7 +3,7 @@ process GATK4_BASERECALIBRATOR_SPARK {
     label 'process_low'
 
     conda "bioconda::gatk4=4.4.0.0 conda-forge::openjdk=8.0.312"
-    container 'nf-core/gatk:4.4.0.0'
+    container "nf-core/gatk:4.4.0.0"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)

--- a/modules/nf-core/gatk4/baserecalibratorspark/main.nf
+++ b/modules/nf-core/gatk4/baserecalibratorspark/main.nf
@@ -3,7 +3,7 @@ process GATK4_BASERECALIBRATOR_SPARK {
     label 'process_low'
 
     conda "bioconda::gatk4=4.4.0.0 conda-forge::openjdk=8.0.312"
-    container 'docker.io/broadinstitute/gatk:4.4.0.0'
+    container 'nf-core/gatk:4.4.0.0'
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)

--- a/modules/nf-core/gatk4/cnnscorevariants/main.nf
+++ b/modules/nf-core/gatk4/cnnscorevariants/main.nf
@@ -3,7 +3,7 @@ process GATK4_CNNSCOREVARIANTS {
     label 'process_low'
 
     //Conda is not supported at the moment: https://github.com/broadinstitute/gatk/issues/7811
-    container "docker.io/broadinstitute/gatk:4.4.0.0" //Biocontainers is missing a package
+    container "nf-core/gatk:4.4.0.0" //Biocontainers is missing a package
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/gatk4/determinegermlinecontigploidy/main.nf
+++ b/modules/nf-core/gatk4/determinegermlinecontigploidy/main.nf
@@ -3,7 +3,7 @@ process GATK4_DETERMINEGERMLINECONTIGPLOIDY {
     label 'process_single'
 
     //Conda is not supported at the moment: https://github.com/broadinstitute/gatk/issues/7811
-    container "docker.io/broadinstitute/gatk:4.4.0.0" //Biocontainers is missing a package
+    container "nf-core/gatk:4.4.0.0" //Biocontainers is missing a package
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/gatk4/germlinecnvcaller/main.nf
+++ b/modules/nf-core/gatk4/germlinecnvcaller/main.nf
@@ -3,7 +3,7 @@ process GATK4_GERMLINECNVCALLER {
     label 'process_single'
 
     //Conda is not supported at the moment: https://github.com/broadinstitute/gatk/issues/7811
-    container "docker.io/broadinstitute/gatk:4.4.0.0" //Biocontainers is missing a package
+    container "nf-core/gatk:4.4.0.0" //Biocontainers is missing a package
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/gatk4/markduplicatesspark/main.nf
+++ b/modules/nf-core/gatk4/markduplicatesspark/main.nf
@@ -3,7 +3,7 @@ process GATK4_MARKDUPLICATES_SPARK {
     label 'process_high'
 
     conda "bioconda::gatk4=4.3.0.0 conda-forge::openjdk=8.0.312"
-    container 'nf-core/gatk:4.4.0.0'
+    container "nf-core/gatk:4.4.0.0"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/gatk4/markduplicatesspark/main.nf
+++ b/modules/nf-core/gatk4/markduplicatesspark/main.nf
@@ -3,7 +3,7 @@ process GATK4_MARKDUPLICATES_SPARK {
     label 'process_high'
 
     conda "bioconda::gatk4=4.3.0.0 conda-forge::openjdk=8.0.312"
-    container 'docker.io/broadinstitute/gatk:4.4.0.0'
+    container 'nf-core/gatk:4.4.0.0'
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/gatk4/postprocessgermlinecnvcalls/main.nf
+++ b/modules/nf-core/gatk4/postprocessgermlinecnvcalls/main.nf
@@ -3,7 +3,7 @@ process GATK4_POSTPROCESSGERMLINECNVCALLS {
     label 'process_single'
 
     //Conda is not supported at the moment: https://github.com/broadinstitute/gatk/issues/7811
-    container "docker.io/broadinstitute/gatk:4.4.0.0" //Biocontainers is missing a package
+    container "nf-core/gatk:4.4.0.0" //Biocontainers is missing a package
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {

--- a/modules/nf-core/universc/README.md
+++ b/modules/nf-core/universc/README.md
@@ -45,10 +45,10 @@ process {
 
 ...
     withName: CELLRANGER_MKGTF {
-        container = "docker.io/nfcore/universc:1.2.5.1"
+        container = "nf-core/universc:1.2.5.1"
     }
     withName: CELLRANGER_MKREF{
-       container = "docker.io/nfcore/universc:1.2.5.1"
+       container = "nf-core/universc:1.2.5.1"
     }
 ...
 }
@@ -66,7 +66,7 @@ and for singularity use the `--writeable` parameter.
 These are set as default in universc/main.nf:
 
 ```
-    container "docker.io/nfcore/universc:1.2.5.1"
+    container "nf-core/universc:1.2.5.1"
     if (workflow.containerEngine == 'docker'){
         containerOptions = "--privileged"
     }
@@ -104,7 +104,7 @@ modify this code provided that they also contain this license.
 
 The tomkellygenetics/universc:<VERSION> container is automatically updated with tomkellygenetics/universc:latest.
 
-A stable release is mirrored at nfcore/universc:1.2.5.1 and will be updated as needed.
+A stable release is mirrored at nf-core/universc:1.2.5.1 and will be updated as needed.
 
 To build an updated container use the Dockerfile provided here:
 

--- a/modules/nf-core/universc/main.nf
+++ b/modules/nf-core/universc/main.nf
@@ -6,7 +6,7 @@ process UNIVERSC {
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
         exit 1, "UNIVERSC module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
-    container "docker.io/nfcore/universc:1.2.5.1"
+    container "nf-core/universc:1.2.5.1"
     if (workflow.containerEngine == 'docker'){
         containerOptions = "--privileged"
     }

--- a/tests/modules/nf-core/universc/nextflow.config
+++ b/tests/modules/nf-core/universc/nextflow.config
@@ -4,14 +4,14 @@ process {
 
     withName: UNIVERSC {
         ext.args = ''
-        container = "docker.io/nfcore/universc:1.2.5.1"
+        container = "nf-core/universc:1.2.5.1"
     }
 
     withName: CELLRANGER_MKGTF {
-        container = "docker.io/nfcore/universc:1.2.5.1"
+        container = "nf-core/universc:1.2.5.1"
     }
     withName: CELLRANGER_MKREF{
-       container = "docker.io/nfcore/universc:1.2.5.1"
+       container = "nf-core/universc:1.2.5.1"
     }
 
 }


### PR DESCRIPTION
I have pulled and pushed the containers in these modules to the nf-core `quay.io` account. Updating modules now, will re-install in the pipeline and create patch releases.