### PR TITLE
Mmseqs: Documentation fix  #3739

### DIFF
--- a/modules/nf-core/mmseqs/cluster/meta.yml
+++ b/modules/nf-core/mmseqs/cluster/meta.yml
@@ -34,7 +34,7 @@ output:
       description: |
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
-  - cluster:
+  - db_cluster:
       type: file
       description: a clustered MMseqs2 database used for clustering
 

--- a/modules/nf-core/mmseqs/createdb/meta.yml
+++ b/modules/nf-core/mmseqs/createdb/meta.yml
@@ -36,7 +36,7 @@ output:
       description: |
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
-  - bam:
+  - db:
       type: directory
       description: The created MMseqs2 database
 

--- a/modules/nf-core/mmseqs/search/meta.yml
+++ b/modules/nf-core/mmseqs/search/meta.yml
@@ -48,7 +48,7 @@ output:
       description: File containing software versions
       pattern: "versions.yml"
 
-  - search_db:
+  - db_search:
       type: directory
       description: an MMseqs2 database with search results
 

--- a/modules/nf-core/mmseqs/tsv2exprofiledb/meta.yml
+++ b/modules/nf-core/mmseqs/tsv2exprofiledb/meta.yml
@@ -28,7 +28,7 @@ output:
       description: |
         File containing software versions
       pattern: "versions.yml"
-  - db_indexed:
+  - db_exprofile:
       type: directory
       description: |
         Directory containing the DB and the generated indexes

--- a/modules/nf-core/mmseqs/tsv2exprofiledb/meta.yml
+++ b/modules/nf-core/mmseqs/tsv2exprofiledb/meta.yml
@@ -31,7 +31,7 @@ output:
   - db_exprofile:
       type: directory
       description: |
-        Directory containing the DB and the generated indexes
+        Directory containing the expandable profile DB
       pattern: "*"
 
 authors:


### PR DESCRIPTION
## PR checklist

As described in attached issue, this PR fixes the incorrect labelling of an output channel in mmseqs_createdb in documentation.

Closes #3739 

- [x] This comment contains a description of changes (with reason).
