### PR TITLE
Adding extra meta-fields for sentieon/dedup

### DIFF
--- a/modules/nf-core/sentieon/dedup/main.nf
+++ b/modules/nf-core/sentieon/dedup/main.nf
@@ -9,18 +9,18 @@ process SENTIEON_DEDUP {
 
     input:
     tuple val(meta), path(bam), path(bai)
-    path  fasta
-    path  fasta_fai
+    tuple val(meta2), path(fasta)
+    tuple val(meta3), path(fasta_fai)
 
     output:
-    tuple val(meta), path("*.cram"),    emit: cram, optional: true
-    tuple val(meta), path("*.crai"),    emit: crai, optional: true
-    tuple val(meta), path("*.bam"),     emit: bam,  optional: true
-    tuple val(meta), path("*.bai"),     emit: bai
-    tuple val(meta), path("*.score"),   emit: score
-    tuple val(meta), path("*.metrics"), emit: metrics
+    tuple val(meta), path("*.cram")               , emit: cram, optional: true
+    tuple val(meta), path("*.crai")               , emit: crai, optional: true
+    tuple val(meta), path("*.bam")                , emit: bam , optional: true
+    tuple val(meta), path("*.bai")                , emit: bai
+    tuple val(meta), path("*.score")              , emit: score
+    tuple val(meta), path("*.metrics")            , emit: metrics
     tuple val(meta), path("*.metrics.multiqc.tsv"), emit: metrics_multiqc_tsv
-    path "versions.yml",                emit: versions
+    path "versions.yml"                           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/sentieon/dedup/meta.yml
+++ b/modules/nf-core/sentieon/dedup/meta.yml
@@ -28,10 +28,20 @@ input:
       type: file
       description: BAI file
       pattern: "*.bai"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information.
+        e.g. [ id:'test', single_end:false ]
   - fasta:
       type: file
       description: Genome fasta file
       pattern: "*.{fa,fasta}"
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing reference information.
+        e.g. [ id:'test', single_end:false ]
   - fasta_fai:
       type: file
       description: The index of the FASTA reference.

--- a/tests/modules/nf-core/sentieon/dedup/main.nf
+++ b/tests/modules/nf-core/sentieon/dedup/main.nf
@@ -16,7 +16,7 @@ workflow test_dedup_mark_duplicate_reads {
         file(params.test_data['sarscov2']['illumina']['test_single_end_sorted_bam_bai'], checkIfExists: true)
     ]
 
-    SENTIEON_DEDUP_MARK ( bam_ch, fasta_file, fasta_fai_file )
+    SENTIEON_DEDUP_MARK ( bam_ch, [[:], fasta_file], [[:], fasta_fai_file] )
 }
 
 workflow test_dedup_remove_duplicate_reads {
@@ -30,5 +30,5 @@ workflow test_dedup_remove_duplicate_reads {
         file(params.test_data['sarscov2']['illumina']['test_single_end_sorted_bam_bai'], checkIfExists: true)
     ]
 
-    SENTIEON_DEDUP_REMOVE ( bam_ch, fasta_file, fasta_fai_file )
+    SENTIEON_DEDUP_MARK ( bam_ch, [[:], fasta_file], [[:], fasta_fai_file] )
 }

--- a/tests/modules/nf-core/sentieon/dedup/main.nf
+++ b/tests/modules/nf-core/sentieon/dedup/main.nf
@@ -30,5 +30,5 @@ workflow test_dedup_remove_duplicate_reads {
         file(params.test_data['sarscov2']['illumina']['test_single_end_sorted_bam_bai'], checkIfExists: true)
     ]
 
-    SENTIEON_DEDUP_MARK ( bam_ch, [[:], fasta_file], [[:], fasta_fai_file] )
+    SENTIEON_DEDUP_REMOVE ( bam_ch, [[:], fasta_file], [[:], fasta_fai_file] )
 }


### PR DESCRIPTION
Adding extra meta-fields for fasta and fai in input section of sentieon/dedup.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
