### PR TITLE
fixup: Snakemake meta.yml was incorrect

### DIFF
--- a/modules/nf-core/snakemake/meta.yml
+++ b/modules/nf-core/snakemake/meta.yml
@@ -22,7 +22,7 @@ input:
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  - bam:
+  - inputs:
       type: file
       description: Any input file required by Snakemake
       pattern: "*"


### PR DESCRIPTION
Snakemake inputs meta.yml was incorrect. This PR fixes it.
