### PR TITLE
Add stub for kmcp profile

### DIFF
--- a/modules/nf-core/kmcp/profile/main.nf
+++ b/modules/nf-core/kmcp/profile/main.nf
@@ -44,7 +44,6 @@ process KMCP_PROFILE {
     prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.profile
-    tar cvzf kmcp_profile.tar.gz ${prefix}.profile
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/kmcp/profile/main.nf
+++ b/modules/nf-core/kmcp/profile/main.nf
@@ -44,6 +44,7 @@ process KMCP_PROFILE {
     prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.profile
+    tar cvzf kmcp_profile.tar.gz ${prefix}.profile
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/kmcp/profile/main.nf
+++ b/modules/nf-core/kmcp/profile/main.nf
@@ -50,4 +50,15 @@ process KMCP_PROFILE {
         kmcp: \$(echo \$(kmcp version 2>&1) | sed -n 1p | sed 's/^.*kmcp v//')
     END_VERSIONS
     """
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.profile
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kmcp: \$(echo \$(kmcp version 2>&1) | sed -n 1p | sed 's/^.*kmcp v//')
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/kmcp/profile/main.nf
+++ b/modules/nf-core/kmcp/profile/main.nf
@@ -50,16 +50,4 @@ process KMCP_PROFILE {
         kmcp: \$(echo \$(kmcp version 2>&1) | sed -n 1p | sed 's/^.*kmcp v//')
     END_VERSIONS
     """
-    stub:
-    def args = task.ext.args ?: ''
-    prefix = task.ext.prefix ?: "${meta.id}"
-    """
-    touch ${prefix}.profile
-    gzip ${prefix}.profile
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kmcp: \$(echo \$(kmcp version 2>&1) | sed -n 1p | sed 's/^.*kmcp v//')
-    END_VERSIONS
-    """
 }

--- a/modules/nf-core/kmcp/profile/main.nf
+++ b/modules/nf-core/kmcp/profile/main.nf
@@ -55,6 +55,7 @@ process KMCP_PROFILE {
     prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.profile
+    gzip ${prefix}.profile
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/tests/modules/nf-core/kmcp/profile/test.yml
+++ b/tests/modules/nf-core/kmcp/profile/test.yml
@@ -1,19 +1,17 @@
 - name: kmcp profile test_kmcp_profile
   command: nextflow run ./tests/modules/nf-core/kmcp/profile -entry test_kmcp_profile -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/kmcp/profile/nextflow.config
   tags:
-    - kmcp
     - kmcp/profile
+    - kmcp
   files:
-    - path: output/untar/kmcp_profile/kmcp_profile.tar.gz
-    - path: output/untar/kmcp_profile/names.dmp
-    - path: output/untar/kmcp_profile/nodes.dmp
+    - path: output/kmcp/test.profile
     - path: output/untar/versions.yml
 
 - name: kmcp profile test_kmcp_profile stub_run
   command: nextflow run ./tests/modules/nf-core/kmcp/profile -entry test_kmcp_profile -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/kmcp/profile/nextflow.config -stub-run
   tags:
-    - kmcp
     - kmcp/profile
+    - kmcp
   files:
-    - path: output/untar/kmcp_profile/kmcp_profile.tar.gz
+    - path: output/kmcp/test.profile
     - path: output/untar/versions.yml

--- a/tests/modules/nf-core/kmcp/profile/test.yml
+++ b/tests/modules/nf-core/kmcp/profile/test.yml
@@ -8,3 +8,14 @@
     - path: output/untar/kmcp_profile/names.dmp
     - path: output/untar/kmcp_profile/nodes.dmp
     - path: output/untar/versions.yml
+
+- name: kmcp profile test_kmcp_profile stub_run
+  command: nextflow run ./tests/modules/nf-core/kmcp/profile -entry test_kmcp_profile -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/kmcp/profile/nextflow.config -stub-run
+  tags:
+    - kmcp
+    - kmcp/profile
+  files:
+    - path: output/untar/kmcp_profile/kmcp_profile.tar.gz
+    - path: output/untar/kmcp_profile/names.dmp
+    - path: output/untar/kmcp_profile/nodes.dmp
+    - path: output/untar/versions.yml

--- a/tests/modules/nf-core/kmcp/profile/test.yml
+++ b/tests/modules/nf-core/kmcp/profile/test.yml
@@ -16,6 +16,4 @@
     - kmcp/profile
   files:
     - path: output/untar/kmcp_profile/kmcp_profile.tar.gz
-    - path: output/untar/kmcp_profile/names.dmp
-    - path: output/untar/kmcp_profile/nodes.dmp
     - path: output/untar/versions.yml


### PR DESCRIPTION
This PR adds stub for [kmcp profile module](https://github.com/nf-core/modules/tree/master/modules/nf-core/kmcp/profile).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
