### PR TITLE
Updated pretext container 

### DIFF
--- a/modules/nf-core/pretextmap/main.nf
+++ b/modules/nf-core/pretextmap/main.nf
@@ -3,10 +3,10 @@ process PRETEXTMAP {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::pretextmap=0.1.9=h9f5acd7_1 bioconda::samtools=1.16.1"
+    conda "bioconda::pretextmap=0.1.9 bioconda::samtools=1.17"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:c6242a6c1a522137de7a9e9ff90779ede11cf5c5-0':
-        'biocontainers/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:c6242a6c1a522137de7a9e9ff90779ede11cf5c5-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61%3A44321ab4d64f0b6d0c93abbd1406369d1b3da684-0':
+        'biocontainers/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:44321ab4d64f0b6d0c93abbd1406369d1b3da684-0' }"
 
     input:
     tuple val(meta), path(input)
@@ -42,7 +42,7 @@ process PRETEXTMAP {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         pretextmap: \$(PretextMap | grep "Version" | sed 's/PretextMap Version //g')
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' ))
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' )
     END_VERSIONS
     """
 

--- a/tests/modules/nf-core/pretextmap/test.yml
+++ b/tests/modules/nf-core/pretextmap/test.yml
@@ -4,9 +4,9 @@
     - "pretextmap"
   files:
     - path: "output/pretextmap/test.pretext"
-      md5sum: 36105209541b09098a2d070cce5866a9
+      md5sum: ae0f18b472e39de970fdc1aebc0f3f8d
     - path: "output/pretextmap/versions.yml"
-      md5sum: 9438beb021f38a4d563238c5ce4eda26
+      md5sum: 6e148d693b1061694fc9b5a9aa806198
 
 - name: "pretextmap_cram"
   command: nextflow run ./tests/modules/nf-core/pretextmap -entry test_pretextmap_cram -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/pretextmap/nextflow.config
@@ -14,9 +14,9 @@
     - "pretextmap"
   files:
     - path: "output/pretextmap/test.pretext"
-      md5sum: 36105209541b09098a2d070cce5866a9
+      md5sum: ae0f18b472e39de970fdc1aebc0f3f8d
     - path: "output/pretextmap/versions.yml"
-      md5sum: 709042783da7ab07098cbe6835380be1
+      md5sum: 318fc06fd6d771fa31004cea03a2a71e
 
 - name: "pretextmap_pairs_gz"
   command: nextflow run ./tests/modules/nf-core/pretextmap -entry test_pretextmap_pairs_gz -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/pretextmap/nextflow.config
@@ -24,6 +24,6 @@
     - "pretextmap"
   files:
     - path: "output/pretextmap/test.pretext"
-      md5sum: 4def3f73634f9866aa911ade21ffe75e
+      md5sum: b47be7fd285a2de68643f73f85ba84f1
     - path: "output/pretextmap/versions.yml"
-      md5sum: 2a119e3f7b526dc7df9ec2b01e934220
+      md5sum: f9ef0be0308bbb9b2697b0f8e7e23919


### PR DESCRIPTION
Updated the container to samtools 1.17 and so that container and bioconda pretext versions now match.
md5sums updated in light of this.

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Emit the `versions.yml` file.
- [X] Follow the naming conventions.
- [X] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [X] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [X] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
