### PR TITLE
Add ngscheckmate bed file to test_data config

### DIFF
--- a/tests/config/test_data.config
+++ b/tests/config/test_data.config
@@ -287,6 +287,7 @@ params {
                 haplotype_map                                  = "${params.test_data_base}/data/genomics/homo_sapiens/genome/chr21/germlineresources/haplotype_map.txt"
                 dbNSFP_4_1a_21_hg38_txt_gz                     = "${params.test_data_base}/data/genomics/homo_sapiens/genome/chr21/germlineresources/dbNSFP4.1a.21.txt.gz"
                 dbNSFP_4_1a_21_hg38_txt_tbi                    = "${params.test_data_base}/data/genomics/homo_sapiens/genome/chr21/germlineresources/dbNSFP4.1a.21.txt.gz.tbi"
+                ngscheckmate_bed                               = "${params.test_data_base}/data/genomics/homo_sapiens/genome/chr21/germlineresources/SNP_GRCh38_hg38_wChr.bed"
 
                 index_salmon                                   = "${params.test_data_base}/data/genomics/homo_sapiens/genome/index/salmon"
                 repeat_expansions                              = "${params.test_data_base}/data/genomics/homo_sapiens/genome/loci/repeat_expansions.json"


### PR DESCRIPTION
Adding the chr21 version of the NGSCheckMate bed file to the config so it can be used.