### PR TITLE
Move conda-checks (fifth batch)

### DIFF
--- a/modules/nf-core/genescopefk/main.nf
+++ b/modules/nf-core/genescopefk/main.nf
@@ -5,11 +5,6 @@ process GENESCOPEFK {
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     container 'ghcr.io/nbisweden/fastk_genescopefk_merquryfk:1.2'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "GENESCOPEFK module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple val(meta), path(fastk_histex_histogram)
 
@@ -26,6 +21,11 @@ process GENESCOPEFK {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "GENESCOPEFK module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
+
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def GENESCOPE_VERSION = '380815c420f50171f9234a0fd1ff426b39829b91' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.

--- a/modules/nf-core/hlala/preparegraph/main.nf
+++ b/modules/nf-core/hlala/preparegraph/main.nf
@@ -2,20 +2,12 @@ process HLALA_PREPAREGRAPH {
     tag "$meta.id"
     label 'process_high'
 
-
-
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/hla-la:1.0.3--hd03093a_0':
         'biocontainers/hla-la:1.0.3--hd03093a_0' }"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "HLALA_PREPAREGRAPH module does not support Conda. Please use Docker or Singularity."
-    }
-
     input:
     tuple val(meta), path(graph)
-
 
     output:
     tuple val(meta), path("${graph}")        , emit: graph
@@ -25,6 +17,10 @@ process HLALA_PREPAREGRAPH {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "HLALA_PREPAREGRAPH module does not support Conda. Please use Docker or Singularity."
+    }
     def args = task.ext.args ?: ''
 
     """

--- a/modules/nf-core/ilastik/multicut/main.nf
+++ b/modules/nf-core/ilastik/multicut/main.nf
@@ -2,11 +2,6 @@ process ILASTIK_MULTICUT {
     tag "$meta.id"
     label 'process_low'
 
-
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "ILASTIK_MULTICUT module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
     container "docker.io/biocontainers/ilastik:1.4.0_cv1"
 
     input:
@@ -22,6 +17,10 @@ process ILASTIK_MULTICUT {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "ILASTIK_MULTICUT module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
@@ -43,6 +42,10 @@ process ILASTIK_MULTICUT {
     """
 
     stub:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "ILASTIK_MULTICUT module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = "1.4.0" // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """

--- a/modules/nf-core/ilastik/pixelclassification/main.nf
+++ b/modules/nf-core/ilastik/pixelclassification/main.nf
@@ -2,10 +2,6 @@ process ILASTIK_PIXELCLASSIFICATION {
     tag "$meta.id"
     label 'process_single'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "ILASTIK_PIXELCLASSIFICATION module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
     container "docker.io/biocontainers/ilastik:1.4.0_cv1"
 
     input:
@@ -20,6 +16,10 @@ process ILASTIK_PIXELCLASSIFICATION {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "ILASTIK_PIXELCLASSIFICATION module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     suffix = task.ext.suffix ?: "h5"
@@ -40,6 +40,10 @@ process ILASTIK_PIXELCLASSIFICATION {
     """
 
     stub:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "ILASTIK_PIXELCLASSIFICATION module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def prefix = task.ext.prefix ?: "${meta.id}"
     suffix = task.ext.suffix ?: "h5"
 

--- a/modules/nf-core/merquryfk/katcomp/main.nf
+++ b/modules/nf-core/merquryfk/katcomp/main.nf
@@ -5,11 +5,6 @@ process MERQURYFK_KATCOMP {
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     container 'ghcr.io/nbisweden/fastk_genescopefk_merquryfk:1.2'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "MERQURYFK_KATCOMP module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple val(meta), path(fastk1_hist), path(fastk1_ktab), path(fastk2_hist), path(fastk2_ktab)
 
@@ -26,6 +21,10 @@ process MERQURYFK_KATCOMP {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "MERQURYFK_KATCOMP module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def FASTK_VERSION = 'f18a4e6d2207539f7b84461daebc54530a9559b0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.

--- a/modules/nf-core/merquryfk/katgc/main.nf
+++ b/modules/nf-core/merquryfk/katgc/main.nf
@@ -5,11 +5,6 @@ process MERQURYFK_KATGC {
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     container 'ghcr.io/nbisweden/fastk_genescopefk_merquryfk:1.2'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "MERQURYFK_KATGC module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple val(meta), path(fastk_hist), path(fastk_ktab)
 
@@ -26,6 +21,10 @@ process MERQURYFK_KATGC {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "MERQURYFK_KATGC module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def FASTK_VERSION   = 'f18a4e6d2207539f7b84461daebc54530a9559b0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.

--- a/modules/nf-core/merquryfk/merquryfk/main.nf
+++ b/modules/nf-core/merquryfk/merquryfk/main.nf
@@ -5,11 +5,6 @@ process MERQURYFK_MERQURYFK {
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     container 'ghcr.io/nbisweden/fastk_genescopefk_merquryfk:1.2'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "MERQURYFK_MERQURYFK module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     tuple val(meta), path(fastk_hist), path(fastk_ktab), path(assembly), path(haplotigs)
 
@@ -36,6 +31,10 @@ process MERQURYFK_MERQURYFK {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "MERQURYFK_MERQURYFK module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     def FASTK_VERSION = 'f18a4e6d2207539f7b84461daebc54530a9559b0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.


### PR DESCRIPTION
Issue #3683 (This is the fourth batch of modules.)

1) Moving conda-check to script-section and stub-section.
2) Replacing `exit 1` with `error()`.

I'll do these updates 5-10 modules per PR in order to ease the reviews and handling of failing tests. 


<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
