### PR TITLE
Fix BCL Convert Container Name

### DIFF
--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -2,7 +2,7 @@ process BCLCONVERT {
     tag {"$meta.lane" ? "$meta.id"+"."+"$meta.lane" : "$meta.id" }
     label 'process_high'
 
-    container "nf-core/bclconvert:4.0.3"
+    container "nfcore/bclconvert:4.0.3"
 
     input:
     tuple val(meta), path(samplesheet), path(run_dir)


### PR DESCRIPTION
There is a typo in the container name for the BCL Convert Process module. It should be `nfcore/bclconvert:4.0.3` instead of `nf-core/bclconvert:4.0.3`. Notice the additional dash.

https://github.com/nf-core/modules/blob/master/modules/nf-core/bclconvert/Dockerfile#L2

As a result, the following error occurs ...

>  docker: Error response from daemon: pull access denied for nf-core/bclconvert, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.

This change fixes the name of the container.