### PR TITLE
Flip order of operations in intialise so --help doesn't error if --input isn't provided

### DIFF
--- a/subworkflows/nf-core/initialise/main.nf
+++ b/subworkflows/nf-core/initialise/main.nf
@@ -23,6 +23,13 @@ workflow INITIALISE {
         System.exit(0)
     }
 
+    // Print help message if needed
+    if (params.help) {
+        def String command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
+        log.info paramsHelp(command)
+        System.exit(0)
+    }
+
     if ( params.validate_parameters != false ){
         validateParameters()
     }
@@ -34,13 +41,6 @@ workflow INITIALISE {
         "* Software dependencies\n" +
         "  ${workflow.manifest.homePage}/blob/master/CITATIONS.md"
     log.info citation
-
-    // Print help message if needed
-    if (params.help) {
-        def String command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
-        log.info paramsHelp(command)
-        System.exit(0)
-    }
 
     if (workflow.profile == 'standard' && workflow.configFiles.size() <= 1) {
         log.warn "[$workflow.manifest.name] You are attempting to run the pipeline without any custom configuration!\n\n" +

--- a/subworkflows/nf-core/initialise/main.nf
+++ b/subworkflows/nf-core/initialise/main.nf
@@ -23,6 +23,14 @@ workflow INITIALISE {
         System.exit(0)
     }
 
+    // Print citation for nf-core
+    def citation = "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
+        "* The nf-core framework\n" +
+        "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
+        "* Software dependencies\n" +
+        "  ${workflow.manifest.homePage}/blob/master/CITATIONS.md"
+    log.info citation
+
     // Print help message if needed
     if (params.help) {
         def String command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
@@ -33,14 +41,6 @@ workflow INITIALISE {
     if ( params.validate_parameters != false ){
         validateParameters()
     }
-
-    // Print citation for nf-core
-    def citation = "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
-        "* The nf-core framework\n" +
-        "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
-        "* Software dependencies\n" +
-        "  ${workflow.manifest.homePage}/blob/master/CITATIONS.md"
-    log.info citation
 
     if (workflow.profile == 'standard' && workflow.configFiles.size() <= 1) {
         log.warn "[$workflow.manifest.name] You are attempting to run the pipeline without any custom configuration!\n\n" +


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
