### PR TITLE
allow tools with no DOI available

### DIFF
--- a/modules/yaml-schema.json
+++ b/modules/yaml-schema.json
@@ -134,9 +134,17 @@
                                 "pattern": "^(http|https)://.*$"
                             },
                             "doi": {
-                                "type": "string",
                                 "description": "DOI of the tool",
-                                "pattern": "^10.\\d{4,9}\\/[^,]+$"
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "pattern": "^10\\.\\d{4,9}\\/[^,]+$"
+                                    },
+                                    {
+                                        "type": "string",
+                                        "enum": ["no DOI available"]
+                                    }
+                                ]
                             },
                             "licence": {
                                 "type": ["array", "string"],


### PR DESCRIPTION
With this PR we make the DOI check less strict and allow the value "no DOI available" as an alternative.