### PR TITLE
Fix inclusion of input bams in work directory

### DIFF
--- a/modules/nf-core/umitools/dedup/main.nf
+++ b/modules/nf-core/umitools/dedup/main.nf
@@ -8,7 +8,7 @@ process UMITOOLS_DEDUP {
         'biocontainers/umi_tools:1.1.4--py38hbff2b2d_1' }"
 
     input:
-    tuple val(meta), path(bam), path(bai)
+    tuple val(meta), path(bam, stageAs: 'input/*'), path(bai, stageAs: 'input/*')
     val get_output_stats
 
     output:

--- a/modules/nf-core/umitools/dedup/meta.yml
+++ b/modules/nf-core/umitools/dedup/meta.yml
@@ -3,6 +3,7 @@ description: Deduplicate reads based on the mapping co-ordinate and the UMI atta
 keywords:
   - umitools
   - deduplication
+  - dedup
 tools:
   - umi_tools:
       description: >


### PR DESCRIPTION
Staged input bam and bai in a subfolder using `stageAs`, in order to prevent the inputs from matching the wildcard in the bam output channel.

## PR checklist

Closes #3504  <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
