### PR TITLE
Update deprecated fastqc image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/data/
 __pycache__
 *.pyo
 *.pyc
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ tests/data/
 __pycache__
 *.pyo
 *.pyc
-.idea

--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -2,9 +2,9 @@ process FASTQC {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::fastqc=0.11.9"
+    conda "bioconda::fastqc=0.12.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
+        'https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0' :
         'biocontainers/fastqc:0.12.1--hdfd78af_0' }"
 
     input:

--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -5,7 +5,7 @@ process FASTQC {
     conda "bioconda::fastqc=0.11.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-        'biocontainers/fastqc:0.11.9--0' }"
+        'biocontainers/fastqc:0.12.1--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/fastqc/tests/main.nf.test.snap
+++ b/modules/nf-core/fastqc/tests/main.nf.test.snap
@@ -2,9 +2,9 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,fe97b802cfb90f1f335e8a77f6258e30"
+                "versions.yml:md5,e1cc25ca8af856014824abd842e93978"
             ]
         ],
-        "timestamp": "2023-10-02T15:26:43+0000"
+        "timestamp": "2023-10-09T23:40:54+0000"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ x ] This comment contains a description of changes (with reason).
- [ x ] Use BioConda and BioContainers if possible to fulfil software requirements.

## PR objective: update deprecated fasqc image

Use of deprecated Docker images can be a problem when using Docker repository proxies (some of them may not allow using deprecated docker images). Changed docker image (fastqc:0.11.9--0) was discovered to be deprecated, and has therefore been changed to the newest one (fastqc:0.12.1--hdfd78af_0), which is not deprecated.

Besides, deprecated Docker images won't be deployable in short time.