### PR TITLE
Convert bclconvert and bcl2fastq modules to nf-test

### DIFF
--- a/modules/nf-core/bcl2fastq/tests/main.nf.test
+++ b/modules/nf-core/bcl2fastq/tests/main.nf.test
@@ -1,0 +1,32 @@
+nextflow_process {
+
+    name "Test Process BCL2FASTQ"
+    script "modules/nf-core/bcl2fastq/main.nf"
+    process "BCL2FASTQ"
+    config "./nextflow.config"
+    tag "bcl2fastq"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("homo sapiens illumina [bcl]") {
+        when {
+            process {
+                //TODO use new test dataset when available, see https://github.com/nf-core/test-datasets/issues/996
+                """
+                input[0] = [
+                    [ id: 'test', lane:1 ],
+                    file(params.test_data['homo_sapiens']['illumina']['test_flowcell_samplesheet'], checkIfExists: true),
+                    file(params.test_data['homo_sapiens']['illumina']['test_flowcell'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/bcl2fastq/tests/main.nf.test.snap
+++ b/modules/nf-core/bcl2fastq/tests/main.nf.test.snap
@@ -1,0 +1,215 @@
+{
+    "homo sapiens illumina [bcl]": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        "Sample1_S1_L001_R1_001.fastq.gz:md5,e92fce7b86c6447b053d72c5cb4be89c"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            [
+                                [
+                                    [
+                                        [
+                                            [
+                                                "lane.html:md5,794e48287f47a9f22dcb6b6d0c22c3eb",
+                                                "laneBarcode.html:md5,2bbdae3ee57151eab520c966597d7438"
+                                            ],
+                                            [
+                                                
+                                            ]
+                                        ]
+                                    ],
+                                    [
+                                        [
+                                            [
+                                                "lane.html:md5,f741870307050dcea79a838f5971770f",
+                                                "laneBarcode.html:md5,ffe2e863811c76cb9da27d5d124e0611"
+                                            ],
+                                            [
+                                                "lane.html:md5,cca97e771d3491dbc8cd3fe389595b09",
+                                                "laneBarcode.html:md5,cca97e771d3491dbc8cd3fe389595b09"
+                                            ]
+                                        ],
+                                        [
+                                            [
+                                                "lane.html:md5,c383b0768d9978733d3f5d3b91c15af0",
+                                                "laneBarcode.html:md5,48842c23b9a2816aec540177df870968"
+                                            ],
+                                            [
+                                                
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                "Report.css:md5,eb7d3eb68fc1539f411404987246b59b",
+                                "index.html:md5,5747c407854ae2c358d0ec201ce622d8",
+                                "tree.html:md5,a1b9bf592973ca829ec69ddf888b7e34"
+                            ]
+                        ]
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "AdapterTrimming.txt:md5,48ed2b914b1246c0b5d8667525550946",
+                            "ConversionStats.xml:md5,8fe0f57f3f5d256a0762dba75ac62d05",
+                            "DemultiplexingStats.xml:md5,2047ff18f5b9107c084de06e9ff943ad",
+                            "DemuxSummaryF1L1.txt:md5,03e5fd0c1e3079c5f8c7b4d0501b37ff",
+                            "FastqSummaryF1L1.txt:md5,0c6f2d87ee183b84d1051cde9a5643d1",
+                            "Stats.json:md5,8e5f038b8aa9e465599d3575f930e604"
+                        ]
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "ControlMetricsOut.bin:md5,6d77b38d0793a6e1ce1e85706e488953",
+                            "CorrectedIntMetricsOut.bin:md5,2bbf84d3be72734addaa2fe794711434",
+                            "ErrorMetricsOut.bin:md5,38c88def138e9bb832539911affdb286",
+                            "ExtractionMetricsOut.bin:md5,7497c3178837eea8f09350b5cd252e99",
+                            "IndexMetricsOut.bin:md5,9e688c58a5487b8eaf69c9e1005ad0bf",
+                            "QMetricsOut.bin:md5,7e9f198d53ebdfbb699a5f94cf1ed51c",
+                            "TileMetricsOut.bin:md5,83891751ec1c91a425a524b476b6ca3c"
+                        ]
+                    ]
+                ],
+                "7": [
+                    "versions.yml:md5,12f3dca40b6a65cec6ba51c0fd872152"
+                ],
+                "fastq": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        "Sample1_S1_L001_R1_001.fastq.gz:md5,e92fce7b86c6447b053d72c5cb4be89c"
+                    ]
+                ],
+                "fastq_idx": [
+                    
+                ],
+                "interop": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "ControlMetricsOut.bin:md5,6d77b38d0793a6e1ce1e85706e488953",
+                            "CorrectedIntMetricsOut.bin:md5,2bbf84d3be72734addaa2fe794711434",
+                            "ErrorMetricsOut.bin:md5,38c88def138e9bb832539911affdb286",
+                            "ExtractionMetricsOut.bin:md5,7497c3178837eea8f09350b5cd252e99",
+                            "IndexMetricsOut.bin:md5,9e688c58a5487b8eaf69c9e1005ad0bf",
+                            "QMetricsOut.bin:md5,7e9f198d53ebdfbb699a5f94cf1ed51c",
+                            "TileMetricsOut.bin:md5,83891751ec1c91a425a524b476b6ca3c"
+                        ]
+                    ]
+                ],
+                "reports": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            [
+                                [
+                                    [
+                                        [
+                                            [
+                                                "lane.html:md5,794e48287f47a9f22dcb6b6d0c22c3eb",
+                                                "laneBarcode.html:md5,2bbdae3ee57151eab520c966597d7438"
+                                            ],
+                                            [
+                                                
+                                            ]
+                                        ]
+                                    ],
+                                    [
+                                        [
+                                            [
+                                                "lane.html:md5,f741870307050dcea79a838f5971770f",
+                                                "laneBarcode.html:md5,ffe2e863811c76cb9da27d5d124e0611"
+                                            ],
+                                            [
+                                                "lane.html:md5,cca97e771d3491dbc8cd3fe389595b09",
+                                                "laneBarcode.html:md5,cca97e771d3491dbc8cd3fe389595b09"
+                                            ]
+                                        ],
+                                        [
+                                            [
+                                                "lane.html:md5,c383b0768d9978733d3f5d3b91c15af0",
+                                                "laneBarcode.html:md5,48842c23b9a2816aec540177df870968"
+                                            ],
+                                            [
+                                                
+                                            ]
+                                        ]
+                                    ]
+                                ],
+                                "Report.css:md5,eb7d3eb68fc1539f411404987246b59b",
+                                "index.html:md5,5747c407854ae2c358d0ec201ce622d8",
+                                "tree.html:md5,a1b9bf592973ca829ec69ddf888b7e34"
+                            ]
+                        ]
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "AdapterTrimming.txt:md5,48ed2b914b1246c0b5d8667525550946",
+                            "ConversionStats.xml:md5,8fe0f57f3f5d256a0762dba75ac62d05",
+                            "DemultiplexingStats.xml:md5,2047ff18f5b9107c084de06e9ff943ad",
+                            "DemuxSummaryF1L1.txt:md5,03e5fd0c1e3079c5f8c7b4d0501b37ff",
+                            "FastqSummaryF1L1.txt:md5,0c6f2d87ee183b84d1051cde9a5643d1",
+                            "Stats.json:md5,8e5f038b8aa9e465599d3575f930e604"
+                        ]
+                    ]
+                ],
+                "undetermined": [
+                    
+                ],
+                "undetermined_idx": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,12f3dca40b6a65cec6ba51c0fd872152"
+                ]
+            }
+        ],
+        "timestamp": "2023-10-25T11:06:04.763448"
+    }
+}

--- a/modules/nf-core/bcl2fastq/tests/nextflow.config
+++ b/modules/nf-core/bcl2fastq/tests/nextflow.config
@@ -1,0 +1,6 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    ext.args = "--tiles s_1_1101"
+}

--- a/modules/nf-core/bcl2fastq/tests/tags.yml
+++ b/modules/nf-core/bcl2fastq/tests/tags.yml
@@ -1,0 +1,2 @@
+bcl2fastq:
+  - modules/nf-core/bcl2fastq/**

--- a/modules/nf-core/bclconvert/tests/main.nf.test
+++ b/modules/nf-core/bclconvert/tests/main.nf.test
@@ -1,0 +1,41 @@
+nextflow_process {
+
+    name "Test Process BCLCONVERT"
+    script "../main.nf"
+    process "BCLCONVERT"
+    config "./nextflow.config"
+    tag "bclconvert"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("homo sapiens illumina [bcl]") {
+        when {
+            process {
+                //TODO use new test dataset when available, see https://github.com/nf-core/test-datasets/issues/996
+                """
+                input[0] = [
+                    [ id: 'test', lane:1 ],
+                    file(params.test_data['homo_sapiens']['illumina']['test_flowcell_samplesheet'], checkIfExists: true),
+                    file(params.test_data['homo_sapiens']['illumina']['test_flowcell'], checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.reports,
+                    process.out.versions,
+                    process.out.fastq,
+                    process.out.undetermined,
+                    file(process.out.logs.get(0).get(1)).list(),
+                    process.out.interop.get(0).get(1).findAll { file(it).name != "IndexMetricsOut.bin" },
+                    ).match()
+                },
+                { assert file(process.out.interop.get(0).get(1).find { file(it).name == "IndexMetricsOut.bin" }).exists() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/bclconvert/tests/main.nf.test
+++ b/modules/nf-core/bclconvert/tests/main.nf.test
@@ -30,7 +30,7 @@ nextflow_process {
                     process.out.versions,
                     process.out.fastq,
                     process.out.undetermined,
-                    file(process.out.logs.get(0).get(1)).list(),
+                    file(process.out.logs.get(0).get(1)).list().sort(),
                     process.out.interop.get(0).get(1).findAll { file(it).name != "IndexMetricsOut.bin" },
                     ).match()
                 },

--- a/modules/nf-core/bclconvert/tests/main.nf.test.snap
+++ b/modules/nf-core/bclconvert/tests/main.nf.test.snap
@@ -45,10 +45,10 @@
                 ]
             ],
             [
-                "Info.log",
                 "Errors.log",
-                "Warnings.log",
-                "FastqComplete.txt"
+                "FastqComplete.txt",
+                "Info.log",
+                "Warnings.log"
             ],
             [
                 "ControlMetricsOut.bin:md5,6d77b38d0793a6e1ce1e85706e488953",
@@ -59,6 +59,6 @@
                 "TileMetricsOut.bin:md5,83891751ec1c91a425a524b476b6ca3c"
             ]
         ],
-        "timestamp": "2023-10-25T11:05:17.96137"
+        "timestamp": "2023-10-25T12:22:57.986028"
     }
 }

