### PR TITLE
Update shinyngs, remove na.omit() from proteus

### DIFF
--- a/modules/nf-core/proteus/readproteingroups/templates/proteus_readproteingroups.R
+++ b/modules/nf-core/proteus/readproteingroups/templates/proteus_readproteingroups.R
@@ -266,7 +266,7 @@ for (normfun in unlist(strsplit(opt\$normfuns, ","))) {
 
     # Apply log2 and remove NAs as these will otherwise mess with some of the following modules
 
-    proteinGroups.normalized\$tab <- na.omit(log2(proteinGroups.normalized\$tab))
+    proteinGroups.normalized\$tab <- log2(proteinGroups.normalized\$tab)
 
     png(paste(output_prefix, 'proteus', normfun, 'normalized_distributions.png', sep='.'), width = 5*300, height = 5*300, res = 300, pointsize = 8)
     print(
@@ -317,7 +317,7 @@ for (normfun in unlist(strsplit(opt\$normfuns, ","))) {
 
 # Process and save raw table
 
-proteinGroups\$tab <- na.omit(log2(proteinGroups\$tab))
+proteinGroups\$tab <- log2(proteinGroups\$tab)
 
 # Generate raw distribution plot
 

--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -13,10 +13,10 @@ process SHINYNGS_APP {
     //
     // Those values must then be set in your Nextflow secrets.
 
-    conda "bioconda::r-shinyngs=1.8.0"
+    conda "bioconda::r-shinyngs=1.8.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.0--r43hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.8.0--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.1--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:1.8.1--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)    // Experiment-level info

--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -13,10 +13,10 @@ process SHINYNGS_APP {
     //
     // Those values must then be set in your Nextflow secrets.
 
-    conda "bioconda::r-shinyngs=1.7.2"
+    conda "bioconda::r-shinyngs=1.8.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.7.2--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.0--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:1.8.0--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)    // Experiment-level info

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICDIFFERENTIAL {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.7.2"
+    conda "bioconda::r-shinyngs=1.8.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.7.2--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.0--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:1.8.0--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICDIFFERENTIAL {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.8.0"
+    conda "bioconda::r-shinyngs=1.8.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.0--r43hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.8.0--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.1--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:1.8.1--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICEXPLORATORY {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.8.0"
+    conda "bioconda::r-shinyngs=1.8.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.0--r43hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.8.0--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.1--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:1.8.1--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_STATICEXPLORATORY {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.7.2"
+    conda "bioconda::r-shinyngs=1.8.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.7.2--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.0--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:1.8.0--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
     tag "$sample"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.7.2"
+    conda "bioconda::r-shinyngs=1.8.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.7.2--r42hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.7.2--r42hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.0--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:1.8.0--r43hdfd78af_0' }"
 
     input:
     tuple val(meta),  path(sample), path(assay_files)

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -2,10 +2,10 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
     tag "$sample"
     label 'process_single'
 
-    conda "bioconda::r-shinyngs=1.8.0"
+    conda "bioconda::r-shinyngs=1.8.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.0--r43hdfd78af_0' :
-        'biocontainers/r-shinyngs:1.8.0--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/r-shinyngs:1.8.1--r43hdfd78af_0' :
+        'biocontainers/r-shinyngs:1.8.1--r43hdfd78af_0' }"
 
     input:
     tuple val(meta),  path(sample), path(assay_files)

--- a/tests/modules/nf-core/proteus/readproteingroups/test.yml
+++ b/tests/modules/nf-core/proteus/readproteingroups/test.yml
@@ -9,17 +9,17 @@
     - path: output/proteus/Celltype.proteus.normalizeMedian.normalized_mean_variance_relationship.png
     - path: output/proteus/Celltype.proteus.normalizeMedian.normalized_proteingroups.rds
     - path: output/proteus/Celltype.proteus.normalizeMedian.normalized_proteingroups_tab.tsv
-      md5sum: 07290a3ccd10019fb4e147f805b3e279
+      md5sum: 408db435ce25eef98b82b17c9515c7cb
     - path: output/proteus/Celltype.proteus.normalizeQuantiles.normalized_dendrogram.png
     - path: output/proteus/Celltype.proteus.normalizeQuantiles.normalized_distributions.png
     - path: output/proteus/Celltype.proteus.normalizeQuantiles.normalized_mean_variance_relationship.png
     - path: output/proteus/Celltype.proteus.normalizeQuantiles.normalized_proteingroups.rds
     - path: output/proteus/Celltype.proteus.normalizeQuantiles.normalized_proteingroups_tab.tsv
-      md5sum: 590dd593bb00617254964da4adfcffd9
+      md5sum: 4a0a74febfc6ba921210f465e890ff5b
     - path: output/proteus/Celltype.proteus.raw_distributions.png
     - path: output/proteus/Celltype.proteus.raw_proteingroups.rds
     - path: output/proteus/Celltype.proteus.raw_proteingroups_tab.tsv
-      md5sum: a0943baaa48ea76bdb8c80a580dc9953
+      md5sum: af7a556997b82f4ba38bfae8a6b91301
     - path: output/proteus/R_sessionInfo.log
       contains: ["proteus_0.2.16", "plotly_4.10.2", "ggplot2_3.4.2", "limma_3.54.0 "]
     - path: output/proteus/versions.yml

--- a/tests/modules/nf-core/shinyngs/app/test.yml
+++ b/tests/modules/nf-core/shinyngs/app/test.yml
@@ -7,7 +7,7 @@
     - path: output/shinyngs/SRP254919/app.R
       md5sum: bedcfc45b6cdcc2b8fe3627987e2b17a
     - path: output/shinyngs/SRP254919/data.rds
-      md5sum: e44dcb923603fae634687219e086b4af
+      md5sum: d6772b22b6e4708ae610fb9ad0b09db0
     - path: output/shinyngs/versions.yml
 
 - name: shinyngs app test_shinyngs_app_single_matrix
@@ -19,5 +19,5 @@
     - path: output/shinyngs/SRP254919/app.R
       md5sum: bedcfc45b6cdcc2b8fe3627987e2b17a
     - path: output/shinyngs/SRP254919/data.rds
-      md5sum: 40935136af5264cebd85e6d63c95b5f9
+      md5sum: 2a8c07908642e5273d03e922f4ac56fc
     - path: output/shinyngs/versions.yml

--- a/tests/modules/nf-core/shinyngs/staticdifferential/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticdifferential/test.yml
@@ -13,5 +13,6 @@
     - shinyngs
   files:
     - path: output/shinyngs/hND6_vs_mCherry_test/html/volcano.html
-      contains: ["-4.0303380084000002,-0.062830270600000002,-0.36022681569999998,-0.60824564309999996", "higher in mCherry"]
+      contains:
+        ["-4.0303380084000002,-0.062830270600000002,-0.36022681569999998,-0.60824564309999996", "higher in mCherry"]
     - path: output/shinyngs/hND6_vs_mCherry_test/png/volcano.png

--- a/tests/modules/nf-core/shinyngs/staticdifferential/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticdifferential/test.yml
@@ -13,5 +13,5 @@
     - shinyngs
   files:
     - path: output/shinyngs/hND6_vs_mCherry_test/html/volcano.html
-      contains: ["-4.0303380084,-0.0628302706,-0.3602268157,-0.6082456431", "higher in mCherry"]
+      contains: ["-4.0303380084000002,-0.062830270600000002,-0.36022681569999998,-0.60824564309999996", "higher in mCherry"]
     - path: output/shinyngs/hND6_vs_mCherry_test/png/volcano.png

--- a/tests/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -15,6 +15,17 @@ workflow test_shinyngs_staticexploratory {
     )
 }
 
+workflow test_shinyngs_staticexploratory_specify_log {
+
+    expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true) 
+    expression_feature_meta = file(params.test_data['mus_musculus']['genome']['rnaseq_genemeta'], checkIfExists: true) 
+    expression_matrix_file = file(params.test_data['mus_musculus']['genome']['rnaseq_matrix'], checkIfExists: true) 
+
+    SHINYNGS_STATICEXPLORATORY ( 
+        [ [ "id":"treatment" ], expression_sample_sheet, expression_feature_meta, [ expression_matrix_file ] ],
+    )
+}
+
 workflow test_shinyngs_staticexploratory_html {
 
     expression_sample_sheet = file(params.test_data['mus_musculus']['genome']['rnaseq_samplesheet'], checkIfExists: true) 

--- a/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
@@ -1,11 +1,7 @@
 process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-    
-    withName: 'test_shinyngs_staticexploratory:SHINYNGS_STATICEXPLORATORY' {
-        ext.args = { "" }
-    }
-    
+
     withName: 'test_shinyngs_staticexploratory_specify_log:SHINYNGS_STATICEXPLORATORY' {
         ext.args = { "--log2_assays '1'" }
     }

--- a/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
@@ -7,7 +7,7 @@ process {
     }
     
     withName: 'test_shinyngs_staticexploratory_specify_log:SHINYNGS_STATICEXPLORATORY' {
-        ext.args = { "" }
+        ext.args = { "--log2_assays '1'" }
     }
     
     withName: 'test_shinyngs_staticexploratory_html:SHINYNGS_STATICEXPLORATORY' {

--- a/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
@@ -2,6 +2,14 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
     
+    withName: 'test_shinyngs_staticexploratory:SHINYNGS_STATICEXPLORATORY' {
+        ext.args = { "--log2_assays ''" }
+    }
+    
+    withName: 'test_shinyngs_staticexploratory_specify_log:SHINYNGS_STATICEXPLORATORY' {
+        ext.args = { "--log2_assays '1'" }
+    }
+    
     withName: 'test_shinyngs_staticexploratory_html:SHINYNGS_STATICEXPLORATORY' {
         ext.args = { "--write_html" }
     }

--- a/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
@@ -3,11 +3,11 @@ process {
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
     
     withName: 'test_shinyngs_staticexploratory:SHINYNGS_STATICEXPLORATORY' {
-        ext.args = { "--log2_assays ''" }
+        ext.args = { "" }
     }
     
     withName: 'test_shinyngs_staticexploratory_specify_log:SHINYNGS_STATICEXPLORATORY' {
-        ext.args = { "--log2_assays '1'" }
+        ext.args = { "" }
     }
     
     withName: 'test_shinyngs_staticexploratory_html:SHINYNGS_STATICEXPLORATORY' {

--- a/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
@@ -11,6 +11,19 @@
     - path: output/shinyngs/treatment/png/pca3d.png
     - path: output/shinyngs/treatment/png/sample_dendrogram.png
 
+- name: shinyngs staticexploratory test_shinyngs_staticexploratory_specify_log
+  command: nextflow run ./tests/modules/nf-core/shinyngs/staticexploratory -entry test_shinyngs_staticexploratory_specify_log -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
+  tags:
+    - shinyngs/staticexploratory
+    - shinyngs
+  files:
+    - path: output/shinyngs/treatment/png/boxplot.png
+    - path: output/shinyngs/treatment/png/density.png
+    - path: output/shinyngs/treatment/png/mad_correlation.png
+    - path: output/shinyngs/treatment/png/pca2d.png
+    - path: output/shinyngs/treatment/png/pca3d.png
+    - path: output/shinyngs/treatment/png/sample_dendrogram.png
+
 - name: shinyngs staticexploratory test_shinyngs_staticexploratory_html
   command: nextflow run ./tests/modules/nf-core/shinyngs/staticexploratory -entry test_shinyngs_staticexploratory_html -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/shinyngs/staticexploratory/nextflow.config
   tags:

--- a/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
+++ b/tests/modules/nf-core/shinyngs/staticexploratory/test.yml
@@ -33,9 +33,9 @@
     - path: output/shinyngs/treatment/html/boxplot.html
       contains: ["SRX8042381", ' ENSMUSG00000027456","Gm37080']
     - path: output/shinyngs/treatment/html/density.html
-      contains: ["4.34767786283394,4.38328343135943,4.41888899988492"]
+      contains: ["4.3476778628339403,4.3832834313594287,4.4188889998849188"]
     - path: output/shinyngs/treatment/html/mad_correlation.html
-      contains: ["0,-0.742952800676994,0.674490759476595,-0.674490759476595"]
+      contains: ["0,-0.74295280067699376,0.67449075947659531,-0.6744907594765952"]
     - path: output/shinyngs/treatment/html/pca2d.html
       contains: ['SRX8042381","SRX8042382']
     - path: output/shinyngs/treatment/html/pca3d.html


### PR DESCRIPTION
This PR updates the shinyngs containers to the latest version 1.8.1 and modifies the tests accordingly. It also removes the na.omit() call in proteus_readproteingroups as with the new shinyngs/static_exploratory, NAs do not throw an error anymore.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
