### PR TITLE
Integrate FASTA and guidetree meta in famsa module

### DIFF
--- a/modules/nf-core/famsa/align/main.nf
+++ b/modules/nf-core/famsa/align/main.nf
@@ -1,7 +1,7 @@
 
 
 process FAMSA_ALIGN {
-    tag "$meta.id"
+    tag "$meta_fasta.id"
     label 'process_medium'
 
     conda "bioconda::famsa=2.2.2"
@@ -10,8 +10,8 @@ process FAMSA_ALIGN {
         'biocontainers/famsa:2.2.2--h9f5acd7_0' }"
 
     input:
-    tuple val(meta),  path(fasta)
-    tuple val(meta2), path(tree)
+    tuple val(meta_fasta),  path(fasta)
+    tuple val(meta_tree), path(tree)
 
     output:
     tuple val(meta), path("*.aln"), emit: alignment
@@ -21,6 +21,7 @@ process FAMSA_ALIGN {
     task.ext.when == null || task.ext.when
 
     script:
+    meta = meta_tree + meta_fasta // merge meta information, preferring the infos in fasta if there is a conflict
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def options_tree = tree ? "-gt import $tree" : ""
@@ -38,6 +39,7 @@ process FAMSA_ALIGN {
     """
 
     stub:
+    meta = meta_tree + meta_fasta // merge meta information, preferring the infos in fasta if there is a conflict
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.aln

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -2,10 +2,10 @@ process MAGUS_ALIGN {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::magus-msa=0.1.1"
+    conda "bioconda::magus-msa=0.1.2a"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/magus-msa:0.1.1':
-        'biocontainers/magus-msa:0.1.1' }"
+        'https://depot.galaxyproject.org/singularity/magus-msa:0.1.2a':
+        'biocontainers/magus-msa:0.1.2a' }"
 
     input:
     tuple val(meta_fasta), path(fasta)

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -22,7 +22,7 @@ process MAGUS_ALIGN {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ? "alignment" : "${meta_fasta.id}"
     def loadtree = tree ? "-t $tree" : ''
-    def meta = meta_tree + meta_fasta
+    meta = meta_tree + meta_fasta
     """
     magus \\
         -np $task.cpus \\
@@ -40,6 +40,7 @@ process MAGUS_ALIGN {
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    meta = meta_tree + meta_fasta
     """
     touch ${prefix}.aln
 

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -33,7 +33,7 @@ process MAGUS_ALIGN {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        : \$(magus --version)
+        MAGUS:\$(magus --version)
     END_VERSIONS
     """
 
@@ -45,7 +45,7 @@ process MAGUS_ALIGN {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        : \$(magus --version)
+        MAGUS:\$(magus --version)
     END_VERSIONS
     """
 }

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -1,5 +1,5 @@
 process MAGUS_ALIGN {
-    tag "$meta.id"
+    tag "$meta_fasta.id"
     label 'process_medium'
 
     conda "bioconda::magus-msa=0.1.2a"

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -20,8 +20,9 @@ process MAGUS_ALIGN {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ? "alignment" : "${meta_fasta.id}"
     def loadtree = tree ? "-t $tree" : ''
+    def meta = meta_tree + meta_fasta
     """
     magus \\
         -np $task.cpus \\

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -23,7 +23,6 @@ process MAGUS_ALIGN {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def loadtree = tree ? "-t $tree" : ''
     """
-    #TODO make proper call, dry run on cluster
     magus \\
         -np $task.cpus \\
         -i $fasta \\

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -20,7 +20,7 @@ process MAGUS_ALIGN {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ? "alignment" : "${meta_fasta.id}"
+    def prefix = task.ext.prefix ?: "${meta_fasta.id}"
     def loadtree = tree ? "-t $tree" : ''
     meta = meta_tree + meta_fasta
     """

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -1,0 +1,50 @@
+process MAGUS_ALIGN {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "bioconda::magus-msa=0.1.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/magus-msa:0.1.0':
+        'biocontainers/magus-msa:0.1.0' }"
+
+    input:
+    tuple val(meta_fasta), path(fasta)
+    tuple val(meta_tree), path(tree)
+
+    output:
+    tuple val(meta), path("*.aln"), emit: alignment
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    #TODO make proper call, dry run on cluster
+    magus \\
+        -@ $task.cpus \\
+        -i $ \\
+        -o ${prefix}.aln \\
+        -T $prefix \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        : \$(magus --version)
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.aln
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        : \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' ))
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/magus/align/main.nf
+++ b/modules/nf-core/magus/align/main.nf
@@ -2,10 +2,10 @@ process MAGUS_ALIGN {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::magus-msa=0.1.0"
+    conda "bioconda::magus-msa=0.1.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/magus-msa:0.1.0':
-        'biocontainers/magus-msa:0.1.0' }"
+        'https://depot.galaxyproject.org/singularity/magus-msa:0.1.1':
+        'biocontainers/magus-msa:0.1.1' }"
 
     input:
     tuple val(meta_fasta), path(fasta)
@@ -21,13 +21,14 @@ process MAGUS_ALIGN {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def loadtree = tree ? "-t $tree" : ''
     """
     #TODO make proper call, dry run on cluster
     magus \\
-        -@ $task.cpus \\
-        -i $ \\
+        -np $task.cpus \\
+        -i $fasta \\
         -o ${prefix}.aln \\
-        -T $prefix \\
+        $loadtree \\
         $args
 
     cat <<-END_VERSIONS > versions.yml
@@ -44,7 +45,7 @@ process MAGUS_ALIGN {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        : \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//' ))
+        : \$(magus --version)
     END_VERSIONS
     """
 }

--- a/modules/nf-core/magus/align/meta.yml
+++ b/modules/nf-core/magus/align/meta.yml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
+name: "magus_align"
+description: Multiple Sequence Alignment using Graph Clustering
+keywords:
+  - MSA
+  - alignment
+  - genomics
+tools:
+  - "magus":
+      description: "Multiple Sequence Alignment using Graph Clustering"
+      homepage: "https://github.com/vlasmirnov/MAGUS"
+      documentation: "https://github.com/vlasmirnov/MAGUS"
+      tool_dev_url: "https://github.com/vlasmirnov/MAGUS"
+      doi: "10.1093/bioinformatics/btaa992"
+      licence: "MIT"
+
+## TODO nf-core: Add a description of all of the variables used as input
+input:
+  # Only when we have meta
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  ## TODO nf-core: Delete / customise this example input
+  - bam:
+      type: file
+      description: Sorted BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+
+## TODO nf-core: Add a description of all of the variables used as output
+output:
+  #Only when we have meta
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  ## TODO nf-core: Delete / customise this example output
+  - bam:
+      type: file
+      description: Sorted BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+
+authors:
+  - "@lrauschning"

--- a/modules/nf-core/magus/align/meta.yml
+++ b/modules/nf-core/magus/align/meta.yml
@@ -26,6 +26,7 @@ input:
       type: file
       description:
       pattern: "*.{fa,fna,fasta}"
+
   - tree:
       type: file
       description: Optional path to a file containing a guide tree in newick format to use as input.

--- a/modules/nf-core/magus/align/meta.yml
+++ b/modules/nf-core/magus/align/meta.yml
@@ -15,24 +15,24 @@ tools:
       doi: "10.1093/bioinformatics/btaa992"
       licence: "MIT"
 
-## TODO nf-core: Add a description of all of the variables used as input
 input:
-  # Only when we have meta
   - meta:
       type: map
       description: |
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
 
-  ## TODO nf-core: Delete / customise this example input
-  - bam:
+  - fasta:
       type: file
-      description: Sorted BAM/CRAM/SAM file
-      pattern: "*.{bam,cram,sam}"
+      description:
+      pattern: "*.{fa,fna,fasta}"
+  - tree:
+      type: file
+      description: Optional path to a file containing a guide tree in newick format to use as input.
+        If empty, or overwritten by passing `-t [fasttree|fasttree-noml|clustal|parttree]`, MAGUS will construct its own guide tree. If empty, `fasttree` is used as a default.
+      pattern: "*.{dnd,txt}"
 
-## TODO nf-core: Add a description of all of the variables used as output
 output:
-  #Only when we have meta
   - meta:
       type: map
       description: |
@@ -43,11 +43,12 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
-  ## TODO nf-core: Delete / customise this example output
-  - bam:
+
+  - alignment:
       type: file
-      description: Sorted BAM/CRAM/SAM file
-      pattern: "*.{bam,cram,sam}"
+      description: File containing the output alignment, in FASTA format containing gaps.
+        The sequences may be in a different order than in the input FASTA.
+      pattern: "*.aln"
 
 authors:
   - "@lrauschning"

--- a/modules/nf-core/magus/align/meta.yml
+++ b/modules/nf-core/magus/align/meta.yml
@@ -16,10 +16,16 @@ tools:
       licence: "MIT"
 
 input:
-  - meta:
+  - meta_fasta:
       type: map
       description: |
-        Groovy Map containing sample information
+        Groovy Map containing sample information for the fasta
+        e.g. `[ id:'test', single_end:false ]`
+
+  - meta_tree:
+      type: map
+      description: |
+        Groovy Map containing sample information for the specified guide tree (if supplied)
         e.g. `[ id:'test', single_end:false ]`
 
   - fasta:
@@ -37,7 +43,7 @@ output:
   - meta:
       type: map
       description: |
-        Groovy Map containing sample information
+        Groovy Map containing sample information. Values in meta_fasta take precedence over values in meta_tree.
         e.g. `[ id:'test', single_end:false ]`
 
   - versions:

--- a/modules/nf-core/magus/align/meta.yml
+++ b/modules/nf-core/magus/align/meta.yml
@@ -24,14 +24,14 @@ input:
 
   - fasta:
       type: file
-      description:
+      description: Input sequences in FASTA format.
       pattern: "*.{fa,fna,fasta}"
 
   - tree:
       type: file
       description: Optional path to a file containing a guide tree in newick format to use as input.
         If empty, or overwritten by passing `-t [fasttree|fasttree-noml|clustal|parttree]`, MAGUS will construct its own guide tree. If empty, `fasttree` is used as a default.
-      pattern: "*.{dnd,txt}"
+      pattern: "*.{dnd,tree}"
 
 output:
   - meta:

--- a/modules/nf-core/magus/guidetree/main.nf
+++ b/modules/nf-core/magus/guidetree/main.nf
@@ -30,7 +30,7 @@ process MAGUS_GUIDETREE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        : \$(magus --version)
+        MAGUS: \$(magus --version)
     END_VERSIONS
     """
 
@@ -42,7 +42,7 @@ process MAGUS_GUIDETREE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        : \$(magus --version)
+        MAGUS: \$(magus --version)
     END_VERSIONS
     """
 }

--- a/modules/nf-core/magus/guidetree/main.nf
+++ b/modules/nf-core/magus/guidetree/main.nf
@@ -1,0 +1,48 @@
+process MAGUS_GUIDETREE {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "bioconda::magus-msa=0.1.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/magus-msa:0.1.1':
+        'biocontainers/magus-msa:0.1.1' }"
+
+    input:
+    tuple val(meta_fasta), path(fasta)
+
+    output:
+    tuple val(meta), path("*.tree"), emit: tree
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    magus \\
+        -np $task.cpus \\
+        -i $fasta \\
+        -o ${prefix}.tree \\
+        --onlyguidetree TRUE \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        : \$(magus --version)
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.tree
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        : \$(magus --version)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/magus/guidetree/main.nf
+++ b/modules/nf-core/magus/guidetree/main.nf
@@ -8,7 +8,7 @@ process MAGUS_GUIDETREE {
         'biocontainers/magus-msa:0.1.1' }"
 
     input:
-    tuple val(meta_fasta), path(fasta)
+    tuple val(meta), path(fasta)
 
     output:
     tuple val(meta), path("*.tree"), emit: tree

--- a/modules/nf-core/magus/guidetree/main.nf
+++ b/modules/nf-core/magus/guidetree/main.nf
@@ -2,10 +2,10 @@ process MAGUS_GUIDETREE {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::magus-msa=0.1.1"
+    conda "bioconda::magus-msa=0.1.2a"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/magus-msa:0.1.1':
-        'biocontainers/magus-msa:0.1.1' }"
+        'https://depot.galaxyproject.org/singularity/magus-msa:0.1.2a':
+        'biocontainers/magus-msa:0.1.2a' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/magus/guidetree/meta.yml
+++ b/modules/nf-core/magus/guidetree/meta.yml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
+name: "magus_guidetree"
+description: Multiple Sequence Alignment using Graph Clustering
+keywords:
+  - MSA
+  - guidetree
+  - genomics
+tools:
+  - "magus":
+      description: "Multiple Sequence Alignment using Graph Clustering"
+      homepage: "https://github.com/vlasmirnov/MAGUS"
+      documentation: "https://github.com/vlasmirnov/MAGUS"
+      tool_dev_url: "https://github.com/vlasmirnov/MAGUS"
+      doi: "10.1093/bioinformatics/btaa992"
+      licence: "MIT"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - fasta:
+      type: file
+      description: Input sequences in FASTA format.
+      pattern: "*.{fa,fna,fasta}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'test', single_end:false ]`
+
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+  - tree:
+      type: file
+      description: File containing the output guidetree, in newick format.
+      pattern: "*.tree"
+
+authors:
+  - "@lrauschning"

--- a/tests/modules/nf-core/magus/align/main.nf
+++ b/tests/modules/nf-core/magus/align/main.nf
@@ -1,7 +1,5 @@
 #!/usr/bin/env nextflow
 
-nextflow.enable.dsl = 2
-
 include { MAGUS_ALIGN } from '../../../../../modules/nf-core/magus/align/main.nf'
 include { MAGUS_GUIDETREE } from '../../../../../modules/nf-core/magus/guidetree/main.nf'
 

--- a/tests/modules/nf-core/magus/align/main.nf
+++ b/tests/modules/nf-core/magus/align/main.nf
@@ -1,0 +1,28 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { MAGUS_ALIGN } from '../../../../../modules/nf-core/magus/align/main.nf'
+include { MAGUS_GUIDETREE } from '../../../../../modules/nf-core/magus/guidetree/main.nf'
+
+workflow test_magus_align {
+
+    input = [
+        [ id:'test' ], // meta map
+        file(params.test_data['multiplesequencealign']['illumina']['contigs_fasta'], checkIfExists: true)
+    ]
+
+    MAGUS_ALIGN ( input, [ [:], [ ] ] )
+}
+
+workflow test_magus_align_with_guide_tree {
+
+    input = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true)
+    ]
+
+    guide_tree = MAGUS_GUIDETREE ( input ).tree
+
+    MAGUS_ALIGN ( input, guide_tree )
+}

--- a/tests/modules/nf-core/magus/align/main.nf
+++ b/tests/modules/nf-core/magus/align/main.nf
@@ -9,7 +9,7 @@ workflow test_magus_align {
 
     input = [
         [ id:'test' ], // meta map
-        file(params.test_data['multiplesequencealign']['illumina']['contigs_fasta'], checkIfExists: true)
+        file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true)
     ]
 
     MAGUS_ALIGN ( input, [ [:], [ ] ] )

--- a/tests/modules/nf-core/magus/align/nextflow.config
+++ b/tests/modules/nf-core/magus/align/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    
+}

--- a/tests/modules/nf-core/magus/align/test.yml
+++ b/tests/modules/nf-core/magus/align/test.yml
@@ -16,8 +16,8 @@
   files:
     - path: output/magus/test.aln
       contains:
-        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - '-TGCTGTAGTTGTCT-'
     - path: output/magus/test.tree
       contains:
-        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - 'NODE_3_length'
     - path: output/magus/versions.yml

--- a/tests/modules/nf-core/magus/align/test.yml
+++ b/tests/modules/nf-core/magus/align/test.yml
@@ -1,13 +1,23 @@
-## TODO nf-core: Please run the following command to build this file:
-#                nf-core modules create-test-yml /align
-- name: "magus align"
+- name: magus align test_magus_align
   command: nextflow run ./tests/modules/nf-core/magus/align -entry test_magus_align -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/magus/align/nextflow.config
   tags:
-    - "magus"
-    - "magus/align"
+    - magus/align
+    - magus
   files:
-    - path: "output/magus/test.bam"
-      md5sum: e667c7caad0bc4b7ac383fd023c654fc
-    - path: "output/magus/versions.yml"
-      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b
-    
+    - path: output/magus/test.aln
+      md5sum: 112100ff69bc49de28f129d811b988e5
+    - path: output/magus/versions.yml
+
+- name: magus align test_magus_align_with_guide_tree
+  command: nextflow run ./tests/modules/nf-core/magus/align -entry test_magus_align_with_guide_tree -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/magus/align/nextflow.config
+  tags:
+    - magus/align
+    - magus
+  files:
+    - path: output/magus/test.aln
+      contains:
+        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/magus/test.tree
+      contains:
+        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/magus/versions.yml

--- a/tests/modules/nf-core/magus/align/test.yml
+++ b/tests/modules/nf-core/magus/align/test.yml
@@ -1,0 +1,13 @@
+## TODO nf-core: Please run the following command to build this file:
+#                nf-core modules create-test-yml /align
+- name: "magus align"
+  command: nextflow run ./tests/modules/nf-core/magus/align -entry test_magus_align -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/magus/align/nextflow.config
+  tags:
+    - "magus"
+    - "magus/align"
+  files:
+    - path: "output/magus/test.bam"
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc
+    - path: "output/magus/versions.yml"
+      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b
+    

--- a/tests/modules/nf-core/magus/align/test.yml
+++ b/tests/modules/nf-core/magus/align/test.yml
@@ -16,8 +16,8 @@
   files:
     - path: output/magus/test.aln
       contains:
-        - '-TGCTGTAGTTGTCT-'
+        - "-TGCTGTAGTTGTCT-"
     - path: output/magus/test.tree
       contains:
-        - 'NODE_3_length'
+        - "NODE_3_length"
     - path: output/magus/versions.yml

--- a/tests/modules/nf-core/magus/guidetree/main.nf
+++ b/tests/modules/nf-core/magus/guidetree/main.nf
@@ -1,0 +1,15 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { MAGUS_GUIDETREE } from '../../../../../modules/nf-core/magus/guidetree/main.nf'
+
+workflow test_magus_guidetree {
+
+    input = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['contigs_fasta'], checkIfExists: true)
+    ]
+
+    MAGUS_GUIDETREE ( input )
+}