--- a/modules/nf-core/bclconvert/tests/main.nf.test.snap
+++ b/modules/nf-core/bclconvert/tests/main.nf.test.snap
@@ -1,0 +1,64 @@
+{
+    "homo sapiens illumina [bcl]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "lane": 1
+                    },
+                    [
+                        "Adapter_Cycle_Metrics.csv:md5,5a0c88793b4a0885fe3dda16609b576e",
+                        "Adapter_Metrics.csv:md5,989240b8840b2169ac1061f952c90f6c",
+                        "Demultiplex_Stats.csv:md5,93949a8cd96f907d83e0808c1ec2a04b",
+                        "Demultiplex_Tile_Stats.csv:md5,83120160b0f22a1303fa1db31c19f6e9",
+                        "IndexMetricsOut.bin:md5,9e688c58a5487b8eaf69c9e1005ad0bf",
+                        "Index_Hopping_Counts.csv:md5,1059369e375fd8f8423c0f6c934be978",
+                        "Quality_Metrics.csv:md5,6614accb1bb414fe312b17b81f5521f7",
+                        "Quality_Tile_Metrics.csv:md5,cdc89fd2962bdd4a24f71e186112118a",
+                        "RunInfo.xml:md5,03038959f4dd181c86bc97ae71fe270a",
+                        "SampleSheet.csv:md5,dc0dffd39541dd6cc5b4801d768a8d2b",
+                        "Top_Unknown_Barcodes.csv:md5,2e2faba761137f228e56bd3428453ccc",
+                        "fastq_list.csv:md5,05bc84f51840f5754cfb8381b36f2cb0"
+                    ]
+                ]
+            ],
+            [
+                "versions.yml:md5,1ad1883e3876b00123255445f1e57f52"
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "lane": 1
+                    },
+                    "Sample1_S1_L001_R1_001.fastq.gz:md5,0a0341e2990b4fa1d9ad4b4c603144c1"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "lane": 1
+                    },
+                    "Undetermined_S0_L001_R1_001.fastq.gz:md5,febef808ae5397ea4ee7ee40e5fd39e0"
+                ]
+            ],
+            [
+                "Info.log",
+                "Errors.log",
+                "Warnings.log",
+                "FastqComplete.txt"
+            ],
+            [
+                "ControlMetricsOut.bin:md5,6d77b38d0793a6e1ce1e85706e488953",
+                "CorrectedIntMetricsOut.bin:md5,2bbf84d3be72734addaa2fe794711434",
+                "ErrorMetricsOut.bin:md5,38c88def138e9bb832539911affdb286",
+                "ExtractionMetricsOut.bin:md5,7497c3178837eea8f09350b5cd252e99",
+                "QMetricsOut.bin:md5,7e9f198d53ebdfbb699a5f94cf1ed51c",
+                "TileMetricsOut.bin:md5,83891751ec1c91a425a524b476b6ca3c"
+            ]
+        ],
+        "timestamp": "2023-10-25T11:05:17.96137"
+    }
+}

