### PR TITLE
Add stub for kmcp search module

### DIFF
--- a/modules/nf-core/kmcp/search/main.nf
+++ b/modules/nf-core/kmcp/search/main.nf
@@ -36,4 +36,17 @@ process KMCP_SEARCH {
         kmcp: \$(echo \$(kmcp version 2>&1) | sed -n 1p | sed 's/^.*kmcp v//')
     END_VERSIONS
     """
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}
+    gzip ${prefix}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kmcp: \$(echo \$(kmcp version 2>&1) | sed -n 1p | sed 's/^.*kmcp v//')
+    END_VERSIONS
+    """
+
 }

--- a/tests/modules/nf-core/kmcp/search/test.yml
+++ b/tests/modules/nf-core/kmcp/search/test.yml
@@ -8,3 +8,14 @@
     - path: output/kmcp/test_/R001/__name_mapping.tsv
     - path: output/kmcp/test_/R001/_block001.uniki
     - path: output/kmcp/versions.yml
+
+- name: kmcp search test_kmcp_search stub_run
+  command: nextflow run ./tests/modules/nf-core/kmcp/search -entry test_kmcp_search -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/kmcp/search/nextflow.config -stub-run
+  tags:
+    - kmcp
+    - kmcp/search
+  files:
+    - path: output/kmcp/test_/R001/__db.yml
+    - path: output/kmcp/test_/R001/__name_mapping.tsv
+    - path: output/kmcp/test_/R001/_block001.uniki
+    - path: output/kmcp/versions.yml


### PR DESCRIPTION
This PR adds stub to [kmcp search module](https://github.com/nf-core/modules/tree/master/modules/nf-core/kmcp/search)
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
