### PR TITLE
Condense linting workflows to one job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -593,7 +593,7 @@ jobs:
 
   confirm-pass:
     runs-on: ubuntu-latest
-    needs: [prettier, editorconfig, pytest-changes, nf-core-lint, pytest, nf-test-changes, nf-test]
+    needs: [lint, pytest-changes, nf-core-lint, pytest, nf-test-changes, nf-test]
     if: always()
     steps:
       - name: All tests ok

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,13 @@ jobs:
       - name: Run ECLint check
         run: editorconfig-checker -exclude README.md $(git ls-files | grep -v test)
 
-  pytest-changes:
-    name: pytest-changes
+  changes:
+    name: changes
     runs-on: ubuntu-latest
     outputs:
       # Expose matched filters as job 'modules' output variable
-      modules: ${{ steps.filter.outputs.changes }}
+      pytest-modules: ${{ steps.pytest-filter.outputs.changes }}
+      nf-test-modules: ${{ steps.nf-test-filter.outputs.changes }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,21 +63,10 @@ jobs:
 
       # TODO: change back to using dorny/paths-filter when https://github.com/dorny/paths-filter/pull/133 is implemented
       - uses: mirpedrol/paths-filter@main
-        id: filter
+        id: pytest-filter
         with:
           filters: "tests/config/pytest_modules.yml"
           token: ""
-
-  nf-test-changes:
-    name: nf-test-changes
-    runs-on: ubuntu-latest
-    outputs:
-      # Expose matched filters as job 'modules' output variable
-      modules: ${{ steps.filter.outputs.changes }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2 # To retrieve the preceding commit.
 
       - name: Combine all tags.yml files
         id: get_tags
@@ -87,7 +77,7 @@ jobs:
 
       # TODO: change back to using dorny/paths-filter when https://github.com/dorny/paths-filter/pull/133 is implemented
       - uses: mirpedrol/paths-filter@main
-        id: filter
+        id: nf-test-filter
         with:
           filters: ".github/tags.yml"
           token: ""
@@ -95,15 +85,15 @@ jobs:
   nf-core-lint:
     runs-on: ubuntu-latest
     name: nf-core-lint
-    needs: [pytest-changes, nf-test-changes]
-    if: ${{ (needs.pytest-changes.outputs.modules != '[]') || (needs.nf-test-changes.outputs.modules != '[]') }}
+    needs: [changes]
+    if: ${{ (needs.changes.outputs.pytest-modules != '[]') || (needs.changes.outputs.nf-test-modules != '[]') }}
     strategy:
       fail-fast: false
       matrix:
         tags:
           [
-            "${{ fromJson(needs.pytest-changes.outputs.modules) }}",
-            "${{ fromJson(needs.nf-test-changes.outputs.modules) }}",
+            "${{ fromJson(needs.changes.outputs.nf-test-modules) }}",
+            "${{ fromJson(needs.changes.outputs.nf-test-modules) }}",
           ]
     steps:
       - uses: actions/checkout@v4
@@ -148,12 +138,12 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     name: pytest
-    needs: [pytest-changes]
-    if: needs.pytest-changes.outputs.modules != '[]'
+    needs: [changes]
+    if: needs.changes.outputs.pytest-modules != '[]'
     strategy:
       fail-fast: false
       matrix:
-        tags: ["${{ fromJson(needs.pytest-changes.outputs.modules) }}"]
+        tags: ["${{ fromJson(needs.changes.outputs.pytest-modules) }}"]
         profile: ["docker", "singularity", "conda"]
         exclude:
           - tags: "nf-test"
@@ -427,12 +417,12 @@ jobs:
   nf-test:
     runs-on: ubuntu-latest
     name: nf-test
-    needs: [nf-test-changes]
-    if: needs.nf-test-changes.outputs.modules != '[]'
+    needs: [changes]
+    if: needs.changes.outputs.nf-test-modules != '[]'
     strategy:
       fail-fast: false
       matrix:
-        tags: ["${{ fromJson(needs.nf-test-changes.outputs.modules) }}"]
+        tags: ["${{ fromJson(needs.changes.outputs.nf-test-modules) }}"]
         profile: ["docker", "singularity", "conda"]
         exclude:
           - tags: "nf-test"
@@ -593,7 +583,7 @@ jobs:
 
   confirm-pass:
     runs-on: ubuntu-latest
-    needs: [lint, pytest-changes, nf-core-lint, pytest, nf-test-changes, nf-test]
+    needs: [lint, nf-core-lint, pytest, nf-test]
     if: always()
     steps:
       - name: All tests ok

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,23 +19,11 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  pre-commit:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3.0.0
-        # FIXME Flip this off once we get to less than a couple hundred. Adding
-        # this so it will only run against changed files. It'll make it much
-        # easier to fix these as they come up rather than everything at once.
-        with:
-          extra_args: ""
-
-  prettier:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
 
       - name: Install NodeJS
         uses: actions/setup-node@v4
@@ -45,20 +33,18 @@ jobs:
       - name: Install Prettier
         run: npm install -g prettier
 
-      - name: Run Prettier --check
-        run: prettier --check .
-
-  editorconfig:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
       - name: Install editorconfig-checker
         run: npm install -g editorconfig-checker
+
+      - uses: pre-commit/action@v3.0.0
+        # FIXME Flip this off once we get to less than a couple hundred. Adding
+        # this so it will only run against changed files. It'll make it much
+        # easier to fix these as they come up rather than everything at once.
+        with:
+          extra_args: ""
+
+      - name: Run Prettier --check
+        run: prettier --check .
 
       - name: Run ECLint check
         run: editorconfig-checker -exclude README.md $(git ls-files | grep -v test)

--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -30,6 +30,8 @@ process FASTQC {
         [ -f "\${new_name}" ] || ln -s \$old_name \$new_name
     done
 
+    # I'm a fake change.
+    
     fastqc \\
         $args \\
         --threads $task.cpus \\


### PR DESCRIPTION
- Condense multiple linting jobs into single linting job
- Condense two check-changes jobs to single job with two outputs

Will require a change on the branch protection.