### PR TITLE
Version updates and yaml changes

### DIFF
--- a/modules/nf-core/bedtools/map/main.nf
+++ b/modules/nf-core/bedtools/map/main.nf
@@ -2,10 +2,10 @@ process BEDTOOLS_MAP {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::bedtools=2.30.0"
+    conda "bioconda::bedtools=2.31.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bedtools:2.30.0--hc088bd4_0' :
-        'biocontainers/bedtools:2.30.0--hc088bd4_0' }"
+        'https://depot.galaxyproject.org/singularity/bedtools:2.31.0--hf5e1c6e_2' :
+        'biocontainers/bedtools:2.31.0--hf5e1c6e_2' }"
 
     input:
     tuple val(meta), path(intervals1), path(intervals2)

--- a/modules/nf-core/bedtools/map/meta.yml
+++ b/modules/nf-core/bedtools/map/meta.yml
@@ -2,7 +2,10 @@ name: bedtools_map
 description: Allows one to screen for overlaps between two sets of genomic features.
 keywords:
   - bed
+  - vcf
+  - gff
   - map
+  - bedtools
 tools:
   - bedtools:
       description: |

--- a/modules/nf-core/busco/meta.yml
+++ b/modules/nf-core/busco/meta.yml
@@ -25,7 +25,7 @@ input:
       description: Nucleic or amino acid sequence file in FASTA format.
       pattern: "*.{fasta,fna,fa,fasta.gz,fna.gz,fa.gz}"
   - lineage:
-      type: value
+      type: string
       description: The BUSCO lineage to use, or "auto" to automatically select lineage
   - busco_lineages_path:
       type: directory

--- a/modules/nf-core/pretextmap/main.nf
+++ b/modules/nf-core/pretextmap/main.nf
@@ -3,10 +3,10 @@ process PRETEXTMAP {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::pretextmap=0.1.9=h9f5acd7_1 bioconda::samtools=1.16.1"
+    conda "bioconda::pretextmap=0.1.9 bioconda::samtools=1.17"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:c6242a6c1a522137de7a9e9ff90779ede11cf5c5-0':
-        'biocontainers/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:c6242a6c1a522137de7a9e9ff90779ede11cf5c5-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61%3A44321ab4d64f0b6d0c93abbd1406369d1b3da684-0':
+        'biocontainers/mulled-v2-f3591ce8609c7b3b33e5715333200aa5c163aa61:44321ab4d64f0b6d0c93abbd1406369d1b3da684-0' }"
 
     input:
     tuple val(meta), path(input)
