### PR TITLE
Wrong module name in `metaphlan3` test

### DIFF
--- a/modules/nf-core/metaphlan3/mergemetaphlantables/meta.yml
+++ b/modules/nf-core/metaphlan3/mergemetaphlantables/meta.yml
@@ -36,7 +36,7 @@ output:
       description: File containing software versions
       pattern: "versions.yml"
   - txt:
-      type: txt
+      type: file
       description: Combined MetaPhlAn3 table
       pattern: "*.txt"
 

--- a/tests/modules/nf-core/metaphlan3/mergemetaphlantables/main.nf
+++ b/tests/modules/nf-core/metaphlan3/mergemetaphlantables/main.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl = 2
 
 include { UNTAR                           } from '../../../../../modules/nf-core/untar/main.nf'
-include { METAPHLAN3                      } from '../../../../../modules/nf-core/metaphlan3/metaphlan3/main.nf'
+include { METAPHLAN3_METAPHLAN3           } from '../../../../../modules/nf-core/metaphlan3/metaphlan3/main.nf'
 include { METAPHLAN3_MERGEMETAPHLANTABLES } from '../../../../../modules/nf-core/metaphlan3/mergemetaphlantables/main.nf'
 
 workflow test_metaphlan3_mergemetaphlantables {
@@ -16,7 +16,7 @@ workflow test_metaphlan3_mergemetaphlantables {
     db    = [ [], file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/metaphlan_database.tar.gz', checkIfExists: true) ]
 
     UNTAR ( db )
-    METAPHLAN3 ( input, UNTAR.out.untar.map{ it[1] } )
-    METAPHLAN3_MERGEMETAPHLANTABLES ( METAPHLAN3.out.profile.map{ [[id:"test"], it[1]] }.groupTuple() )
+    METAPHLAN3_METAPHLAN3 ( input, UNTAR.out.untar.map{ it[1] } )
+    METAPHLAN3_MERGEMETAPHLANTABLES ( METAPHLAN3_METAPHLAN3.out.profile.map{ [[id:"test"], it[1]] }.groupTuple() )
 
 }

--- a/tests/modules/nf-core/metaphlan3/mergemetaphlantables/nextflow.config
+++ b/tests/modules/nf-core/metaphlan3/mergemetaphlantables/nextflow.config
@@ -2,7 +2,7 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
-    withName: METAPHLAN3 {
+    withName: METAPHLAN3_METAPHLAN3 {
         ext.args = '--index mpa_v30_CHOCOPhlAn_201901 --add_viruses --bt2_ps very-sensitive-local'
     }
 


### PR DESCRIPTION
The test hasn't been updated when the `METAPHLAN3` module got renamed + a bit of linting.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