--- a/tests/modules/nf-core/magus/guidetree/main.nf
+++ b/tests/modules/nf-core/magus/guidetree/main.nf
@@ -1,7 +1,5 @@
 #!/usr/bin/env nextflow
 
-nextflow.enable.dsl = 2
-
 include { MAGUS_GUIDETREE } from '../../../../../modules/nf-core/magus/guidetree/main.nf'
 
 workflow test_magus_guidetree {

--- a/tests/modules/nf-core/magus/guidetree/nextflow.config
+++ b/tests/modules/nf-core/magus/guidetree/nextflow.config
@@ -1,0 +1,5 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+    
+}

--- a/tests/modules/nf-core/magus/guidetree/test.yml
+++ b/tests/modules/nf-core/magus/guidetree/test.yml
@@ -1,0 +1,11 @@
+- name: "magus guidetree"
+  command: nextflow run ./tests/modules/nf-core/magus/guidetree -entry test_magus_guidetree -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/magus/guidetree/nextflow.config
+  tags:
+    - "magus"
+    - "magus/guidetree"
+  files:
+    - path: "output/magus/test.bam"
+      md5sum: e667c7caad0bc4b7ac383fd023c654fc
+    - path: "output/magus/versions.yml"
+      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b
+

--- a/tests/modules/nf-core/magus/guidetree/test.yml
+++ b/tests/modules/nf-core/magus/guidetree/test.yml
@@ -6,5 +6,5 @@
   files:
     - path: output/magus/test.tree
       contains:
