### PR TITLE
Fix bug in pyrodigal module

### DIFF
--- a/modules/nf-core/pyrodigal/main.nf
+++ b/modules/nf-core/pyrodigal/main.nf
@@ -34,7 +34,7 @@ process PYRODIGAL {
         -a ${prefix}.faa \\
         -s ${prefix}.score
 
-    pigz -nm ${prefix}*
+    pigz -nmf ${prefix}*
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Added "--force" to pigz which should prevent errors reported on Slack ([link to thread](https://nfcore.slack.com/archives/C02K5GX2W93/p1688471831570479)).

I don't think we need to care about being more specific with the filename pattern when zipping the output like `pigz -nmf ${prefix}*`, since only the output files (not input fasta) should be present in the folder. And it worked like this before the symbolic link error came in ;)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
