### PR TITLE
Update sentieon dnascope

### DIFF
--- a/modules/nf-core/sentieon/dnascope/main.nf
+++ b/modules/nf-core/sentieon/dnascope/main.nf
@@ -37,7 +37,7 @@ process SENTIEON_DNASCOPE {
     def args2                     = task.ext.args2                     ?: ''  // options for the vcf generation
     def args3                     = task.ext.args3                     ?: ''  // options for the gvcf generation
     def interval                  = intervals                          ? "--interval ${intervals}"               : ''
-    def dbsnp_str                 = dbsnp                              ? "-d ${dbsnp}"                           : ''
+    def dbsnp_cmd                 = dbsnp                              ? "-d ${dbsnp}"                           : ''
     def model_cmd                 = ml_model                           ? " --model ${ml_model}"                  : ''
     def pcr_indel_model_cmd       = pcr_indel_model                    ? " --pcr_indel_model ${pcr_indel_model}" : ''
     def prefix                    = task.ext.prefix                    ?: "${meta.id}"

--- a/modules/nf-core/sentieon/dnascope/main.nf
+++ b/modules/nf-core/sentieon/dnascope/main.nf
@@ -45,7 +45,7 @@ process SENTIEON_DNASCOPE {
     def sentieon_auth_data_base64 = task.ext.sentieon_auth_data_base64 ?: ''
     def vcf_cmd                   = ""
     def gvcf_cmd                  = ""
-    def base_cmd                  = '--algo DNAscope ' + dbsnp_str
+    def base_cmd                  = '--algo DNAscope ' + dbsnp_cmd
 
     if (emit_vcf) {  // emit_vcf can be the empty string, 'variant', 'confident' or 'all' but NOT 'gvcf'
         vcf_cmd = base_cmd + args2 + model_cmd + pcr_indel_model_cmd + ' --emit_mode ' + emit_vcf + ' ' + prefix + '.unfiltered.vcf.gz'

--- a/modules/nf-core/sentieon/dnascope/main.nf
+++ b/modules/nf-core/sentieon/dnascope/main.nf
@@ -8,18 +8,22 @@ process SENTIEON_DNASCOPE {
     container 'nf-core/sentieon:202112.06'
 
     input:
-    tuple val(meta), path(bam), path(bai)
+    tuple val(meta), path(bam), path(bai), path(intervals)
     tuple val(meta2), path(fasta)
     tuple val(meta3), path(fai)
     tuple val(meta4), path(dbsnp)
     tuple val(meta5), path(dbsnp_tbi)
-    tuple val(meta6), path(call_interval)
-    tuple val(meta7), path(ml_model)
+    tuple val(meta6), path(ml_model)
+    val(pcr_indel_model)
+    val(emit_vcf)
+    val(emit_gvcf)
 
     output:
-    tuple val(meta), path("*.vcf.gz")                      , emit: vcf
-    tuple val(meta), path("*.vcf.gz.tbi")                  , emit: index
-    path "versions.yml"                                    , emit: versions
+    tuple val(meta), path("*.unfiltered.vcf.gz")    , optional:true, emit: vcf   // added the substring ".unfiltered" in the filename of the vcf-files since without that the g.vcf.gz-files were ending up in the vcf-channel
+    tuple val(meta), path("*.unfiltered.vcf.gz.tbi"), optional:true, emit: vcf_tbi
+    tuple val(meta), path("*.g.vcf.gz")             , optional:true, emit: gvcf   // these output-files have to have the extension ".vcf.gz", otherwise the subsequent GATK-MergeVCFs will fail.
+    tuple val(meta), path("*.g.vcf.gz.tbi")         , optional:true, emit: gvcf_tbi
+    path "versions.yml"                             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,14 +33,27 @@ process SENTIEON_DNASCOPE {
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
         error "Sentieon modules do not support Conda. Please use Docker / Singularity / Podman instead."
     }
-    def args      = task.ext.args   ?: ''
-    def args2     = task.ext.args2  ?: ''
-    def interval  = call_interval   ? "--interval ${call_interval}" : ''
-    def dbsnp_str = dbsnp           ? "-d ${dbsnp}"                 : ''
-    def model     = ml_model        ? "--model ${ml_model}"         : ''
-    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def args                      = task.ext.args                      ?: ''  // options for the driver
+    def args2                     = task.ext.args2                     ?: ''  // options for the vcf generation
+    def args3                     = task.ext.args3                     ?: ''  // options for the gvcf generation
+    def interval                  = intervals                          ? "--interval ${intervals}"               : ''
+    def dbsnp_str                 = dbsnp                              ? "-d ${dbsnp}"                           : ''
+    def model_cmd                 = ml_model                           ? " --model ${ml_model}"                  : ''
+    def pcr_indel_model_cmd       = pcr_indel_model                    ? " --pcr_indel_model ${pcr_indel_model}" : ''
+    def prefix                    = task.ext.prefix                    ?: "${meta.id}"
     def sentieon_auth_mech_base64 = task.ext.sentieon_auth_mech_base64 ?: ''
     def sentieon_auth_data_base64 = task.ext.sentieon_auth_data_base64 ?: ''
+    def vcf_cmd                   = ""
+    def gvcf_cmd                  = ""
+    def base_cmd                  = '--algo DNAscope ' + dbsnp_str
+
+    if (emit_vcf) {  // emit_vcf can be the empty string, 'variant', 'confident' or 'all' but NOT 'gvcf'
+        vcf_cmd = base_cmd + args2 + model_cmd + pcr_indel_model_cmd + ' --emit_mode ' + emit_vcf + ' ' + prefix + '.unfiltered.vcf.gz'
+    }
+
+    if (emit_gvcf) { // emit_gvcf can be either true or false
+        gvcf_cmd = base_cmd + args3 + model_cmd + pcr_indel_model_cmd + ' --emit_mode gvcf ' + prefix + '.g.vcf.gz'
+    }
 
     """
     if [ "\${#SENTIEON_LICENSE_BASE64}" -lt "1500" ]; then  # If the string SENTIEON_LICENSE_BASE64 is short, then it is an encrypted url.
@@ -55,17 +72,7 @@ process SENTIEON_DNASCOPE {
         echo "Decoded and exported Sentieon test-license system environment variables"
     fi
 
-    sentieon driver \\
-        -t $task.cpus \\
-        -r $fasta \\
-        $args \\
-        $interval \\
-        -i $bam \\
-        --algo DNAscope \\
-        $dbsnp_str \\
-        $args2 \\
-        $model \\
-        ${prefix}.vcf.gz
+    sentieon driver $args -r $fasta -t $task.cpus -i $bam $interval $vcf_cmd $gvcf_cmd
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -80,8 +87,10 @@ process SENTIEON_DNASCOPE {
         error "Sentieon modules do not support Conda. Please use Docker / Singularity / Podman instead."
     }
     """
-    touch ${prefix}.vcf.gz
-    touch ${prefix}.vcf.gz.tbi
+    touch ${prefix}.unfiltered.vcf.gz
+    touch ${prefix}.unfiltered.vcf.gz.tbi
+    touch ${prefix}.g.vcf.gz
+    touch ${prefix}.g.vcf.gz.tbi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/sentieon/dnascope/meta.yml
+++ b/modules/nf-core/sentieon/dnascope/meta.yml
@@ -1,5 +1,5 @@
 name: sentieon_dnascope
-description: TO-DO UPDATE THIS FILE!!! DNAscope algorithm performs an improved version of Haplotype variant calling.
+description: DNAscope algorithm performs an improved version of Haplotype variant calling.
 keywords:
   - dnascope
   - sentieon
@@ -17,36 +17,6 @@ input:
       description: |
         Groovy Map containing sample information.
         e.g. [ id:'test', single_end:false ]
-  - meta2:
-      type: map
-      description: |
-        Groovy Map containing reference information.
-        e.g. [ id:'test' ]
-  - meta3:
-      type: map
-      description: |
-        Groovy Map containing reference information.
-        e.g. [ id:'test' ]
-  - meta4:
-      type: map
-      description: |
-        Groovy Map containing reference information.
-        e.g. [ id:'test' ]
-  - meta5:
-      type: map
-      description: |
-        Groovy Map containing reference information.
-        e.g. [ id:'test' ]
-  - meta6:
-      type: map
-      description: |
-        Groovy Map containing reference information.
-        e.g. [ id:'test' ]
-  - meta7:
-      type: map
-      description: |
-        Groovy Map containing reference information.
-        e.g. [ id:'test' ]
   - bam:
       type: file
       description: BAM file.
@@ -55,31 +25,69 @@ input:
       type: file
       description: BAI file
       pattern: "*.bai"
+  - intervals:
+      type: file
+      description: bed or interval_list file containing interval in the reference that will be used in the analysis
+      pattern: "*.{bed,interval_list}"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing meta information for fasta.
   - fasta:
       type: file
       description: Genome fasta file
       pattern: "*.{fa,fasta}"
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing meta information for fasta index.
   - fai:
       type: file
       description: Index of the genome fasta file
       pattern: "*.fai"
+  - meta4:
+      type: map
+      description: |
+        Groovy Map containing meta information for dbsnp.
   - dbsnp:
       type: file
       description: Single Nucleotide Polymorphism database (dbSNP) file
       pattern: "*.vcf.gz"
+  - meta5:
+      type: map
+      description: |
+        Groovy Map containing meta information for dbsnp_tbi.
   - dbsnp_tbi:
       type: file
       description: Index of the Single Nucleotide Polymorphism database (dbSNP) file
       pattern: "*.vcf.gz.tbi"
-  - call_interval:
-      type: file
-      description: bed or interval_list file containing interval in the reference that will be used in the analysis
-      pattern: "*.{bed,interval_list}"
+  - meta6:
+      type: map
+      description: |
+        Groovy Map containing meta information for machine learning model for Dnascope.
   - ml_model:
       type: file
       description: machine learning model file
       pattern: "*.model"
-
+  - ml_model:
+      type: file
+      description: machine learning model file
+      pattern: "*.model"
+  - pcr_indel_model:
+      type: string
+      description: |
+        Controls the option pcr_indel_model for Dnascope.
+        The possible options are "NONE" (used for PCR free samples), and "HOSTILE", "AGGRESSIVE" and "CONSERVATIVE".
+        See Sentieons documentation for further explanation.
+  - emit_vcf:
+      type: string
+      description: |
+        Controls the vcf output from Dnascope.
+        Possible options are "all", "confident" and "variant".
+        See Sentieons documentation for further explanation.
+  - emit_gvcf:
+      type: boolean
+      description: If true, the haplotyper will output a gvcf
 output:
   - meta:
       type: map
@@ -88,12 +96,20 @@ output:
         e.g. [ id:'test', single_end:false ]
   - vcf:
       type: file
-      description: VCF file
-      pattern: "*.{vcf.gz}"
-  - index:
+      description: Compressed VCF file
+      pattern: "*.unfiltered.vcf.gz"
+  - vcf_tbi:
       type: file
-      description: Index of the VCF file
-      pattern: "*.vcf.gz.tbi"
+      description: Index of VCF file
+      pattern: "*.unfiltered.vcf.gz.tbi"
+  - gvcf:
+      type: file
+      description: Compressed GVCF file
+      pattern: "*.g.vcf.gz"
+  - gvcf_tbi:
+      type: file
+      description: Index of GVCF file
+      pattern: "*.g.vcf.gz.tbi"
   - versions:
       type: file
       description: File containing software versions

--- a/modules/nf-core/sentieon/dnascope/meta.yml
+++ b/modules/nf-core/sentieon/dnascope/meta.yml
@@ -1,5 +1,5 @@
 name: sentieon_dnascope
-description: DNAscope algorithm performs an improved version of Haplotype variant calling.
+description: TO-DO UPDATE THIS FILE!!! DNAscope algorithm performs an improved version of Haplotype variant calling.
 keywords:
   - dnascope
   - sentieon

--- a/tests/modules/nf-core/sentieon/dnascope/main.nf
+++ b/tests/modules/nf-core/sentieon/dnascope/main.nf
@@ -4,7 +4,7 @@ nextflow.enable.dsl = 2
 
 include { SENTIEON_DNASCOPE   } from '../../../../../modules/nf-core/sentieon/dnascope/main.nf'
 
-workflow test_dnascope {
+workflow test_dnascope_conservative_pcr_indel_model {
 
     fasta = Channel.of([ [ id:'test' ], file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]).collect()
     fai   = Channel.of([ [ id:'test' ], file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)]).collect()
@@ -12,10 +12,72 @@ workflow test_dnascope {
     input = [
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true)
+        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+        [] // no intervals
     ]
 
     ml_model = file("https://s3.amazonaws.com/sentieon-release/other/SentieonDNAscopeModel1.0.model", checkIfExists: true)
 
-    SENTIEON_DNASCOPE ( input, fasta, fai, [[:],[]], [[:],[]], [[:],[]], [[:],ml_model] )
+    SENTIEON_DNASCOPE (
+        input,
+        fasta,
+        fai,
+        [[:], []],
+        [[:], []],
+        [[:], ml_model],
+        'CONSERVATIVE', // pcr_indel_model
+        'variant',  // emit_vcf
+        false) // emit_gvcf
+}
+
+workflow test_dnascope_aggressive_pcr_indel_model_vcf_all {
+
+    fasta = Channel.of([ [ id:'test' ], file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]).collect()
+    fai   = Channel.of([ [ id:'test' ], file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)]).collect()
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
+        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+        [] // no intervals
+    ]
+
+    ml_model = file("https://s3.amazonaws.com/sentieon-release/other/SentieonDNAscopeModel1.0.model", checkIfExists: true)
+
+    SENTIEON_DNASCOPE (
+        input,
+        fasta,
+        fai,
+        [[:], []],
+        [[:], []],
+        [[:], ml_model],
+        'AGGRESSIVE', // pcr_indel_model
+        'all',  // emit_vcf
+        false) // emit_gvcf
+}
+
+workflow test_dnascope_hostile_pcr_indel_model_vcf_confident_gvcf {
+
+    fasta = Channel.of([ [ id:'test' ], file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]).collect()
+    fai   = Channel.of([ [ id:'test' ], file(params.test_data['homo_sapiens']['genome']['genome_fasta_fai'], checkIfExists: true)]).collect()
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
+        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_bam_bai'], checkIfExists: true),
+        [] // no intervals
+    ]
+
+    ml_model = file("https://s3.amazonaws.com/sentieon-release/other/SentieonDNAscopeModel1.0.model", checkIfExists: true)
+
+    SENTIEON_DNASCOPE (
+        input,
+        fasta,
+        fai,
+        [[:], []],
+        [[:], []],
+        [[:], []],
+        'HOSTILE', // pcr_indel_model
+        'confident',  // emit_vcf
+        true) // emit_gvcf
 }

--- a/tests/modules/nf-core/sentieon/dnascope/test.yml
+++ b/tests/modules/nf-core/sentieon/dnascope/test.yml
@@ -3,8 +3,6 @@
   tags:
     - sentieon
     - sentieon/dnascope
-    - conservative_pcr_indel_model
-    - emit_vcf_variant
   files:
     - path: ./output/sentieon/test.unfiltered.vcf.gz
     - path: ./output/sentieon/test.unfiltered.vcf.gz.tbi
@@ -14,8 +12,6 @@
   tags:
     - sentieon
     - sentieon/dnascope
-    - aggressive_pcr_indel_model
-    - emit_vcf_all
   files:
     - path: ./output/sentieon/test.unfiltered.vcf.gz
     - path: ./output/sentieon/test.unfiltered.vcf.gz.tbi
@@ -25,9 +21,6 @@
   tags:
     - sentieon
     - sentieon/dnascope
-    - hostile_pcr_indel_model
-    - emit_vcf_confident
-    - emit_gvcf
   files:
     - path: ./output/sentieon/test.unfiltered.vcf.gz
     - path: ./output/sentieon/test.unfiltered.vcf.gz.tbi

--- a/tests/modules/nf-core/sentieon/dnascope/test.yml
+++ b/tests/modules/nf-core/sentieon/dnascope/test.yml
@@ -1,9 +1,36 @@
-- name: sentieon test_dnascope
-  command: nextflow run ./tests/modules/nf-core/sentieon/dnascope -entry test_dnascope -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/sentieon/dnascope/nextflow.config
+- name: sentieon test_dnascope_conservative_pcr_indel_model
+  command: nextflow run ./tests/modules/nf-core/sentieon/dnascope -entry test_dnascope_conservative_pcr_indel_model -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/sentieon/dnascope/nextflow.config
   tags:
     - sentieon
     - sentieon/dnascope
+    - conservative_pcr_indel_model
+    - emit_vcf_variant
   files:
-    - path: ./output/sentieon/test.vcf.gz
-    - path: ./output/sentieon/test.vcf.gz.tbi
+    - path: ./output/sentieon/test.unfiltered.vcf.gz
+    - path: ./output/sentieon/test.unfiltered.vcf.gz.tbi
+    - path: ./output/sentieon/versions.yml
+- name: sentieon test_dnascope_aggressive_pcr_indel_model_vcf_all
+  command: nextflow run ./tests/modules/nf-core/sentieon/dnascope -entry test_dnascope_aggressive_pcr_indel_model_vcf_all -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/sentieon/dnascope/nextflow.config
+  tags:
+    - sentieon
+    - sentieon/dnascope
+    - aggressive_pcr_indel_model
+    - emit_vcf_all
+  files:
+    - path: ./output/sentieon/test.unfiltered.vcf.gz
+    - path: ./output/sentieon/test.unfiltered.vcf.gz.tbi
+    - path: ./output/sentieon/versions.yml
+- name: sentieon test_dnascope_hostile_pcr_indel_model_vcf_confident_gvcf
+  command: nextflow run ./tests/modules/nf-core/sentieon/dnascope -entry test_dnascope_hostile_pcr_indel_model_vcf_confident_gvcf -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/sentieon/dnascope/nextflow.config
+  tags:
+    - sentieon
+    - sentieon/dnascope
+    - hostile_pcr_indel_model
+    - emit_vcf_confident
+    - emit_gvcf
+  files:
+    - path: ./output/sentieon/test.unfiltered.vcf.gz
+    - path: ./output/sentieon/test.unfiltered.vcf.gz.tbi
+    - path: ./output/sentieon/test.g.vcf.gz
+    - path: ./output/sentieon/test.g.vcf.gz.tbi
     - path: ./output/sentieon/versions.yml


### PR DESCRIPTION
Updating Sentieon Dnascope module to facilitate both vcf and gvcf output from one invocation.

Added option for `pcr_indel_model`.

Added some extra pytests.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
