### PR TITLE
Convert Kraken2 tests to nf-test

### DIFF
--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test
@@ -1,0 +1,145 @@
+nextflow_process {
+    name "Test Process KRAKEN2_KRAKEN2"
+    script "../main.nf"
+    process "KRAKEN2_KRAKEN2"
+    tag "kraken2_kraken2"
+    tag "modules"
+    tag "modules_nfcore"
+
+    setup {
+        run("UNTAR") {
+            script "modules/nf-core/untar/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    [],
+                    file(
+                        params.test_data['sarscov2']['genome']['kraken2_tar_gz'],
+                        checkIfExists: true
+                    )
+                ])
+                """
+            }
+        }
+    }
+
+    test("sarscov2 illumina single end [fastq]") {
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(
+                        params.test_data['sarscov2']['illumina']['test_1_fastq_gz'],
+                        checkIfExists: true
+                    )]
+                ]
+                input[1] = UNTAR.out.untar.map{ it[1] }
+                input[2] = true
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(
+                    process.out.report,
+                    process.out.versions,
+                ).match()
+            },
+            { assert process.out.classified_reads_fastq.get(0).get(1) ==~ ".*/test.classified.fastq.gz" },
+            { assert process.out.unclassified_reads_fastq.get(0).get(1) ==~ ".*/test.unclassified.fastq.gz" },
+            )
+        }
+    }
+
+    test("sarscov2 illumina paired end [fastq]") {
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(
+                            params.test_data['sarscov2']['illumina']['test_1_fastq_gz'],
+                            checkIfExists: true
+                        ),
+                        file(
+                            params.test_data['sarscov2']['illumina']['test_2_fastq_gz'],
+                            checkIfExists: true
+                        )
+
+                    ]
+                ]
+                input[1] = UNTAR.out.untar.map{ it[1] }
+                input[2] = true
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(
+                    process.out.report,
+                    process.out.versions,
+                ).match()
+            },
+            { assert process.out.classified_reads_fastq.get(0).get(1).get(0)
+                ==~ ".*/test.classified_1.fastq.gz" },
+            { assert process.out.classified_reads_fastq.get(0).get(1).get(1)
+                ==~ ".*/test.classified_2.fastq.gz" },
+            { assert process.out.unclassified_reads_fastq.get(0).get(1).get(0)
+                ==~ ".*/test.unclassified_1.fastq.gz" },
+            { assert process.out.unclassified_reads_fastq.get(0).get(1).get(1)
+                ==~ ".*/test.unclassified_2.fastq.gz" },
+            )
+        }
+    }
+
+    test("sarscov2 illumina single end [fastq] + save_reads_assignment") {
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(
+                        params.test_data['sarscov2']['illumina']['test_1_fastq_gz'],
+                        checkIfExists: true
+                    )]
+                ]
+                input[1] = UNTAR.out.untar.map{ it[1] }
+                input[2] = false
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(
+                    process.out.report,
+                    process.out.classified_reads_assignment,
+                    process.out.versions,
+                ).match()
+            },
+            )
+        }
+    }
+}

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test
@@ -25,10 +25,6 @@ nextflow_process {
 
     test("sarscov2 illumina single end [fastq]") {
         when {
-            params {
-                outdir   = "$outputDir"
-            }
-
             process {
                 """
                 input[0] = [

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test
@@ -2,6 +2,7 @@ nextflow_process {
     name "Test Process KRAKEN2_KRAKEN2"
     script "../main.nf"
     process "KRAKEN2_KRAKEN2"
+    tag "kraken2"
     tag "kraken2/kraken2"
     tag "modules"
     tag "modules_nfcore"

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test
@@ -2,7 +2,7 @@ nextflow_process {
     name "Test Process KRAKEN2_KRAKEN2"
     script "../main.nf"
     process "KRAKEN2_KRAKEN2"
-    tag "kraken2_kraken2"
+    tag "kraken2/kraken2"
     tag "modules"
     tag "modules_nfcore"
 

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test.snap
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test.snap
@@ -1,0 +1,62 @@
+{
+    "sarscov2 illumina single end [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
+                ]
+            ],
+            [
+                "versions.yml:md5,bcb3e2520685846df02bb27cc6b1794b"
+            ]
+        ],
+        "timestamp": "2023-10-25T09:01:29.775797"
+    },
+    "sarscov2 illumina paired end [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
+                ]
+            ],
+            [
+                "versions.yml:md5,bcb3e2520685846df02bb27cc6b1794b"
+            ]
+        ],
+        "timestamp": "2023-10-25T09:01:37.025389"
+    },
+    "sarscov2 illumina single end [fastq] + save_reads_assignment": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.kraken2.classifiedreads.txt:md5,e7a90531f0d8d777316515c36fe4cae0"
+                ]
+            ],
+            [
+                "versions.yml:md5,bcb3e2520685846df02bb27cc6b1794b"
+            ]
+        ],
+        "timestamp": "2023-10-25T09:01:45.775262"
+    }
+}

--- a/modules/nf-core/kraken2/kraken2/tests/tags.yml
+++ b/modules/nf-core/kraken2/kraken2/tests/tags.yml
@@ -1,3 +1,3 @@
-kraken2_kraken2:
+kraken2/kraken2:
   - modules/nf-core/kraken2/kraken2/**
   - modules/nf-core/untar/**

--- a/modules/nf-core/kraken2/kraken2/tests/tags.yml
+++ b/modules/nf-core/kraken2/kraken2/tests/tags.yml
@@ -1,0 +1,3 @@
+kraken2_kraken2:
+  - modules/nf-core/kraken2/kraken2/**
+  - modules/nf-core/untar/**

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -2000,11 +2000,6 @@ kofamscan:
   - modules/nf-core/kofamscan/**
   - tests/modules/nf-core/kofamscan/**
 
-kraken2/kraken2:
-  - modules/nf-core/kraken2/kraken2/**
-  - modules/nf-core/untar/**
-  - tests/modules/nf-core/kraken2/kraken2/**
-
 krakentools/combinekreports:
   - modules/nf-core/krakentools/combinekreports/**
   - tests/modules/nf-core/krakentools/combinekreports/**


### PR DESCRIPTION
This PR converts the Kraken2 tests to nf-test.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Follow the naming conventions.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
