### PR TITLE
Remove leftover symlinks to build

### DIFF
--- a/tests/modules/nf-core/bowtie2/build
+++ b/tests/modules/nf-core/bowtie2/build
@@ -1,1 +1,0 @@
-build_test/

--- a/tests/modules/nf-core/hisat2/build
+++ b/tests/modules/nf-core/hisat2/build
@@ -1,1 +1,0 @@
-build_test/


### PR DESCRIPTION
Removes some left over symlinks to folders that no longer exist, that were [breaking pytest](https://github.com/nf-core/modules/actions/runs/7095156771/job/19316099849).