### PR TITLE
This MD5 differs between Conda and Singularity

### DIFF
--- a/tests/modules/nf-core/plasmidid/test.yml
+++ b/tests/modules/nf-core/plasmidid/test.yml
@@ -44,7 +44,6 @@
     - path: output/plasmidid/test/kmer/database.filtered_0.8_term.0.5.representative.fasta
       md5sum: 483f4a5dfe60171c86ee9b7e6dff908b
     - path: output/plasmidid/test/kmer/database.filtered_0.8_term.0.5.representative.fasta.blast.tmp.ndb
-      md5sum: f67f8be1e00eb7d3512869071fb4c2c2
     - path: output/plasmidid/test/kmer/database.filtered_0.8_term.fasta
       md5sum: c7fe0e9e9a94d98d7f85a7be99c032fd
     - path: output/plasmidid/test/kmer/database.filtered_0.8_term.mash.distances.tab


### PR DESCRIPTION
As I'm slowly going my way through #2154 I found that in this case, it's just this file that differs between Conda and Singularity. Everything else is identical, so I think it's fine to just remove the MD5 check.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
