### PR TITLE
License on sentieon script

### DIFF
--- a/modules/nf-core/sentieon/setup.md
+++ b/modules/nf-core/sentieon/setup.md
@@ -1,13 +1,13 @@
-# How to use the Sentieon modules
+# How to use the sentieon modules
 
-Except the sentieon bwaindex module, these nextflow sentieon modules need the sentieon license string (probably some url) to be base64-encoded and stored in a nextflow secret named `SENTIEON_LICENSE_BASE64`. The encoding can be done like this:
+Except the sentieon bwaindex module, these nextflow sentieon modules require a license. Sentieon supply license in the form of a string-value (a url) or a file. It should be base64-encoded and stored in a nextflow secret named `SENTIEON_LICENSE_BASE64`. If a license string (url) is supplied, then the nextflow secret should be set like this:
 
 ```bash
-SENTIEON_LICENSE_BASE64=$(echo -n <sentieon_license_string> | base64 -w 0)
+nextflow secret set SENTIEON_LICENSE_BASE64 $(echo -n <sentieon_license_string> | base64 -w 0)
 ```
 
-The Nextflow secret is then set like this:
+If a license file is supplied, then the nextflow secret should be set like this:
 
 ```bash
-nextflow secret set SENTIEON_LICENSE_BASE64 $SENTIEON_LICENSE_BASE64
+nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)
 ```

--- a/tests/modules/nf-core/sentieon/license_message.py
+++ b/tests/modules/nf-core/sentieon/license_message.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+#########################################
+# Author: [DonFreed](https://github.com/DonFreed)
+# File: license_message.py
+# Source: https://github.com/DonFreed/docker-actions-test/blob/main/.github/scripts/license_message.py
+# Source+commit: https://github.com/DonFreed/docker-actions-test/blob/aa1051a9f53b3a1e801953748d062cad74dca9a9/.github/scripts/license_message.py
+# Download Date: 2023-07-04, commit: aa1051a
+# This source code is licensed under the BSD 2-Clause license
+#########################################
+
 """
 Functions for generating and sending license messages
 """


### PR DESCRIPTION
Adding BSD 2-Clause license statement the sentieon script `tests/modules/nf-core/sentieon/license_message.py`.

Updating `modules/nf-core/sentieon/setup.md` with info on how to use the sentieon modules with a file-based sentieon license.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
