### PR TITLE
INITIALISE uses take and emit

### DIFF
--- a/subworkflows/nf-core/initialise/main.nf
+++ b/subworkflows/nf-core/initialise/main.nf
@@ -2,54 +2,67 @@
 // The role of this subworkflow is to check the input parameters and print help messages
 // Use this to start your nf-core pipeline
 
-include { paramsHelp; paramsSummaryLog; validateParameters } from 'plugin/nf-validation'
+include { paramsHelp; paramsSummaryLog; paramsSummaryMap; validateParameters } from 'plugin/nf-validation'
 
 workflow INITIALISE {
 
-    // Print workflow version and exit on --version
-    if (params.version) {
-        String version_string = ""
+    take:
+        version         // bool
+        help            // bool
+        validate_params // bool
 
-        if (workflow.manifest.version) {
-            def prefix_v = workflow.manifest.version[0] != 'v' ? 'v' : ''
-            version_string += "${prefix_v}${workflow.manifest.version}"
+    main:
+
+        // Print workflow version and exit on --version
+        if (version) {
+            String version_string = ""
+
+            if (workflow.manifest.version) {
+                def prefix_v = workflow.manifest.version[0] != 'v' ? 'v' : ''
+                version_string += "${prefix_v}${workflow.manifest.version}"
+            }
+
+            if (workflow.commitId) {
+                def git_shortsha = workflow.commitId.substring(0, 7)
+                version_string += "-g${git_shortsha}"
+            }
+            log.info "${workflow.manifest.name} ${version_string}"
+            System.exit(0)
         }
 
-        if (workflow.commitId) {
-            def git_shortsha = workflow.commitId.substring(0, 7)
-            version_string += "-g${git_shortsha}"
+        // Print citation for nf-core
+        def citation = "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
+            "* The nf-core framework\n" +
+            "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
+            "* Software dependencies\n" +
+            "  ${workflow.manifest.homePage}/blob/master/CITATIONS.md"
+        log.info citation
+
+        // Print help message if needed
+        if (params.help) {
+            def String command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
+            log.info paramsHelp(command)
+            System.exit(0)
         }
-        log.info "${workflow.manifest.name} ${version_string}"
-        System.exit(0)
-    }
 
-    // Print citation for nf-core
-    def citation = "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
-        "* The nf-core framework\n" +
-        "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
-        "* Software dependencies\n" +
-        "  ${workflow.manifest.homePage}/blob/master/CITATIONS.md"
-    log.info citation
+        if ( params.validate_params != false ){
+            validateParameters()
+        }
 
-    // Print help message if needed
-    if (params.help) {
-        def String command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv -profile docker"
-        log.info paramsHelp(command)
-        System.exit(0)
-    }
+        if (workflow.profile == 'standard' && workflow.configFiles.size() <= 1) {
+            log.warn "[$workflow.manifest.name] You are attempting to run the pipeline without any custom configuration!\n\n" +
+                    "This will be dependent on your local compute environment but can be achieved via one or more of the following:\n" +
+                    "   (1) Using an existing pipeline profile e.g. `-profile docker` or `-profile singularity`\n" +
+                    "   (2) Using an existing nf-core/configs for your Institution e.g. `-profile crick` or `-profile uppmax`\n" +
+                    "   (3) Using your own local custom config e.g. `-c /path/to/your/custom.config`\n\n" +
+                    "Please refer to the quick start section and usage docs for the pipeline.\n "
+        }
 
-    if ( params.validate_parameters != false ){
-        validateParameters()
-    }
+        log.info paramsSummaryLog(workflow)
 
-    if (workflow.profile == 'standard' && workflow.configFiles.size() <= 1) {
-        log.warn "[$workflow.manifest.name] You are attempting to run the pipeline without any custom configuration!\n\n" +
-                "This will be dependent on your local compute environment but can be achieved via one or more of the following:\n" +
-                "   (1) Using an existing pipeline profile e.g. `-profile docker` or `-profile singularity`\n" +
-                "   (2) Using an existing nf-core/configs for your Institution e.g. `-profile crick` or `-profile uppmax`\n" +
-                "   (3) Using your own local custom config e.g. `-c /path/to/your/custom.config`\n\n" +
-                "Please refer to the quick start section and usage docs for the pipeline.\n "
-    }
+        summary_params = paramsSummaryMap(workflow)
+    
+    emit:
+        summary_params
 
-    log.info paramsSummaryLog(workflow)
 }

--- a/subworkflows/nf-core/initialise/main.nf
+++ b/subworkflows/nf-core/initialise/main.nf
@@ -61,7 +61,7 @@ workflow INITIALISE {
         log.info paramsSummaryLog(workflow)
 
         summary_params = paramsSummaryMap(workflow)
-    
+
     emit:
         summary_params
 

--- a/subworkflows/nf-core/initialise/meta.yml
+++ b/subworkflows/nf-core/initialise/meta.yml
@@ -8,6 +8,26 @@ keywords:
   - version
 modules:
 input:
+  - version:
+    type: boolean
+    description: |
+      Structure: val(version)
+      Boolean to show the pipeline version and exit.
+  - help:
+    type: boolean
+    description: |
+      Structure: val(help)
+      Boolean to show the pipeline help message and exit.
+  - validate_params:
+    type: boolean
+    description: |
+      Structure: val(validate_params)
+      Whether to validate the parameters prior to starting the pipeline.
 output:
+  - summary_params:
+    type: value
+    description: |
+      Structure: val(summary_params)
+      A map of the parameters used in the pipeline.
 authors:
   - "@adamrtalbot"

--- a/tests/subworkflows/nf-core/initialise/main.nf
+++ b/tests/subworkflows/nf-core/initialise/main.nf
@@ -5,5 +5,9 @@ nextflow.enable.dsl = 2
 include { INITIALISE } from '../../../../subworkflows/nf-core/initialise/main.nf'
 
 workflow test_initialise {
-    INITIALISE ( )
+    INITIALISE ( 
+        params.version,
+        params.help,
+        params.validate_params
+    )
 }

--- a/tests/subworkflows/nf-core/initialise/nextflow.config
+++ b/tests/subworkflows/nf-core/initialise/nextflow.config
@@ -1,7 +1,7 @@
 params {
     help                = false
     version             = false
-    validate_parameters = false
+    validate_params     = false
     test_data           = null
     monochrome_logs     = true
 }

--- a/tests/subworkflows/nf-core/initialise/nextflow_schema.json
+++ b/tests/subworkflows/nf-core/initialise/nextflow_schema.json
@@ -10,9 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "outdir"
-            ],
+            "required": ["outdir"],
             "properties": {
                 "validate_params": {
                     "type": "boolean",
@@ -69,14 +67,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "monochrome_logs": {

--- a/tests/subworkflows/nf-core/initialise/nextflow_schema.json
+++ b/tests/subworkflows/nf-core/initialise/nextflow_schema.json
@@ -10,9 +10,11 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["outdir"],
+            "required": [
+                "outdir"
+            ],
             "properties": {
-                "validate_parameters": {
+                "validate_params": {
                     "type": "boolean",
                     "description": "Validate parameters?",
                     "default": true,
@@ -67,7 +69,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "monochrome_logs": {


### PR DESCRIPTION
- INTIALISE suboworkflow uses take and emit for better modularity

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
