### PR TITLE
Add module famsa_align

### DIFF
--- a/modules/nf-core/famsa/align/main.nf
+++ b/modules/nf-core/famsa/align/main.nf
@@ -1,0 +1,50 @@
+
+
+process FAMSA_ALIGN {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "bioconda::famsa=2.2.2"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/famsa:2.2.2--h9f5acd7_0':
+        'biocontainers/famsa:2.2.2--h9f5acd7_0' }"
+
+    input:
+    tuple val(meta),  path(fasta)
+    tuple val(meta2), path(tree)
+
+    output:
+    tuple val(meta), path("*.aln"), emit: alignment
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def options_tree = tree ? "-gt import $tree" : ""
+    """
+    famsa $options_tree \\
+        $args \\
+        -t ${task.cpus} \\
+        ${fasta} \\
+        ${prefix}.aln 
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        famsa: \$( famsa -help 2>&1 | head -n 2 | tail -n 1 | sed 's/ version //g' )
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.aln
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        famsa: \$( famsa -help 2>&1 | head -n 2 | tail -n 1 | sed 's/ version //g' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/famsa/align/main.nf
+++ b/modules/nf-core/famsa/align/main.nf
@@ -29,7 +29,7 @@ process FAMSA_ALIGN {
         $args \\
         -t ${task.cpus} \\
         ${fasta} \\
-        ${prefix}.aln 
+        ${prefix}.aln
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/famsa/align/meta.yml
+++ b/modules/nf-core/famsa/align/meta.yml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
+name: "famsa_align"
+description: Aligns sequences using FAMSA
+keywords:
+  - alignment
+  - MSA
+  - genomics
+tools:
+  - "famsa":
+      description: "Algorithm for large-scale multiple sequence alignments"
+      homepage: "https://github.com/refresh-bio/FAMSA"
+      documentation: "https://github.com/refresh-bio/FAMSA"
+      tool_dev_url: "https://github.com/refresh-bio/FAMSA"
+      doi: "10.1038/srep33964"
+      licence: "['GPL v3']"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test']`
+
+  - fasta:
+      type: file
+      description: Input sequences in FASTA format
+      pattern: "*.{fa,fasta}"
+
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing tree information
+        e.g. `[ id:'test_tree']`
+
+  - tree:
+      type: file
+      description: Input guide tree in Newick format
+      pattern: "*.{dnd}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test']`
+
+  - alignment:
+      type: file
+      description: Alignment file.
+      pattern: "*.{aln}"
+
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@luisas"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -1110,6 +1110,10 @@ falco:
   - modules/nf-core/falco/**
   - tests/modules/nf-core/falco/**
 
+famsa/align:
+  - modules/nf-core/famsa/align/**
+  - tests/modules/nf-core/famsa/align/**
+
 famsa/guidetree:
   - modules/nf-core/famsa/guidetree/**
   - tests/modules/nf-core/famsa/guidetree/**

--- a/tests/modules/nf-core/famsa/align/main.nf
+++ b/tests/modules/nf-core/famsa/align/main.nf
@@ -1,0 +1,32 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { FAMSA_GUIDETREE } from '../../../../../modules/nf-core/famsa/guidetree/main.nf'
+include { FAMSA_ALIGN     } from '../../../../../modules/nf-core/famsa/align/main.nf'
+
+workflow test_famsa_align {
+    
+    input = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true)
+    ]
+        
+    FAMSA_ALIGN ( input , [[:],[]] )
+
+}
+
+
+workflow test_famsa_align_with_tree {
+    
+    input = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true)
+    ]
+
+    
+    ch_tree = FAMSA_GUIDETREE ( input ).tree
+
+    FAMSA_ALIGN ( input , ch_tree )
+
+}

--- a/tests/modules/nf-core/famsa/align/nextflow.config
+++ b/tests/modules/nf-core/famsa/align/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    
+}

--- a/tests/modules/nf-core/famsa/align/test.yml
+++ b/tests/modules/nf-core/famsa/align/test.yml
@@ -1,0 +1,21 @@
+- name: famsa align test_famsa_align
+  command: nextflow run ./tests/modules/nf-core/famsa/align -entry test_famsa_align -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/famsa/align/nextflow.config
+  tags:
+    - famsa/align
+    - famsa
+  files:
+    - path: output/famsa/test.aln
+      md5sum: 7cf7375f2ba360814ea978731838b972
+    - path: output/famsa/versions.yml
+
+- name: famsa align test_famsa_align_with_tree
+  command: nextflow run ./tests/modules/nf-core/famsa/align -entry test_famsa_align_with_tree -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/famsa/align/nextflow.config
+  tags:
+    - famsa/align
+    - famsa
+  files:
+    - path: output/famsa/test.aln
+      md5sum: 7cf7375f2ba360814ea978731838b972
+    - path: output/famsa/test.dnd
+      md5sum: f3ef8b16a7a16cb4548942ebf2e7bad6
+    - path: output/famsa/versions.yml


### PR DESCRIPTION
Add module: famsa/align 

Takes as input a fast file and optionally a tree in Newick format.
Outputs a multiple sequence alignment computed with famsa.


## PR checklist

Closes https://github.com/nf-core/modules/issues/3696

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
