### PR TITLE
Emit gffread_gff output channel when '-T' argument is absent

### DIFF
--- a/modules/nf-core/gffread/main.nf
+++ b/modules/nf-core/gffread/main.nf
@@ -11,20 +11,22 @@ process GFFREAD {
     path gff
 
     output:
-    path "*.gtf"        , emit: gtf
+    path "*.gtf"        , emit: gtf         , optional: true
+    path "*.gff3"       , emit: gffread_gff , optional: true
     path "versions.yml" , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args   = task.ext.args   ?: ''
-    def prefix = task.ext.prefix ?: "${gff.baseName}"
+    def args        = task.ext.args   ?: ''
+    def prefix      = task.ext.prefix ?: "${gff.baseName}"
+    def extension   = args.contains("-T") ? 'gtf' : 'gffread.gff3'
     """
     gffread \\
         $gff \\
         $args \\
-        -o ${prefix}.gtf
+        -o ${prefix}.${extension}
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         gffread: \$(gffread --version 2>&1)

--- a/modules/nf-core/gffread/meta.yml
+++ b/modules/nf-core/gffread/meta.yml
@@ -20,8 +20,12 @@ input:
 output:
   - gtf:
       type: file
-      description: GTF file resulting from the conversion of the GFF input file
+      description: GTF file resulting from the conversion of the GFF input file if '-T' argument is present
       pattern: "*.{gtf}"
+  - gffread_gff:
+      type: file
+      description: GFF3 file resulting from the conversion of the GFF input file if '-T' argument is absent
+      pattern: "*.{gff3}"
   - versions:
       type: file
       description: File containing software versions

--- a/modules/nf-core/gffread/tests/main.nf.test
+++ b/modules/nf-core/gffread/tests/main.nf.test
@@ -3,11 +3,14 @@ nextflow_process {
     name "Test Process GFFREAD"
     script "../main.nf"
     process "GFFREAD"
+
     tag "gffread"
     tag "modules_nfcore"
     tag "modules"
 
-    test("Should run without failures") {
+    test("sarscov2-gff3-gtf") {
+
+        config "./nextflow.config"
 
         when {
             params {
@@ -23,7 +26,33 @@ nextflow_process {
         then {
             assertAll (
             { assert process.success },
-            { assert snapshot(process.out).match() }
+            { assert snapshot(process.out).match() },
+            { assert process.out.gtf != null },
+            { assert process.out.gffread_gff == [] }
+            )
+        }
+
+    }
+
+    test("sarscov2-gff3-gff3") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = file(params.test_data['sarscov2']['genome']['genome_gff3'], checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll (
+            { assert process.success },
+            { assert snapshot(process.out).match() },
+            { assert process.out.gtf == [] },
+            { assert process.out.gffread_gff != null },
             )
         }
 

--- a/modules/nf-core/gffread/tests/main.nf.test.snap
+++ b/modules/nf-core/gffread/tests/main.nf.test.snap
@@ -1,21 +1,52 @@
 {
-    "Should run without failures": {
+    "sarscov2-gff3-gtf": {
         "content": [
             {
                 "0": [
-                    "genome.gtf:md5,f184f856b7fe3e159d21b052b5dd3954"
+                    "genome.gtf:md5,2394072d7d31530dfd590c4a117bf6e3"
                 ],
                 "1": [
+                    
+                ],
+                "2": [
                     "versions.yml:md5,a71b6cdfa528dd206a238ec64bae13d6"
                 ],
+                "gffread_gff": [
+                    
+                ],
                 "gtf": [
-                    "genome.gtf:md5,f184f856b7fe3e159d21b052b5dd3954"
+                    "genome.gtf:md5,2394072d7d31530dfd590c4a117bf6e3"
                 ],
                 "versions": [
                     "versions.yml:md5,a71b6cdfa528dd206a238ec64bae13d6"
                 ]
             }
         ],
-        "timestamp": "2023-10-17T10:00:08.542490523"
+        "timestamp": "2023-11-29T15:39:30.006985"
+    },
+    "sarscov2-gff3-gff3": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    "genome.gffread.gff3:md5,a7d40d99dcddac23ac673c473279ea2d"
+                ],
+                "2": [
+                    "versions.yml:md5,a71b6cdfa528dd206a238ec64bae13d6"
+                ],
+                "gffread_gff": [
+                    "genome.gffread.gff3:md5,a7d40d99dcddac23ac673c473279ea2d"
+                ],
+                "gtf": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,a71b6cdfa528dd206a238ec64bae13d6"
+                ]
+            }
+        ],
+        "timestamp": "2023-11-29T15:39:34.636061"
     }
 }

--- a/modules/nf-core/gffread/tests/nextflow.config
+++ b/modules/nf-core/gffread/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: GFFREAD {
+        ext.args = '-T'
+    }
+}


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] Added an optional `gffread_gff` channel so that a gff3 file can be correctly emitted from the module. This change should not affect the existing module users.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