-        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+        - 'NODE_3_length'
     - path: output/magus/versions.yml

--- a/tests/modules/nf-core/magus/guidetree/test.yml
+++ b/tests/modules/nf-core/magus/guidetree/test.yml
@@ -6,5 +6,5 @@
   files:
     - path: output/magus/test.tree
       contains:
-        - 'NODE_3_length'
+        - "NODE_3_length"
     - path: output/magus/versions.yml

--- a/tests/modules/nf-core/magus/guidetree/test.yml
+++ b/tests/modules/nf-core/magus/guidetree/test.yml
@@ -1,11 +1,10 @@
-- name: "magus guidetree"
+- name: magus guidetree test_magus_guidetree
   command: nextflow run ./tests/modules/nf-core/magus/guidetree -entry test_magus_guidetree -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/magus/guidetree/nextflow.config
   tags:
-    - "magus"
-    - "magus/guidetree"
+    - magus/guidetree
+    - magus
   files:
-    - path: "output/magus/test.bam"
-      md5sum: e667c7caad0bc4b7ac383fd023c654fc
-    - path: "output/magus/versions.yml"
-      md5sum: a01fe51bc4c6a3a6226fbf77b2c7cf3b
-
+    - path: output/magus/test.tree
+      contains:
+        - '# TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead '
+    - path: output/magus/versions.yml


### PR DESCRIPTION
Changes the metadata handling in the famsa module to no longer discard the guidetree meta information but to merge it with the metadata  from the input fasta, preferring the fasta information in case of a conflict, the same as it is handled in the MAGUS PR (#3839).

## PR checklist
- [x] This comment contains a description of changes (with reason).