### PR TITLE
Move conda-checks (seventh batch)

### DIFF
--- a/modules/nf-core/spaceranger/count/main.nf
+++ b/modules/nf-core/spaceranger/count/main.nf
@@ -4,12 +4,6 @@ process SPACERANGER_COUNT {
 
     container "docker.io/nfcore/spaceranger:2.1.0"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "SPACERANGER_COUNT module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
-
     input:
     tuple val(meta), path(reads), path(image), path(cytaimage), path(darkimage), path(colorizedimage), path(alignment), path(slidefile)
     path(reference)
@@ -23,6 +17,10 @@ process SPACERANGER_COUNT {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "SPACERANGER_COUNT module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     // Add flags for optional inputs on demand.
@@ -56,6 +54,10 @@ process SPACERANGER_COUNT {
     """
 
     stub:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "SPACERANGER_COUNT module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     mkdir -p "${prefix}/outs/"

--- a/modules/nf-core/spaceranger/mkref/main.nf
+++ b/modules/nf-core/spaceranger/mkref/main.nf
@@ -4,11 +4,6 @@ process SPACERANGER_MKREF {
 
     container "docker.io/nfcore/spaceranger:2.1.0"
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "SPACERANGER_MKREF module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     input:
     path fasta
     path gtf
@@ -22,6 +17,10 @@ process SPACERANGER_MKREF {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "SPACERANGER_MKREF module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     """
     spaceranger \\

--- a/modules/nf-core/universc/main.nf
+++ b/modules/nf-core/universc/main.nf
@@ -2,10 +2,6 @@ process UNIVERSC {
     tag "$meta.id"
     label 'process_medium'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "UNIVERSC module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
     container "nf-core/universc:1.2.5.1"
     if (workflow.containerEngine == 'docker'){
         containerOptions = "--privileged"
@@ -31,6 +27,10 @@ process UNIVERSC {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "UNIVERSC module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     def args = task.ext.args ?: ''
     def sample_arg = meta.samples.unique().join(",")
     def reference_name = reference.name
@@ -63,6 +63,10 @@ process UNIVERSC {
 
 
     stub:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "UNIVERSC module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
     """
     mkdir -p "sample-${meta.id}/outs/"
     touch sample-${meta.id}/outs/fake_file.txt

--- a/modules/nf-core/unzip/main.nf
+++ b/modules/nf-core/unzip/main.nf
@@ -19,7 +19,7 @@ process UNZIP {
 
     script:
     def args = task.ext.args ?: ''
-    if ( archive instanceof List && archive.name.size > 1 ) { exit 1, "[UNZIP] error: 7za only accepts a single archive as input. Please check module input." }
+    if ( archive instanceof List && archive.name.size > 1 ) { error "[UNZIP] error: 7za only accepts a single archive as input. Please check module input." }
 
     prefix = task.ext.prefix ?: ( meta.id ? "${meta.id}" : archive.baseName)
     """

--- a/modules/nf-core/unzip/meta.yml
+++ b/modules/nf-core/unzip/meta.yml
@@ -3,6 +3,8 @@ description: Unzip ZIP archive files
 keywords:
   - unzip
   - decompression
+  - zip
+  - archiving
 tools:
   - unzip:
       description: p7zip is a quick port of 7z.exe and 7za.exe (command line version of 7zip, see www.7-zip.org) for Unix.

--- a/modules/nf-core/unzipfiles/main.nf
+++ b/modules/nf-core/unzipfiles/main.nf
@@ -19,7 +19,7 @@ process UNZIPFILES {
 
     script:
     def args = task.ext.args ?: ''
-    if ( archive instanceof List && archive.name.size > 1 ) { exit 1, "[UNZIP] error: 7za only accepts a single archive as input. Please check module input." }
+    if ( archive instanceof List && archive.name.size > 1 ) { error "[UNZIP] error: 7za only accepts a single archive as input. Please check module input." }
 
     prefix = task.ext.prefix ?: ( meta.id ? "${meta.id}" : archive.baseName)
     """

--- a/modules/nf-core/unzipfiles/meta.yml
+++ b/modules/nf-core/unzipfiles/meta.yml
@@ -3,6 +3,8 @@ description: Unzip ZIP archive files
 keywords:
   - unzip
   - decompression
+  - zip
+  - archiving
 tools:
   - unzip:
       description: p7zip is a quick port of 7z.exe and 7za.exe (command line version of 7zip, see www.7-zip.org) for Unix.

--- a/subworkflows/nf-core/fasta_index_dna/main.nf
+++ b/subworkflows/nf-core/fasta_index_dna/main.nf
@@ -65,7 +65,7 @@ workflow FASTA_INDEX_DNA {
             ch_versions = ch_versions.mix(SNAP_INDEX.out.versions)
             break
         default:
-            exit 1, "Unknown aligner: ${val_aligner}"
+            error "Unknown aligner: ${val_aligner}"
     }
 
     emit:

--- a/subworkflows/nf-core/fastq_align_dna/main.nf
+++ b/subworkflows/nf-core/fastq_align_dna/main.nf
@@ -57,7 +57,7 @@ workflow FASTQ_ALIGN_DNA {
                 ch_versions = ch_versions.mix(SNAP_ALIGN.out.versions)
                 break
             default:
-                exit 1, "Unknown aligner: ${aligner}"
+                error "Unknown aligner: ${aligner}"
         }
 
     emit:


### PR DESCRIPTION
Issue #3683 (This is the seventh - and probably last - PR in this sad series.)

1) Moving conda-check to script-section and stub-section.
2) Replacing `exit 1` with `error()`.
 
------

The usual lint error for `spaceranger/count` and `spaceranger/mkref` : "Unable to connect ..." 403.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
