### PR TITLE
Output parameterised Rmd from RMARKDOWNNOTEBOOK

### DIFF
--- a/modules/nf-core/rmarkdownnotebook/main.nf
+++ b/modules/nf-core/rmarkdownnotebook/main.nf
@@ -54,7 +54,6 @@ process RMARKDOWNNOTEBOOK {
         params_cmd = dump_params_yml(nb_params)
         render_cmd = """\
             params = yaml::read_yaml('.params.yml')
-            rmarkdown::render('${prefix}.Rmd', params=params, envir=new.env())
 
             # As well as rendering with params, produce a version of the R
             # markdown with param definitions set, so the notebook itself can
@@ -80,9 +79,12 @@ process RMARKDOWNNOTEBOOK {
             rmd_content <- append(rmd_content, values = unlist(strsplit(updated_yaml_content, split = "\\n")), after = start_idx)
 
             writeLines(rmd_content, '${prefix}.parameterised.Rmd')
+
+            # Render based on the updated file
+            rmarkdown::render('${prefix}.parameterised.Rmd', output_file='${prefix}.html')
         """
     } else {
-        render_cmd = "rmarkdown::render('${prefix}.Rmd')"
+        render_cmd = "rmarkdown::render('${prefix}.Rmd', output_file='${prefix}.html')"
     }
 
     """

--- a/modules/nf-core/rmarkdownnotebook/main.nf
+++ b/modules/nf-core/rmarkdownnotebook/main.nf
@@ -64,17 +64,18 @@ process RMARKDOWNNOTEBOOK {
             # Extract YAML content between the first two '---'
             start_idx <- which(rmd_content == "---")[1]
             end_idx <- which(rmd_content == "---")[2]
-            rmd_yaml_content <- paste(rmd_content[(start_idx+1):(end_idx-1)], collapse = "\n")
+            rmd_yaml_content <- paste(rmd_content[(start_idx+1):(end_idx-1)], collapse = "\\n")
+            print(rmd_yaml_content)
             rmd_params <- yaml::yaml.load(rmd_yaml_content)
 
             # Override the params
-            rmd_params$params <- modifyList(rmd_params$params, external_params)
+            rmd_params[['params']] <- modifyList(rmd_params[['params']], params)
 
             # Convert back to YAML string
             updated_yaml_content <- as.character(yaml::as.yaml(rmd_params))
 
             # Replace the YAML in Rmd
-            rmd_content[(start_idx+1):(end_idx-1)] <- unlist(strsplit(updated_yaml_content, "\n"))
+            rmd_content[(start_idx+1):(end_idx-1)] <- unlist(strsplit(updated_yaml_content, "\\n"))
 
             writeLines(rmd_content, '${prefix}.parameterised.Rmd')
         """

