### PR TITLE
Different approach to handling sralite files when using prefetch.

### DIFF
--- a/modules/nf-core/sratools/fasterqdump/main.nf
+++ b/modules/nf-core/sratools/fasterqdump/main.nf
@@ -2,10 +2,10 @@ process SRATOOLS_FASTERQDUMP {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::sra-tools=2.11.0 conda-forge::pigz=2.6"
+    conda "bioconda::sra-tools=3.0.8 conda-forge::pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' :
-        'biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:6a9ff0e76ec016c3d0d27e0c0d362339f2d787e6-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' :
+        'biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' }"
 
     input:
     tuple val(meta), path(sra)

--- a/modules/nf-core/sratools/fasterqdump/main.nf
+++ b/modules/nf-core/sratools/fasterqdump/main.nf
@@ -33,7 +33,7 @@ process SRATOOLS_FASTERQDUMP {
         --threads $task.cpus \\
         --outfile $outfile \\
         ${key_file} \\
-        ${sra.name}
+        ${sra}
 
     pigz \\
         $args2 \\

--- a/modules/nf-core/sratools/prefetch/main.nf
+++ b/modules/nf-core/sratools/prefetch/main.nf
@@ -13,8 +13,8 @@ process SRATOOLS_PREFETCH {
     path certificate
 
     output:
-    tuple val(meta), path(id), emit: sra
-    path 'versions.yml'      , emit: versions
+    tuple val(meta), path("${id}{,.sralite}"), emit: sra
+    path 'versions.yml'                      , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/sratools/prefetch/main.nf
+++ b/modules/nf-core/sratools/prefetch/main.nf
@@ -2,10 +2,10 @@ process SRATOOLS_PREFETCH {
     tag "$id"
     label 'process_low'
 
-    conda "bioconda::sra-tools=3.0.8 conda-forge::pigz=2.6"
+    conda "bioconda::sra-tools=3.0.8"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' :
-        'biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' }"
+        'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
+        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
 
     input:
     tuple val(meta), val(id)

--- a/modules/nf-core/sratools/prefetch/main.nf
+++ b/modules/nf-core/sratools/prefetch/main.nf
@@ -2,10 +2,10 @@ process SRATOOLS_PREFETCH {
     tag "$id"
     label 'process_low'
 
-    conda "bioconda::sra-tools=2.11.0"
+    conda "bioconda::sra-tools=3.0.8"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sra-tools:2.11.0--pl5321ha49a11a_3' :
-        'biocontainers/sra-tools:2.11.0--pl5321ha49a11a_3' }"
+        'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
+        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
 
     input:
     tuple val(meta), val(id)

--- a/modules/nf-core/sratools/prefetch/main.nf
+++ b/modules/nf-core/sratools/prefetch/main.nf
@@ -2,10 +2,10 @@ process SRATOOLS_PREFETCH {
     tag "$id"
     label 'process_low'
 
-    conda "bioconda::sra-tools=3.0.8"
+    conda "bioconda::sra-tools=2.11.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
-        'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
+        'https://depot.galaxyproject.org/singularity/sra-tools:2.11.0--pl5321ha49a11a_3' :
+        'biocontainers/sra-tools:2.11.0--pl5321ha49a11a_3' }"
 
     input:
     tuple val(meta), val(id)
@@ -13,8 +13,8 @@ process SRATOOLS_PREFETCH {
     path certificate
 
     output:
-    tuple val(meta), path("${id}{,.sralite}"), emit: sra
-    path 'versions.yml'                      , emit: versions
+    tuple val(meta), path(id), emit: sra
+    path 'versions.yml'      , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/sratools/prefetch/main.nf
+++ b/modules/nf-core/sratools/prefetch/main.nf
@@ -2,10 +2,10 @@ process SRATOOLS_PREFETCH {
     tag "$id"
     label 'process_low'
 
-    conda "bioconda::sra-tools=2.11.0"
+    conda "bioconda::sra-tools=3.0.8 conda-forge::pigz=2.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sra-tools:2.11.0--pl5321ha49a11a_3' :
-        'biocontainers/sra-tools:2.11.0--pl5321ha49a11a_3' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' :
+        'biocontainers/mulled-v2-5f89fe0cd045cb1d615630b9261a1d17943a9b6a:2f4a4c900edd6801ff0068c2b3048b4459d119eb-0' }"
 
     input:
     tuple val(meta), val(id)

--- a/modules/nf-core/sratools/prefetch/templates/retry_with_backoff.sh
+++ b/modules/nf-core/sratools/prefetch/templates/retry_with_backoff.sh
@@ -47,7 +47,7 @@ retry_with_backoff !{args2} \
     !{args} \
     !{id}
 
-vdb-validate !{id}
+[ -f !{id}.sralite ] && vdb-validate !{id}.sralite || vdb-validate !{id}
 
 cat <<-END_VERSIONS > versions.yml
 "!{task.process}":

--- a/modules/nf-core/sratools/prefetch/templates/retry_with_backoff.sh
+++ b/modules/nf-core/sratools/prefetch/templates/retry_with_backoff.sh
@@ -47,9 +47,7 @@ retry_with_backoff !{args2} \
     !{args} \
     !{id}
 
-[ -f !{id}.sralite ] && { mkdir -p !{id}; mv "!{id}.sralite" !{id}/; }
-
-vdb-validate !{id}
+[ -f !{id}.sralite ] && vdb-validate !{id}.sralite || vdb-validate !{id}
 
 cat <<-END_VERSIONS > versions.yml
 "!{task.process}":

--- a/modules/nf-core/sratools/prefetch/templates/retry_with_backoff.sh
+++ b/modules/nf-core/sratools/prefetch/templates/retry_with_backoff.sh
@@ -47,7 +47,7 @@ retry_with_backoff !{args2} \
     !{args} \
     !{id}
 
-[ -f !{id}.sralite ] && vdb-validate !{id}.sralite || vdb-validate !{id}
+vdb-validate !{id}
 
 cat <<-END_VERSIONS > versions.yml
 "!{task.process}":

--- a/tests/modules/nf-core/sratools/fasterqdump/test.yml
+++ b/tests/modules/nf-core/sratools/fasterqdump/test.yml
@@ -10,7 +10,7 @@
       md5sum: 466d05dafb2eec672150754168010b4d
     - path: output/sratools/versions.yml
       contains:
-        - "sratools: 2.11.0"
+        - "sratools: 3.0.8"
 
 - name: sratools fasterqdump test_sratools_fasterqdump_paired_end
   command: nextflow run ./tests/modules/nf-core/sratools/fasterqdump -entry test_sratools_fasterqdump_paired_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/sratools/fasterqdump/nextflow.config
@@ -26,4 +26,4 @@
       md5sum: 065666caf5b2d5dfb0cb25d5f3abe659
     - path: output/sratools/versions.yml
       contains:
-        - "sratools: 2.11.0"
+        - "sratools: 3.0.8"

--- a/tests/modules/nf-core/sratools/prefetch/test.yml
+++ b/tests/modules/nf-core/sratools/prefetch/test.yml
@@ -16,7 +16,7 @@
     - sratools/prefetch
     - sratools
   files:
-    - path: output/sratools/SRR1170046/SRR1170046.sralite
+    - path: output/sratools/SRR1170046.sralite
       md5sum: 7acfce556ca0951aff49d780899c105b
     - path: output/sratools/versions.yml
       contains:

--- a/tests/modules/nf-core/sratools/prefetch/test.yml
+++ b/tests/modules/nf-core/sratools/prefetch/test.yml
@@ -16,7 +16,7 @@
     - sratools/prefetch
     - sratools
   files:
-    - path: output/sratools/SRR1170046.sralite
+    - path: output/sratools/SRR1170046/SRR1170046.sralite
       md5sum: 7acfce556ca0951aff49d780899c105b
     - path: output/sratools/versions.yml
       contains:

--- a/tests/modules/nf-core/sratools/prefetch/test.yml
+++ b/tests/modules/nf-core/sratools/prefetch/test.yml
@@ -8,7 +8,7 @@
       md5sum: 7647dba20c89c0e3d7ad13842f060eb0
     - path: output/sratools/versions.yml
       contains:
-        - "sratools: 2.11.0"
+        - "sratools: 3.0.8"
 
 - name: sratools prefetch test_sratools_prefetch_with_sralite
   command: nextflow run ./tests/modules/nf-core/sratools/prefetch -entry test_sratools_prefetch_with_sralite -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/sratools/prefetch/nextflow.config
@@ -20,4 +20,4 @@
       md5sum: 7acfce556ca0951aff49d780899c105b
     - path: output/sratools/versions.yml
       contains:
-        - "sratools: 2.11.0"
+        - "sratools: 3.0.8"


### PR DESCRIPTION
## Overview

The SRA uses two file formats used to store the short read data: sra and sralite, and we want to support both formats.

When using `prefetch ID`, the behaviour of the resulting files differs depending on whether the format of `ID` stored at NCBI is sra or sralite. 

If the backend format is sra (using `ID=SRR6242565` as an example), the `prefetch $ID` command writes into a directory keyed by the ID:
```
SRR6242565
└── SRR6242565.sra
```

If the backend format is sralite (using `ID=SRR042042` as an example), the `prefetch $ID` command writes a single file to the current working directory:
```
SRR042042.sralite
```

Previously, we simply moved the sralite file into a new directory to match the sra format output, but this can break downstream tools. The most important is `fasterq-fetch` which requires the path to the file in the case of sralite, and the path to the parent directory in the case of sra.  If we simply emit as output the file for sralite and the parent directory for sra, the downstream `fasterq-fetch` doesn't need any additional logic to differentiate the format.

This variability requires two changes (included in this PR):
1) The path provided to the `vdb-validate` command inside the script block
2) The path required in the `output` block of the process

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
