### PR TITLE
fix `no locator available for file` error

### DIFF
--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -27,7 +27,7 @@ if ("$PROFILE" == "singularity") {
     docker.enabled = true
     docker.userEmulation = false
     docker.fixOwnership = true
-    docker.runOptions = '--platform=linux/amd64 -u $(id -u):$(id -g)'
+    docker.runOptions = '--platform=linux/amd64'
 }
 
 docker.registry = 'quay.io'

--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -31,7 +31,7 @@ profiles {
         docker.enabled = true
         docker.userEmulation = false
         docker.fixOwnership = true
-        docker.runOptions = '--platform=linux/amd64 -u $(id -u):$(id -g)'
+        docker.runOptions = '--platform=linux/amd64'
     }
 }
 


### PR DESCRIPTION
we added this trying to fix the AWS runners, but without success. now it seems to also break github runners so removing it again.