### PR TITLE
Update module hifiasm

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -122,7 +122,8 @@ jobs:
             tags: subworkflows/bcl_demultiplex
           - profile: "conda"
             tags: subworkflows/vcf_annotate_ensemblvep
-
+          - profile: "conda"
+            tags: subworkflows/fasta_clean_fcs
     env:
       NXF_ANSI_LOG: false
       SENTIEON_LICENSE_BASE64: ${{ secrets.SENTIEON_LICENSE_BASE64 }}

--- a/modules/nf-core/hifiasm/meta.yml
+++ b/modules/nf-core/hifiasm/meta.yml
@@ -32,15 +32,21 @@ input:
   - maternal_kmer_dump:
       type: file
       description: Yak kmer dump file for maternal reads (can be used for haplotype resolution). It can have an arbitrary extension.
-  - use_parental_kmers:
-      type: logical
-      description: A flag (true or false) signalling if the module should use the paternal and maternal kmer dumps.
   - hic_read1:
       type: file
       description: Hi-C data Forward reads.
   - hic_read2:
       type: file
       description: Hi-C data Reverse reads.
+  - ont_ul:
+      type: file
+      description: ONT (Nanopore) ultra-long reads.
+  - ploidy:
+      type: string
+      description: Ploidy for the specie of interest
+  - gen_size_kb:
+      type: string
+      description: Estimated genome size for the specie of interest (in kb)
 
 output:
   - meta:
@@ -68,13 +74,13 @@ output:
       type: file
       description: Alternative contigs
       pattern: "*.asm.a_ctg.gfa"
-  - paternal_contigs:
+  - hap1_contigs:
       type: file
-      description: Paternal contigs
+      description: haplotype 1 contigs (can be apternal)
       pattern: "*.hap1.p_ctg.gfa"
-  - maternal_contigs:
+  - hap2_contigs:
       type: file
-      description: Maternal contigs
+      description: haplotype 2 contigs (can be maternal)
       pattern: "*.hap2.p_ctg.gfa"
   - corrected_reads:
       type: file

--- a/tests/modules/nf-core/hifiasm/main.nf
+++ b/tests/modules/nf-core/hifiasm/main.nf
@@ -13,7 +13,7 @@ workflow test_hifiasm_hifi_only {
         [ file(params.test_data['homo_sapiens']['pacbio']['hifi'], checkIfExists: true) ]
     ]
 
