### PR TITLE
modified proteus to output both raw and log2 intensities

### DIFF
--- a/modules/nf-core/proteus/readproteingroups/main.nf
+++ b/modules/nf-core/proteus/readproteingroups/main.nf
@@ -13,11 +13,13 @@ process PROTEUS_READPROTEINGROUPS {
     output:
     tuple val(meta), path("*dendrogram.png")                    , emit: dendro_plot
     tuple val(meta), path("*mean_variance_relationship.png")    , emit: mean_var_plot
-    tuple val(meta), path("*raw_distributions.png")             , emit: raw_dist_plot
+    tuple val(meta), path("*log2_distributions.png")            , emit: log2_dist_plot
     tuple val(meta), path("*normalized_distributions.png")      , emit: norm_dist_plot
     tuple val(meta), path("*raw_proteingroups.rds")             , emit: raw_rdata
+    tuple val(meta), path("*log2_proteingroups.rds")            , emit: log2_rdata
     tuple val(meta), path("*normalized_proteingroups.rds")      , emit: norm_rdata
     tuple val(meta), path("*raw_proteingroups_tab.tsv")         , emit: raw_tab
+    tuple val(meta), path("*log2_proteingroups_tab.tsv")        , emit: log2_tab
     tuple val(meta), path("*normalized_proteingroups_tab.tsv")  , emit: norm_tab
     tuple val(meta), path("*R_sessionInfo.log")                 , emit: session_info
     path "versions.yml"                                         , emit: versions

--- a/modules/nf-core/proteus/readproteingroups/meta.yml
+++ b/modules/nf-core/proteus/readproteingroups/meta.yml
@@ -44,10 +44,10 @@ output:
       type: file
       description: |
         PNG file; plot of the log-intensity variance vs log-intensity mean of each condition in the normalized samples
-  - raw_dist_plot:
+  - log2_dist_plot:
       type: file
       description: |
-        PNG file; plot of the intensity/ratio distributions of the raw samples
+        PNG file; plot of the intensity/ratio distributions of the log2 samples
   - norm_dist_plot:
       type: file
       description: |
@@ -56,6 +56,10 @@ output:
       type: file
       description: |
         RDS file of a proteinGroups object from Proteus, contains raw protein intensities and additional info
+  - log2_rdata:
+      type: file
+      description: |
+        RDS file of a proteinGroups object from Proteus, contains log2 protein intensities and additional info
   - norm_rdata:
       type: file
       description: |
@@ -64,6 +68,10 @@ output:
       type: file
       description: |
         TSV-format intensities table from Proteus, contains raw protein intensities
+  - log2_tab:
+      type: file
+      description: |
+        TSV-format intensities table from Proteus, contains log2 protein intensities
   - norm_tab:
       type: file
       description: |

--- a/modules/nf-core/proteus/readproteingroups/templates/proteus_readproteingroups.R
+++ b/modules/nf-core/proteus/readproteingroups/templates/proteus_readproteingroups.R
@@ -248,6 +248,27 @@ proteinGroups <- readProteinGroups(
     data.cols=proteinColumns
 )
 
+# R object for other processes to use
+
+saveRDS(proteinGroups, file = 'raw_proteingroups.rds')
+
+# Write raw intensities matrix
+
+out_df <- data.frame(
+        round_dataframe_columns(proteinGroups\$tab, digits=opt\$round_digits),
+        check.names = FALSE
+    )
+out_df[[opt\$protein_id_col]] <- rownames(proteinGroups\$tab) # proteus saves the IDs as rownames; save these to a separate column
+out_df <- out_df[c(opt\$protein_id_col, colnames(out_df)[colnames(out_df) != opt\$protein_id_col])] # move ID column to first position
+write.table(
+    out_df,
+    file = 'raw_proteingroups_tab.tsv',
+    col.names = TRUE,
+    row.names = FALSE,
+    sep = '\t',
+    quote = FALSE
+)
+
 # Define valid normalization functions
 
 valid_norm_functions <- list("normalizeMedian", "normalizeQuantiles")
@@ -308,15 +329,16 @@ write.table(
     quote = FALSE
 )
 
-# Process and save raw table
+# get log2 table
 
-proteinGroups\$tab <- log2(proteinGroups\$tab)
+proteinGroups.log2 <- proteinGroups
+proteinGroups.log2\$tab <- log2(proteinGroups.log2\$tab)
 
-# Generate raw distribution plot
+# Generate log2 distribution plot
 
-png('raw_distributions.png', width = 5*300, height = 5*300, res = 300, pointsize = 8)
+png('log2_distributions.png', width = 5*300, height = 5*300, res = 300, pointsize = 8)
 print(
-    plotSampleDistributions(proteinGroups, title=paste("Raw sample distributions in contrast", opt\$contrast_variable), fill="condition", method=opt\$plotsd_method)
+    plotSampleDistributions(proteinGroups.log2, title=paste("Log2 sample distributions in contrast", opt\$contrast_variable), fill="condition", method=opt\$plotsd_method)
         + scale_fill_brewer(palette=opt\$palette_name, name=opt\$contrast_variable)
         + theme(plot.title = element_text(size = 12))
     )
@@ -324,22 +346,19 @@ dev.off()
 
 # R object for other processes to use
 
-saveRDS(proteinGroups, file = 'raw_proteingroups.rds')
-
+saveRDS(proteinGroups.log2, file = 'log2_proteingroups.rds')
 
 # Write raw intensities matrix
 
 out_df <- data.frame(
-        round_dataframe_columns(proteinGroups\$tab, digits=opt\$round_digits),
+        round_dataframe_columns(proteinGroups.log2\$tab, digits=opt\$round_digits),
         check.names = FALSE
     )
-out_df[[opt\$protein_id_col]] <- rownames(proteinGroups\$tab) # proteus saves the IDs as rownames; save these to a separate column
+out_df[[opt\$protein_id_col]] <- rownames(proteinGroups.log2\$tab) # proteus saves the IDs as rownames; save these to a separate column
 out_df <- out_df[c(opt\$protein_id_col, colnames(out_df)[colnames(out_df) != opt\$protein_id_col])] # move ID column to first position
-
-
 write.table(
     out_df,
-    file = 'raw_proteingroups_tab.tsv',
+    file = 'log2_proteingroups_tab.tsv',
     col.names = TRUE,
     row.names = FALSE,
     sep = '\t',

--- a/tests/modules/nf-core/proteus/readproteingroups/test.yml
+++ b/tests/modules/nf-core/proteus/readproteingroups/test.yml
@@ -17,5 +17,5 @@
       md5sum: af7a556997b82f4ba38bfae8a6b91301
     - path: output/proteus/raw_proteingroups.rds
     - path: output/proteus/raw_proteingroups_tab.tsv
-      md5sum: af7a556997b82f4ba38bfae8a6b91301
+      md5sum: f4242ccf1621935d802024e112c42ac6
     - path: output/proteus/versions.yml

--- a/tests/modules/nf-core/proteus/readproteingroups/test.yml
+++ b/tests/modules/nf-core/proteus/readproteingroups/test.yml
@@ -11,7 +11,10 @@
     - path: output/proteus/normalizeQuantiles.normalized_proteingroups.rds
     - path: output/proteus/normalizeQuantiles.normalized_proteingroups_tab.tsv
       md5sum: 4a0a74febfc6ba921210f465e890ff5b
-    - path: output/proteus/raw_distributions.png
+    - path: output/proteus/log2_distributions.png
+    - path: output/proteus/log2_proteingroups.rds
+    - path: output/proteus/log2_proteingroups_tab.tsv
+      md5sum: af7a556997b82f4ba38bfae8a6b91301
     - path: output/proteus/raw_proteingroups.rds
     - path: output/proteus/raw_proteingroups_tab.tsv
       md5sum: af7a556997b82f4ba38bfae8a6b91301


### PR DESCRIPTION
currently, proteus module only outputs log2 and normalized intensities.
Sometimes, we do want to raw intensities.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
