### PR TITLE
Hisat2-build: index construction w/ truly optional inputs 

### DIFF
--- a/modules/nf-core/hisat2/build/main.nf
+++ b/modules/nf-core/hisat2/build/main.nf
@@ -37,9 +37,9 @@ process HISAT2_BUILD {
     def hisat2_build_memory = params.hisat2_build_memory ? (params.hisat2_build_memory as nextflow.util.MemoryUnit).toGiga() : 0
     if (avail_mem >= hisat2_build_memory) {
         log.info "[HISAT2 index build] At least ${hisat2_build_memory} GB available, so using splice sites and exons to build HISAT2 index"
-        extract_exons = "hisat2_extract_exons.py $gtf > ${gtf.baseName}.exons.txt"
-        ss = "--ss $splicesites"
-        exon = "--exon ${gtf.baseName}.exons.txt"
+        extract_exons = gtf ? "hisat2_extract_exons.py $gtf > ${gtf.baseName}.exons.txt" : ""
+        ss = splicesites ? "--ss $splicesites" : ""
+        exon = gtf ? "--exon ${gtf.baseName}.exons.txt" : ""
     } else {
         log.info "[HISAT2 index build] Less than ${hisat2_build_memory} GB available, so NOT using splice sites and exons to build HISAT2 index."
         log.info "[HISAT2 index build] Use --hisat2_build_memory [small number] to skip this check."

--- a/tests/modules/nf-core/hisat2/build_test/main.nf
+++ b/tests/modules/nf-core/hisat2/build_test/main.nf
@@ -7,10 +7,10 @@ include { HISAT2_BUILD              } from '../../../../../modules/nf-core/hisat
 
 workflow test_hisat2_build {
     fasta = [ [id:'genome'],
-              file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'genome'],
-              file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
+              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
             ]
     HISAT2_EXTRACTSPLICESITES ( gtf )
     HISAT2_BUILD ( fasta, gtf, HISAT2_EXTRACTSPLICESITES.out.txt )
@@ -18,21 +18,21 @@ workflow test_hisat2_build {
 
 workflow test_hisat2_build_fasta_only {
     fasta = [ [id:'genome'],
-              file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'genome'],
-              file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
+              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
             ]
-    HISAT2_BUILD ( fasta, [[],[]], [[],[]] )
+    HISAT2_BUILD ( fasta, [[:],[]], [[:],[]] )
 }
 
 workflow test_hisat2_build_fasta_ss_only {
     fasta = [ [id:'genome'],
-              file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'genome'],
-              file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
+              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
             ]
     HISAT2_EXTRACTSPLICESITES ( gtf )
-    HISAT2_BUILD ( fasta, [[],[]], HISAT2_EXTRACTSPLICESITES.out.txt )
+    HISAT2_BUILD ( fasta, [[:],[]], HISAT2_EXTRACTSPLICESITES.out.txt )
 }

--- a/tests/modules/nf-core/hisat2/build_test/main.nf
+++ b/tests/modules/nf-core/hisat2/build_test/main.nf
@@ -23,7 +23,6 @@ workflow test_hisat2_build_fasta_only {
     gtf   = [ [id:'genome'],
               file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
             ]
-    HISAT2_EXTRACTSPLICESITES ( gtf )
     HISAT2_BUILD ( fasta, [[],[]], [[],[]] )
 }
 

--- a/tests/modules/nf-core/hisat2/build_test/main.nf
+++ b/tests/modules/nf-core/hisat2/build_test/main.nf
@@ -15,3 +15,35 @@ workflow test_hisat2_build {
     HISAT2_EXTRACTSPLICESITES ( gtf )
     HISAT2_BUILD ( fasta, gtf, HISAT2_EXTRACTSPLICESITES.out.txt )
 }
+
+workflow test_hisat2_build_fasta_only {
+    fasta = [ [id:'genome'],
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            ]
+    gtf   = [ [id:'genome'],
+              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+            ]
+    HISAT2_EXTRACTSPLICESITES ( gtf )
+    HISAT2_BUILD ( fasta, [[],[]], [[],[]] )
+}
+
+workflow test_hisat2_build_fasta_ss_only {
+    fasta = [ [id:'genome'],
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            ]
+    gtf   = [ [id:'genome'],
+              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+            ]
+    HISAT2_EXTRACTSPLICESITES ( gtf )
+    HISAT2_BUILD ( fasta, [[],[]], HISAT2_EXTRACTSPLICESITES.out.txt )
+}
+
+workflow test_hisat2_build_fasta_gtf_only {
+    fasta = [ [id:'genome'],
+              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            ]
+    gtf   = [ [id:'genome'],
+              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+            ]
+    HISAT2_BUILD ( fasta, gtf, [[],[]] )
+}

--- a/tests/modules/nf-core/hisat2/build_test/main.nf
+++ b/tests/modules/nf-core/hisat2/build_test/main.nf
@@ -7,10 +7,10 @@ include { HISAT2_BUILD              } from '../../../../../modules/nf-core/hisat
 
 workflow test_hisat2_build {
     fasta = [ [id:'genome'],
-              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+              file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'genome'],
-              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+              file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
             ]
     HISAT2_EXTRACTSPLICESITES ( gtf )
     HISAT2_BUILD ( fasta, gtf, HISAT2_EXTRACTSPLICESITES.out.txt )
@@ -18,10 +18,10 @@ workflow test_hisat2_build {
 
 workflow test_hisat2_build_fasta_only {
     fasta = [ [id:'genome'],
-              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+              file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'genome'],
-              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+              file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
             ]
     HISAT2_EXTRACTSPLICESITES ( gtf )
     HISAT2_BUILD ( fasta, [[],[]], [[],[]] )
@@ -29,21 +29,11 @@ workflow test_hisat2_build_fasta_only {
 
 workflow test_hisat2_build_fasta_ss_only {
     fasta = [ [id:'genome'],
-              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+              file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'genome'],
-              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+              file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
             ]
     HISAT2_EXTRACTSPLICESITES ( gtf )
     HISAT2_BUILD ( fasta, [[],[]], HISAT2_EXTRACTSPLICESITES.out.txt )
-}
-
-workflow test_hisat2_build_fasta_gtf_only {
-    fasta = [ [id:'genome'],
-              file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-            ]
-    gtf   = [ [id:'genome'],
-              file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
-            ]
-    HISAT2_BUILD ( fasta, gtf, [[],[]] )
 }

--- a/tests/modules/nf-core/hisat2/build_test/test.yml
+++ b/tests/modules/nf-core/hisat2/build_test/test.yml
@@ -5,21 +5,21 @@
     - hisat2
   files:
     - path: output/hisat2/hisat2/genome.1.ht2
-      md5sum: 8f8a9b1b43511fbc679454cc6f93d203
+      md5sum: 057cfa8a22b97ee9cff4c8d342498803
     - path: output/hisat2/hisat2/genome.2.ht2
-      md5sum: afe55bf628b41121cf2c9a999e1dbbcb
+      md5sum: 47b153cd1319abc88dda532462651fcf
     - path: output/hisat2/hisat2/genome.3.ht2
-      md5sum: 123b1717a761500ffa59d54959215d26
+      md5sum: 4ed93abba181d8dfab2e303e33114777
     - path: output/hisat2/hisat2/genome.4.ht2
-      md5sum: 7c9d42e29a60c13a65dd0046a012d848
+      md5sum: c25be5f8b0378abf7a58c8a880b87626
     - path: output/hisat2/hisat2/genome.5.ht2
-      md5sum: 0c5bdeb9777a0bb5c2da117c7b0e2a85
+      md5sum: 91198831aaba993acac1734138c5f173
     - path: output/hisat2/hisat2/genome.6.ht2
-      md5sum: e055ccdcad39cf608d234ab650eabbb2
+      md5sum: 265e1284ce85686516fae5d35540994a
     - path: output/hisat2/hisat2/genome.7.ht2
-      md5sum: b9e300d0e85cdde63bd6fdcc0d5d5097
+      md5sum: 9013eccd91ad614d7893c739275a394f
     - path: output/hisat2/hisat2/genome.8.ht2
-      md5sum: 6ae6e44dc59b540e1caadb5b8eeb394a
+      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
     - path: output/hisat2/versions.yml
 
 - name: hisat2 build test_hisat2_build_fasta_only
@@ -29,17 +29,17 @@
     - hisat2
   files:
     - path: output/hisat2/hisat2/genome.1.ht2
-      md5sum: a27e7c15adba2d3d6be7d3537792a7a5
+      md5sum: 98284d11e09faba5be6caeacceae7b3c
     - path: output/hisat2/hisat2/genome.2.ht2
-      md5sum: 10a474242f1d77979e1dfc3d862faac8
+      md5sum: 47b153cd1319abc88dda532462651fcf
     - path: output/hisat2/hisat2/genome.3.ht2
-      md5sum: 123b1717a761500ffa59d54959215d26
+      md5sum: 4ed93abba181d8dfab2e303e33114777
     - path: output/hisat2/hisat2/genome.4.ht2
-      md5sum: 7c9d42e29a60c13a65dd0046a012d848
+      md5sum: c25be5f8b0378abf7a58c8a880b87626
     - path: output/hisat2/hisat2/genome.5.ht2
-      md5sum: 2d7070c84ba61c87cd75deb3fa08769f
+      md5sum: 4db21638bce5ab535147c14a8c5ed27b
     - path: output/hisat2/hisat2/genome.6.ht2
-      md5sum: f28bdaa34f41d3dd773942576d03a685
+      md5sum: 265e1284ce85686516fae5d35540994a
     - path: output/hisat2/hisat2/genome.7.ht2
       md5sum: 9013eccd91ad614d7893c739275a394f
     - path: output/hisat2/hisat2/genome.8.ht2
@@ -53,19 +53,19 @@
     - hisat2
   files:
     - path: output/hisat2/hisat2/genome.1.ht2
-      md5sum: 8f8a9b1b43511fbc679454cc6f93d203
+      md5sum: 057cfa8a22b97ee9cff4c8d342498803
     - path: output/hisat2/hisat2/genome.2.ht2
-      md5sum: afe55bf628b41121cf2c9a999e1dbbcb
+      md5sum: 47b153cd1319abc88dda532462651fcf
     - path: output/hisat2/hisat2/genome.3.ht2
-      md5sum: 123b1717a761500ffa59d54959215d26
+      md5sum: 4ed93abba181d8dfab2e303e33114777
     - path: output/hisat2/hisat2/genome.4.ht2
-      md5sum: 7c9d42e29a60c13a65dd0046a012d848
+      md5sum: c25be5f8b0378abf7a58c8a880b87626
     - path: output/hisat2/hisat2/genome.5.ht2
-      md5sum: 0c5bdeb9777a0bb5c2da117c7b0e2a85
+      md5sum: 91198831aaba993acac1734138c5f173
     - path: output/hisat2/hisat2/genome.6.ht2
-      md5sum: e055ccdcad39cf608d234ab650eabbb2
+      md5sum: 265e1284ce85686516fae5d35540994a
     - path: output/hisat2/hisat2/genome.7.ht2
-      md5sum: c63cf0d429428f3b344138764b82446b
+      md5sum: 9013eccd91ad614d7893c739275a394f
     - path: output/hisat2/hisat2/genome.8.ht2
-      md5sum: b97a91edde6af73eb33dca21f7d6d3db
+      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
     - path: output/hisat2/versions.yml

--- a/tests/modules/nf-core/hisat2/build_test/test.yml
+++ b/tests/modules/nf-core/hisat2/build_test/test.yml
@@ -1,8 +1,8 @@
 - name: hisat2 build test_hisat2_build
   command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
   tags:
-    - hisat2
     - hisat2/build
+    - hisat2
   files:
     - path: output/hisat2/hisat2/genome.1.ht2
       md5sum: 8f8a9b1b43511fbc679454cc6f93d203
@@ -25,8 +25,8 @@
 - name: hisat2 build test_hisat2_build_fasta_only
   command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build_fasta_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
   tags:
-    - hisat2
     - hisat2/build
+    - hisat2
   files:
     - path: output/hisat2/hisat2/genome.1.ht2
       md5sum: a27e7c15adba2d3d6be7d3537792a7a5
@@ -49,8 +49,8 @@
 - name: hisat2 build test_hisat2_build_fasta_ss_only
   command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build_fasta_ss_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
   tags:
-    - hisat2
     - hisat2/build
+    - hisat2
   files:
     - path: output/hisat2/hisat2/genome.1.ht2
       md5sum: 8f8a9b1b43511fbc679454cc6f93d203

--- a/tests/modules/nf-core/hisat2/build_test/test.yml
+++ b/tests/modules/nf-core/hisat2/build_test/test.yml
@@ -1,23 +1,97 @@
 - name: hisat2 build test_hisat2_build
-  command: nextflow run ./tests/modules/nf-core/hisat2/build_test -entry test_hisat2_build -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
   tags:
-    - hisat2
-    - hisat2/build
+  - hisat2/build
+  - hisat2
   files:
-    - path: output/hisat2/genome.splice_sites.txt
-    - path: output/hisat2/hisat2/genome.5.ht2
-      md5sum: 91198831aaba993acac1734138c5f173
-    - path: output/hisat2/hisat2/genome.7.ht2
-      md5sum: 9013eccd91ad614d7893c739275a394f
-    - path: output/hisat2/hisat2/genome.1.ht2
-      md5sum: 057cfa8a22b97ee9cff4c8d342498803
-    - path: output/hisat2/hisat2/genome.2.ht2
-      md5sum: 47b153cd1319abc88dda532462651fcf
-    - path: output/hisat2/hisat2/genome.6.ht2
-      md5sum: 265e1284ce85686516fae5d35540994a
-    - path: output/hisat2/hisat2/genome.3.ht2
-      md5sum: 4ed93abba181d8dfab2e303e33114777
-    - path: output/hisat2/hisat2/genome.8.ht2
-      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
-    - path: output/hisat2/hisat2/genome.4.ht2
-      md5sum: c25be5f8b0378abf7a58c8a880b87626
+  - path: output/hisat2/genome.splice_sites.txt
+    md5sum: d41d8cd98f00b204e9800998ecf8427e
+  - path: output/hisat2/hisat2/genome.1.ht2
+    md5sum: 057cfa8a22b97ee9cff4c8d342498803
+  - path: output/hisat2/hisat2/genome.2.ht2
+    md5sum: 47b153cd1319abc88dda532462651fcf
+  - path: output/hisat2/hisat2/genome.3.ht2
+    md5sum: 4ed93abba181d8dfab2e303e33114777
+  - path: output/hisat2/hisat2/genome.4.ht2
+    md5sum: c25be5f8b0378abf7a58c8a880b87626
+  - path: output/hisat2/hisat2/genome.5.ht2
+    md5sum: 91198831aaba993acac1734138c5f173
+  - path: output/hisat2/hisat2/genome.6.ht2
+    md5sum: 265e1284ce85686516fae5d35540994a
+  - path: output/hisat2/hisat2/genome.7.ht2
+    md5sum: 9013eccd91ad614d7893c739275a394f
+  - path: output/hisat2/hisat2/genome.8.ht2
+    md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+
+- name: hisat2 build test_hisat2_build_fasta_only
+  command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build_fasta_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
+  tags:
+  - hisat2/build
+  - hisat2
+  files:
+  - path: output/hisat2/genome.splice_sites.txt
+    md5sum: d41d8cd98f00b204e9800998ecf8427e
+  - path: output/hisat2/hisat2/genome.1.ht2
+    md5sum: 98284d11e09faba5be6caeacceae7b3c
+  - path: output/hisat2/hisat2/genome.2.ht2
+    md5sum: 47b153cd1319abc88dda532462651fcf
+  - path: output/hisat2/hisat2/genome.3.ht2
+    md5sum: 4ed93abba181d8dfab2e303e33114777
+  - path: output/hisat2/hisat2/genome.4.ht2
+    md5sum: c25be5f8b0378abf7a58c8a880b87626
+  - path: output/hisat2/hisat2/genome.5.ht2
+    md5sum: 4db21638bce5ab535147c14a8c5ed27b
+  - path: output/hisat2/hisat2/genome.6.ht2
+    md5sum: 265e1284ce85686516fae5d35540994a
+  - path: output/hisat2/hisat2/genome.7.ht2
+    md5sum: 9013eccd91ad614d7893c739275a394f
+  - path: output/hisat2/hisat2/genome.8.ht2
+    md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+
+- name: hisat2 build test_hisat2_build_fasta_ss_only
+  command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build_fasta_ss_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
+  tags:
+  - hisat2/build
+  - hisat2
+  files:
+  - path: output/hisat2/genome.splice_sites.txt
+    md5sum: d41d8cd98f00b204e9800998ecf8427e
+  - path: output/hisat2/hisat2/genome.1.ht2
+    md5sum: 057cfa8a22b97ee9cff4c8d342498803
+  - path: output/hisat2/hisat2/genome.2.ht2
+    md5sum: 47b153cd1319abc88dda532462651fcf
+  - path: output/hisat2/hisat2/genome.3.ht2
+    md5sum: 4ed93abba181d8dfab2e303e33114777
+  - path: output/hisat2/hisat2/genome.4.ht2
+    md5sum: c25be5f8b0378abf7a58c8a880b87626
+  - path: output/hisat2/hisat2/genome.5.ht2
+    md5sum: 91198831aaba993acac1734138c5f173
+  - path: output/hisat2/hisat2/genome.6.ht2
+    md5sum: 265e1284ce85686516fae5d35540994a
+  - path: output/hisat2/hisat2/genome.7.ht2
+    md5sum: 9013eccd91ad614d7893c739275a394f
+  - path: output/hisat2/hisat2/genome.8.ht2
+    md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+
+- name: hisat2 build test_hisat2_build_fasta_gtf_only
+  command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build_fasta_gtf_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
+  tags:
+  - hisat2/build
+  - hisat2
+  files:
+  - path: output/hisat2/hisat2/genome.1.ht2
+    md5sum: 057cfa8a22b97ee9cff4c8d342498803
+  - path: output/hisat2/hisat2/genome.2.ht2
+    md5sum: 47b153cd1319abc88dda532462651fcf
+  - path: output/hisat2/hisat2/genome.3.ht2
+    md5sum: 4ed93abba181d8dfab2e303e33114777
+  - path: output/hisat2/hisat2/genome.4.ht2
+    md5sum: c25be5f8b0378abf7a58c8a880b87626
+  - path: output/hisat2/hisat2/genome.5.ht2
+    md5sum: 91198831aaba993acac1734138c5f173
+  - path: output/hisat2/hisat2/genome.6.ht2
+    md5sum: 265e1284ce85686516fae5d35540994a
+  - path: output/hisat2/hisat2/genome.7.ht2
+    md5sum: 9013eccd91ad614d7893c739275a394f
+  - path: output/hisat2/hisat2/genome.8.ht2
+    md5sum: 33cdeccccebe80329f1fdbee7f5874cb

--- a/tests/modules/nf-core/hisat2/build_test/test.yml
+++ b/tests/modules/nf-core/hisat2/build_test/test.yml
@@ -1,97 +1,77 @@
 - name: hisat2 build test_hisat2_build
   command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
   tags:
-  - hisat2/build
-  - hisat2
+    - hisat2
+    - hisat2/build
   files:
-  - path: output/hisat2/genome.splice_sites.txt
-    md5sum: d41d8cd98f00b204e9800998ecf8427e
-  - path: output/hisat2/hisat2/genome.1.ht2
-    md5sum: 057cfa8a22b97ee9cff4c8d342498803
-  - path: output/hisat2/hisat2/genome.2.ht2
-    md5sum: 47b153cd1319abc88dda532462651fcf
-  - path: output/hisat2/hisat2/genome.3.ht2
-    md5sum: 4ed93abba181d8dfab2e303e33114777
-  - path: output/hisat2/hisat2/genome.4.ht2
-    md5sum: c25be5f8b0378abf7a58c8a880b87626
-  - path: output/hisat2/hisat2/genome.5.ht2
-    md5sum: 91198831aaba993acac1734138c5f173
-  - path: output/hisat2/hisat2/genome.6.ht2
-    md5sum: 265e1284ce85686516fae5d35540994a
-  - path: output/hisat2/hisat2/genome.7.ht2
-    md5sum: 9013eccd91ad614d7893c739275a394f
-  - path: output/hisat2/hisat2/genome.8.ht2
-    md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+    - path: output/hisat2/genome.splice_sites.txt
+      md5sum: dc6da761e1dda4b7c490eea01260ee21
+    - path: output/hisat2/hisat2/genome.1.ht2
+      md5sum: 8f8a9b1b43511fbc679454cc6f93d203
+    - path: output/hisat2/hisat2/genome.2.ht2
+      md5sum: afe55bf628b41121cf2c9a999e1dbbcb
+    - path: output/hisat2/hisat2/genome.3.ht2
+      md5sum: 123b1717a761500ffa59d54959215d26
+    - path: output/hisat2/hisat2/genome.4.ht2
+      md5sum: 7c9d42e29a60c13a65dd0046a012d848
+    - path: output/hisat2/hisat2/genome.5.ht2
+      md5sum: 0c5bdeb9777a0bb5c2da117c7b0e2a85
+    - path: output/hisat2/hisat2/genome.6.ht2
+      md5sum: e055ccdcad39cf608d234ab650eabbb2
+    - path: output/hisat2/hisat2/genome.7.ht2
+      md5sum: b9e300d0e85cdde63bd6fdcc0d5d5097
+    - path: output/hisat2/hisat2/genome.8.ht2
+      md5sum: 6ae6e44dc59b540e1caadb5b8eeb394a
+    - path: output/hisat2/versions.yml
 
 - name: hisat2 build test_hisat2_build_fasta_only
   command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build_fasta_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
   tags:
-  - hisat2/build
-  - hisat2
+    - hisat2
+    - hisat2/build
   files:
-  - path: output/hisat2/genome.splice_sites.txt
-    md5sum: d41d8cd98f00b204e9800998ecf8427e
-  - path: output/hisat2/hisat2/genome.1.ht2
-    md5sum: 98284d11e09faba5be6caeacceae7b3c
-  - path: output/hisat2/hisat2/genome.2.ht2
-    md5sum: 47b153cd1319abc88dda532462651fcf
-  - path: output/hisat2/hisat2/genome.3.ht2
-    md5sum: 4ed93abba181d8dfab2e303e33114777
-  - path: output/hisat2/hisat2/genome.4.ht2
-    md5sum: c25be5f8b0378abf7a58c8a880b87626
-  - path: output/hisat2/hisat2/genome.5.ht2
-    md5sum: 4db21638bce5ab535147c14a8c5ed27b
-  - path: output/hisat2/hisat2/genome.6.ht2
-    md5sum: 265e1284ce85686516fae5d35540994a
-  - path: output/hisat2/hisat2/genome.7.ht2
-    md5sum: 9013eccd91ad614d7893c739275a394f
-  - path: output/hisat2/hisat2/genome.8.ht2
-    md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+    - path: output/hisat2/genome.splice_sites.txt
+      md5sum: dc6da761e1dda4b7c490eea01260ee21
+    - path: output/hisat2/hisat2/genome.1.ht2
+      md5sum: a27e7c15adba2d3d6be7d3537792a7a5
+    - path: output/hisat2/hisat2/genome.2.ht2
+      md5sum: 10a474242f1d77979e1dfc3d862faac8
+    - path: output/hisat2/hisat2/genome.3.ht2
+      md5sum: 123b1717a761500ffa59d54959215d26
+    - path: output/hisat2/hisat2/genome.4.ht2
+      md5sum: 7c9d42e29a60c13a65dd0046a012d848
+    - path: output/hisat2/hisat2/genome.5.ht2
+      md5sum: 2d7070c84ba61c87cd75deb3fa08769f
+    - path: output/hisat2/hisat2/genome.6.ht2
+      md5sum: f28bdaa34f41d3dd773942576d03a685
+    - path: output/hisat2/hisat2/genome.7.ht2
+      md5sum: 9013eccd91ad614d7893c739275a394f
+    - path: output/hisat2/hisat2/genome.8.ht2
+      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+    - path: output/hisat2/versions.yml
 
 - name: hisat2 build test_hisat2_build_fasta_ss_only
   command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build_fasta_ss_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
   tags:
-  - hisat2/build
-  - hisat2
+    - hisat2
+    - hisat2/build
   files:
-  - path: output/hisat2/genome.splice_sites.txt
-    md5sum: d41d8cd98f00b204e9800998ecf8427e
-  - path: output/hisat2/hisat2/genome.1.ht2
-    md5sum: 057cfa8a22b97ee9cff4c8d342498803
-  - path: output/hisat2/hisat2/genome.2.ht2
-    md5sum: 47b153cd1319abc88dda532462651fcf
-  - path: output/hisat2/hisat2/genome.3.ht2
-    md5sum: 4ed93abba181d8dfab2e303e33114777
-  - path: output/hisat2/hisat2/genome.4.ht2
-    md5sum: c25be5f8b0378abf7a58c8a880b87626
-  - path: output/hisat2/hisat2/genome.5.ht2
-    md5sum: 91198831aaba993acac1734138c5f173
-  - path: output/hisat2/hisat2/genome.6.ht2
-    md5sum: 265e1284ce85686516fae5d35540994a
-  - path: output/hisat2/hisat2/genome.7.ht2
-    md5sum: 9013eccd91ad614d7893c739275a394f
-  - path: output/hisat2/hisat2/genome.8.ht2
-    md5sum: 33cdeccccebe80329f1fdbee7f5874cb
-
-- name: hisat2 build test_hisat2_build_fasta_gtf_only
-  command: nextflow run ./tests/modules/nf-core/hisat2/build -entry test_hisat2_build_fasta_gtf_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/build/nextflow.config
-  tags:
-  - hisat2/build
-  - hisat2
-  files:
-  - path: output/hisat2/hisat2/genome.1.ht2
-    md5sum: 057cfa8a22b97ee9cff4c8d342498803
-  - path: output/hisat2/hisat2/genome.2.ht2
-    md5sum: 47b153cd1319abc88dda532462651fcf
-  - path: output/hisat2/hisat2/genome.3.ht2
-    md5sum: 4ed93abba181d8dfab2e303e33114777
-  - path: output/hisat2/hisat2/genome.4.ht2
-    md5sum: c25be5f8b0378abf7a58c8a880b87626
-  - path: output/hisat2/hisat2/genome.5.ht2
-    md5sum: 91198831aaba993acac1734138c5f173
-  - path: output/hisat2/hisat2/genome.6.ht2
-    md5sum: 265e1284ce85686516fae5d35540994a
-  - path: output/hisat2/hisat2/genome.7.ht2
-    md5sum: 9013eccd91ad614d7893c739275a394f
-  - path: output/hisat2/hisat2/genome.8.ht2
-    md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+    - path: output/hisat2/genome.splice_sites.txt
+      md5sum: dc6da761e1dda4b7c490eea01260ee21
+    - path: output/hisat2/hisat2/genome.1.ht2
+      md5sum: 8f8a9b1b43511fbc679454cc6f93d203
+    - path: output/hisat2/hisat2/genome.2.ht2
+      md5sum: afe55bf628b41121cf2c9a999e1dbbcb
+    - path: output/hisat2/hisat2/genome.3.ht2
+      md5sum: 123b1717a761500ffa59d54959215d26
+    - path: output/hisat2/hisat2/genome.4.ht2
+      md5sum: 7c9d42e29a60c13a65dd0046a012d848
+    - path: output/hisat2/hisat2/genome.5.ht2
+      md5sum: 0c5bdeb9777a0bb5c2da117c7b0e2a85
+    - path: output/hisat2/hisat2/genome.6.ht2
+      md5sum: e055ccdcad39cf608d234ab650eabbb2
+    - path: output/hisat2/hisat2/genome.7.ht2
+      md5sum: c63cf0d429428f3b344138764b82446b
+    - path: output/hisat2/hisat2/genome.8.ht2
+      md5sum: b97a91edde6af73eb33dca21f7d6d3db
+    - path: output/hisat2/versions.yml

--- a/tests/modules/nf-core/hisat2/build_test/test.yml
+++ b/tests/modules/nf-core/hisat2/build_test/test.yml
@@ -4,8 +4,6 @@
     - hisat2
     - hisat2/build
   files:
-    - path: output/hisat2/genome.splice_sites.txt
-      md5sum: dc6da761e1dda4b7c490eea01260ee21
     - path: output/hisat2/hisat2/genome.1.ht2
       md5sum: 8f8a9b1b43511fbc679454cc6f93d203
     - path: output/hisat2/hisat2/genome.2.ht2
@@ -30,8 +28,6 @@
     - hisat2
     - hisat2/build
   files:
-    - path: output/hisat2/genome.splice_sites.txt
-      md5sum: dc6da761e1dda4b7c490eea01260ee21
     - path: output/hisat2/hisat2/genome.1.ht2
       md5sum: a27e7c15adba2d3d6be7d3537792a7a5
     - path: output/hisat2/hisat2/genome.2.ht2
@@ -56,8 +52,6 @@
     - hisat2
     - hisat2/build
   files:
-    - path: output/hisat2/genome.splice_sites.txt
-      md5sum: dc6da761e1dda4b7c490eea01260ee21
     - path: output/hisat2/hisat2/genome.1.ht2
       md5sum: 8f8a9b1b43511fbc679454cc6f93d203
     - path: output/hisat2/hisat2/genome.2.ht2


### PR DESCRIPTION
## PR checklist

Closes #3648 

- [x] This comment contains a description of changes (with reason).

I have adapted the existing module to only use these optional inputs if they are provided. Previously the `--exons` and `--ss` parameters were optional dependent on available memory. Simpler indices were constructed if the memory requirement was not satisfied. This PR makes it so that nf-core users can intentionally build these 'non-splice aware' indices if they so choose (example use case is where there is no splicing). 