### PR TITLE
Use "error" rather than "exit 1", and removed `quay.io/`

### DIFF
--- a/modules/nf-core/cellrangeratac/count/main.nf
+++ b/modules/nf-core/cellrangeratac/count/main.nf
@@ -6,7 +6,7 @@ process CELLRANGERATAC_COUNT {
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "CELLRANGERATAC_COUNT module does not support Conda. Please use Docker / Singularity / Podman instead."
+        error "CELLRANGERATAC_COUNT module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
 
     input:

--- a/modules/nf-core/cellrangeratac/mkfastq/main.nf
+++ b/modules/nf-core/cellrangeratac/mkfastq/main.nf
@@ -6,7 +6,7 @@ process CELLRANGERATAC_MKFASTQ {
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "CELLRANGERATAC_MKFASTQ module does not support Conda. Please use Docker / Singularity / Podman instead."
+        error "CELLRANGERATAC_MKFASTQ module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
 
     input:

--- a/modules/nf-core/cellrangeratac/mkref/main.nf
+++ b/modules/nf-core/cellrangeratac/mkref/main.nf
@@ -6,7 +6,7 @@ process CELLRANGERATAC_MKREF {
 
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "CELLRANGERATAC_MKREF module does not support Conda. Please use Docker / Singularity / Podman instead."
+        error "CELLRANGERATAC_MKREF module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
 
     input:

--- a/modules/nf-core/ganon/buildcustom/main.nf
+++ b/modules/nf-core/ganon/buildcustom/main.nf
@@ -5,7 +5,7 @@ process GANON_BUILDCUSTOM {
     conda 'modules/nf-core/ganon/buildcustom/environment.yml'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ganon:1.5.1--py310h8abeb55_0':
-        'quay.io/biocontainers/ganon:1.5.1--py310h8abeb55_0' }"
+        'biocontainers/ganon:1.5.1--py310h8abeb55_0' }"
 
     input:
     tuple val(meta), path(input)

--- a/modules/nf-core/icountmini/segment/main.nf
+++ b/modules/nf-core/icountmini/segment/main.nf
@@ -5,7 +5,7 @@ process ICOUNTMINI_SEGMENT {
     conda 'modules/nf-core/icountmini/segment/environment.yml'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/icount-mini:2.0.3--pyh5e36f6f_0' :
-        'quay.io/biocontainers/icount-mini:2.0.3--pyh5e36f6f_0' }"
+        'biocontainers/icount-mini:2.0.3--pyh5e36f6f_0' }"
 
     input:
     tuple val(meta), path(gtf)

--- a/modules/nf-core/kmcp/index/main.nf
+++ b/modules/nf-core/kmcp/index/main.nf
@@ -5,7 +5,7 @@ process KMCP_INDEX {
     conda 'modules/nf-core/kmcp/index/environment.yml'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/kmcp:0.9.1--h9ee0642_0':
-        'quay.io/biocontainers/kmcp:0.9.1--h9ee0642_0' }"
+        'biocontainers/kmcp:0.9.1--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(compute_dir)

--- a/modules/nf-core/kmcp/merge/main.nf
+++ b/modules/nf-core/kmcp/merge/main.nf
@@ -6,7 +6,7 @@ process KMCP_MERGE {
     conda 'modules/nf-core/kmcp/merge/environment.yml'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/kmcp:0.9.1--h9ee0642_0':
-        'quay.io/biocontainers/kmcp:0.9.1--h9ee0642_0' }"
+        'biocontainers/kmcp:0.9.1--h9ee0642_0' }"
 
 
     input:

--- a/modules/nf-core/mitohifi/mitohifi/main.nf
+++ b/modules/nf-core/mitohifi/mitohifi/main.nf
@@ -37,14 +37,14 @@ process MITOHIFI_MITOHIFI {
     script:
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "MitoHiFi module does not support Conda. Please use Docker / Singularity instead."
+        error "MitoHiFi module does not support Conda. Please use Docker / Singularity instead."
     }
 
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def script_input = args2.equals("-r") ? "-r ${input}" :
                 args2.equals("-c") ? "-c ${input}" :
