### PR TITLE
Fix filename check for cellranger count

### DIFF
--- a/modules/nf-core/cellranger/count/templates/cellranger_count.py
+++ b/modules/nf-core/cellranger/count/templates/cellranger_count.py
@@ -27,8 +27,8 @@ fastq_all = Path("./fastq_all")
 fastq_all.mkdir(exist_ok=True)
 
 # Match R1 in the filename, but only if it is followed by a non-digit or non-character
-# match "file_R1.fastq.gz", "file.R1_000.fastq.gz", etc. but 
-# do not match "SRR12345", "file_INFIXR12", etc  
+# match "file_R1.fastq.gz", "file.R1_000.fastq.gz", etc. but
+# do not match "SRR12345", "file_INFIXR12", etc
 filename_pattern =  r'([^a-zA-Z0-9])R1([^a-zA-Z0-9])'
 
 for i, (r1, r2) in enumerate(chunk_iter(fastqs, 2)):
@@ -37,9 +37,9 @@ for i, (r1, r2) in enumerate(chunk_iter(fastqs, 2)):
             dedent(
                 f"""\
                 We expect R1 and R2 of the same sample to have the same filename except for R1/R2.
-                This has been checked by replacing "R1" with "R2" in the first filename and comparing it to the second filename. 
+                This has been checked by replacing "R1" with "R2" in the first filename and comparing it to the second filename.
                 If you believe this check shouldn't have failed on your filenames, please report an issue on GitHub!
-                
+
                 Files involved:
                     - {r1}
                     - {r2}

--- a/modules/nf-core/cellranger/count/templates/cellranger_count.py
+++ b/modules/nf-core/cellranger/count/templates/cellranger_count.py
@@ -3,6 +3,7 @@ from subprocess import run
 from pathlib import Path
 from textwrap import dedent
 import shlex
+import re
 
 
 def chunk_iter(seq, size):
@@ -25,13 +26,20 @@ assert len(fastqs) % 2 == 0
 fastq_all = Path("./fastq_all")
 fastq_all.mkdir(exist_ok=True)
 
+# Match R1 in the filename, but only if it is followed by a non-digit or non-character
+# match "file_R1.fastq.gz", "file.R1_000.fastq.gz", etc. but 
+# do not match "SRR12345", "file_INFIXR12", etc  
+filename_pattern =  r'([^a-zA-Z0-9])R1([^a-zA-Z0-9])'
 
 for i, (r1, r2) in enumerate(chunk_iter(fastqs, 2)):
-    if r1.name.replace("R1", "R2") != r2.name:
+    if re.sub(filename_pattern, r'\1R2\2', r1.name) != r2.name:
         raise AssertionError(
             dedent(
                 f"""\
                 We expect R1 and R2 of the same sample to have the same filename except for R1/R2.
+                This has been checked by replacing "R1" with "R2" in the first filename and comparing it to the second filename. 
+                If you believe this check shouldn't have failed on your filenames, please report an issue on GitHub!
+                
                 Files involved:
                     - {r1}
                     - {r2}

--- a/modules/nf-core/cellranger/count/templates/cellranger_count.py
+++ b/modules/nf-core/cellranger/count/templates/cellranger_count.py
@@ -32,7 +32,8 @@ fastq_all.mkdir(exist_ok=True)
 filename_pattern =  r'([^a-zA-Z0-9])R1([^a-zA-Z0-9])'
 
 for i, (r1, r2) in enumerate(chunk_iter(fastqs, 2)):
-    if re.sub(filename_pattern, r'\1R2\2', r1.name) != r2.name:
+    # double escapes are required because nextflow processes this python 'template'
+    if re.sub(filename_pattern, r'\\1R2\\2', r1.name) != r2.name:
         raise AssertionError(
             dedent(
                 f"""\


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

The filename check for consistency between R1 and R2 filename was a bit naive and led to false positives (e.g. on SRR12345 in the filename. It now uses a regex that is a bit cleverer. 

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
