### PR TITLE
Add test for stub for kmcp index module

### DIFF
--- a/tests/modules/nf-core/kmcp/index/test.yml
+++ b/tests/modules/nf-core/kmcp/index/test.yml
@@ -9,3 +9,12 @@
     - path: output/kmcp/test_/R001/__name_mapping.tsv
     - path: output/kmcp/test_/R001/_block001.uniki
     - path: output/kmcp/versions.yml
+
+- name: kmcp index test_kmcp_index stub_run
+  command: nextflow run ./tests/modules/nf-core/kmcp/index -entry test_kmcp_index -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/kmcp/index/nextflow.config -stub-run
+  tags:
+    - kmcp/index
+    - kmcp
+  files:
+    - path: output/kmcp/test_.log
+    - path: output/kmcp/versions.yml


### PR DESCRIPTION
This PR adds test for stub for [kmcp/index module](https://github.com/nf-core/modules/tree/master/modules/nf-core/kmcp/index)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
