### PR TITLE
Use `gzip -cd` because `gunzip` preserves the group ownership

### DIFF
--- a/modules/nf-core/gunzip/main.nf
+++ b/modules/nf-core/gunzip/main.nf
@@ -21,6 +21,9 @@ process GUNZIP {
     def args = task.ext.args ?: ''
     gunzip = archive.toString() - '.gz'
     """
+    # Not calling gunzip itself because it creates files
+    # with the original group ownership rather than the
+    # default one for that user / the work directory
     gzip \\
         -cd \\
         $args \\

--- a/modules/nf-core/gunzip/main.nf
+++ b/modules/nf-core/gunzip/main.nf
@@ -21,10 +21,11 @@ process GUNZIP {
     def args = task.ext.args ?: ''
     gunzip = archive.toString() - '.gz'
     """
-    gunzip \\
-        -f \\
+    gzip \\
+        -cd \\
         $args \\
-        $archive
+        $archive \\
+        > $gunzip
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Hello,

I've found out that `gunzip` creates the uncompress file under the same group ownership as the compressed file. This may cause some issues when the work directory is on a filesystem where this group doesn't have a quota. It also breaks the assumption that all the files created by Nextflow are under the primary group of the user (or the group of the holding directory if the setgid permission is used) and is painful to debug.

Here, I propose passing through the shell to get the file created to guarantee the group ownership follows the usual rules.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