-                exit("-r for reads or -c for contigs must be specified")
+                error "-r for reads or -c for contigs must be specified"
     """
     mitohifi.py ${script_input} \\
         -f ${ref_fa} \\

--- a/modules/nf-core/mitohifi/mitohifi/main.nf
+++ b/modules/nf-core/mitohifi/mitohifi/main.nf
@@ -42,9 +42,10 @@ process MITOHIFI_MITOHIFI {
 
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
-    def script_input = args2.equals("-r") ? "-r ${input}" :
-                args2.equals("-c") ? "-c ${input}" :
-                error "-r for reads or -c for contigs must be specified"
+    if (! ["-c", "-r"].contains(args2)) {
+        error "-r for reads or -c for contigs must be specified"
+    }
+    def script_input = "${args2} ${input}"
     """
     mitohifi.py ${script_input} \\
         -f ${ref_fa} \\

--- a/modules/nf-core/purecn/coverage/main.nf
+++ b/modules/nf-core/purecn/coverage/main.nf
@@ -7,7 +7,7 @@ process PURECN_COVERAGE {
     conda 'modules/nf-core/purecn/coverage/environment.yml'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0':
-        'quay.io/biocontainers/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0' }"
+        'biocontainers/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/purecn/coverage/main.nf
+++ b/modules/nf-core/purecn/coverage/main.nf
@@ -30,9 +30,9 @@ process PURECN_COVERAGE {
     def VERSION = '2.4.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
     if (task.stageInMode != 'link') {
-        System.err.println("ERROR: purecn/coverage can not handle staging files with symlinks. Please change the stageInmode option to 'Link'")
-        System.exit(1)
-    } else {
+        error "purecn/coverage can not handle staging files with symlinks. Please change the stageInmode option to 'Link'"
+    }
+
     """
     library_path=\$(Rscript -e 'cat(.libPaths(), sep = "\\n")')
     Rscript "\$library_path"/PureCN/extdata/Coverage.R \\
@@ -47,7 +47,6 @@ process PURECN_COVERAGE {
         purecn: ${VERSION}
     END_VERSIONS
     """
-    }
 
     stub:
 
@@ -59,9 +58,9 @@ process PURECN_COVERAGE {
     def VERSION = '2.4.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
     if (task.stageInMode != 'link') {
-        System.err.println("ERROR: purecn/coverage can not handle staging files with symlinks. Please change the stageInmode option to 'Link'")
-        System.exit(1)
-    } else {
+        error "purecn/coverage can not handle staging files with symlinks. Please change the stageInmode option to 'Link'"
+    }
+
     """
     touch ${prefix}.txt
     touch ${prefix}.bed
@@ -74,5 +73,4 @@ process PURECN_COVERAGE {
         purecn: ${VERSION}
     END_VERSIONS
     """
-    }
 }

--- a/modules/nf-core/purecn/normaldb/main.nf
+++ b/modules/nf-core/purecn/normaldb/main.nf
@@ -6,7 +6,7 @@ process PURECN_NORMALDB {
     conda 'modules/nf-core/purecn/normaldb/environment.yml'
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0':
-        'quay.io/biocontainers/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0' }"
+        'biocontainers/mulled-v2-582ac26068889091d5e798347c637f8208d77a71:a29c64a63498b1ee8b192521fdf6ed3c65506994-0' }"
 
     input:
     tuple val(meta), path(coverage_files), path(normal_vcf), path(normal_vcf_tbi)


### PR DESCRIPTION
1. @mahesh-panchal found an instance of `exit 1` in `mitohifi/mitohifi` after #4193 got merged. I found a few other instances across modules and decided to open a separate pull-request. I believe the rationale for using "error" instead of "exit 1" is expressed in #3683.
2. One of those modules was still using `quay.io/` as a container prefix, so I added another commit that removes the prefix from the few modules that still had it (see #3380).

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
