### PR TITLE
3630 add unstitched reads as emitted output of ngmerge

### DIFF
--- a/modules/nf-core/ngmerge/main.nf
+++ b/modules/nf-core/ngmerge/main.nf
@@ -8,7 +8,7 @@ process NGMERGE {
         'biocontainers/ngmerge:0.3--ha92aebf_1' }"
 
     input:
-    tuple val(meta), path(reads1), path(reads2)
+    tuple val(meta), path(reads)
 
     output:
     tuple val(meta), path("*.merged.fq.gz"), emit: merged_reads
@@ -25,10 +25,10 @@ process NGMERGE {
 
     """
     NGmerge \\
-        -1 $reads1 \\
-        -2 $reads2 \\
+        -1 ${reads[0]} \\
+        -2 ${reads[1]} \\
         -o ${prefix}.merged.fq.gz \\
-        -f ${prefix} \\
+        -f ${prefix}_unstitched \\
         -z \\
         -n $task.cpus \\
         $args

--- a/modules/nf-core/ngmerge/main.nf
+++ b/modules/nf-core/ngmerge/main.nf
@@ -12,6 +12,8 @@ process NGMERGE {
 
     output:
     tuple val(meta), path("*.merged.fq.gz"), emit: merged_reads
+    tuple val(meta), path("*_1.fastq.gz")  , emit: unstitched_read1
+    tuple val(meta), path("*_2.fastq.gz")  , emit: unstitched_read2
     path "versions.yml"                    , emit: versions
 
     when:
@@ -26,6 +28,7 @@ process NGMERGE {
         -1 $reads1 \\
         -2 $reads2 \\
         -o ${prefix}.merged.fq.gz \\
+        -f ${prefix} \\
         -z \\
         -n $task.cpus \\
         $args

--- a/modules/nf-core/ngmerge/meta.yml
+++ b/modules/nf-core/ngmerge/meta.yml
@@ -22,14 +22,10 @@ input:
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
 
-  - reads1:
+  - reads:
       type: file
-      description: fastq file paired end read 1
-      pattern: "*.{fa,fasta,fastq,fq,fa.gz,fasta.gz,fastq.gz,fq.gz}"
-
-  - reads2:
-      type: file
-      description: fastq file paired end read 2
+      description: |
+        List of input FastQ files of size 2; i.e., paired-end data.
       pattern: "*.{fa,fasta,fastq,fq,fa.gz,fasta.gz,fastq.gz,fq.gz}"
 
 output:
@@ -46,7 +42,17 @@ output:
 
   - merged_reads:
       type: file
-      description: fastq file paired end read 2
+      description: fastq file merged reads
+      pattern: "*.{fa,fasta,fastq,fq,fa.gz,fasta.gz,fastq.gz,fq.gz}"
+
+  - unstitched_read1:
+      type: file
+      description: fastq file unstitched read 1
+      pattern: "*.{fa,fasta,fastq,fq,fa.gz,fasta.gz,fastq.gz,fq.gz}"
+
+  - unstitched_read2:
+      type: file
+      description: fastq file unstitched read 2
       pattern: "*.{fa,fasta,fastq,fq,fa.gz,fasta.gz,fastq.gz,fq.gz}"
 
 authors:

--- a/tests/modules/nf-core/ngmerge/main.nf
+++ b/tests/modules/nf-core/ngmerge/main.nf
@@ -7,8 +7,8 @@ include { NGMERGE } from '../../../../modules/nf-core/ngmerge/main.nf'
 workflow test_ngmerge {
     input = [
         [ id:'test', single_end:false ], // meta map
-        [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)],
-        [ file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)]
+        [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)]
     ]
 
     NGMERGE ( input )

--- a/tests/modules/nf-core/ngmerge/test.yml
+++ b/tests/modules/nf-core/ngmerge/test.yml
@@ -4,4 +4,6 @@
     - ngmerge
   files:
     - path: output/ngmerge/test.merged.fq.gz
+    - path: output/ngmerge/test_unstitched_1.fastq.gz
+    - path: output/ngmerge/test_unstitched_2.fastq.gz
     - path: output/ngmerge/versions.yml


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #3630 <!-- If this PR fixes an issue, please link it here! -->

add -f option and emit unstitched read 1 and read 2 as output so they can be used by downstream processes if required

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
