### PR TITLE
Fix metaeuk_easypredict when using mmseqs database

### DIFF
--- a/modules/nf-core/metaeuk/easypredict/main.nf
+++ b/modules/nf-core/metaeuk/easypredict/main.nf
@@ -25,9 +25,17 @@ process METAEUK_EASYPREDICT {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     """
+    if [ -d ${database} ]; then
+        ## if supplying an mmseqs database as a directory, metaeuk requires the basename of the database
+        DBBASE=`find ${database}/ -name "*.version" -exec sh -c 'file=\$(basename {}); echo \${file%%.*}' \\;`
+        DB=`echo "${database}/\${DBBASE}"`
+    else
+        DB=${database}
+    fi
+
     metaeuk easy-predict \\
         ${fasta} \\
-        ${database} \\
+        \${DB} \\
         ${prefix} \\
         tmp/ \\
         ${args}

--- a/tests/modules/nf-core/metaeuk/easypredict/main.nf
+++ b/tests/modules/nf-core/metaeuk/easypredict/main.nf
@@ -2,18 +2,35 @@
 
 nextflow.enable.dsl = 2
 
-include { METAEUK_EASYPREDICT } from '../../../../../modules/nf-core/metaeuk/easypredict/main.nf'
+include { MMSEQS_DATABASES                                  } from '../../../../../modules/nf-core/mmseqs/databases/main.nf'
+include { METAEUK_EASYPREDICT as METAEUK_EASYPREDICT_FASTA  } from '../../../../../modules/nf-core/metaeuk/easypredict/main.nf'
+include { METAEUK_EASYPREDICT as METAEUK_EASYPREDICT_MMSEQS } from '../../../../../modules/nf-core/metaeuk/easypredict/main.nf'
 
-workflow test_metaeuk_easypredict {
+workflow test_metaeuk_easypredict_fasta {
 
     input = [
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
     ]
 
-    database = [
+    fasta = [
         file(params.test_data['proteomics']['database']['yeast_ups'], checkIfExists: true)
     ]
 
-    METAEUK_EASYPREDICT ( input, database )
+    METAEUK_EASYPREDICT_FASTA ( input, fasta )
+
+}
+
+workflow test_metaeuk_easypredict_mmseqs {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+
+    MMSEQS_DATABASES ( 'UniProtKB/Swiss-Prot' )
+    database = MMSEQS_DATABASES.out.database
+
+    METAEUK_EASYPREDICT_MMSEQS ( input, database )
+
 }

--- a/tests/modules/nf-core/metaeuk/easypredict/test.yml
+++ b/tests/modules/nf-core/metaeuk/easypredict/test.yml
@@ -1,5 +1,5 @@
-- name: metaeuk easypredict test_metaeuk_easypredict
-  command: nextflow run ./tests/modules/nf-core/metaeuk/easypredict -entry test_metaeuk_easypredict -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/metaeuk/easypredict/nextflow.config
+- name: metaeuk easypredict test_metaeuk_easypredict_fasta
+  command: nextflow run ./tests/modules/nf-core/metaeuk/easypredict -entry test_metaeuk_easypredict_fasta -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/metaeuk/easypredict/nextflow.config
   tags:
     - metaeuk/easypredict
     - metaeuk
@@ -13,3 +13,27 @@
     - path: output/metaeuk/test.headersMap.tsv
       md5sum: b3628c76d7385d326bd8a7931d974cff
     - path: output/metaeuk/versions.yml
+
+- name: metaeuk easypredict test_metaeuk_easypredict_mmseqs
+  command: nextflow run ./tests/modules/nf-core/metaeuk/easypredict -entry test_metaeuk_easypredict_mmseqs -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/metaeuk/easypredict/nextflow.config
+  tags:
+    - metaeuk/easypredict
+    - metaeuk
+  files:
+    - path: output/metaeuk/test.codon.fas
+    - path: output/metaeuk/test.fas
+    - path: output/metaeuk/test.gff
+    - path: output/metaeuk/test.headersMap.tsv
+    - path: output/metaeuk/versions.yml
+    - path: output/mmseqs/mmseqs_database/database
+    - path: output/mmseqs/mmseqs_database/database.dbtype
+    - path: output/mmseqs/mmseqs_database/database.index
+    - path: output/mmseqs/mmseqs_database/database.lookup
+    - path: output/mmseqs/mmseqs_database/database.source
+    - path: output/mmseqs/mmseqs_database/database.version
+    - path: output/mmseqs/mmseqs_database/database_h
+    - path: output/mmseqs/mmseqs_database/database_h.dbtype
+    - path: output/mmseqs/mmseqs_database/database_h.index
+    - path: output/mmseqs/mmseqs_database/database_mapping
+    - path: output/mmseqs/mmseqs_database/database_taxonomy
+    - path: output/mmseqs/versions.yml


### PR DESCRIPTION
Fixes a bug with metaeuk_easypredict - when calling with an mmseqs2-formatted database, it turns out it also requires the file basename to be supplied, rather than just a directory, which I didn't realise 😅

Also adds a test to download the SwissProt DB (~80mb) and test the tool with this input type. As the DB is not versioned, the test just checks for the existence of the output files as the results are likely to change.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
