### PR TITLE
Adding extra meta-fields for sentieon/applyvarcal

### DIFF
--- a/modules/nf-core/sentieon/applyvarcal/main.nf
+++ b/modules/nf-core/sentieon/applyvarcal/main.nf
@@ -9,8 +9,8 @@ process SENTIEON_APPLYVARCAL {
 
     input:
     tuple val(meta), path(vcf), path(vcf_tbi), path(recal), path(recal_index), path(tranches)
-    path  fasta
-    path  fai
+    tuple val(meta2), path(fasta)
+    tuple val(meta2), path(fai)
 
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf

--- a/modules/nf-core/sentieon/applyvarcal/main.nf
+++ b/modules/nf-core/sentieon/applyvarcal/main.nf
@@ -10,7 +10,7 @@ process SENTIEON_APPLYVARCAL {
     input:
     tuple val(meta), path(vcf), path(vcf_tbi), path(recal), path(recal_index), path(tranches)
     tuple val(meta2), path(fasta)
-    tuple val(meta2), path(fai)
+    tuple val(meta3), path(fai)
 
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf

--- a/modules/nf-core/sentieon/applyvarcal/meta.yml
+++ b/modules/nf-core/sentieon/applyvarcal/meta.yml
@@ -44,10 +44,20 @@ input:
       type: file
       description: Tranches file produced when the input vcf was run through VariantRecalibrator in stage 1.
       pattern: ".tranches"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test']
   - fasta:
       type: file
       description: The reference fasta file
       pattern: "*.fasta"
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test']
   - fai:
       type: file
       description: Index of reference fasta file

--- a/tests/modules/nf-core/sentieon/applyvarcal/main.nf
+++ b/tests/modules/nf-core/sentieon/applyvarcal/main.nf
@@ -15,5 +15,5 @@ workflow test_sentieon_applyvarcal {
     fasta = file(params.test_data['homo_sapiens']['genome']['genome_21_fasta'], checkIfExists: true)
     fai = file(params.test_data['homo_sapiens']['genome']['genome_21_fasta_fai'], checkIfExists: true)
 
-    SENTIEON_APPLYVARCAL( input, fasta, fai )
+    SENTIEON_APPLYVARCAL( input, [ [:], fasta], [ [:], fai] )
 }


### PR DESCRIPTION
Adding extra meta-fields for fasta and fai in input section of sentieon/applyvarcal.

N.B. This PR is made directly from the nf-core/modules-repo as that is necessary in order for the sentieon-based CI-tests to have access to the GH-secrets.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
