### PR TITLE
Now throwing an error if CAT_CAT prefix is not correctly configured

### DIFF
--- a/modules/nf-core/cat/cat/main.nf
+++ b/modules/nf-core/cat/cat/main.nf
@@ -35,6 +35,7 @@ process CAT_CAT {
     in_zip   = file_list[0].endsWith('.gz')
     command1 = (in_zip && !out_zip) ? 'zcat' : 'cat'
     command2 = (!in_zip && out_zip) ? "| pigz -c -p $task.cpus $args2" : ''
+    if(file_list.contains(prefix.trim())) { error "CAT_CAT prefix $prefix is conflicted with an input file name" }
     """
     $command1 \\
         $args \\
@@ -51,6 +52,7 @@ process CAT_CAT {
     stub:
     def file_list = files_in.collect { it.toString() }
     prefix   = task.ext.prefix ?: "${meta.id}${file_list[0].substring(file_list[0].lastIndexOf('.'))}"
+    if(file_list.contains(prefix.trim())) { error "CAT_CAT prefix $prefix is conflicted with an input file name" }
     """
     touch $prefix
 

--- a/modules/nf-core/cat/cat/tests/main.nf.test
+++ b/modules/nf-core/cat/cat/tests/main.nf.test
@@ -8,6 +8,32 @@ nextflow_process {
     tag "cat"
     tag "cat/cat"
 
+    test("test_cat_name_conflict") {
+        when {
+            params {
+                outdir   = "${outputDir}"
+            }
+            process {
+                """
+                input[0] =
+                    [
+                        [ id:'genome', single_end:true ],
+                        [
+                            file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
+                            file(params.test_data['sarscov2']['genome']['genome_sizes'], checkIfExists: true)
+                        ]
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("CAT_CAT prefix genome.fasta is conflicted with an input file name") }
+            )
+        }
+    }
+
     test("test_cat_unzipped_unzipped") {
         when {
             params {


### PR DESCRIPTION
## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] In some situations CAT_CAT must be configured through `ext.prefix` so that it assigns an output file name which does not conflict with any input file name. An example is a workflow which takes a `fasta`, performs 2 parallel operations on the `fasta` to produce two bam files and then cats these bams into a single bam. If the same `meta` is propagated through the workflow and if the developer does not configure CAT_CAT, it can lead to file overwrite without any warning. Detecting the resultant bug can be hard and time consuming. Now, CAT_CAT will throw an error in such a situation.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
