### PR TITLE
fix integer overflow

### DIFF
--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
@@ -14,7 +14,7 @@ import groovy.json.JsonSlurper
 
 def getFastpReadsAfterFiltering(json_file) {
     def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('summary')
-    return json['after_filtering']['total_reads'].toInteger()
+    return json['after_filtering']['total_reads'].toLong()
 }
 
 workflow FASTQ_FASTQC_UMITOOLS_FASTP {
@@ -100,7 +100,7 @@ workflow FASTQ_FASTQC_UMITOOLS_FASTP {
             .set { ch_num_trimmed_reads }
 
         ch_num_trimmed_reads
-            .filter { meta, reads, num_reads -> num_reads >= min_trimmed_reads.toInteger() }
+            .filter { meta, reads, num_reads -> num_reads >= min_trimmed_reads.toLong() }
             .map { meta, reads, num_reads -> [ meta, reads ] }
             .set { trim_reads }
 

--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
@@ -13,7 +13,7 @@ import groovy.json.JsonSlurper
 
 def getFastpReadsAfterFiltering(json_file) {
     def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('summary')
-    return json['after_filtering']['total_reads'].toInteger()
+    return json['after_filtering']['total_reads'].toLong()
 }
 
 workflow FASTQ_TRIM_FASTP_FASTQC {


### PR DESCRIPTION
Very large fastqs can cause `num_reads` in the `fastq_fastqc_umitools_fastp` and `fastq_trim_fastp_fastqc` subworkflows to overflow and mistakenly skip samples.

I'm not sure how to test this. Probably a unit test of the `getFastpReadsAfterFiltering()` method would be best, but i'm not familiar enough with groovy to know how to do that.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
