### PR TITLE
Fix output for bcl2fastq & bclconvert

### DIFF
--- a/modules/nf-core/bcl2fastq/main.nf
+++ b/modules/nf-core/bcl2fastq/main.nf
@@ -8,8 +8,8 @@ process BCL2FASTQ {
     tuple val(meta), path(samplesheet), path(run_dir)
 
     output:
-    tuple val(meta), path("**[!Undetermined]_S*_R?_00?.fastq.gz"), emit: fastq
-    tuple val(meta), path("**[!Undetermined]_S*_I?_00?.fastq.gz"), optional:true, emit: fastq_idx
+    tuple val(meta), path("**_S[1-9]*_R?_00?.fastq.gz")          , emit: fastq
+    tuple val(meta), path("**_S[1-9]*_I?_00?.fastq.gz")          , optional:true, emit: fastq_idx
     tuple val(meta), path("**Undetermined_S0*_R?_00?.fastq.gz")  , optional:true, emit: undetermined
     tuple val(meta), path("**Undetermined_S0*_I?_00?.fastq.gz")  , optional:true, emit: undetermined_idx
     tuple val(meta), path("Reports")                             , emit: reports

--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -8,8 +8,8 @@ process BCLCONVERT {
     tuple val(meta), path(samplesheet), path(run_dir)
 
     output:
-    tuple val(meta), path("**[!Undetermined]_S*_R?_00?.fastq.gz"), emit: fastq
-    tuple val(meta), path("**[!Undetermined]_S*_I?_00?.fastq.gz"), optional:true, emit: fastq_idx
+    tuple val(meta), path("**_S[1-9]*_R?_00?.fastq.gz")          , emit: fastq
+    tuple val(meta), path("**_S[1-9]*_I?_00?.fastq.gz")          , optional:true, emit: fastq_idx
     tuple val(meta), path("**Undetermined_S0*_R?_00?.fastq.gz")  , optional:true, emit: undetermined
     tuple val(meta), path("**Undetermined_S0*_I?_00?.fastq.gz")  , optional:true, emit: undetermined_idx
     tuple val(meta), path("Reports")                             , emit: reports

--- a/tests/modules/nf-core/bcl2fastq/main.nf
+++ b/tests/modules/nf-core/bcl2fastq/main.nf
@@ -5,6 +5,7 @@ nextflow.enable.dsl = 2
 include { BCL2FASTQ } from '../../../../modules/nf-core/bcl2fastq/main.nf'
 
 workflow test_bcl2fastq {
+    //TODO use new test dataset when available, see https://github.com/nf-core/test-datasets/issues/996
     ch_flowcell = Channel.value([
             [id:'test', lane:1 ], // meta map
             file(params.test_data['homo_sapiens']['illumina']['test_flowcell_samplesheet'], checkIfExists: true),
@@ -20,3 +21,4 @@ workflow test_bcl2fastq {
 
     BCL2FASTQ (ch_flowcell_merge)
 }
+

--- a/tests/modules/nf-core/bclconvert/main.nf
+++ b/tests/modules/nf-core/bclconvert/main.nf
@@ -5,6 +5,7 @@ nextflow.enable.dsl = 2
 include { BCLCONVERT } from '../../../../modules/nf-core/bclconvert/main.nf'
 
 workflow test_bclconvert {
+    //TODO use new test dataset when available, see https://github.com/nf-core/test-datasets/issues/996
     ch_flowcell = Channel.value([
             [id:'test', lane:1 ], // meta map
             file(params.test_data['homo_sapiens']['illumina']['test_flowcell_samplesheet'], checkIfExists: true),


### PR DESCRIPTION
In a nutshell, the previous glob would miss files where the sample name ends with one of these letters `[Udeimnrt]`, see issue #3794 for more details.

This PR matches fastq files using their sample number instead, which will be 0 for Undetermined files and >1 for other files (see [bcl2fastq docs](https://support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/bcl2fastq/bcl2fastq2-v2-20-software-guide-15051736-03.pdf), page 17).

I'm not sure about how to update the tests though... I guess I would need to update the samplesheet at https://github.com/nf-core/test-datasets/blob/modules/data/genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.csv but that would probably break a cascade of other tests I guess? Or is there a way to edit the samplesheet in place if I create a new test?

## PR checklist

Closes #3794 

- [X] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, include test data in your PR.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [X] `PROFILE=docker pytest --tag bcl2fastq --symlink --keep-workflow-wd --git-aware`
  - [X] `PROFILE=docker pytest --tag bclconvert --symlink --keep-workflow-wd --git-aware`
  - [X] `PROFILE=singularity pytest --tag bcl2fastq --symlink --keep-workflow-wd --git-aware`
  - [X] `PROFILE=singularity pytest --tag bclconvert --symlink --keep-workflow-wd --git-aware`
