### PR TITLE
Merge metas of guide tree and input fasta in famsa module (resubmitted) 

### DIFF
--- a/modules/nf-core/famsa/align/main.nf
+++ b/modules/nf-core/famsa/align/main.nf
@@ -1,7 +1,7 @@
 
 
 process FAMSA_ALIGN {
-    tag "$meta.id"
+    tag "$meta_fasta.id"
     label 'process_medium'
 
     conda "bioconda::famsa=2.2.2"
@@ -10,8 +10,8 @@ process FAMSA_ALIGN {
         'biocontainers/famsa:2.2.2--h9f5acd7_0' }"
 
     input:
-    tuple val(meta),  path(fasta)
-    tuple val(meta2), path(tree)
+    tuple val(meta_fasta),  path(fasta)
+    tuple val(meta_tree), path(tree)
 
     output:
     tuple val(meta), path("*.aln"), emit: alignment
@@ -21,6 +21,7 @@ process FAMSA_ALIGN {
     task.ext.when == null || task.ext.when
 
     script:
+    meta = meta_tree + meta_fasta // merge meta information, preferring the infos in fasta if there is a conflict
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def options_tree = tree ? "-gt import $tree" : ""
@@ -38,6 +39,7 @@ process FAMSA_ALIGN {
     """
 
     stub:
+    meta = meta_tree + meta_fasta // merge meta information, preferring the infos in fasta if there is a conflict
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.aln


### PR DESCRIPTION
Changes the metadata handling in the famsa module to no longer discard the guidetree meta information but to merge it with the metadata from the input fasta, preferring the fasta information in case of a conflict, the same as it is handled in the MAGUS PR (#3839).

## PR checklist
 * [x]  This comment contains a description of changes (with reason).