### PR TITLE
Added support for multiple regions and added per-site r^2 optional output

### DIFF
--- a/modules/nf-core/glimpse2/concordance/main.nf
+++ b/modules/nf-core/glimpse2/concordance/main.nf
@@ -33,7 +33,7 @@ process GLIMPSE2_CONCORDANCE {
     def bins_cmd     = bins                   ? "--bins ${bins}"                   : ""
     def ac_bins_cmd  = ac_bins                ? "--ac-bins ${ac_bins}"             : ""
     def ale_ct_cmd   = allele_counts          ? "--allele-counts ${allele_counts}" : ""
-    def region_str   = region instanceof List ? region.join('\\n')                  : region
+    def region_str   = region instanceof List ? region.join('\\n')                 : region
 
     if (((groups ? 1:0) + (bins ? 1:0) + (ac_bins ? 1:0) + (allele_counts ? 1:0)) != 1) error "One and only one argument should be selected between groups, bins, ac_bins, allele_counts"
 

--- a/modules/nf-core/glimpse2/concordance/main.nf
+++ b/modules/nf-core/glimpse2/concordance/main.nf
@@ -19,24 +19,27 @@ process GLIMPSE2_CONCORDANCE {
     tuple val(meta), path("*.error.spl.txt.gz")  , emit: errors_spl
     tuple val(meta), path("*.rsquare.grp.txt.gz"), emit: rsquare_grp
     tuple val(meta), path("*.rsquare.spl.txt.gz"), emit: rsquare_spl
+    tuple val(meta), path("*_r2_sites.txt.gz")   , emit: rsquare_per_site, optional: true
     path "versions.yml"                          , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args         = task.ext.args   ?: ''
-    def prefix       = task.ext.prefix ?: "${meta.id}"
-    def samples_cmd  = samples         ? "--samples ${samples}"             : ""
-    def groups_cmd   = groups          ? "--groups ${groups}"               : ""
-    def bins_cmd     = bins            ? "--bins ${bins}"                   : ""
-    def ac_bins_cmd  = ac_bins         ? "--ac-bins ${ac_bins}"             : ""
-    def ale_ct_cmd   = allele_counts   ? "--allele-counts ${allele_counts}" : ""
+    def args         = task.ext.args          ?: ''
+    def prefix       = task.ext.prefix        ?: "${meta.id}"
+    def samples_cmd  = samples                ? "--samples ${samples}"             : ""
+    def groups_cmd   = groups                 ? "--groups ${groups}"               : ""
+    def bins_cmd     = bins                   ? "--bins ${bins}"                   : ""
+    def ac_bins_cmd  = ac_bins                ? "--ac-bins ${ac_bins}"             : ""
+    def ale_ct_cmd   = allele_counts          ? "--allele-counts ${allele_counts}" : ""
+    def region_str   = region instanceof List ? region.join('\\n')                  : region
 
     if (((groups ? 1:0) + (bins ? 1:0) + (ac_bins ? 1:0) + (allele_counts ? 1:0)) != 1) error "One and only one argument should be selected between groups, bins, ac_bins, allele_counts"
 
     """
-    echo $region $freq $truth $estimate > input.txt
+    printf '$region_str' > regions.txt
+    sed 's/\$/ $freq $truth $estimate/' regions.txt > input.txt
     GLIMPSE2_concordance \\
         $args \\
         $samples_cmd \\
@@ -51,8 +54,8 @@ process GLIMPSE2_CONCORDANCE {
         --output ${prefix}
 
     cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            glimpse2: "\$(GLIMPSE2_concordance --help | sed -nr '/Version/p' | grep -o -E '([0-9]+.){1,2}[0-9]' | head -1)"
+    "${task.process}":
+        glimpse2: "\$(GLIMPSE2_concordance --help | sed -nr '/Version/p' | grep -o -E '([0-9]+.){1,2}[0-9]' | head -1)"
     END_VERSIONS
     """
 }

--- a/modules/nf-core/glimpse2/concordance/meta.yml
+++ b/modules/nf-core/glimpse2/concordance/meta.yml
@@ -23,7 +23,7 @@ input:
 
   - region:
       type: string
-      description: Target region used for imputation, including left and right buffers (e.g. chr20:1000000-2000000).
+      description: Target region used for imputation, including left and right buffers (e.g. chr20:1000000-2000000). Can also be a list of such regions.
       pattern: "chrXX:leftBufferPosition-rightBufferPosition"
 
   - freq:
@@ -110,15 +110,20 @@ output:
       description: Samples correlation errors between imputed dosages (in MAF bins) and highly-confident genotype.
       pattern: "*.errors.spl.txt.gz"
 
-  - rsquared_grp:
+  - rsquare_grp:
       type: file
       description: Groups r-squared correlation between imputed dosages (in MAF bins) and highly-confident genotype.
       pattern: "*.rsquare.grp.txt.gz"
 
-  - rsquared_spl:
+  - rsquare_spl:
       type: file
       description: Samples r-squared correlation between imputed dosages (in MAF bins) and highly-confident genotype.
       pattern: "*.rsquare.spl.txt.gz"
+
+  - rsquare_per_site:
+      type: file
+      description: Variant r-squared correlation between imputed dosages (in MAF bins) and highly-confident genotype.
+      pattern: "_r2_sites.txt.gz"
 
 authors:
   - "@louislenezet"

--- a/tests/modules/nf-core/glimpse2/concordance/nextflow.config
+++ b/tests/modules/nf-core/glimpse2/concordance/nextflow.config
@@ -1,3 +1,7 @@
 process {
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    withName:GLIMPSE2_CONCORDANCE_R2_PER_SITE {
+        ext.args = "--out-r2-per-site"
+    }
 }

--- a/tests/modules/nf-core/glimpse2/concordance/test.yml
+++ b/tests/modules/nf-core/glimpse2/concordance/test.yml
@@ -13,3 +13,34 @@
     - path: output/glimpse2/input.rsquare.spl.txt.gz
     - path: output/glimpse2/input_chr21_16650000-16750000.bcf
     - path: output/glimpse2/versions.yml
+- name: glimpse2 concordance test_list_region
+  command: nextflow run ./tests/modules/nf-core/glimpse2/concordance -entry test_list_region -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/glimpse2/concordance/nextflow.config
+  tags:
+    - glimpse2
+    - glimpse2/concordance
+  files:
+    - path: output/bcftools/input_chr21_16650000-16750000.bcf.csi
+    - path: output/bcftools/versions.yml
+    - path: output/glimpse2/input.error.cal.txt.gz
+    - path: output/glimpse2/input.error.grp.txt.gz
+    - path: output/glimpse2/input.error.spl.txt.gz
+    - path: output/glimpse2/input.rsquare.grp.txt.gz
+    - path: output/glimpse2/input.rsquare.spl.txt.gz
+    - path: output/glimpse2/input_chr21_16650000-16750000.bcf
+    - path: output/glimpse2/versions.yml
+- name: glimpse2 concordance test_r2_per_site
+  command: nextflow run ./tests/modules/nf-core/glimpse2/concordance -entry test_r2_per_site -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/glimpse2/concordance/nextflow.config
+  tags:
+    - glimpse2
+    - glimpse2/concordance
+  files:
+    - path: output/bcftools/input_chr21_16650000-16750000.bcf.csi
+    - path: output/bcftools/versions.yml
+    - path: output/glimpse2/input.error.cal.txt.gz
+    - path: output/glimpse2/input.error.grp.txt.gz
+    - path: output/glimpse2/input.error.spl.txt.gz
+    - path: output/glimpse2/input.rsquare.grp.txt.gz
+    - path: output/glimpse2/input.rsquare.spl.txt.gz
+    - path: output/glimpse2/input_r2_sites.txt.gz
+    - path: output/glimpse2/input_chr21_16650000-16750000.bcf
+    - path: output/glimpse2/versions.yml


### PR DESCRIPTION
I added the optional output that is produced when using the flag --out_r2_per_site and modified the code for producing input.txt so that it can also be run in multiple chromosomes by providing a list of regions as input in val(region). This still allows for a single input.

Running on multiple regions is important to calculate aggregated MAF bin metrics for the whole genome for example.

I also removed the indentation from the version HEREDOCS since it is causing problems with dumpsoftwareversions.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
