### PR TITLE
Update: Nonpareil modules - latest biocontainer build for all modules

### DIFF
--- a/modules/nf-core/nonpareil/curve/main.nf
+++ b/modules/nf-core/nonpareil/curve/main.nf
@@ -4,8 +4,8 @@ process NONPAREIL_CURVE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nonpareil:3.4.1--r42h9f5acd7_2':
-        'biocontainers/nonpareil:3.4.1--r42h9f5acd7_2' }"
+        'https://depot.galaxyproject.org/singularity/nonpareil:3.4.1--r42h4ac6f70_4':
+        'biocontainers/nonpareil:3.4.1--r42h4ac6f70_4' }"
 
     input:
     tuple val(meta), path(npo)

--- a/modules/nf-core/nonpareil/nonpareil/main.nf
+++ b/modules/nf-core/nonpareil/nonpareil/main.nf
@@ -1,12 +1,11 @@
-
 process NONPAREIL_NONPAREIL {
     tag "$meta.id"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nonpareil:3.4.1--r42h9f5acd7_3':
-        'biocontainers/nonpareil:3.4.1--r42h9f5acd7_3' }"
+        'https://depot.galaxyproject.org/singularity/nonpareil:3.4.1--r42h4ac6f70_4':
+        'biocontainers/nonpareil:3.4.1--r42h4ac6f70_4' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/nonpareil/set/main.nf
+++ b/modules/nf-core/nonpareil/set/main.nf
@@ -4,8 +4,8 @@ process NONPAREIL_SET {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nonpareil:3.4.1--r42h9f5acd7_2':
-        'biocontainers/nonpareil:3.4.1--r42h9f5acd7_2' }"
+        'https://depot.galaxyproject.org/singularity/nonpareil:3.4.1--r42h4ac6f70_4':
+        'biocontainers/nonpareil:3.4.1--r42h4ac6f70_4' }"
 
     input:
     tuple val(meta), path(npos)


### PR DESCRIPTION
I'm very confused why nf-core tools picked up two different types, and older ones at that... but now in sync to prevent multiple containers being downloaded in one pipeline run

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
