### PR TITLE
Additional optional output to homer/annotatepeaks 

### DIFF
--- a/modules/nf-core/homer/annotatepeaks/main.nf
+++ b/modules/nf-core/homer/annotatepeaks/main.nf
@@ -15,6 +15,7 @@ process HOMER_ANNOTATEPEAKS {
 
     output:
     tuple val(meta), path("*annotatePeaks.txt"), emit: txt
+    tuple val(meta), path("*annStats.txt"), emit: stats, optional: true
     path  "versions.yml"                       , emit: versions
 
     when:

--- a/modules/nf-core/homer/annotatepeaks/meta.yml
+++ b/modules/nf-core/homer/annotatepeaks/meta.yml
@@ -39,6 +39,10 @@ output:
       type: file
       description: The annotated peaks
       pattern: "*annotatePeaks.txt"
+  - annotation_stats:
+      type: file
+      description: the annStats file output from -annStats parameter
+      pattern: "*annStats.txt"
   - versions:
       type: file
       description: File containing software versions

--- a/tests/modules/nf-core/homer/annotatepeaks/nextflow.config
+++ b/tests/modules/nf-core/homer/annotatepeaks/nextflow.config
@@ -1,5 +1,6 @@
 process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    ext.args = {"-annStats ${meta.id}.annStats.txt"}
 
 }

--- a/tests/modules/nf-core/homer/annotatepeaks/test.yml
+++ b/tests/modules/nf-core/homer/annotatepeaks/test.yml
@@ -5,3 +5,4 @@
     - homer/annotatepeaks
   files:
     - path: output/homer/test.annotatePeaks.txt
+    - path: output/homer/test.annStats.txt


### PR DESCRIPTION
<!--

Hi there,

I was utilizing the homer annotate peaks module and wanted the output from the -annStats parameter, which is a stats summary file containing calculated observed/expected enrichment for peaks of different feature types. I can provide the -annStats argument in the ext.args but could not figure out a way to get the additional output to successfully be saved in the publishDir. This is in the context of another pipeline--nf-core/atacseq. Would nf-core accept adding an additional optional output to this module?  It looks like it can be supported by just the addition of an optional output channel, and the user would add the -annStats parameter to ext.args in a config. 

Thanks,
Laura

# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ X] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
