### PR TITLE
Fix Snakemake output channel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -491,6 +491,12 @@ jobs:
         with:
           singularity-version: 3.7.1
 
+      - name: Set up Singularity
+        if: matrix.profile == 'singularity'
+        run: |
+          mkdir -p $NXF_SINGULARITY_CACHEDIR
+          mkdir -p $NXF_SINGULARITY_LIBRARYDIR
+
       - name: Set up miniconda
         if: matrix.profile == 'conda'
         uses: conda-incubator/setup-miniconda@v2

--- a/modules/nf-core/snakemake/main.nf
+++ b/modules/nf-core/snakemake/main.nf
@@ -14,7 +14,7 @@ process SNAKEMAKE {
     tuple val(meta2), path(snakefile)
 
     output:
-    tuple val(meta), path("[!.snakemake|versions.yml]**"), emit: outputs, optional: true
+    tuple val(meta), path("[!.snakemake|versions.yml]**")         , emit: outputs      , optional: true
     tuple val(meta), path(".snakemake", type: 'dir', hidden: true), emit: snakemake_dir
     path "versions.yml"                                           , emit: versions
 

--- a/modules/nf-core/snakemake/main.nf
+++ b/modules/nf-core/snakemake/main.nf
@@ -14,7 +14,7 @@ process SNAKEMAKE {
     tuple val(meta2), path(snakefile)
 
     output:
-    tuple val(meta), path("**[!.snakemake]"), optional: true      , emit: outputs
+    tuple val(meta), path("[!.snakemake|versions.yml]**"), emit: outputs, optional: true
     tuple val(meta), path(".snakemake", type: 'dir', hidden: true), emit: snakemake_dir
     path "versions.yml"                                           , emit: versions
 

--- a/tests/modules/nf-core/snakemake/main.nf.test
+++ b/tests/modules/nf-core/snakemake/main.nf.test
@@ -41,7 +41,7 @@ rule hello_world:
 
         then {
             assert process.success
-            assert snapshot(process.out.outputs).match()
+            assert snapshot(process.out.outputs, process.out.versions).match()
         }
 
     }

--- a/tests/modules/nf-core/snakemake/main.nf.test
+++ b/tests/modules/nf-core/snakemake/main.nf.test
@@ -41,7 +41,7 @@ rule hello_world:
 
         then {
             assert process.success
-            assert snapshot(process.out.ouputs).match()
+            assert snapshot(process.out.outputs).match()
         }
 
     }

--- a/tests/modules/nf-core/snakemake/main.nf.test
+++ b/tests/modules/nf-core/snakemake/main.nf.test
@@ -40,8 +40,10 @@ rule hello_world:
         }
 
         then {
-            assert process.success
-            assert snapshot(process.out.outputs, process.out.versions).match()
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.outputs, process.out.versions).match() }
+            )
         }
 
     }

--- a/tests/modules/nf-core/snakemake/main.nf.test.snap
+++ b/tests/modules/nf-core/snakemake/main.nf.test.snap
@@ -1,6 +1,20 @@
 {
     "Should run without failures": {
-        "content": null,
-        "timestamp": "2023-07-31T09:50:07+0000"
+        "content": [
+            [
+                [
+                    {
+                        "id": "input"
+                    },
+                    [
+                        "2023-08-17T130538.107091.snakemake.log:md5,0953efcb09e3871e31509cea056d1c24",
+                        "aGVsbG8udHh0:md5,3a2cfeaa6f03e95a319b0a92e4ad1cd2",
+                        "hello.txt:md5,e59ff97941044f85df5297e1c302d260",
+                        "versions.yml:md5,91f038cba572e2b7b6dfe06e0e088ce5"
+                    ]
+                ]
+            ]
+        ],
+        "timestamp": "2023-08-17T13:05:42+0000"
     }
 }

--- a/tests/modules/nf-core/snakemake/main.nf.test.snap
+++ b/tests/modules/nf-core/snakemake/main.nf.test.snap
@@ -7,8 +7,6 @@
                         "id": "input"
                     },
                     [
-                        "2023-08-17T130538.107091.snakemake.log:md5,0953efcb09e3871e31509cea056d1c24",
-                        "aGVsbG8udHh0:md5,3a2cfeaa6f03e95a319b0a92e4ad1cd2",
                         "hello.txt:md5,e59ff97941044f85df5297e1c302d260",
                         "versions.yml:md5,91f038cba572e2b7b6dfe06e0e088ce5"
                     ]

--- a/tests/modules/nf-core/snakemake/main.nf.test.snap
+++ b/tests/modules/nf-core/snakemake/main.nf.test.snap
@@ -6,13 +6,13 @@
                     {
                         "id": "input"
                     },
-                    [
-                        "hello.txt:md5,e59ff97941044f85df5297e1c302d260",
-                        "versions.yml:md5,91f038cba572e2b7b6dfe06e0e088ce5"
-                    ]
+                    "hello.txt:md5,e59ff97941044f85df5297e1c302d260"
                 ]
+            ],
+            [
+                "versions.yml:md5,91f038cba572e2b7b6dfe06e0e088ce5"
             ]
         ],
-        "timestamp": "2023-08-17T13:05:42+0000"
+        "timestamp": "2023-08-17T14:14:11+0000"
     }
 }


### PR DESCRIPTION
I done messed up with the output channels in Snakemake.

- Correct filtering to avoid `.snakemake` output folder in main channel
- Corrects nf-test outputs (snap)
- pytest-workflow unaffected

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
