### PR TITLE
fix ownership for nf-test

### DIFF
--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -30,6 +30,7 @@ profiles {
     docker {
         docker.enabled = true
         docker.userEmulation = true
+        docker.fixOwnership = true
         docker.runOptions = "--platform linux/x86_64"
     }
 }


### PR DESCRIPTION
Copying the settings from `tests/nextflow.config`