### PR TITLE
Parabricks use stageInMode to prevent unpredictable file operations while running

### DIFF
--- a/modules/nf-core/parabricks/fq2bam/main.nf
+++ b/modules/nf-core/parabricks/fq2bam/main.nf
@@ -4,6 +4,13 @@ process PARABRICKS_FQ2BAM {
 
     container "nvcr.io/nvidia/clara/clara-parabricks:4.0.1-1"
 
+    /*
+    NOTE: Parabricks requires the files to be non-symlinked
+    Do not change the stageInMode to soft linked! This is default on Nextflow.
+    If you change this setting be careful.
+    */
+    stageInMode "copy"
+
     input:
     tuple val(meta), path(reads), path(interval_file)
     tuple val(meta2), path(fasta)
@@ -35,15 +42,6 @@ process PARABRICKS_FQ2BAM {
     """
 
     INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
-    # index and fasta need to be in the same dir as regular files (not symlinks)
-    #   and have the same base name for pbrun to function
-    #   here we copy the index into the staging dir of fasta
-    FASTA_PATH=`readlink -f $fasta`
-    cp \$INDEX.amb \$FASTA_PATH.amb
-    cp \$INDEX.ann \$FASTA_PATH.ann
-    cp \$INDEX.bwt \$FASTA_PATH.bwt
-    cp \$INDEX.pac \$FASTA_PATH.pac
-    cp \$INDEX.sa \$FASTA_PATH.sa
 
     pbrun \\
         fq2bam \\

--- a/modules/nf-core/parabricks/fq2bam/meta.yml
+++ b/modules/nf-core/parabricks/fq2bam/meta.yml
@@ -1,5 +1,5 @@
 name: "parabricks_fq2bam"
-description: NVIDIA Clara Parabricks GPU-accelerated alignment, sorting, BQSR calculation, and duplicate marking.
+description: NVIDIA Clara Parabricks GPU-accelerated alignment, sorting, BQSR calculation, and duplicate marking. Note this nf-core module requires files to be copied into the working directory and not symlinked.
 keywords:
   - align
   - sort
@@ -80,3 +80,4 @@ output:
 
 authors:
   - "@bsiranosian"
+  - "@adamrtalbot"


### PR DESCRIPTION
The parabricks/fq2bam module had hard copies from the previous working dir to the local working directory to remove the affect of symlinks. However, this will fail on a number of cases therefore this commit replaces them with the stageInDirective of Nextflow.

Would like to merge after #3738 is merged for tests.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