--- a/modules/nf-core/rmarkdownnotebook/main.nf
+++ b/modules/nf-core/rmarkdownnotebook/main.nf
@@ -71,15 +71,15 @@ process RMARKDOWNNOTEBOOK {
 
             # Recursive function to add 'value' to list elements, except for top-level
             add_value_recursively <- function(lst, is_top_level = FALSE) {
-              if (!is.list(lst)) {
-                return(lst)
-              }
+                if (!is.list(lst)) {
+                    return(lst)
+                }
 
-              lst <- lapply(lst, add_value_recursively)
-              if (!is_top_level) {
-                lst <- list(value = lst)
-              }
-              return(lst)
+                lst <- lapply(lst, add_value_recursively)
+                if (!is_top_level) {
+                    lst <- list(value = lst)
+                }
+                return(lst)
             }
 
             # Reformat nested lists under 'params' to have a 'value' key recursively

--- a/modules/nf-core/rmarkdownnotebook/main.nf
+++ b/modules/nf-core/rmarkdownnotebook/main.nf
@@ -65,7 +65,6 @@ process RMARKDOWNNOTEBOOK {
             start_idx <- which(rmd_content == "---")[1]
             end_idx <- which(rmd_content == "---")[2]
             rmd_yaml_content <- paste(rmd_content[(start_idx+1):(end_idx-1)], collapse = "\\n")
-            print(rmd_yaml_content)
             rmd_params <- yaml::yaml.load(rmd_yaml_content)
 
             # Override the params
@@ -74,8 +73,11 @@ process RMARKDOWNNOTEBOOK {
             # Convert back to YAML string
             updated_yaml_content <- as.character(yaml::as.yaml(rmd_params))
 
-            # Replace the YAML in Rmd
-            rmd_content[(start_idx+1):(end_idx-1)] <- unlist(strsplit(updated_yaml_content, "\\n"))
+            # Remove the old YAML content
+            rmd_content <- rmd_content[-((start_idx+1):(end_idx-1))]
+
+            # Insert the updated YAML content at the right position
+            rmd_content <- append(rmd_content, values = unlist(strsplit(updated_yaml_content, split = "\\n")), after = start_idx)
 
             writeLines(rmd_content, '${prefix}.parameterised.Rmd')
         """

--- a/modules/nf-core/rmarkdownnotebook/main.nf
+++ b/modules/nf-core/rmarkdownnotebook/main.nf
@@ -55,7 +55,7 @@ process RMARKDOWNNOTEBOOK {
         render_cmd = """\
             params = yaml::read_yaml('.params.yml')
 
-            # As well as rendering with params, produce a version of the R
+            # Instead of rendering with params, produce a version of the R
             # markdown with param definitions set, so the notebook itself can
             # be reused
             rmd_content <- readLines('${prefix}.Rmd')

--- a/modules/nf-core/rmarkdownnotebook/main.nf
+++ b/modules/nf-core/rmarkdownnotebook/main.nf
@@ -63,11 +63,11 @@ process RMARKDOWNNOTEBOOK {
 
             # Substitute values
             for (key in names(params)) {
-              # Generate pattern for substitution. Assumes each parameter in
-              # the Rmd is in the format: key: value
-              pattern <- paste0("^\\\s*", key, ":.*\$")
-              replacement <- paste0(key, ": ", params[[key]])
-              rmd_content <- gsub(pattern, replacement, rmd_content)
+                # Generate pattern for substitution. Assumes each parameter in
+                # the Rmd is in the format: key: value
+                pattern <- paste0("^\\\s*", key, ":.*\$")
+                replacement <- paste0(key, ": ", params[[key]])
+                rmd_content <- gsub(pattern, replacement, rmd_content)
             }
             writeLines(rmd_content, '${prefix}.parameterised.Rmd')
         """

--- a/modules/nf-core/rmarkdownnotebook/main.nf
+++ b/modules/nf-core/rmarkdownnotebook/main.nf
@@ -65,7 +65,7 @@ process RMARKDOWNNOTEBOOK {
             start_idx <- which(rmd_content == "---")[1]
             end_idx <- which(rmd_content == "---")[2]
             rmd_yaml_content <- paste(rmd_content[(start_idx+1):(end_idx-1)], collapse = "\n")
-            rmd_params <- yaml.load(rmd_yaml_content)
+            rmd_params <- yaml::yaml.load(rmd_yaml_content)
 
             # Override the params
             rmd_params$params <- modifyList(rmd_params$params, external_params)

--- a/tests/modules/nf-core/rmarkdownnotebook/test.yml
+++ b/tests/modules/nf-core/rmarkdownnotebook/test.yml
@@ -27,5 +27,5 @@
       contains:
         - "n_iter = 12"
     - path: output/rmarkdownnotebook/test_rmd.parameterised.Rmd
-      md5sum: bc3e20742dfa96c98b434f8cc2866762
+      md5sum: 59e184e50aadb66a821a2acce6a7c27c
     - path: output/rmarkdownnotebook/versions.yml

--- a/tests/modules/nf-core/rmarkdownnotebook/test.yml
+++ b/tests/modules/nf-core/rmarkdownnotebook/test.yml
@@ -27,5 +27,5 @@
       contains:
         - "n_iter = 12"
     - path: output/rmarkdownnotebook/test_rmd.parameterised.Rmd
-      md5sum: 0b84c05d6dbfe7aca2ebe7992e588e75
+      md5sum: bc3e20742dfa96c98b434f8cc2866762
     - path: output/rmarkdownnotebook/versions.yml

--- a/tests/modules/nf-core/rmarkdownnotebook/test.yml
+++ b/tests/modules/nf-core/rmarkdownnotebook/test.yml
@@ -10,6 +10,7 @@
     - path: output/rmarkdownnotebook/test_rmd.html
       contains:
         - "n_iter = 10"
+    - path: output/rmarkdownnotebook/versions.yml
 
 - name: rmarkdownnotebook test_rmarkdown_parametrize
   command: nextflow run ./tests/modules/nf-core/rmarkdownnotebook -entry test_rmarkdown_parametrize -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/rmarkdownnotebook/nextflow.config
@@ -25,3 +26,6 @@
     - path: output/rmarkdownnotebook/test_rmd.html
       contains:
         - "n_iter = 12"
+    - path: output/rmarkdownnotebook/test_rmd.parameterised.Rmd
+      md5sum: 0b84c05d6dbfe7aca2ebe7992e588e75
+    - path: output/rmarkdownnotebook/versions.yml


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

This PR suggests a change from native use of 'params' in the RMarkdown `render()` function, to rather edit the R Markdown document to substitute the params in the YAML-format header matter.

The main motivation for this is to produce a Markdown file which can be used an played with by users downstream, in addition to rendered HTML. I do not believe it's possible to simply 'render' a markdown file to another Rmarkdown file with variables resolved, though that would be a much neater solution.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