@@ -42,7 +42,7 @@ process PRETEXTMAP {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         pretextmap: \$(PretextMap | grep "Version" | sed 's/PretextMap Version //g')
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' ))
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' )
     END_VERSIONS
     """
 

--- a/modules/nf-core/seqtk/cutn/main.nf
+++ b/modules/nf-core/seqtk/cutn/main.nf
@@ -2,10 +2,10 @@ process SEQTK_CUTN {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::seqtk=1.3"
+    conda "bioconda::seqtk=1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/seqtk:1.3--h5bf99c6_3' :
-        'biocontainers/seqtk:1.3--h5bf99c6_3' }"
+        'https://depot.galaxyproject.org/singularity/seqtk:1.4--he4a0461_1' :
+        'biocontainers/seqtk:1.4--he4a0461_1' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/seqtk/cutn/meta.yml
+++ b/modules/nf-core/seqtk/cutn/meta.yml
@@ -3,6 +3,7 @@ description: Generates a BED file containing genomic locations of lengths of N.
 keywords:
   - cut
   - fasta
+  - seqtk
 tools:
   - seqtk:
       description: Seqtk is a fast and lightweight tool for processing sequences in the FASTA or FASTQ format. Seqtk mergepe command merges pair-end reads into one interleaved file.

--- a/modules/nf-core/windowmasker/mk_counts/main.nf
+++ b/modules/nf-core/windowmasker/mk_counts/main.nf
@@ -2,10 +2,10 @@ process WINDOWMASKER_MKCOUNTS {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::blast=2.13.0"
+    conda "bioconda::blast=2.14.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/blast:2.13.0--hf3cf87c_0':
-        'biocontainers/blast:2.13.0--hf3cf87c_0' }"
+        'https://depot.galaxyproject.org/singularity/blast:2.14.0--h7d5a4b4_1':
+        'biocontainers/blast:2.14.0--h7d5a4b4_1' }"
 
     input:
     tuple val(meta), path(ref)

--- a/modules/nf-core/windowmasker/mk_counts/meta.yml
+++ b/modules/nf-core/windowmasker/mk_counts/meta.yml
@@ -3,6 +3,7 @@ description: A program to generate frequency counts of repetitive units.
 keywords:
   - fasta
   - interval
+  - windowmasker
 tools:
   - windowmasker:
       description: |

--- a/modules/nf-core/windowmasker/ustat/main.nf
+++ b/modules/nf-core/windowmasker/ustat/main.nf
@@ -2,10 +2,10 @@ process WINDOWMASKER_USTAT {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::blast=2.13.0"
+    conda "bioconda::blast=2.14.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/blast:2.13.0--hf3cf87c_0':
-        'biocontainers/blast:2.13.0--hf3cf87c_0' }"
+        'https://depot.galaxyproject.org/singularity/blast:2.14.0--h7d5a4b4_1':
+        'biocontainers/blast:2.14.0--h7d5a4b4_1' }"
 
     input:
     tuple val(meta) , path(counts)

--- a/modules/nf-core/windowmasker/ustat/meta.yml
+++ b/modules/nf-core/windowmasker/ustat/meta.yml
@@ -3,6 +3,7 @@ description: A program to take a counts file and creates a file of genomic co-or
 keywords:
   - fasta
   - interval
+  - windowmasker
 tools:
   - windowmasker:
       description: |

--- a/tests/modules/nf-core/bedtools/map/test.yml
+++ b/tests/modules/nf-core/bedtools/map/test.yml
@@ -6,6 +6,8 @@
   files:
     - path: output/bedtools/test_out.bed
       md5sum: d3aeb1ec7b90e0d5a6d1b9a4614ab96a
+    - path: output/bedtools/versions.yml
+      md5sum: 6c219404bf848cd4bd672a934dd4ed56
 
 - name: bedtools map test_bedtools_map_vcf
   command: nextflow run ./tests/modules/nf-core/bedtools/map -entry test_bedtools_map_vcf -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bedtools/map/nextflow.config
@@ -15,3 +17,5 @@
   files:
     - path: output/bedtools/test_out.bed
       md5sum: cabd34d1132834581e31f53dfa66ec03
+    - path: output/bedtools/versions.yml
+      md5sum: ab927c219959af17dc370b0b8eda78bd

--- a/tests/modules/nf-core/seqtk/cutn/test.yml
+++ b/tests/modules/nf-core/seqtk/cutn/test.yml
@@ -7,3 +7,4 @@
     - path: output/seqtk/test.bed
       md5sum: 16cbba84e3a4bdbb52217afb5051f948
     - path: output/seqtk/versions.yml
+      md5sum: ebd701588cdf06646b6177d2c1038b75

--- a/tests/modules/nf-core/windowmasker/mk_counts/test.yml
+++ b/tests/modules/nf-core/windowmasker/mk_counts/test.yml
@@ -3,6 +3,7 @@
   tags:
     - windowmasker
   files:
-    - path: output/windowmasker/test.interval
-      md5sum: 2e8a3ece921560393ec36426fbcfb6ed
-    - path: output/miniprot/versions.yml
+    - path: output/windowmasker/test.txt
+      md5sum: 5f5d7e926fdf13b0c57651f962cc1253
+    - path: output/windowmasker/versions.yml
+      md5sum: 768975023f6b0112a3f14de93fb2b68d

--- a/tests/modules/nf-core/windowmasker/ustat/test.yml
+++ b/tests/modules/nf-core/windowmasker/ustat/test.yml
@@ -3,8 +3,7 @@
   tags:
     - windowmasker
   files:
-    - path: output/windowmasker/test.txt
-      md5sum: 902be82b1b12b7cd1637ed9a7ab1fc7a
     - path: output/windowmasker/test.interval
-      md5sum: 2e8a3ece921560393ec36426fbcfb6ed
+      md5sum: 2ff2fc70bd79fed04e13e30fbd6f5708
     - path: output/miniprot/versions.yml
+      md5sum: 575007fad2c1552e3cd535d46a4bf1a5


### PR DESCRIPTION
Updated the versions and md5sums of 
bedtools map
busco <- just yaml def
windowmasker <- also changed yaml so it is acurately checking its own output file md5sum
seqtk cutn

- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [X] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [X] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
