### PR TITLE
Update NGSCheckMate/ncm

### DIFF
--- a/modules/nf-core/bcftools/mpileup/main.nf
+++ b/modules/nf-core/bcftools/mpileup/main.nf
@@ -9,7 +9,7 @@ process BCFTOOLS_MPILEUP {
 
     input:
     tuple val(meta), path(bam), path(intervals)
-    path fasta
+    tuple val(meta2), path(fasta)
     val save_mpileup
 
     output:

--- a/modules/nf-core/bcftools/mpileup/meta.yml
+++ b/modules/nf-core/bcftools/mpileup/meta.yml
@@ -25,6 +25,10 @@ input:
   - intervals:
       type: file
       description: Input intervals file. A file (commonly '.bed') containing regions to subset
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing information about the genome fasta, e.g. [ id: 'sarscov2' ]
   - fasta:
       type: file
       description: FASTA reference file

--- a/modules/nf-core/ngscheckmate/ncm/main.nf
+++ b/modules/nf-core/ngscheckmate/ncm/main.nf
@@ -48,7 +48,7 @@ process NGSCHECKMATE_NCM {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "ngscheckmate"
+    def prefix = task.ext.prefix ?: "$meta.id"
     """
     touch ${prefix}_output_corr_matrix.txt
     touch ${prefix}_matched.txt

--- a/modules/nf-core/ngscheckmate/ncm/main.nf
+++ b/modules/nf-core/ngscheckmate/ncm/main.nf
@@ -1,21 +1,21 @@
 process NGSCHECKMATE_NCM {
     label 'process_low'
 
-    conda "bioconda::ngscheckmate=1.0.0"
+    conda "bioconda::ngscheckmate=1.0.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.0--py27r41hdfd78af_3':
-        'biocontainers/ngscheckmate:1.0.0--py27r41hdfd78af_3' }"
+        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1':
+        'biocontainers/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1' }"
 
     input:
-    path files
-    path snp_bed
-    path fasta
+    tuple val(meta) , path(files)
+    tuple val(meta2), path(snp_bed)
+    tuple val(meta3), path(fasta)
 
     output:
-    path "*.pdf"            , emit: pdf, optional: true
     path "*_corr_matrix.txt", emit: corr_matrix
     path "*_matched.txt"    , emit: matched
     path "*_all.txt"        , emit: all
+    path "*.pdf"            , emit: pdf, optional: true
     path "*.vcf"            , emit: vcf, optional: true
     path "versions.yml"     , emit: versions
 

--- a/modules/nf-core/ngscheckmate/ncm/main.nf
+++ b/modules/nf-core/ngscheckmate/ncm/main.nf
@@ -24,7 +24,7 @@ process NGSCHECKMATE_NCM {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "ngscheckmate"
+    def prefix = task.ext.prefix ?: "$meta.id"
     def unzip = files.any { it.toString().endsWith(".vcf.gz") }
     """
     if $unzip

--- a/modules/nf-core/ngscheckmate/ncm/main.nf
+++ b/modules/nf-core/ngscheckmate/ncm/main.nf
@@ -12,11 +12,11 @@ process NGSCHECKMATE_NCM {
     tuple val(meta3), path(fasta)
 
     output:
-    path "*_corr_matrix.txt", emit: corr_matrix
-    path "*_matched.txt"    , emit: matched
-    path "*_all.txt"        , emit: all
-    path "*.pdf"            , emit: pdf, optional: true
-    path "*.vcf"            , emit: vcf, optional: true
+    tuple val(meta), path("*_corr_matrix.txt"), emit: corr_matrix
+    tuple val(meta), path("*_matched.txt")    , emit: matched
+    tuple val(meta), path("*_all.txt")        , emit: all
+    tuple val(meta), path("*.pdf")            , emit: pdf, optional: true
+    tuple val(meta), path("*.vcf")            , emit: vcf, optional: true
     path "versions.yml"     , emit: versions
 
     when:
@@ -46,4 +46,19 @@ process NGSCHECKMATE_NCM {
         ngscheckmate: \$(ncm.py --help | sed "7!d;s/ *Ensuring Sample Identity v//g")
     END_VERSIONS
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_corr_matrix.txt
+    touch ${prefix}_matched.txt
+    touch ${prefix}_all.txt
+    touch ${prefix}.pdf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        ngscheckmate: \$(ncm.py --help | sed "7!d;s/ *Ensuring Sample Identity v//g")
+    END_VERSIONS
+    """
+
 }

--- a/modules/nf-core/ngscheckmate/ncm/main.nf
+++ b/modules/nf-core/ngscheckmate/ncm/main.nf
@@ -24,7 +24,7 @@ process NGSCHECKMATE_NCM {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "output"
+    def prefix = task.ext.prefix ?: "ngscheckmate"
     def unzip = files.any { it.toString().endsWith(".vcf.gz") }
     """
     if $unzip
@@ -48,9 +48,9 @@ process NGSCHECKMATE_NCM {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "ngscheckmate"
     """
-    touch ${prefix}_corr_matrix.txt
+    touch ${prefix}_output_corr_matrix.txt
     touch ${prefix}_matched.txt
     touch ${prefix}_all.txt
     touch ${prefix}.pdf

--- a/modules/nf-core/ngscheckmate/ncm/meta.yml
+++ b/modules/nf-core/ngscheckmate/ncm/meta.yml
@@ -14,16 +14,29 @@ tools:
       licence: ["MIT"]
 
 input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test']
   - files:
       type: file
       description: VCF or BAM files for each sample, in a merged channel (possibly gzipped). BAM files require an index too.
       pattern: "*.{vcf,vcf.gz,bam,bai}"
-
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing SNP information
+        e.g. [ id:'test' ]
   - snp_bed:
       type: file
       description: BED file containing the SNPs to analyse
       pattern: "*.{bed}"
-
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing reference fasta index information
+        e.g. [ id:'test' ]
   - fasta:
       type: file
       description: fasta file for the genome, only used in the bam mode

--- a/subworkflows/nf-core/bam_ngscheckmate/main.nf
+++ b/subworkflows/nf-core/bam_ngscheckmate/main.nf
@@ -1,18 +1,23 @@
-include { BCFTOOLS_MPILEUP     } from '../../../modules/nf-core/bcftools/mpileup/main'
+include { BCFTOOLS_MPILEUP } from '../../../modules/nf-core/bcftools/mpileup/main'
 include { NGSCHECKMATE_NCM } from '../../../modules/nf-core/ngscheckmate/ncm/main'
 
 workflow BAM_NGSCHECKMATE {
 
     take:
-    ch_input            // channel: [ val(meta), bam/cram ]
-    ch_bed              // channel: [ bed ]
-    ch_fasta            // channel: [ fasta ]
+    ch_input            // channel: [ val(meta1), bam/cram ]
+    ch_snp_bed          // channel: [ val(meta2), bed ]
+    ch_fasta            // channel: [ val(meta3), fasta ]
 
     main:
 
     ch_versions = Channel.empty()
 
-    ch_input_bed = ch_input.combine(ch_bed)
+    ch_input_bed = ch_input.combine(ch_snp_bed)
+                        // do something to combine the metas?
+                        .map{ input_meta, input_file, bed_meta, bed_file ->
+                            [input_meta, input_file, bed_file]
+                        }
+                        .view()
 
     BCFTOOLS_MPILEUP (ch_input_bed, ch_fasta.collect(), false)
     ch_versions = ch_versions.mix(BCFTOOLS_MPILEUP.out.versions)
@@ -20,19 +25,20 @@ workflow BAM_NGSCHECKMATE {
     BCFTOOLS_MPILEUP
     .out
     .vcf
-    .map{meta, vcf -> vcf}
-    .collect()
+    .map{meta, vcf -> vcf}    // discard individual metas
+    .collect()                // group into one channel
+    .map{it -> [[ meta2, it]} // use the snp_bed file meta as the meta for the merged channel
     .set {ch_flat_vcfs}
 
     NGSCHECKMATE_NCM (ch_flat_vcfs, ch_bed, ch_fasta)
     ch_versions = ch_versions.mix(NGSCHECKMATE_NCM.out.versions)
 
     emit:
-    pdf          = NGSCHECKMATE_NCM.out.pdf          // channel: [ pdf ]
-    corr_matrix  = NGSCHECKMATE_NCM.out.corr_matrix  // channel: [ corr_matrix ]
-    matched      = NGSCHECKMATE_NCM.out.matched      // channel: [ matched ]
-    all          = NGSCHECKMATE_NCM.out.all          // channel: [ all ]
+    corr_matrix  = NGSCHECKMATE_NCM.out.corr_matrix  // channel: [ meta, corr_matrix ]
+    matched      = NGSCHECKMATE_NCM.out.matched      // channel: [ meta, matched ]
+    all          = NGSCHECKMATE_NCM.out.all          // channel: [ meta, all ]
     vcf          = BCFTOOLS_MPILEUP.out.vcf          // channel: [ meta, vcf ]
+    pdf          = NGSCHECKMATE_NCM.out.pdf          // channel: [ meta, pdf ]
     versions     = ch_versions                       // channel: [ versions.yml ]
 
 }

--- a/subworkflows/nf-core/bam_ngscheckmate/meta.yml
+++ b/subworkflows/nf-core/bam_ngscheckmate/meta.yml
@@ -10,7 +10,7 @@ components:
   - bcftools/mpileup
   - ngscheckmate/ncm
 input:
-  - meta:
+  - meta1:
       type: map
       description: |
         Groovy Map containing sample information
@@ -19,11 +19,20 @@ input:
       type: file
       description: BAM files for each sample
       pattern: "*.{bam}"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing bed file information
+        e.g. [ id:'sarscov2' ]
   - snp_bed:
       type: file
       description: BED file containing the SNPs to analyse. NGSCheckMate provides some default ones for hg19/hg38.
       pattern: "*.{bed}"
-
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing reference genome meta information
+        e.g. [ id:'sarscov2' ]
   - fasta:
       type: file
       description: fasta file for the genome

--- a/tests/modules/nf-core/bcftools/mpileup/main.nf
+++ b/tests/modules/nf-core/bcftools/mpileup/main.nf
@@ -11,7 +11,12 @@ workflow test_bcftools_mpileup {
         [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ],
         []
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+
+    fasta = [
+        [ id:'sarscov2' ], // meta map
+        [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+    ]
+
     save_mpileup = false
 
     BCFTOOLS_MPILEUP ( input, fasta, save_mpileup )
@@ -24,7 +29,12 @@ workflow test_bcftools_save_mpileup {
         [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ],
         []
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+
+    fasta = [
+        [ id:'sarscov2' ], // meta map
+        [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+    ]
+
     save_mpileup = true
 
     BCFTOOLS_MPILEUP ( input, fasta, save_mpileup )
@@ -35,9 +45,14 @@ workflow test_bcftools_mpileup_intervals {
     input = [
         [ id:'test' ], // meta map
         [ file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true) ],
-        [file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)]
+        [ file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)]
     ]
-    fasta = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+
+    fasta = [
+        [ id:'sarscov2' ], // meta map
+        [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+    ]
+
     save_mpileup = false
 
     BCFTOOLS_MPILEUP ( input, fasta, save_mpileup )

--- a/tests/modules/nf-core/bcftools/mpileup/test.yml
+++ b/tests/modules/nf-core/bcftools/mpileup/test.yml
@@ -1,40 +1,43 @@
 - name: bcftools mpileup test_bcftools_mpileup
   command: nextflow run ./tests/modules/nf-core/bcftools/mpileup -entry test_bcftools_mpileup -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bcftools/mpileup/nextflow.config
   tags:
-    - bcftools/mpileup
     - bcftools
+    - bcftools/mpileup
   files:
     - path: output/bcftools/test.bcftools_stats.txt
       md5sum: 652ead9184c18167613a3bfc75b99111
-    - path: output/bcftools/test.vcf.gz.tbi
-      md5sum: 23e5a910227891c53bb34196be7c00b4
     - path: output/bcftools/test.vcf.gz
       md5sum: 960b84036dd0a532b338b1a95813fc25
+    - path: output/bcftools/test.vcf.gz.tbi
+      md5sum: 23e5a910227891c53bb34196be7c00b4
+    - path: output/bcftools/versions.yml
 
 - name: bcftools mpileup test_bcftools_save_mpileup
   command: nextflow run ./tests/modules/nf-core/bcftools/mpileup -entry test_bcftools_save_mpileup -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bcftools/mpileup/nextflow.config
   tags:
-    - bcftools/mpileup
     - bcftools
+    - bcftools/mpileup
   files:
     - path: output/bcftools/test.bcftools_stats.txt
       md5sum: 652ead9184c18167613a3bfc75b99111
-    - path: output/bcftools/test.vcf.gz.tbi
-      md5sum: 23e5a910227891c53bb34196be7c00b4
-    - path: output/bcftools/test.vcf.gz
-      md5sum: 960b84036dd0a532b338b1a95813fc25
     - path: output/bcftools/test.mpileup.gz
       md5sum: dd424be36720bb09007233bd367796f1
+    - path: output/bcftools/test.vcf.gz
+      md5sum: 960b84036dd0a532b338b1a95813fc25
+    - path: output/bcftools/test.vcf.gz.tbi
+      md5sum: 23e5a910227891c53bb34196be7c00b4
+    - path: output/bcftools/versions.yml
 
 - name: bcftools mpileup test_bcftools_mpileup_intervals
-  command: nextflow run ./tests/modules/nf-core/bcftools/mpileup -entry test_bcftools_mpileup_intervals -c ./tests/config/nextflow.config     -c ./tests/modules/nf-core/bcftools/mpileup/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/bcftools/mpileup -entry test_bcftools_mpileup_intervals -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bcftools/mpileup/nextflow.config
   tags:
-    - bcftools/mpileup
     - bcftools
+    - bcftools/mpileup
   files:
     - path: output/bcftools/test.bcftools_stats.txt
       md5sum: 405eee1f452446e34f3dcfc2b00e5fab
-    - path: output/bcftools/test.vcf.gz.tbi
-      md5sum: 3a50baca0fb70eaab68c44cb9bd4d4a3
     - path: output/bcftools/test.vcf.gz
       md5sum: 1feaf4810f6b57f32ea7fd2dbc4da9a0
+    - path: output/bcftools/test.vcf.gz.tbi
+      md5sum: 3a50baca0fb70eaab68c44cb9bd4d4a3
+    - path: output/bcftools/versions.yml

--- a/tests/modules/nf-core/ngscheckmate/ncm/test.yml
+++ b/tests/modules/nf-core/ngscheckmate/ncm/test.yml
@@ -7,12 +7,12 @@
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
     - path: output/bedtools/versions.yml
-    - path: output/ngscheckmate/ngscheckmate.pdf
-    - path: output/ngscheckmate/ngscheckmate_all.txt
+    - path: output/ngscheckmate/combined_bams.pdf
+    - path: output/ngscheckmate/combined_bams_all.txt
       md5sum: 14d0b35765e127aab0ffa5ea5406b4ab
-    - path: output/ngscheckmate/ngscheckmate_matched.txt
+    - path: output/ngscheckmate/combined_bams_matched.txt
       md5sum: 14d0b35765e127aab0ffa5ea5406b4ab
-    - path: output/ngscheckmate/ngscheckmate_output_corr_matrix.txt
+    - path: output/ngscheckmate/combined_bams_output_corr_matrix.txt
       md5sum: b8bfd203232680b746ac91ccb290b5e3
     - path: output/ngscheckmate/test.paired_end.methylated.sorted.vcf
     - path: output/ngscheckmate/test.paired_end.sorted.vcf
@@ -40,11 +40,11 @@
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
     - path: output/bedtools/versions.yml
-    - path: output/ngscheckmate/ngscheckmate.pdf
-    - path: output/ngscheckmate/ngscheckmate_all.txt
+    - path: output/ngscheckmate/combined_vcfs.pdf
+    - path: output/ngscheckmate/combined_vcfs_all.txt
       md5sum: fd74956dcac279b6f58e82ea73e344f8
-    - path: output/ngscheckmate/ngscheckmate_matched.txt
+    - path: output/ngscheckmate/combined_vcfs_matched.txt
       md5sum: fd74956dcac279b6f58e82ea73e344f8
-    - path: output/ngscheckmate/ngscheckmate_output_corr_matrix.txt
+    - path: output/ngscheckmate/combined_vcfs_output_corr_matrix.txt
       md5sum: 0c86bdad2721c470fe6be119f291c8e5
     - path: output/ngscheckmate/versions.yml

--- a/tests/modules/nf-core/ngscheckmate/ncm/test.yml
+++ b/tests/modules/nf-core/ngscheckmate/ncm/test.yml
@@ -9,11 +9,11 @@
     - path: output/bedtools/versions.yml
     - path: output/ngscheckmate/output.pdf
     - path: output/ngscheckmate/output_all.txt
-      md5sum: f71a712c3f6ecf64dd526365212f1b7c
-    - path: output/ngscheckmate/output_corr_matrix.txt
-      md5sum: 6777377aa9ae3d57f841b12896318db0
+      md5sum: 14d0b35765e127aab0ffa5ea5406b4ab
     - path: output/ngscheckmate/output_matched.txt
-      md5sum: f71a712c3f6ecf64dd526365212f1b7c
+      md5sum: 14d0b35765e127aab0ffa5ea5406b4ab
+    - path: output/ngscheckmate/output_output_corr_matrix.txt
+      md5sum: b8bfd203232680b746ac91ccb290b5e3
     - path: output/ngscheckmate/test.paired_end.methylated.sorted.vcf
     - path: output/ngscheckmate/test.paired_end.sorted.vcf
     - path: output/ngscheckmate/versions.yml
@@ -25,11 +25,17 @@
     - ngscheckmate
   files:
     - path: output/bcftools/test1.bcftools_stats.txt
+      md5sum: 4b4b957c245341829d828808b0569f63
     - path: output/bcftools/test1.vcf.gz
+      md5sum: 0bcee2be4a5be5ec1e43a6405fd9a3ec
     - path: output/bcftools/test1.vcf.gz.tbi
+      md5sum: 3a50baca0fb70eaab68c44cb9bd4d4a3
     - path: output/bcftools/test2.bcftools_stats.txt
+      md5sum: d7cdcb4eff626f2105ac87d5e1e010d8
     - path: output/bcftools/test2.vcf.gz
+      md5sum: 14071a9f4a444521af9978d8051227f3
     - path: output/bcftools/test2.vcf.gz.tbi
+      md5sum: 812b2fb12736532054d51e63aa16e966
     - path: output/bcftools/versions.yml
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
@@ -37,8 +43,8 @@
     - path: output/ngscheckmate/output.pdf
     - path: output/ngscheckmate/output_all.txt
       md5sum: fd74956dcac279b6f58e82ea73e344f8
-    - path: output/ngscheckmate/output_corr_matrix.txt
-      md5sum: 0c86bdad2721c470fe6be119f291c8e5
     - path: output/ngscheckmate/output_matched.txt
       md5sum: fd74956dcac279b6f58e82ea73e344f8
+    - path: output/ngscheckmate/output_output_corr_matrix.txt
+      md5sum: 0c86bdad2721c470fe6be119f291c8e5
     - path: output/ngscheckmate/versions.yml

--- a/tests/modules/nf-core/ngscheckmate/ncm/test.yml
+++ b/tests/modules/nf-core/ngscheckmate/ncm/test.yml
@@ -7,12 +7,12 @@
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
     - path: output/bedtools/versions.yml
-    - path: output/ngscheckmate/output.pdf
-    - path: output/ngscheckmate/output_all.txt
+    - path: output/ngscheckmate/ngscheckmate.pdf
+    - path: output/ngscheckmate/ngscheckmate_all.txt
       md5sum: 14d0b35765e127aab0ffa5ea5406b4ab
-    - path: output/ngscheckmate/output_matched.txt
+    - path: output/ngscheckmate/ngscheckmate_matched.txt
       md5sum: 14d0b35765e127aab0ffa5ea5406b4ab
-    - path: output/ngscheckmate/output_output_corr_matrix.txt
+    - path: output/ngscheckmate/ngscheckmate_output_corr_matrix.txt
       md5sum: b8bfd203232680b746ac91ccb290b5e3
     - path: output/ngscheckmate/test.paired_end.methylated.sorted.vcf
     - path: output/ngscheckmate/test.paired_end.sorted.vcf
@@ -40,11 +40,11 @@
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
     - path: output/bedtools/versions.yml
-    - path: output/ngscheckmate/output.pdf
-    - path: output/ngscheckmate/output_all.txt
+    - path: output/ngscheckmate/ngscheckmate.pdf
+    - path: output/ngscheckmate/ngscheckmate_all.txt
       md5sum: fd74956dcac279b6f58e82ea73e344f8
-    - path: output/ngscheckmate/output_matched.txt
+    - path: output/ngscheckmate/ngscheckmate_matched.txt
       md5sum: fd74956dcac279b6f58e82ea73e344f8
-    - path: output/ngscheckmate/output_output_corr_matrix.txt
+    - path: output/ngscheckmate/ngscheckmate_output_corr_matrix.txt
       md5sum: 0c86bdad2721c470fe6be119f291c8e5
     - path: output/ngscheckmate/versions.yml

--- a/tests/subworkflows/nf-core/bam_ngscheckmate/main.nf
+++ b/tests/subworkflows/nf-core/bam_ngscheckmate/main.nf
@@ -8,10 +8,8 @@ include { BEDTOOLS_MAKEWINDOWS } from '../../../../modules/nf-core/bedtools/make
 workflow test_bam_ngscheckmate_bam {
 
     inputBed = [ [ id:'test_bed'],
-                file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)]
-
-    BEDTOOLS_MAKEWINDOWS(Channel.of(inputBed))
-    snp_bed  = BEDTOOLS_MAKEWINDOWS.out.bed
+                file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+                ]
 
     input   = [[
             [ id:'test1' ], // meta map
@@ -22,13 +20,12 @@ workflow test_bam_ngscheckmate_bam {
         ]
     ]
 
-    fasta      = file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    fasta    = [ [ id:'sarscov2'],
+                file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                ]
 
-    ch_input   = Channel.fromList(input)
-    ch_snp_bed = BEDTOOLS_MAKEWINDOWS.out.bed.map{it[1]}
-    ch_fasta   = Channel.of(fasta)
-
-    BAM_NGSCHECKMATE( ch_input, ch_snp_bed , ch_fasta)
+    BEDTOOLS_MAKEWINDOWS( Channel.of(inputBed) )
+    BAM_NGSCHECKMATE(Channel.fromList(input), BEDTOOLS_MAKEWINDOWS.out.bed , Channel.of(fasta))
 
 }
 
@@ -43,14 +40,15 @@ workflow test_bam_ngscheckmate_cram {
         ]
     ]
 
-    snp_bed    = file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_bed'], checkIfExists: true)
+    inputBed  = [ [ id:'snp_bed'],
+                file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_bed'], checkIfExists: true)
+                ]
 
-    fasta      = file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+    fasta    = [ [ id:'homo_sapiens'],
+                file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)
+                ]
 
-    ch_input   = Channel.fromList(input)
-    ch_snp_bed = Channel.of(snp_bed)
-    ch_fasta   = Channel.of(fasta)
-
-    BAM_NGSCHECKMATE( ch_input, ch_snp_bed , ch_fasta)
+    BEDTOOLS_MAKEWINDOWS( Channel.of(inputBed) )
+    BAM_NGSCHECKMATE(Channel.fromList(input), BEDTOOLS_MAKEWINDOWS.out.bed , Channel.of(fasta))
 
 }

--- a/tests/subworkflows/nf-core/bam_ngscheckmate/main.nf
+++ b/tests/subworkflows/nf-core/bam_ngscheckmate/main.nf
@@ -7,7 +7,7 @@ include { BEDTOOLS_MAKEWINDOWS } from '../../../../modules/nf-core/bedtools/make
 
 workflow test_bam_ngscheckmate_bam {
 
-    inputBed = [ [ id:'test_bed'],
+    inputBed = [ [ id:'sarscov2_bed'],
                 file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
                 ]
 
@@ -31,6 +31,10 @@ workflow test_bam_ngscheckmate_bam {
 
 workflow test_bam_ngscheckmate_cram {
 
+    inputBed  = [ [ id:'homo_sapiens_bed'],
+                file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_bed'], checkIfExists: true)
+                ]
+
     input   = [[
             [ id:'test1' ], // meta map
             file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true)
@@ -39,10 +43,6 @@ workflow test_bam_ngscheckmate_cram {
             file(params.test_data['homo_sapiens']['illumina']['test2_paired_end_sorted_cram'], checkIfExists: true)
         ]
     ]
-
-    inputBed  = [ [ id:'snp_bed'],
-                file(params.test_data['homo_sapiens']['illumina']['test_genome_vcf_bed'], checkIfExists: true)
-                ]
 
     fasta    = [ [ id:'homo_sapiens'],
                 file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)

--- a/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
+++ b/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
@@ -23,8 +23,6 @@
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
     - path: output/ngscheckmate/output.pdf
-      contains:
-        - " # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead "
     - path: output/ngscheckmate/output_all.txt
       md5sum: efdecd402fb7f1425d96624a73ba33b2
     - path: output/ngscheckmate/output_matched.txt
@@ -57,8 +55,6 @@
     - path: output/bedtools/test_split.bed
       md5sum: 5b596df60679cc68b67ba00b9226a8ea
     - path: output/ngscheckmate/output.pdf
-      contains:
-        - " # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead "
     - path: output/ngscheckmate/output_all.txt
       md5sum: 35339268c624c8bfda5d48d80ac6fbbc
     - path: output/ngscheckmate/output_matched.txt

--- a/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
+++ b/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
@@ -22,12 +22,12 @@
       md5sum: 3d2568ae4b8aa1193dacb91f0980aabf
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
-    - path: output/ngscheckmate/ngscheckmate.pdf
-    - path: output/ngscheckmate/ngscheckmate_all.txt
+    - path: output/ngscheckmate/sarscov2_bed.pdf
+    - path: output/ngscheckmate/sarscov2_bed_all.txt
       md5sum: efdecd402fb7f1425d96624a73ba33b2
-    - path: output/ngscheckmate/ngscheckmate_matched.txt
+    - path: output/ngscheckmate/sarscov2_bed_matched.txt
       md5sum: efdecd402fb7f1425d96624a73ba33b2
-    - path: output/ngscheckmate/ngscheckmate_output_corr_matrix.txt
+    - path: output/ngscheckmate/sarscov2_bed_output_corr_matrix.txt
       md5sum: 8b8acb28a3a2bc7c450a15eed397d8d8
 
 - name: bam_ngscheckmate test_bam_ngscheckmate_cram
@@ -54,10 +54,10 @@
       md5sum: 58f333f170bcf99d593eab8b64b5ef2e
     - path: output/bedtools/test_split.bed
       md5sum: 5b596df60679cc68b67ba00b9226a8ea
-    - path: output/ngscheckmate/ngscheckmate.pdf
-    - path: output/ngscheckmate/ngscheckmate_all.txt
+    - path: output/ngscheckmate/homo_sapiens_bed.pdf
+    - path: output/ngscheckmate/homo_sapiens_bed_all.txt
       md5sum: 35339268c624c8bfda5d48d80ac6fbbc
-    - path: output/ngscheckmate/ngscheckmate_matched.txt
+    - path: output/ngscheckmate/homo_sapiens_bed_matched.txt
       md5sum: 35339268c624c8bfda5d48d80ac6fbbc
-    - path: output/ngscheckmate/ngscheckmate_output_corr_matrix.txt
+    - path: output/ngscheckmate/homo_sapiens_bed_output_corr_matrix.txt
       md5sum: e82495c1d7dd4520a25e85725fcd109c

--- a/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
+++ b/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
@@ -22,13 +22,6 @@
       md5sum: 3d2568ae4b8aa1193dacb91f0980aabf
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
-    - path: output/ngscheckmate/output.pdf
-    - path: output/ngscheckmate/output_all.txt
-      md5sum: efdecd402fb7f1425d96624a73ba33b2
-    - path: output/ngscheckmate/output_matched.txt
-      md5sum: efdecd402fb7f1425d96624a73ba33b2
-    - path: output/ngscheckmate/output_output_corr_matrix.txt
-      md5sum: 8b8acb28a3a2bc7c450a15eed397d8d8
 
 - name: bam_ngscheckmate test_bam_ngscheckmate_cram
   command: nextflow run ./tests/subworkflows/nf-core/bam_ngscheckmate -entry test_bam_ngscheckmate_cram -c ./tests/config/nextflow.config
@@ -54,10 +47,3 @@
       md5sum: 58f333f170bcf99d593eab8b64b5ef2e
     - path: output/bedtools/test_split.bed
       md5sum: 5b596df60679cc68b67ba00b9226a8ea
-    - path: output/ngscheckmate/output.pdf
-    - path: output/ngscheckmate/output_all.txt
-      md5sum: 35339268c624c8bfda5d48d80ac6fbbc
-    - path: output/ngscheckmate/output_matched.txt
-      md5sum: 35339268c624c8bfda5d48d80ac6fbbc
-    - path: output/ngscheckmate/output_output_corr_matrix.txt
-      md5sum: e82495c1d7dd4520a25e85725fcd109c

--- a/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
+++ b/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
@@ -24,7 +24,7 @@
       md5sum: 5058157987313b598f1c260e6965d6f7
     - path: output/ngscheckmate/output.pdf
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - " # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead "
     - path: output/ngscheckmate/output_all.txt
       md5sum: efdecd402fb7f1425d96624a73ba33b2
     - path: output/ngscheckmate/output_matched.txt
@@ -58,7 +58,7 @@
       md5sum: 5b596df60679cc68b67ba00b9226a8ea
     - path: output/ngscheckmate/output.pdf
       contains:
-        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - " # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead "
     - path: output/ngscheckmate/output_all.txt
       md5sum: 35339268c624c8bfda5d48d80ac6fbbc
     - path: output/ngscheckmate/output_matched.txt

--- a/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
+++ b/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
@@ -22,6 +22,13 @@
       md5sum: 3d2568ae4b8aa1193dacb91f0980aabf
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
+    - path: output/ngscheckmate/ngscheckmate.pdf
+    - path: output/ngscheckmate/ngscheckmate_all.txt
+      md5sum: efdecd402fb7f1425d96624a73ba33b2
+    - path: output/ngscheckmate/ngscheckmate_matched.txt
+      md5sum: efdecd402fb7f1425d96624a73ba33b2
+    - path: output/ngscheckmate/ngscheckmate_output_corr_matrix.txt
+      md5sum: 8b8acb28a3a2bc7c450a15eed397d8d8
 
 - name: bam_ngscheckmate test_bam_ngscheckmate_cram
   command: nextflow run ./tests/subworkflows/nf-core/bam_ngscheckmate -entry test_bam_ngscheckmate_cram -c ./tests/config/nextflow.config
@@ -47,3 +54,10 @@
       md5sum: 58f333f170bcf99d593eab8b64b5ef2e
     - path: output/bedtools/test_split.bed
       md5sum: 5b596df60679cc68b67ba00b9226a8ea
+    - path: output/ngscheckmate/ngscheckmate.pdf
+    - path: output/ngscheckmate/ngscheckmate_all.txt
+      md5sum: 35339268c624c8bfda5d48d80ac6fbbc
+    - path: output/ngscheckmate/ngscheckmate_matched.txt
+      md5sum: 35339268c624c8bfda5d48d80ac6fbbc
+    - path: output/ngscheckmate/ngscheckmate_output_corr_matrix.txt
+      md5sum: e82495c1d7dd4520a25e85725fcd109c

--- a/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
+++ b/tests/subworkflows/nf-core/bam_ngscheckmate/test.yml
@@ -23,12 +23,14 @@
     - path: output/bedtools/test_split.bed
       md5sum: 5058157987313b598f1c260e6965d6f7
     - path: output/ngscheckmate/output.pdf
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/ngscheckmate/output_all.txt
       md5sum: efdecd402fb7f1425d96624a73ba33b2
-    - path: output/ngscheckmate/output_corr_matrix.txt
-      md5sum: 8b8acb28a3a2bc7c450a15eed397d8d8
     - path: output/ngscheckmate/output_matched.txt
       md5sum: efdecd402fb7f1425d96624a73ba33b2
+    - path: output/ngscheckmate/output_output_corr_matrix.txt
+      md5sum: 8b8acb28a3a2bc7c450a15eed397d8d8
 
 - name: bam_ngscheckmate test_bam_ngscheckmate_cram
   command: nextflow run ./tests/subworkflows/nf-core/bam_ngscheckmate -entry test_bam_ngscheckmate_cram -c ./tests/config/nextflow.config
@@ -43,19 +45,23 @@
     - path: output/bcftools/test1.bcftools_stats.txt
       md5sum: 5b7ce8a5a1537552f48d3ec1f6ea09d5
     - path: output/bcftools/test1.vcf.gz
-      md5sum: 9835085fde06b8cdc6cff7a69e397d2e
+      md5sum: e0c0930b39c02151b2e097a59b7bfac7
     - path: output/bcftools/test1.vcf.gz.tbi
       md5sum: 6fc7d8cdf94ef3f5de2856570a33cdf9
     - path: output/bcftools/test2.bcftools_stats.txt
       md5sum: 165b983283ab3150c0fa0c5ba1f7ea72
     - path: output/bcftools/test2.vcf.gz
-      md5sum: e1d2ce2d6282fadd25d18d5e55a3de8d
+      md5sum: 8330fd1a1e9f57c3efbd9c803f2b9966
     - path: output/bcftools/test2.vcf.gz.tbi
-      md5sum: 7f087f60490ad9e6885355d879267271
+      md5sum: 58f333f170bcf99d593eab8b64b5ef2e
+    - path: output/bedtools/test_split.bed
+      md5sum: 5b596df60679cc68b67ba00b9226a8ea
     - path: output/ngscheckmate/output.pdf
+      contains:
+        - ' # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
     - path: output/ngscheckmate/output_all.txt
       md5sum: 35339268c624c8bfda5d48d80ac6fbbc
-    - path: output/ngscheckmate/output_corr_matrix.txt
-      md5sum: e82495c1d7dd4520a25e85725fcd109c
     - path: output/ngscheckmate/output_matched.txt
       md5sum: 35339268c624c8bfda5d48d80ac6fbbc
+    - path: output/ngscheckmate/output_output_corr_matrix.txt
+      md5sum: e82495c1d7dd4520a25e85725fcd109c


### PR DESCRIPTION
Updating NGSCheckMate to the newest version, and while I'm at it added meta maps to the various inputs.
This also required updating bcftools/mpileup, as that didn't have the meta map on one of its inputs.

The subworkflow I'm not sure what to do with the meta maps, so looking for input there.