### PR TITLE
Adding extra meta-fields for sentieon/bwamem

### DIFF
--- a/modules/nf-core/sentieon/bwamem/main.nf
+++ b/modules/nf-core/sentieon/bwamem/main.nf
@@ -10,8 +10,8 @@ process SENTIEON_BWAMEM {
     input:
     tuple val(meta), path(reads)
     tuple val(meta2), path(index)
-    path(fasta)
-    path(fasta_fai)
+    tuple val(meta3), path(fasta)
+    tuple val(meta4), path(fasta_fai)
 
     output:
     tuple val(meta), path("*.bam"), path("*.bai"), emit: bam_and_bai

--- a/modules/nf-core/sentieon/bwamem/meta.yml
+++ b/modules/nf-core/sentieon/bwamem/meta.yml
@@ -33,10 +33,20 @@ input:
       type: file
       description: BWA genome index files
       pattern: "*.{amb,ann,bwt,pac,sa}"
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing reference information.
+        e.g. [ id:'test', single_end:false ]
   - fasta:
       type: file
       description: Genome fasta file
       pattern: "*.{fa,fasta}"
+  - meta4:
+      type: map
+      description: |
+        Groovy Map containing reference information.
+        e.g. [ id:'test', single_end:false ]
   - fasta_fai:
       type: file
       description: The index of the FASTA reference.

--- a/tests/modules/nf-core/sentieon/bwamem/main.nf
+++ b/tests/modules/nf-core/sentieon/bwamem/main.nf
@@ -25,7 +25,7 @@ workflow test_sentieon_bwamem_single_end {
     ]
 
     SENTIEON_BWAINDEX ( fasta_ch )
-    SENTIEON_BWAMEM ( input_ch, SENTIEON_BWAINDEX.out.index, fasta_file, fasta_fai_file )
+    SENTIEON_BWAMEM ( input_ch, SENTIEON_BWAINDEX.out.index, fasta_ch, [[:], fasta_fai_file] )
 }
 
 
@@ -51,6 +51,5 @@ workflow test_sentieon_bwa_mem_paired_end {
     ]
 
     SENTIEON_BWAINDEX ( fasta_ch )
-    SENTIEON_BWAMEM ( input_ch, SENTIEON_BWAINDEX.out.index, fasta_file, fasta_fai_file )
-
+    SENTIEON_BWAMEM ( input_ch, SENTIEON_BWAINDEX.out.index, fasta_ch, [[:], fasta_fai_file] )
 }


### PR DESCRIPTION
Adding extra meta-fields for fasta and fai in input section of sentieon/bwamem.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
