### PR TITLE
Hisat2 align splicesitesoptional

### DIFF
--- a/modules/nf-core/hisat2/align/main.nf
+++ b/modules/nf-core/hisat2/align/main.nf
@@ -33,6 +33,7 @@ process HISAT2_ALIGN {
     } else if (meta.strandedness == 'reverse') {
         strandedness = meta.single_end ? '--rna-strandness R' : '--rna-strandness RF'
     }
+    ss = $splicesites ? "--known-splicesite-infile $splicesites" : ''
     def seq_center = params.seq_center ? "--rg-id ${prefix} --rg SM:$prefix --rg CN:${params.seq_center.replaceAll('\\s','_')}" : "--rg-id ${prefix} --rg SM:$prefix"
     if (meta.single_end) {
         def unaligned = params.save_unaligned ? "--un-gz ${prefix}.unmapped.fastq.gz" : ''

--- a/modules/nf-core/hisat2/align/main.nf
+++ b/modules/nf-core/hisat2/align/main.nf
@@ -43,7 +43,7 @@ process HISAT2_ALIGN {
             -x \$INDEX \\
             -U $reads \\
             $strandedness \\
-            --known-splicesite-infile $splicesites \\
+            $ss \\
             --summary-file ${prefix}.hisat2.summary.log \\
             --threads $task.cpus \\
             $seq_center \\
@@ -66,7 +66,7 @@ process HISAT2_ALIGN {
             -1 ${reads[0]} \\
             -2 ${reads[1]} \\
             $strandedness \\
-            --known-splicesite-infile $splicesites \\
+            $ss \\
             --summary-file ${prefix}.hisat2.summary.log \\
             --threads $task.cpus \\
             $seq_center \\

--- a/modules/nf-core/hisat2/align/main.nf
+++ b/modules/nf-core/hisat2/align/main.nf
@@ -33,7 +33,7 @@ process HISAT2_ALIGN {
     } else if (meta.strandedness == 'reverse') {
         strandedness = meta.single_end ? '--rna-strandness R' : '--rna-strandness RF'
     }
-    ss = $splicesites ? "--known-splicesite-infile $splicesites" : ''
+    ss = "$splicesites" ? "--known-splicesite-infile $splicesites" : ''
     def seq_center = params.seq_center ? "--rg-id ${prefix} --rg SM:$prefix --rg CN:${params.seq_center.replaceAll('\\s','_')}" : "--rg-id ${prefix} --rg SM:$prefix"
     if (meta.single_end) {
         def unaligned = params.save_unaligned ? "--un-gz ${prefix}.unmapped.fastq.gz" : ''

--- a/tests/modules/nf-core/hisat2/align/main.nf
+++ b/tests/modules/nf-core/hisat2/align/main.nf
@@ -10,14 +10,14 @@ workflow test_hisat2_align_single_end {
     input = [
         [ id:'test', single_end:true ], // meta map
         [
-            file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
         ]
     ]
     fasta = [ [id:'genome'],
-            file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'test'],
-            file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
+            file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
             ]
 
     HISAT2_EXTRACTSPLICESITES ( gtf )
@@ -29,15 +29,15 @@ workflow test_hisat2_align_paired_end {
     input = [
         [ id:'test', single_end:false ], // meta map
         [
-            file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-            file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
     fasta = [ [id:'genome'],
-            file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'test'],
-            file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
+            file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
             ]
 
     HISAT2_EXTRACTSPLICESITES ( gtf )
@@ -49,16 +49,32 @@ workflow test_hisat2_align_single_end_no_ss {
     input = [
         [ id:'test', single_end:true ], // meta map
         [
-            file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
         ]
     ]
     fasta = [ [id:'genome'],
-            file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
-            ]
-    gtf   = [ [id:'test'],
-            file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
+            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
             ]
 
-    HISAT2_BUILD ( fasta, [[],[]], [[],[]] )
-    HISAT2_ALIGN ( input, HISAT2_BUILD.out.index, [[],[]] )
+    HISAT2_BUILD ( fasta, [[:],[]], [[:],[]] )
+    HISAT2_ALIGN ( input, HISAT2_BUILD.out.index, [[:],[]] )
+}
+
+workflow test_hisat2_align_paired_end_no_ss {
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        [
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+        ]
+    ]
+    fasta = [ [id:'genome'],
+            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            ]
+    gtf   = [ [id:'test'],
+            file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+            ]
+
+    HISAT2_BUILD ( fasta, [[:],[]], [[:],[]])
+    HISAT2_ALIGN ( input, HISAT2_BUILD.out.index, [[:],[]] )
 }

--- a/tests/modules/nf-core/hisat2/align/main.nf
+++ b/tests/modules/nf-core/hisat2/align/main.nf
@@ -44,3 +44,21 @@ workflow test_hisat2_align_paired_end {
     HISAT2_BUILD ( fasta, gtf, HISAT2_EXTRACTSPLICESITES.out.txt )
     HISAT2_ALIGN ( input, HISAT2_BUILD.out.index, HISAT2_EXTRACTSPLICESITES.out.txt )
 }
+
+workflow test_hisat2_align_single_end_no_ss {
+    input = [
+        [ id:'test', single_end:true ], // meta map
+        [
+            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+        ]
+    ]
+    fasta = [ [id:'genome'],
+            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            ]
+    gtf   = [ [id:'test'],
+            file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+            ]
+
+    HISAT2_BUILD ( fasta, [[],[]], [[],[]] )
+    HISAT2_ALIGN ( input, [[],[]], [[],[]] )
+}

--- a/tests/modules/nf-core/hisat2/align/main.nf
+++ b/tests/modules/nf-core/hisat2/align/main.nf
@@ -10,14 +10,14 @@ workflow test_hisat2_align_single_end {
     input = [
         [ id:'test', single_end:true ], // meta map
         [
-            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true)
         ]
     ]
     fasta = [ [id:'genome'],
-            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'test'],
-            file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
             ]
 
     HISAT2_EXTRACTSPLICESITES ( gtf )
@@ -29,15 +29,15 @@ workflow test_hisat2_align_paired_end {
     input = [
         [ id:'test', single_end:false ], // meta map
         [
-            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+            file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
     fasta = [ [id:'genome'],
-            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'test'],
-            file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
             ]
 
     HISAT2_EXTRACTSPLICESITES ( gtf )
@@ -49,16 +49,16 @@ workflow test_hisat2_align_single_end_no_ss {
     input = [
         [ id:'test', single_end:true ], // meta map
         [
-            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true)
         ]
     ]
     fasta = [ [id:'genome'],
-            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
             ]
     gtf   = [ [id:'test'],
-            file(params.test_data['sarscov2']['genome']['genome_gtf'], checkIfExists: true)
+            file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)
             ]
 
     HISAT2_BUILD ( fasta, [[],[]], [[],[]] )
-    HISAT2_ALIGN ( input, [[],[]], [[],[]] )
+    HISAT2_ALIGN ( input, HISAT2_BUILD.out.index, [[],[]] )
 }

--- a/tests/modules/nf-core/hisat2/align/test.yml
+++ b/tests/modules/nf-core/hisat2/align/test.yml
@@ -4,26 +4,26 @@
     - hisat2
     - hisat2/align
   files:
-    - path: output/hisat2/test.hisat2.summary.log
-      md5sum: 7b8a9e61b7646da1089b041333c41a87
-    - path: output/hisat2/genome.splice_sites.txt
-    - path: output/hisat2/test.bam
-    - path: output/hisat2/hisat2/genome.5.ht2
-      md5sum: 91198831aaba993acac1734138c5f173
-    - path: output/hisat2/hisat2/genome.7.ht2
-      md5sum: 9013eccd91ad614d7893c739275a394f
     - path: output/hisat2/hisat2/genome.1.ht2
       md5sum: 057cfa8a22b97ee9cff4c8d342498803
     - path: output/hisat2/hisat2/genome.2.ht2
       md5sum: 47b153cd1319abc88dda532462651fcf
-    - path: output/hisat2/hisat2/genome.6.ht2
-      md5sum: 265e1284ce85686516fae5d35540994a
     - path: output/hisat2/hisat2/genome.3.ht2
       md5sum: 4ed93abba181d8dfab2e303e33114777
-    - path: output/hisat2/hisat2/genome.8.ht2
-      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
     - path: output/hisat2/hisat2/genome.4.ht2
       md5sum: c25be5f8b0378abf7a58c8a880b87626
+    - path: output/hisat2/hisat2/genome.5.ht2
+      md5sum: 91198831aaba993acac1734138c5f173
+    - path: output/hisat2/hisat2/genome.6.ht2
+      md5sum: 265e1284ce85686516fae5d35540994a
+    - path: output/hisat2/hisat2/genome.7.ht2
+      md5sum: 9013eccd91ad614d7893c739275a394f
+    - path: output/hisat2/hisat2/genome.8.ht2
+      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+    - path: output/hisat2/test.bam
+    - path: output/hisat2/test.hisat2.summary.log
+      md5sum: 7b8a9e61b7646da1089b041333c41a87
+    - path: output/hisat2/versions.yml
 
 - name: hisat2 align test_hisat2_align_paired_end
   command: nextflow run ./tests/modules/nf-core/hisat2/align -entry test_hisat2_align_paired_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/align/nextflow.config
@@ -31,23 +31,77 @@
     - hisat2
     - hisat2/align
   files:
-    - path: output/hisat2/test.hisat2.summary.log
-      md5sum: 9839b31db795958cc4b70711a3414e9c
-    - path: output/hisat2/genome.splice_sites.txt
-    - path: output/hisat2/test.bam
-    - path: output/hisat2/hisat2/genome.5.ht2
-      md5sum: 91198831aaba993acac1734138c5f173
-    - path: output/hisat2/hisat2/genome.7.ht2
-      md5sum: 9013eccd91ad614d7893c739275a394f
     - path: output/hisat2/hisat2/genome.1.ht2
       md5sum: 057cfa8a22b97ee9cff4c8d342498803
     - path: output/hisat2/hisat2/genome.2.ht2
       md5sum: 47b153cd1319abc88dda532462651fcf
-    - path: output/hisat2/hisat2/genome.6.ht2
-      md5sum: 265e1284ce85686516fae5d35540994a
     - path: output/hisat2/hisat2/genome.3.ht2
       md5sum: 4ed93abba181d8dfab2e303e33114777
-    - path: output/hisat2/hisat2/genome.8.ht2
-      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
     - path: output/hisat2/hisat2/genome.4.ht2
       md5sum: c25be5f8b0378abf7a58c8a880b87626
+    - path: output/hisat2/hisat2/genome.5.ht2
+      md5sum: 91198831aaba993acac1734138c5f173
+    - path: output/hisat2/hisat2/genome.6.ht2
+      md5sum: 265e1284ce85686516fae5d35540994a
+    - path: output/hisat2/hisat2/genome.7.ht2
+      md5sum: 9013eccd91ad614d7893c739275a394f
+    - path: output/hisat2/hisat2/genome.8.ht2
+      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+    - path: output/hisat2/test.bam
+    - path: output/hisat2/test.hisat2.summary.log
+      md5sum: 9839b31db795958cc4b70711a3414e9c
+    - path: output/hisat2/versions.yml
+
+- name: hisat2 align test_hisat2_align_single_end_no_ss
+  command: nextflow run ./tests/modules/nf-core/hisat2/align -entry test_hisat2_align_single_end_no_ss -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/align/nextflow.config
+  tags:
+    - hisat2
+    - hisat2/align
+  files:
+    - path: output/hisat2/hisat2/genome.1.ht2
+      md5sum: 98284d11e09faba5be6caeacceae7b3c
+    - path: output/hisat2/hisat2/genome.2.ht2
+      md5sum: 47b153cd1319abc88dda532462651fcf
+    - path: output/hisat2/hisat2/genome.3.ht2
+      md5sum: 4ed93abba181d8dfab2e303e33114777
+    - path: output/hisat2/hisat2/genome.4.ht2
+      md5sum: c25be5f8b0378abf7a58c8a880b87626
+    - path: output/hisat2/hisat2/genome.5.ht2
+      md5sum: 4db21638bce5ab535147c14a8c5ed27b
+    - path: output/hisat2/hisat2/genome.6.ht2
+      md5sum: 265e1284ce85686516fae5d35540994a
+    - path: output/hisat2/hisat2/genome.7.ht2
+      md5sum: 9013eccd91ad614d7893c739275a394f
+    - path: output/hisat2/hisat2/genome.8.ht2
+      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+    - path: output/hisat2/test.bam
+    - path: output/hisat2/test.hisat2.summary.log
+      md5sum: 7b8a9e61b7646da1089b041333c41a87
+    - path: output/hisat2/versions.yml
+
+- name: hisat2 align test_hisat2_align_paired_end_no_ss
+  command: nextflow run ./tests/modules/nf-core/hisat2/align -entry test_hisat2_align_paired_end_no_ss -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hisat2/align/nextflow.config
+  tags:
+    - hisat2
+    - hisat2/align
+  files:
+    - path: output/hisat2/hisat2/genome.1.ht2
+      md5sum: 98284d11e09faba5be6caeacceae7b3c
+    - path: output/hisat2/hisat2/genome.2.ht2
+      md5sum: 47b153cd1319abc88dda532462651fcf
+    - path: output/hisat2/hisat2/genome.3.ht2
+      md5sum: 4ed93abba181d8dfab2e303e33114777
+    - path: output/hisat2/hisat2/genome.4.ht2
+      md5sum: c25be5f8b0378abf7a58c8a880b87626
+    - path: output/hisat2/hisat2/genome.5.ht2
+      md5sum: 4db21638bce5ab535147c14a8c5ed27b
+    - path: output/hisat2/hisat2/genome.6.ht2
+      md5sum: 265e1284ce85686516fae5d35540994a
+    - path: output/hisat2/hisat2/genome.7.ht2
+      md5sum: 9013eccd91ad614d7893c739275a394f
+    - path: output/hisat2/hisat2/genome.8.ht2
+      md5sum: 33cdeccccebe80329f1fdbee7f5874cb
+    - path: output/hisat2/test.bam
+    - path: output/hisat2/test.hisat2.summary.log
+      md5sum: 9839b31db795958cc4b70711a3414e9c
+    - path: output/hisat2/versions.yml


### PR DESCRIPTION
Updated Hisat2 align to allow splice sites to actually be optional 
Changes involve the specification of the splice sites paramater being defined outside the command so that if it is empty (' ') then it will not throw an error. 

Closes #3653 
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!

