### PR TITLE
Fix tag quotes in mmseqs_databases

### DIFF
--- a/modules/nf-core/mmseqs/databases/main.nf
+++ b/modules/nf-core/mmseqs/databases/main.nf
@@ -1,5 +1,5 @@
 process MMSEQS_DATABASES {
-    tag '$database'
+    tag "${database}"
     label 'process_medium'
 
     conda "bioconda::mmseqs2=14.7e284"


### PR DESCRIPTION
Accidentally used single quotes so variable not expanded!

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