--- a/modules/nf-core/bclconvert/tests/nextflow.config
+++ b/modules/nf-core/bclconvert/tests/nextflow.config
@@ -1,0 +1,10 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    ext.args = {[
+        meta.lane ? "--bcl-only-lane ${meta.lane}" : "",
+        "--force",
+        "--first-tile-only true"
+    ].join(" ").trim()}
+}

--- a/modules/nf-core/bclconvert/tests/tags.yml
+++ b/modules/nf-core/bclconvert/tests/tags.yml
@@ -1,0 +1,2 @@
+bclconvert:
+  - modules/nf-core/bclconvert/**

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -331,11 +331,6 @@ bcftools/view:
   - modules/nf-core/bcftools/view/**
   - tests/modules/nf-core/bcftools/view/**
 
-bcl2fastq:
-  - modules/nf-core/bcl2fastq/**
-  - modules/nf-core/untar/**
-  - tests/modules/nf-core/bcl2fastq/**
-
 bclconvert:
   - modules/nf-core/bclconvert/**
   - modules/nf-core/untar/**

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -331,11 +331,6 @@ bcftools/view:
   - modules/nf-core/bcftools/view/**
   - tests/modules/nf-core/bcftools/view/**
 
-bclconvert:
-  - modules/nf-core/bclconvert/**
-  - modules/nf-core/untar/**
-  - tests/modules/nf-core/bclconvert/**
-
 beagle5/beagle:
   - modules/nf-core/beagle5/beagle/**
   - tests/modules/nf-core/beagle5/beagle/**


### PR DESCRIPTION
This PR converts the bclconvert and bcl2fastq tests to nf-test.

NB: the `TODO` statements are imported from the old pytest tests

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Follow the naming conventions.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`