### PR TITLE
Revert "run migration notice on pull_request_target"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-  pull_request_target:
-    branches: [master]
   merge_group:
     types: [checks_requested]
     branches: [master]
@@ -160,7 +158,7 @@ jobs:
     steps:
       - name: Migration Comment
         uses: mshick/add-pr-comment@v2
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           message: |
             Hello!


### PR DESCRIPTION
Reverts nf-core/modules#4421
Because it makes paths-filer fail https://github.com/nf-core/modules/actions/runs/7006198435/job/19057567113?pr=4423