### PR TITLE
fix empty channel assignment in FASTQ_TRIM_FASTP_FASTQC subworkflow

### DIFF
--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/main.nf
@@ -35,8 +35,8 @@ workflow FASTQ_TRIM_FASTP_FASTQC {
         FASTQC_RAW (
             ch_reads
         )
-        fastqc_raw_html = FASTQC_RAW.out.html
-        fastqc_raw_zip  = FASTQC_RAW.out.zip
+        ch_fastqc_raw_html = FASTQC_RAW.out.html
+        ch_fastqc_raw_zip  = FASTQC_RAW.out.zip
         ch_versions     = ch_versions.mix(FASTQC_RAW.out.versions.first())
     }
 


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`

## Description of the bug

Channels outputting `fastqc_raw*`  files are empty due to incorrect variable name assignment. This caused fastqc_raw channels emitted by the subworkflow to always be empty.

