### PR TITLE
Fix Pangolin Docker container name

### DIFF
--- a/modules/nf-core/pangolin/main.nf
+++ b/modules/nf-core/pangolin/main.nf
@@ -5,7 +5,7 @@ process PANGOLIN {
     conda "bioconda::pangolin=4.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/pangolin:4.2--pyhdfd78af_1' :
-        'biocontainers/pangolin:4.2--pyhdfd78af_1' }"
+        'quay.io/biocontainers/pangolin:4.2--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(fasta)


### PR DESCRIPTION
Similarly to https://github.com/nf-core/modules/pull/3785, the Pangolin Docker container name was incorrect. This change updates the container name to the correct one.