-    HIFIASM ( input, [], [], [], [] )
+    HIFIASM ( input, [], [], [], [], [], [], [] )
 }
 
 /*
@@ -27,11 +27,11 @@ workflow test_hifiasm_with_parental_reads {
     paternal_kmer_dump = file(params.test_data['homo_sapiens']['illumina']['test_yak'], checkIfExists: true)
     maternal_kmer_dump = file(params.test_data['homo_sapiens']['illumina']['test2_yak'], checkIfExists: true)
 
-    HIFIASM ( input, paternal_kmer_dump, maternal_kmer_dump, [], [] )
+    HIFIASM ( input, paternal_kmer_dump, maternal_kmer_dump, [], [], [], [], [] )
 }
 
 /*
- * Test with parental reads for phasing
+ * Test with hic reads for phasing
  */
 workflow test_hifiasm_with_hic {
     input = [
@@ -41,6 +41,34 @@ workflow test_hifiasm_with_hic {
     hic_reads1 = file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true)
     hic_reads2 = file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
 
-    HIFIASM ( input, [], [], hic_reads1, hic_reads2 )
+    HIFIASM ( input, [], [], hic_reads1, hic_reads2, [], [], [] )
 }
 
+
+/*
+ * Test with Nanopore ultra-long reads
+ */
+workflow test_hifiasm_with_ul {
+    input = [
+        [ id:'test' ], // meta map
+        [ file(params.test_data['homo_sapiens']['pacbio']['hifi'], checkIfExists: true) ]
+    ]
+    ont_ul = file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+
+    HIFIASM ( input, [], [], [], [], ont_ul, [], [] )
+}
+
+/*
+ * Test with Nanopore ultra-long reads and HiC
+ */
+workflow test_hifiasm_with_hic_and_ul {
+    input = [
+        [ id:'test' ], // meta map
+        [ file(params.test_data['homo_sapiens']['pacbio']['hifi'], checkIfExists: true) ]
+    ]
+    hic_reads1 = file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+    hic_reads2 = file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+    ont_ul = file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+
+    HIFIASM ( input, [], [], hic_reads1, hic_reads2, ont_ul, [], [] )
+}

--- a/tests/modules/nf-core/hifiasm/test.yml
+++ b/tests/modules/nf-core/hifiasm/test.yml
@@ -1,53 +1,90 @@
 - name: hifiasm test_hifiasm_hifi_only
-  command: nextflow run ./tests/modules/nf-core/hifiasm -entry test_hifiasm_hifi_only -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hifiasm/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/hifiasm -entry test_hifiasm_hifi_only -c ./tests/config/nextflow.config
   tags:
     - hifiasm
   files:
     - path: output/hifiasm/test.asm.bp.hap1.p_ctg.gfa
       md5sum: 1206beee1cda7b39e48e0a080fde0801
     - path: output/hifiasm/test.asm.bp.hap2.p_ctg.gfa
-      md5sum: 7bbec1988f296dd0930b0b619cc0a096
+      md5sum: 765b53fbf44b43826174585438a3578e
     - path: output/hifiasm/test.asm.bp.p_utg.gfa
       md5sum: 3e2b4815145b06bb74f1b74876e767dc
     - path: output/hifiasm/test.asm.bp.r_utg.gfa
-      md5sum: ba90af06b466342b893a99d9d25dd792
+      md5sum: 9cb983397b093bcf9ef5a01c5aa52c6c
     - path: output/hifiasm/test.asm.ec.bin
-    - path: output/hifiasm/test.asm.ovlp.reverse.bin
     - path: output/hifiasm/test.asm.ovlp.source.bin
+      md5sum: 9b512facb0e27f7f959fd6bc02e32034
     - path: output/hifiasm/versions.yml
 
 - name: hifiasm test_hifiasm_with_parental_reads
-  command: nextflow run ./tests/modules/nf-core/hifiasm -entry test_hifiasm_with_parental_reads -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hifiasm/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/hifiasm -entry test_hifiasm_with_parental_reads -c ./tests/config/nextflow.config
   tags:
     - hifiasm
   files:
     - path: output/hifiasm/test.asm.dip.hap1.p_ctg.gfa
       md5sum: 9d4d20104ef4bc3d2896ae25c6b35c06
     - path: output/hifiasm/test.asm.dip.hap2.p_ctg.gfa
-      md5sum: 4d7368ae39d0ae26018a766361e558a0
     - path: output/hifiasm/test.asm.dip.p_utg.gfa
       md5sum: 3e2b4815145b06bb74f1b74876e767dc
     - path: output/hifiasm/test.asm.dip.r_utg.gfa
-      md5sum: ba90af06b466342b893a99d9d25dd792
+      md5sum: 9cb983397b093bcf9ef5a01c5aa52c6c
     - path: output/hifiasm/test.asm.ec.bin
     - path: output/hifiasm/test.asm.ovlp.reverse.bin
     - path: output/hifiasm/test.asm.ovlp.source.bin
+      md5sum: 9b512facb0e27f7f959fd6bc02e32034
     - path: output/hifiasm/versions.yml
 
 - name: hifiasm test_hifiasm_with_hic
-  command: nextflow run ./tests/modules/nf-core/hifiasm -entry test_hifiasm_with_hic -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/hifiasm/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/hifiasm -entry test_hifiasm_with_hic -c ./tests/config/nextflow.config
   tags:
     - hifiasm
   files:
     - path: output/hifiasm/test.asm.ec.bin
     - path: output/hifiasm/test.asm.hic.hap1.p_ctg.gfa
-      md5sum: 6125ded0610bc69863da7da4915078d8
+      md5sum: 467a7f7d6dd15b773f15ccce84e0f28d
     - path: output/hifiasm/test.asm.hic.hap2.p_ctg.gfa
-      md5sum: 6d4de879612fc92a10b2976d7d57444d
     - path: output/hifiasm/test.asm.hic.p_utg.gfa
       md5sum: 3e2b4815145b06bb74f1b74876e767dc
     - path: output/hifiasm/test.asm.hic.r_utg.gfa
-      md5sum: ba90af06b466342b893a99d9d25dd792
+      md5sum: 9cb983397b093bcf9ef5a01c5aa52c6c
     - path: output/hifiasm/test.asm.ovlp.reverse.bin
     - path: output/hifiasm/test.asm.ovlp.source.bin
+      md5sum: 9b512facb0e27f7f959fd6bc02e32034
+    - path: output/hifiasm/versions.yml
+
+- name: hifiasm test_hifiasm_with_ul
+  command: nextflow run ./tests/modules/nf-core/hifiasm -entry test_hifiasm_with_ul -c ./tests/config/nextflow.config
+  tags:
+    - hifiasm
+  files:
+    - path: output/hifiasm/test.asm.bp.hap1.p_ctg.gfa
+      md5sum: 3bc69568257d8a4fe7c2071208dcf1fb
+    - path: output/hifiasm/test.asm.bp.hap2.p_ctg.gfa
+      md5sum: 573f9de5ff22aa07e245a52a9b4a09b7
+    - path: output/hifiasm/test.asm.bp.p_utg.gfa
+      md5sum: 83e8bc2ba69df13c2bde750cf90d69eb
+    - path: output/hifiasm/test.asm.bp.r_utg.gfa
+      md5sum: 9cb983397b093bcf9ef5a01c5aa52c6c
+    - path: output/hifiasm/test.asm.ec.bin
+    - path: output/hifiasm/test.asm.ovlp.reverse.bin
+    - path: output/hifiasm/test.asm.ovlp.source.bin
+      md5sum: 9b512facb0e27f7f959fd6bc02e32034
+    - path: output/hifiasm/versions.yml
+
+- name: hifiasm test_hifiasm_with_hic_and_ul
+  command: nextflow run ./tests/modules/nf-core/hifiasm -entry test_hifiasm_with_hic_and_ul -c ./tests/config/nextflow.config
+  tags:
+    - hifiasm
+  files:
+    - path: output/hifiasm/test.asm.ec.bin
+    - path: output/hifiasm/test.asm.hic.hap1.p_ctg.gfa
+      md5sum: 3fe26b67ec37b4ef44beb8a5f1666692
+    - path: output/hifiasm/test.asm.hic.hap2.p_ctg.gfa
+    - path: output/hifiasm/test.asm.hic.p_utg.gfa
+      md5sum: 83e8bc2ba69df13c2bde750cf90d69eb
+    - path: output/hifiasm/test.asm.hic.r_utg.gfa
+      md5sum: 9cb983397b093bcf9ef5a01c5aa52c6c
+    - path: output/hifiasm/test.asm.ovlp.reverse.bin
+    - path: output/hifiasm/test.asm.ovlp.source.bin
+      md5sum: 9b512facb0e27f7f959fd6bc02e32034
     - path: output/hifiasm/versions.yml


### PR DESCRIPTION
Proposing an update to the hifiasm module : 
- Updated the software version
- Changed the output name (from paternal and maternal contig to haplotype 1 and 2 as it may not be maternal and paternal).
- Added the option to use nanopore ultra-long sequences to do the assembly
- Added the options of policy and estimated genome size

## PR checklist


- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
