### PR TITLE
METABAT2: reduced number of mv operations

### DIFF
--- a/modules/nf-core/metabat2/metabat2/main.nf
+++ b/modules/nf-core/metabat2/metabat2/main.nf
@@ -11,12 +11,12 @@ process METABAT2_METABAT2 {
     tuple val(meta), path(fasta), path(depth)
 
     output:
-    tuple val(meta), path("metabat2/*.tooShort.fa.gz"), optional:true, emit: tooshort
-    tuple val(meta), path("metabat2/*.lowDepth.fa.gz"), optional:true, emit: lowdepth
-    tuple val(meta), path("metabat2/*.unbinned.fa.gz"), optional:true, emit: unbinned
-    tuple val(meta), path("metabat2/*.tsv.gz")        , optional:true, emit: membership
-    tuple val(meta), path("metabat2/*[!lowDepth|tooShort|unbinned].fa.gz")         , optional:true, emit: fasta
-    path "versions.yml"                                              , emit: versions
+    tuple val(meta), path("metabat2/*.tooShort.fa.gz")                    , optional:true, emit: tooshort
+    tuple val(meta), path("metabat2/*.lowDepth.fa.gz")                    , optional:true, emit: lowdepth
+    tuple val(meta), path("metabat2/*.unbinned.fa.gz")                    , optional:true, emit: unbinned
+    tuple val(meta), path("metabat2/*.tsv.gz")                            , optional:true, emit: membership
+    tuple val(meta), path("metabat2/*[!lowDepth|tooShort|unbinned].fa.gz"), optional:true, emit: fasta
+    path "versions.yml"                                                                  , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/metabat2/metabat2/main.nf
+++ b/modules/nf-core/metabat2/metabat2/main.nf
@@ -16,16 +16,16 @@ process METABAT2_METABAT2 {
     tuple val(meta), path("*.unbinned.fa.gz")                    , optional:true, emit: unbinned
     tuple val(meta), path("*.tsv.gz")                            , optional:true, emit: membership
     tuple val(meta), path("*[!lowDepth|tooShort|unbinned].fa.gz"), optional:true, emit: fasta
-    path "versions.yml"                                                                  , emit: versions
+    path "versions.yml"                                                         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    def decompress_depth = depth ? "gzip -d -f $depth" : ""
-    def depth_file = depth ? "-a ${depth.baseName}" : ""
+    def args             = task.ext.args   ?: ''
+    def prefix           = task.ext.prefix ?: "${meta.id}"
+    def decompress_depth = depth           ? "gzip -d -f $depth"    : ""
+    def depth_file       = depth           ? "-a ${depth.baseName}" : ""
     """
     $decompress_depth
 

--- a/modules/nf-core/metabat2/metabat2/main.nf
+++ b/modules/nf-core/metabat2/metabat2/main.nf
@@ -11,11 +11,11 @@ process METABAT2_METABAT2 {
     tuple val(meta), path(fasta), path(depth)
 
     output:
-    tuple val(meta), path("metabat2/*.tooShort.fa.gz")                    , optional:true, emit: tooshort
-    tuple val(meta), path("metabat2/*.lowDepth.fa.gz")                    , optional:true, emit: lowdepth
-    tuple val(meta), path("metabat2/*.unbinned.fa.gz")                    , optional:true, emit: unbinned
-    tuple val(meta), path("metabat2/*.tsv.gz")                            , optional:true, emit: membership
-    tuple val(meta), path("metabat2/*[!lowDepth|tooShort|unbinned].fa.gz"), optional:true, emit: fasta
+    tuple val(meta), path("*.tooShort.fa.gz")                    , optional:true, emit: tooshort
+    tuple val(meta), path("*.lowDepth.fa.gz")                    , optional:true, emit: lowdepth
+    tuple val(meta), path("*.unbinned.fa.gz")                    , optional:true, emit: unbinned
+    tuple val(meta), path("*.tsv.gz")                            , optional:true, emit: membership
+    tuple val(meta), path("*[!lowDepth|tooShort|unbinned].fa.gz"), optional:true, emit: fasta
     path "versions.yml"                                                                  , emit: versions
 
     when:
@@ -35,10 +35,10 @@ process METABAT2_METABAT2 {
         $depth_file \\
         -t $task.cpus \\
         --saveCls \\
-        -o metabat2/${prefix}
+        -o ${prefix}
 
-    gzip -cn metabat2/${prefix} > metabat2/${prefix}.tsv.gz
-    find ./metabat2/ -name "*.fa" -type f | xargs -t -n 1 bgzip -@ ${task.cpus}
+    gzip -cn ${prefix} > ${prefix}.tsv.gz
+    find . -name "*.fa" -type f | xargs -t -n 1 bgzip -@ ${task.cpus}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/metabat2/metabat2/main.nf
+++ b/modules/nf-core/metabat2/metabat2/main.nf
@@ -15,7 +15,7 @@ process METABAT2_METABAT2 {
     tuple val(meta), path("metabat2/*.lowDepth.fa.gz"), optional:true, emit: lowdepth
     tuple val(meta), path("metabat2/*.unbinned.fa.gz"), optional:true, emit: unbinned
     tuple val(meta), path("metabat2/*.tsv.gz")        , optional:true, emit: membership
-    tuple val(meta), path("metabat2/*.fa.gz")         , optional:true, emit: fasta
+    tuple val(meta), path("metabat2/*[!lowDepth|tooShort|unbinned].fa.gz")         , optional:true, emit: fasta
     path "versions.yml"                                              , emit: versions
 
     when:

--- a/modules/nf-core/metabat2/metabat2/main.nf
+++ b/modules/nf-core/metabat2/metabat2/main.nf
@@ -11,12 +11,12 @@ process METABAT2_METABAT2 {
     tuple val(meta), path(fasta), path(depth)
 
     output:
-    tuple val(meta), path("*.tooShort.fa.gz")       , optional:true , emit: tooshort
-    tuple val(meta), path("*.lowDepth.fa.gz")       , optional:true , emit: lowdepth
-    tuple val(meta), path("*.unbinned.fa.gz")       , optional:true , emit: unbinned
-    tuple val(meta), path("*.tsv.gz")               , optional:true , emit: membership
-    tuple val(meta), path("bins/*.fa.gz")           , optional:true , emit: fasta
-    path "versions.yml"                                             , emit: versions
+    tuple val(meta), path("metabat2/*.tooShort.fa.gz"), optional:true, emit: tooshort
+    tuple val(meta), path("metabat2/*.lowDepth.fa.gz"), optional:true, emit: lowdepth
+    tuple val(meta), path("metabat2/*.unbinned.fa.gz"), optional:true, emit: unbinned
+    tuple val(meta), path("metabat2/*.tsv.gz")        , optional:true, emit: membership
+    tuple val(meta), path("metabat2/*.fa.gz")         , optional:true, emit: fasta
+    path "versions.yml"                                              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -37,12 +37,8 @@ process METABAT2_METABAT2 {
         --saveCls \\
         -o metabat2/${prefix}
 
-    mv metabat2/${prefix} ${prefix}.tsv
-    mv metabat2 bins
-
-    gzip -n ${prefix}.tsv
-    find ./bins/ -name "*.fa" -type f | xargs -t -n 1 bgzip -@ ${task.cpus}
-    find ./bins/ -name "*[lowDepth,tooShort,unbinned].fa.gz" -type f -exec mv {} . \\;
+    gzip -cn metabat2/${prefix} > metabat2/${prefix}.tsv.gz
+    find ./metabat2/ -name "*.fa" -type f | xargs -t -n 1 bgzip -@ ${task.cpus}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/tests/modules/nf-core/metabat2/metabat2/test.yml
+++ b/tests/modules/nf-core/metabat2/metabat2/test.yml
@@ -4,10 +4,12 @@
     - metabat2
     - metabat2/metabat2
   files:
-    - path: output/metabat2/bins/test.1.fa.gz
+    - path: output/metabat2/metabat2/test.1.fa.gz
       contains:
         - ">MT192765.1"
-    - path: output/metabat2/test.tsv.gz
+    - path: output/metabat2/metabat2/test.tsv.gz
+      contains:
+        - "MT192765.1\t1"
     - path: output/metabat2/versions.yml
 
 - name: metabat2 metabat2 test_metabat2_depth
@@ -16,9 +18,10 @@
     - metabat2
     - metabat2/metabat2
   files:
-    - path: output/metabat2/bins/test.1.fa.gz
+    - path: output/metabat2/metabat2/test.1.fa.gz
       contains:
         - ">MT192765.1"
-    - path: output/metabat2/test.tsv.gz
-    - path: output/metabat2/test.txt.gz
+    - path: output/metabat2/metabat2/test.tsv.gz
+      contains:
+        - "MT192765.1\t1"
     - path: output/metabat2/versions.yml

--- a/tests/modules/nf-core/metabat2/metabat2/test.yml
+++ b/tests/modules/nf-core/metabat2/metabat2/test.yml
@@ -4,10 +4,10 @@
     - metabat2
     - metabat2/metabat2
   files:
-    - path: output/metabat2/metabat2/test.1.fa.gz
+    - path: output/metabat2/test.1.fa.gz
       contains:
         - ">MT192765.1"
-    - path: output/metabat2/metabat2/test.tsv.gz
+    - path: output/metabat2/test.tsv.gz
       contains:
         - "MT192765.1\t1"
     - path: output/metabat2/versions.yml
@@ -18,10 +18,10 @@
     - metabat2
     - metabat2/metabat2
   files:
-    - path: output/metabat2/metabat2/test.1.fa.gz
+    - path: output/metabat2/test.1.fa.gz
       contains:
         - ">MT192765.1"
-    - path: output/metabat2/metabat2/test.tsv.gz
+    - path: output/metabat2/test.tsv.gz
       contains:
         - "MT192765.1\t1"
     - path: output/metabat2/versions.yml


### PR DESCRIPTION
- mv operations were causing problems on certain filesystems.
- This commit removes the mv operations in favour of using the existing files directly.
- Uses Nextflow native output operators to locate output files
- Outputs of METABAT2_METABAT2 will appear in a subfolder `metabat2/` unless changed in the publishDir as part of the pipeline.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
