### PR TITLE
Added a SAMTOOLS_PIPELINE to run multiple samtools commands at once

### DIFF
--- a/modules/nf-core/samtools/pipeline/environment.yml
+++ b/modules/nf-core/samtools/pipeline/environment.yml
@@ -1,0 +1,7 @@
+name: samtools_pipeline
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.18

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -46,29 +46,29 @@ process SAMTOOLS_PIPELINE {
             case !"reheader":
                 // "reheader" is the only command not to offer these
                 command << "-@ $task.cpus"
-                command << fasta && last ? "--reference ${fasta}" : ''
-                command << !last ? '-u' : ''
+                command << (fasta && last ? "--reference ${fasta}" : '')
+                command << (!last ? '-u' : '')
                 // NOTE: no "break" here because we want to run the next batch of "case"
 
             //// Then the input/ouput parameters, which differ between commands
             case "collate":
                 // [-o OUTPUT|-O] [INPUT|-]
-                command << last ? "-o ${prefix}.${extension}" : "-O"
-                command << first ? input : '-'
+                command << (last ? "-o ${prefix}.${extension}" : "-O")
+                command << (first ? input : '-')
                 break
             case ["addreplacerg", "sort", "view"]:
                 // [-o OUTPUT] [INPUT|-]
-                command << last ? "-o ${prefix}.${extension}" : ""
-                command << first ? input : '-'
+                command << (last ? "-o ${prefix}.${extension}" : "")
+                command << (first ? input : '-')
                 break
             case "reheader":
                 // [INPUT|-]
-                command << first ? input : '-'
+                command << (first ? input : '-')
                 break
             case ["fixmate", "markdup"]:
                 // [INPUT|-] [OUTPUT|-]
-                command << first ? input : '-'
-                command << last ? "${prefix}.${extension}" : "-"
+                command << (first ? input : '-')
+                command << (last ? "${prefix}.${extension}" : "-")
                 break
             default:
                 assert false: "$cmd is not supported"

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -86,7 +86,15 @@ process SAMTOOLS_PIPELINE {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def cmd_size  = commands.size()
+    def last_args = task.ext."args$cmd_size" ?: ''
+    def extension = last_args.contains("--output-fmt sam") ? "sam" :
+                    last_args.contains("--output-fmt bam") ? "bam" :
+                    last_args.contains("--output-fmt cram") ? "cram" :
+                    input.extension
+    assert "$input" != "${prefix}.${extension}" : "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+
     """
     touch ${prefix}.${extension}
 

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -40,12 +40,15 @@ process SAMTOOLS_PIPELINE {
             task.ext."args${first ? '' : index+1}" ?: ''
         ]
         switch(cmd){
+            //// First the common options
             case !"reheader":
-                // The reheader has no useful option
+                // "reheader" is the only command not to offer these
                 command << "-@ $task.cpus"
                 command << fasta && last ? "--reference ${fasta}" : ''
                 command << !last ? '-u' : ''
-            // samtools commands have slightly different syntax
+                // NOTE: no "break" here because we want to run the next batch of "case"
+
+            //// Then the input/ouput parameters, which differ between commands
             case "collate":
                 // [-o OUTPUT|-O] [INPUT|-]
                 command << last ? "-o ${prefix}.${extension}" : "-O"

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -89,4 +89,15 @@ process SAMTOOLS_PIPELINE {
         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
     END_VERSIONS
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.${extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -14,6 +14,7 @@ process SAMTOOLS_PIPELINE {
 
     output:
     tuple val(meta), path("*.{bam,cram,sam}"), emit: output
+    tuple val(meta), path("*.{bai,csi,crai}"), emit: index, optional: true
     path "versions.yml",                       emit: versions
 
     when:

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -1,0 +1,92 @@
+process SAMTOOLS_PIPELINE {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samtools:1.18--h50ea8bc_1':
+        'biocontainers/samtools:1.18--h50ea8bc_1' }"
+
+    input:
+    tuple val(meta), path(input)
+    tuple val(meta2), path(fasta)
+    val commands
+
+    output:
+    tuple val(meta), path("*.{bam,cram,sam}"), emit: output
+    path "versions.yml",                       emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+
+    // Check that we are asked to run a pipeline
+    def n_commands = commands.size()
+    if (n_commands < 2) error "SAMTOOLS_PIPELINE is used to chain 2 or more samtools commands"
+
+    // Fetch the arguments
+    def all_args = []
+    for (int index = 0; index < n_commands; index++) {
+        all_args.add( task.ext.args?[ commands[index] ] ?: '' )
+    }
+    def last_args = all_args[-1]
+
+    // Output file
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference = fasta ? "--reference ${fasta}" : ""
+    def extension = last_args.contains("--output-fmt sam") ? "sam" :
+                    last_args.contains("--output-fmt bam") ? "bam" :
+                    last_args.contains("--output-fmt cram") ? "cram" :
+                    "bam"
+    if ("$input" == "${prefix}.${extension}") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+
+    def pipeline_command = ""
+    for (int index = 0; index < commands.size(); index++) {
+        def this_command = """
+        samtools \\
+            ${commands[index]} \\
+            ${all_args[index]} \\
+            -@ $task.cpus \\
+        """
+        if (commands[index] != "fixmate") {
+            this_command += "    -T ${prefix}.tmp.${commands[index]} \\\n"
+        }
+        this_command += "    "
+        if (index < (n_commands - 1)) {
+            this_command += "-u "
+        }
+        this_input = (index ? "-" : "$input")
+        if (["collate", "sort"].contains(commands[index])) {
+            if (index == (n_commands - 1)) {
+                this_command += "-o ${prefix}.${extension} "
+            } else {
+                if (commands[index] != "sort") {
+                    this_command += "-O "
+                }
+            }
+            this_command += this_input
+        } else {
+            // e.g. fixmate, markdup
+            this_command += this_input
+            if (index == (n_commands - 1)) {
+                this_command += " ${prefix}.${extension}"
+            } else {
+                this_command += " -"
+            }
+        }
+        pipeline_command += this_command
+        if (index < (n_commands - 1)) {
+            pipeline_command += " | \\"
+        }
+    }
+
+    """
+    $pipeline_command
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -41,16 +41,15 @@ process SAMTOOLS_PIPELINE {
             "samtools $cmd",
             task.ext."args${first ? '' : index+1}" ?: ''
         ]
+        // First the common options
+        if (cmd != "reheader") {
+            // "reheader" is the only command not to offer these
+            command << "-@ $task.cpus"
+            command << (fasta && last ? "--reference ${fasta}" : '')
+            command << (!last ? '-u' : '')
+        }
+        // Then the input/ouput parameters, which differ between commands
         switch(cmd){
-            //// First the common options
-            case !"reheader":
-                // "reheader" is the only command not to offer these
-                command << "-@ $task.cpus"
-                command << (fasta && last ? "--reference ${fasta}" : '')
-                command << (!last ? '-u' : '')
-                // NOTE: no "break" here because we want to run the next batch of "case"
-
-            //// Then the input/ouput parameters, which differ between commands
             case "collate":
                 // [-o OUTPUT|-O] [INPUT|-]
                 command << (last ? "-o ${prefix}.${extension}" : "-O")

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -47,17 +47,15 @@ process SAMTOOLS_PIPELINE {
         def is_last_command = (index == (n_commands - 1))
 
         pipeline_command += """
-        samtools ${this_command} ${all_args[index]} -@ $task.cpus \\
+        samtools ${this_command} ${all_args[index]} \\
         """
 
-        if (is_last_command) {
-            // All commands support --reference, except reheader
-            if (! ["reheader"].contains(this_command)) {
+        // The reheader has no useful option
+        if (! ["reheader"].contains(this_command)) {
+            pipeline_command += " -@ $task.cpus"
+            if (is_last_command) {
                 pipeline_command += fasta ? " --reference ${fasta}" : ""
-            }
-        } else {
-            // All commands support uncompressed output, except reheader
-            if (! ["reheader"].contains(this_command)) {
+            } else {
                 pipeline_command += " -u"
             }
         }

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -49,20 +49,20 @@ process SAMTOOLS_PIPELINE {
             case "collate":
                 // [-o OUTPUT|-O] [INPUT|-]
                 command << last ? "-o ${prefix}.${extension}" : "-O"
-                command << first ? index : '-'
+                command << first ? input : '-'
                 break
             case ["addreplacerg", "sort", "view"]:
                 // [-o OUTPUT] [INPUT|-]
                 command << last ? "-o ${prefix}.${extension}" : ""
-                command << first ? index : '-'
+                command << first ? input : '-'
                 break
             case "reheader":
                 // [INPUT|-]
-                command << first ? index : '-'
+                command << first ? input : '-'
                 break
             case ["fixmate", "markdup"]:
                 // [INPUT|-] [OUTPUT|-]
-                command << first ? index : '-'
+                command << first ? input : '-'
                 command << last ? "${prefix}.${extension}" : "-"
                 break
             default:

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -30,7 +30,7 @@ process SAMTOOLS_PIPELINE {
     def extension = last_args.contains("--output-fmt sam") ? "sam" :
                     last_args.contains("--output-fmt bam") ? "bam" :
                     last_args.contains("--output-fmt cram") ? "cram" :
-                    "bam"
+                    input.extension
     assert "$input" != "${prefix}.${extension}" : "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
 
     // Compose pipe

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -43,41 +43,41 @@ process SAMTOOLS_PIPELINE {
 
     def pipeline_command = ""
     for (int index = 0; index < n_commands; index++) {
+        def this_command = commands[index]
         def is_first_command = (index == 0)
         def is_last_command = (index == (n_commands - 1))
-        def this_command = """
+        pipeline_command += """
         samtools \\
-            ${commands[index]} \\
+            ${this_command} \\
             ${all_args[index]} \\
             -@ $task.cpus \\
         """
-        if (commands[index] != "fixmate") {
-            this_command += "    -T ${prefix}.tmp.${commands[index]} \\\n"
+        if (this_command != "fixmate") {
+            pipeline_command += "    -T ${prefix}.tmp.${this_command} \\\n"
         }
-        this_command += "    "
+        pipeline_command += "    "
         if (!is_last_command) {
-            this_command += "-u "
+            pipeline_command += "-u "
         }
         this_input = (is_first_command ? "$input" : "-")
-        if (["collate", "sort"].contains(commands[index])) {
+        if (["collate", "sort"].contains(this_command)) {
             if (is_last_command) {
-                this_command += "-o ${prefix}.${extension} "
+                pipeline_command += "-o ${prefix}.${extension} "
             } else {
-                if (commands[index] != "sort") {
-                    this_command += "-O "
+                if (this_command != "sort") {
+                    pipeline_command += "-O "
                 }
             }
-            this_command += this_input
+            pipeline_command += this_input
         } else {
             // e.g. fixmate, markdup
-            this_command += this_input
+            pipeline_command += this_input
             if (is_last_command) {
-                this_command += " ${prefix}.${extension}"
+                pipeline_command += " ${prefix}.${extension}"
             } else {
-                this_command += " -"
+                pipeline_command += " -"
             }
         }
-        pipeline_command += this_command
         if (!is_last_command) {
             pipeline_command += " | \\"
         }

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -50,7 +50,7 @@ process SAMTOOLS_PIPELINE {
         samtools ${this_command} ${all_args[index]} \\
         """
 
-        // The reheader has no useful option
+        // The reheader has none of these options
         if (! ["reheader"].contains(this_command)) {
             pipeline_command += " -@ $task.cpus"
             if (is_last_command) {

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -20,17 +20,19 @@ process SAMTOOLS_PIPELINE {
     task.ext.when == null || task.ext.when
 
     script:
+    def prefix   = task.ext.prefix ?: "${meta.id}"
 
     // Check that we are asked to run more than 1 command
-    assert commands.size() > 1
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    def cmd_size  = commands.size()
+    def cmd_size = commands.size()
+    assert cmd_size > 1
+
     def last_args = task.ext."args$cmd_size" ?: ''
     def extension = last_args.contains("--output-fmt sam") ? "sam" :
                     last_args.contains("--output-fmt bam") ? "bam" :
                     last_args.contains("--output-fmt cram") ? "cram" :
                     "bam"
     assert "$input" != "${prefix}.${extension}" : "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+
     // Compose pipe
     def cmds = commands.indexed().collect { index, cmd ->
         def first = index == 0

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -45,11 +45,9 @@ process SAMTOOLS_PIPELINE {
         def this_command = commands[index]
         def is_first_command = (index == 0)
         def is_last_command = (index == (n_commands - 1))
+
         pipeline_command += """
-        samtools \\
-            ${this_command} \\
-            ${all_args[index]} \\
-            -@ $task.cpus \\
+        samtools ${this_command} ${all_args[index]} -@ $task.cpus \\
         """
 
         if (is_last_command) {
@@ -90,7 +88,7 @@ process SAMTOOLS_PIPELINE {
         }
 
         if (!is_last_command) {
-            pipeline_command += " | \\"
+            pipeline_command += " |"
         }
     }
 

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -21,7 +21,7 @@ process SAMTOOLS_PIPELINE {
 
     script:
 
-    // Check that we are asked to run a pipeline
+    // Check that we are asked to run more than 1 command
     def n_commands = commands.size()
     if (n_commands < 2) error "SAMTOOLS_PIPELINE is used to chain 2 or more samtools commands"
 

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -37,7 +37,7 @@ process SAMTOOLS_PIPELINE {
         def last = index == cmd_size-1
         def command = [
             "samtools $cmd",
-            task.ext."args${index!=0 ? index+1 : ''}" ?: ''
+            task.ext."args${first ? '' : index+1}" ?: ''
         ]
         switch(cmd){
             case !"reheader":

--- a/modules/nf-core/samtools/pipeline/main.nf
+++ b/modules/nf-core/samtools/pipeline/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_PIPELINE {
 
     input:
     tuple val(meta), path(input)
-    tuple val(meta2), path(fasta)
+    tuple val(meta2), path(fasta), path(fai)
     val commands
 
     output:

--- a/modules/nf-core/samtools/pipeline/meta.yml
+++ b/modules/nf-core/samtools/pipeline/meta.yml
@@ -32,32 +32,26 @@ input:
       type: file
       description: FASTA reference file
       pattern: "*.{fasta,fa}"
+  - commands:
+      type: list
+      description: |
+        List of the samtools command names to run (in order). Currently
+        supported: addreplacerg, collate, fixmate, markdup, reheader, sort,
+        view
 output:
   - meta:
       type: map
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  - bam:
-      type: file
-      description: optional output BAM file
-      pattern: "*.{bam}"
-  - cram:
-      type: file
-      description: optional output BAM file
-      pattern: "*.{cram}"
-  - sam:
-      type: file
-      description: optional output BAM file
-      pattern: "*.{sam}"
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
   - output:
       type: file
       description: Collated BAM/CRAM/SAM file
       pattern: "*.{bam,cram,sam}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 authors:
   - "@muffato"
 maintainers:

--- a/modules/nf-core/samtools/pipeline/meta.yml
+++ b/modules/nf-core/samtools/pipeline/meta.yml
@@ -1,0 +1,64 @@
+name: "samtools_pipeline"
+description: custom bash pipeline made of samtools commands
+keywords:
+  - pipeline
+  - bam
+  - sam
+  - cram
+tools:
+  - "samtools":
+      description: "Tools for dealing with SAM, BAM and CRAM files"
+      homepage: "http://www.htslib.org"
+      documentation: "https://www.htslib.org/doc/samtools.html"
+      tool_dev_url: "https://github.com/samtools/samtools"
+      doi: "10.1093/bioinformatics/btp352"
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - input:
+      type: file
+      description: BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
+  - fasta:
+      type: file
+      description: FASTA reference file
+      pattern: "*.{fasta,fa}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - bam:
+      type: file
+      description: optional output BAM file
+      pattern: "*.{bam}"
+  - cram:
+      type: file
+      description: optional output BAM file
+      pattern: "*.{cram}"
+  - sam:
+      type: file
+      description: optional output BAM file
+      pattern: "*.{sam}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - output:
+      type: file
+      description: Collated BAM/CRAM/SAM file
+      pattern: "*.{bam,cram,sam}"
+authors:
+  - "@muffato"
+maintainers:
+  - "@muffato"

--- a/modules/nf-core/samtools/pipeline/meta.yml
+++ b/modules/nf-core/samtools/pipeline/meta.yml
@@ -46,7 +46,7 @@ output:
         e.g. [ id:'test', single_end:false ]
   - output:
       type: file
-      description: Collated BAM/CRAM/SAM file
+      description: Output BAM/CRAM/SAM file (defaults to the same extension as the input)
       pattern: "*.{bam,cram,sam}"
   - versions:
       type: file

--- a/modules/nf-core/samtools/pipeline/meta.yml
+++ b/modules/nf-core/samtools/pipeline/meta.yml
@@ -1,5 +1,5 @@
 name: "samtools_pipeline"
-description: custom bash pipeline made of samtools commands
+description: custom bash pipeline made only of samtools commands
 keywords:
   - pipeline
   - bam

--- a/modules/nf-core/samtools/pipeline/meta.yml
+++ b/modules/nf-core/samtools/pipeline/meta.yml
@@ -32,6 +32,10 @@ input:
       type: file
       description: FASTA reference file
       pattern: "*.{fasta,fa}"
+  - fai:
+      type: file
+      description: Index of the reference file for the CRAM
+      pattern: "*.fai"
   - commands:
       type: list
       description: |

--- a/modules/nf-core/samtools/pipeline/meta.yml
+++ b/modules/nf-core/samtools/pipeline/meta.yml
@@ -48,6 +48,10 @@ output:
       type: file
       description: Output BAM/CRAM/SAM file (defaults to the same extension as the input)
       pattern: "*.{bam,cram,sam}"
+  - index:
+      type: file
+      description: BAM.BAI/BAM.CSI/CRAM.CRAI file (optional)
+      pattern: "*.{.bai,.csi,.crai}"
   - versions:
       type: file
       description: File containing software versions

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -2132,6 +2132,9 @@ samtools/import:
 samtools/markdup:
   - modules/nf-core/samtools/markdup/**
   - tests/modules/nf-core/samtools/markdup/**
+samtools/pipeline:
+  - modules/nf-core/samtools/pipeline/**
+  - tests/modules/nf-core/samtools/pipeline/**
 samtools/reheader:
   - modules/nf-core/samtools/reheader/**
   - tests/modules/nf-core/samtools/reheader/**

--- a/tests/modules/nf-core/samtools/pipeline/main.nf
+++ b/tests/modules/nf-core/samtools/pipeline/main.nf
@@ -5,6 +5,7 @@ nextflow.enable.dsl = 2
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_SORMADUP     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXMSORT } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXM     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
+include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXM_B2C } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_ALL          } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 
 workflow test_samtools_pipeline_sormadup {
@@ -57,3 +58,16 @@ workflow test_samtools_pipeline_collate_fixmate_cram {
     SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[]], commands )
 }
 
+workflow test_samtools_pipeline_collate_fixmate_bam2cram {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
+    fasta = [
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+    commands = ['collate', 'fixmate']
+    SAMTOOLS_PIPELINE_COLLFIXM_B2C ( input, fasta, commands )
+}

--- a/tests/modules/nf-core/samtools/pipeline/main.nf
+++ b/tests/modules/nf-core/samtools/pipeline/main.nf
@@ -5,9 +5,10 @@ nextflow.enable.dsl = 2
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_SORMADUP     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXMSORT } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXM     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
+include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_ALL          } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 
 workflow test_samtools_pipeline_sormadup {
-    
+
     input = [
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
@@ -17,7 +18,7 @@ workflow test_samtools_pipeline_sormadup {
 }
 
 workflow test_samtools_pipeline_collate_fixmate_sort {
-    
+
     input = [
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
@@ -27,11 +28,21 @@ workflow test_samtools_pipeline_collate_fixmate_sort {
 }
 
 workflow test_samtools_pipeline_collate_fixmate {
-    
+
     input = [
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
     ]
     commands = ['collate', 'fixmate']
     SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[]], commands )
+}
+
+workflow test_samtools_pipeline_all {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
+    commands = ['collate', 'addreplacerg', 'fixmate', 'reheader', 'sort', 'markdup', 'view']
+    SAMTOOLS_PIPELINE_ALL ( input, [[],[]], commands )
 }

--- a/tests/modules/nf-core/samtools/pipeline/main.nf
+++ b/tests/modules/nf-core/samtools/pipeline/main.nf
@@ -5,7 +5,6 @@ nextflow.enable.dsl = 2
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_SORMADUP     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXMSORT } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXM     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
-include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXM_B2C } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_ALL          } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 
 workflow test_samtools_pipeline_sormadup {
@@ -56,14 +55,4 @@ workflow test_samtools_pipeline_collate_fixmate_cram {
     ]
     commands = ['collate', 'fixmate']
     SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[],[]], commands )
-}
-
-workflow test_samtools_pipeline_collate_fixmate_bam2cram {
-
-    input = [
-        [ id:'test', single_end:false ], // meta map
-        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
-    ]
-    commands = ['collate', 'fixmate']
-    SAMTOOLS_PIPELINE_COLLFIXM_B2C ( input, [[],[],[]], commands )
 }

--- a/tests/modules/nf-core/samtools/pipeline/main.nf
+++ b/tests/modules/nf-core/samtools/pipeline/main.nf
@@ -46,3 +46,14 @@ workflow test_samtools_pipeline_all {
     commands = ['collate', 'addreplacerg', 'fixmate', 'reheader', 'sort', 'markdup', 'view']
     SAMTOOLS_PIPELINE_ALL ( input, [[],[]], commands )
 }
+
+workflow test_samtools_pipeline_collate_fixmate_cram {
+
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true)
+    ]
+    commands = ['collate', 'fixmate']
+    SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[]], commands )
+}
+

--- a/tests/modules/nf-core/samtools/pipeline/main.nf
+++ b/tests/modules/nf-core/samtools/pipeline/main.nf
@@ -64,11 +64,6 @@ workflow test_samtools_pipeline_collate_fixmate_bam2cram {
         [ id:'test', single_end:false ], // meta map
         file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
     ]
-    fasta = [
-        [ id:'test' ], // meta map
-        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
-        file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
-    ]
     commands = ['collate', 'fixmate']
-    SAMTOOLS_PIPELINE_COLLFIXM_B2C ( input, fasta, commands )
+    SAMTOOLS_PIPELINE_COLLFIXM_B2C ( input, [[],[],[]], commands )
 }

--- a/tests/modules/nf-core/samtools/pipeline/main.nf
+++ b/tests/modules/nf-core/samtools/pipeline/main.nf
@@ -6,7 +6,7 @@ include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_SORMADUP     } from '../../../.
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXMSORT } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXM     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
 
-workflow test_samtools_pipeline_complete_sormadup {
+workflow test_samtools_pipeline_sormadup {
     
     input = [
         [ id:'test', single_end:false ], // meta map

--- a/tests/modules/nf-core/samtools/pipeline/main.nf
+++ b/tests/modules/nf-core/samtools/pipeline/main.nf
@@ -1,0 +1,37 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_SORMADUP     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
+include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXMSORT } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
+include { SAMTOOLS_PIPELINE as SAMTOOLS_PIPELINE_COLLFIXM     } from '../../../../../modules/nf-core/samtools/pipeline/main.nf'
+
+workflow test_samtools_pipeline_complete_sormadup {
+    
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
+    commands = ['collate', 'fixmate', 'sort', 'markdup']
+    SAMTOOLS_PIPELINE_SORMADUP ( input, [[],[]], commands )
+}
+
+workflow test_samtools_pipeline_collate_fixmate_sort {
+    
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
+    commands = ['collate', 'fixmate', 'sort']
+    SAMTOOLS_PIPELINE_COLLFIXMSORT ( input, [[],[]], commands )
+}
+
+workflow test_samtools_pipeline_collate_fixmate {
+    
+    input = [
+        [ id:'test', single_end:false ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
+    ]
+    commands = ['collate', 'fixmate']
+    SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[]], commands )
+}

--- a/tests/modules/nf-core/samtools/pipeline/main.nf
+++ b/tests/modules/nf-core/samtools/pipeline/main.nf
@@ -15,7 +15,7 @@ workflow test_samtools_pipeline_sormadup {
         file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
     ]
     commands = ['collate', 'fixmate', 'sort', 'markdup']
-    SAMTOOLS_PIPELINE_SORMADUP ( input, [[],[]], commands )
+    SAMTOOLS_PIPELINE_SORMADUP ( input, [[],[],[]], commands )
 }
 
 workflow test_samtools_pipeline_collate_fixmate_sort {
@@ -25,7 +25,7 @@ workflow test_samtools_pipeline_collate_fixmate_sort {
         file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
     ]
     commands = ['collate', 'fixmate', 'sort']
-    SAMTOOLS_PIPELINE_COLLFIXMSORT ( input, [[],[]], commands )
+    SAMTOOLS_PIPELINE_COLLFIXMSORT ( input, [[],[],[]], commands )
 }
 
 workflow test_samtools_pipeline_collate_fixmate {
@@ -35,7 +35,7 @@ workflow test_samtools_pipeline_collate_fixmate {
         file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
     ]
     commands = ['collate', 'fixmate']
-    SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[]], commands )
+    SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[],[]], commands )
 }
 
 workflow test_samtools_pipeline_all {
@@ -45,7 +45,7 @@ workflow test_samtools_pipeline_all {
         file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
     ]
     commands = ['collate', 'addreplacerg', 'fixmate', 'reheader', 'sort', 'markdup', 'view']
-    SAMTOOLS_PIPELINE_ALL ( input, [[],[]], commands )
+    SAMTOOLS_PIPELINE_ALL ( input, [[],[],[]], commands )
 }
 
 workflow test_samtools_pipeline_collate_fixmate_cram {
@@ -55,7 +55,7 @@ workflow test_samtools_pipeline_collate_fixmate_cram {
         file(params.test_data['homo_sapiens']['illumina']['test_paired_end_sorted_cram'], checkIfExists: true)
     ]
     commands = ['collate', 'fixmate']
-    SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[]], commands )
+    SAMTOOLS_PIPELINE_COLLFIXM ( input, [[],[],[]], commands )
 }
 
 workflow test_samtools_pipeline_collate_fixmate_bam2cram {
@@ -66,7 +66,8 @@ workflow test_samtools_pipeline_collate_fixmate_bam2cram {
     ]
     fasta = [
         [ id:'test' ], // meta map
-        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
+        file(params.test_data['sarscov2']['genome']['genome_fasta_fai'], checkIfExists: true)
     ]
     commands = ['collate', 'fixmate']
     SAMTOOLS_PIPELINE_COLLFIXM_B2C ( input, fasta, commands )

--- a/tests/modules/nf-core/samtools/pipeline/nextflow.config
+++ b/tests/modules/nf-core/samtools/pipeline/nextflow.config
@@ -23,11 +23,6 @@ process {
         ext.args2 = '-m'       // fixmate
     }
 
-    withName: SAMTOOLS_PIPELINE_COLLFIXM_B2C {
-        ext.args  = '-T .'                 // collate
-        ext.args2 = '-m --output-fmt cram' // fixmate
-    }
-
     withName: SAMTOOLS_PIPELINE_ALL {
         ext.args  = '-T .'                 // collate
         ext.args2 = '-r ID:FOO'            // addreplacerg

--- a/tests/modules/nf-core/samtools/pipeline/nextflow.config
+++ b/tests/modules/nf-core/samtools/pipeline/nextflow.config
@@ -4,19 +4,28 @@ process {
 
     withName: SAMTOOLS_PIPELINE_SORMADUP {
         ext.args = [
-            fixmate: '-m'
+            fixmate: '-m',
         ]
     }
 
     withName: SAMTOOLS_PIPELINE_COLLFIXMSORT {
         ext.args = [
-            fixmate: '-m'
+            fixmate: '-m',
         ]
     }
 
     withName: SAMTOOLS_PIPELINE_COLLFIXM {
         ext.args = [
-            fixmate: '-m'
+            fixmate: '-m',
+        ]
+    }
+
+    withName: SAMTOOLS_PIPELINE_ALL {
+        ext.args = [
+            addreplacerg: '-r ID:FOO',
+            fixmate: '-m',
+            reheader: '-c "sed s/FOO/BAR/"',
+            view: '-F 0x08',
         ]
     }
 }

--- a/tests/modules/nf-core/samtools/pipeline/nextflow.config
+++ b/tests/modules/nf-core/samtools/pipeline/nextflow.config
@@ -13,8 +13,9 @@ process {
     }
 
     withName: SAMTOOLS_PIPELINE_COLLFIXMSORT {
-        ext.args  = '-T .'     // collate
-        ext.args2 = '-m'       // fixmate
+        ext.args  = '-T .'          // collate
+        ext.args2 = '-m'            // fixmate
+        ext.args3 = '--write-index' // sort
     }
 
     withName: SAMTOOLS_PIPELINE_COLLFIXM {

--- a/tests/modules/nf-core/samtools/pipeline/nextflow.config
+++ b/tests/modules/nf-core/samtools/pipeline/nextflow.config
@@ -8,33 +8,25 @@ process {
     // location.
 
     withName: SAMTOOLS_PIPELINE_SORMADUP {
-        ext.args = [
-            collate: '-T .',
-            fixmate: '-m',
-        ]
+        ext.args  = '-T .'     // collate
+        ext.args2 = '-m'       // fixmate
     }
 
     withName: SAMTOOLS_PIPELINE_COLLFIXMSORT {
-        ext.args = [
-            collate: '-T .',
-            fixmate: '-m',
-        ]
+        ext.args  = '-T .'     // collate
+        ext.args2 = '-m'       // fixmate
     }
 
     withName: SAMTOOLS_PIPELINE_COLLFIXM {
-        ext.args = [
-            collate: '-T .',
-            fixmate: '-m',
-        ]
+        ext.args  = '-T .'     // collate
+        ext.args2 = '-m'       // fixmate
     }
 
     withName: SAMTOOLS_PIPELINE_ALL {
-        ext.args = [
-            collate: '-T .',
-            addreplacerg: '-r ID:FOO',
-            fixmate: '-m',
-            reheader: '-c "sed s/FOO/BAR/"',
-            view: '-F 0x08',
-        ]
+        ext.args  = '-T .'                 // collate
+        ext.args2 = '-r ID:FOO'            // addreplacerg
+        ext.args3 = '-m'                   // fixmate
+        ext.args4 = '-c "sed s/FOO/BAR/"'  // reheader
+        ext.args7 = '-F 0x08'              // view
     }
 }

--- a/tests/modules/nf-core/samtools/pipeline/nextflow.config
+++ b/tests/modules/nf-core/samtools/pipeline/nextflow.config
@@ -1,0 +1,22 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    withName: SAMTOOLS_PIPELINE_SORMADUP {
+        ext.args = [
+            fixmate: '-m'
+        ]
+    }
+
+    withName: SAMTOOLS_PIPELINE_COLLFIXMSORT {
+        ext.args = [
+            fixmate: '-m'
+        ]
+    }
+
+    withName: SAMTOOLS_PIPELINE_COLLFIXM {
+        ext.args = [
+            fixmate: '-m'
+        ]
+    }
+}

--- a/tests/modules/nf-core/samtools/pipeline/nextflow.config
+++ b/tests/modules/nf-core/samtools/pipeline/nextflow.config
@@ -22,6 +22,11 @@ process {
         ext.args2 = '-m'       // fixmate
     }
 
+    withName: SAMTOOLS_PIPELINE_COLLFIXM_B2C {
+        ext.args  = '-T .'                 // collate
+        ext.args2 = '-m --output-fmt cram' // fixmate
+    }
+
     withName: SAMTOOLS_PIPELINE_ALL {
         ext.args  = '-T .'                 // collate
         ext.args2 = '-r ID:FOO'            // addreplacerg

--- a/tests/modules/nf-core/samtools/pipeline/nextflow.config
+++ b/tests/modules/nf-core/samtools/pipeline/nextflow.config
@@ -2,26 +2,35 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
+    // NOTE: collate needs to creata temporary files. CI sets TMPDIR to ~,
+    // which is not mounted any more in Singularity since Nextflow 23.10. We
+    // add "-T ." so that the temporary files are created in a writable
+    // location.
+
     withName: SAMTOOLS_PIPELINE_SORMADUP {
         ext.args = [
+            collate: '-T .',
             fixmate: '-m',
         ]
     }
 
     withName: SAMTOOLS_PIPELINE_COLLFIXMSORT {
         ext.args = [
+            collate: '-T .',
             fixmate: '-m',
         ]
     }
 
     withName: SAMTOOLS_PIPELINE_COLLFIXM {
         ext.args = [
+            collate: '-T .',
             fixmate: '-m',
         ]
     }
 
     withName: SAMTOOLS_PIPELINE_ALL {
         ext.args = [
+            collate: '-T .',
             addreplacerg: '-r ID:FOO',
             fixmate: '-m',
             reheader: '-c "sed s/FOO/BAR/"',

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -16,7 +16,7 @@
   files:
     - path: output/samtools/test.bam
       md5sum: aab086c3bfc7e32cef9e8e62c6f1f774
-    - path: output/samtools/test.bami.csi
+    - path: output/samtools/test.bam.csi
       md5sum: b9378d1e55b1dfecc5610a61cfd80724
     - path: output/samtools/versions.yml
 

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -16,6 +16,8 @@
   files:
     - path: output/samtools/test.bam
       md5sum: aab086c3bfc7e32cef9e8e62c6f1f774
+    - path: output/samtools/test.bami.csi
+      md5sum: b9378d1e55b1dfecc5610a61cfd80724
     - path: output/samtools/versions.yml
 
 - name: samtools pipeline test_samtools_pipeline_collate_fixmate

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -46,3 +46,12 @@
     - path: output/samtools/test.cram
       md5sum: b71fc2e9b7c04e32b13e6071f955434d
     - path: output/samtools/versions.yml
+- name: samtools pipeline test_samtools_pipeline_collate_fixmate_bam2cram
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_bam2cram -c ./tests/config/nextflow.config
+  tags:
+    - samtools
+    - samtools/pipeline
+  files:
+    - path: output/samtools/test.cram
+      md5sum: b71fc2e9b7c04e32b13e6071f955434d
+    - path: output/samtools/versions.yml

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -1,29 +1,39 @@
 - name: samtools pipeline test_samtools_pipeline_sormadup
-  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_sormadup -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/samtools/pipeline/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_sormadup -c ./tests/config/nextflow.config
   tags:
-    - samtools/pipeline
     - samtools
+    - samtools/pipeline
   files:
     - path: output/samtools/test.bam
-      md5sum: d505badd610ef5a32d28db3ec8e6aea1
+      md5sum: 6ffaaac1f4a02cc67eb68027c9bcd997
     - path: output/samtools/versions.yml
 
 - name: samtools pipeline test_samtools_pipeline_collate_fixmate_sort
-  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_sort -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/samtools/pipeline/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_sort -c ./tests/config/nextflow.config
   tags:
-    - samtools/pipeline
     - samtools
+    - samtools/pipeline
   files:
     - path: output/samtools/test.bam
-      md5sum: 543221828943029864db75bd617b79d1
+      md5sum: e1c8f4b07b535c037694b4ed5dbbacb2
     - path: output/samtools/versions.yml
 
 - name: samtools pipeline test_samtools_pipeline_collate_fixmate
-  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/samtools/pipeline/nextflow.config
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate -c ./tests/config/nextflow.config
   tags:
-    - samtools/pipeline
     - samtools
+    - samtools/pipeline
   files:
     - path: output/samtools/test.bam
-      md5sum: 37f2c0f510aff13bc73c7ddd6989c1f7
+      md5sum: af385ec8b3038bb9ae54b5ea1e87d58f
+    - path: output/samtools/versions.yml
+
+- name: samtools pipeline test_samtools_pipeline_all
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_all -c ./tests/config/nextflow.config
+  tags:
+    - samtools
+    - samtools/pipeline
+  files:
+    - path: output/samtools/test.bam
+      md5sum: ca506ea8953682f8409667aa549a9fe3
     - path: output/samtools/versions.yml

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -1,0 +1,29 @@
+- name: samtools pipeline test_samtools_pipeline_complete_sormadup
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_complete_sormadup -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/samtools/pipeline/nextflow.config
+  tags:
+    - samtools/pipeline
+    - samtools
+  files:
+    - path: output/samtools/test.bam
+      md5sum: d505badd610ef5a32d28db3ec8e6aea1
+    - path: output/samtools/versions.yml
+
+- name: samtools pipeline test_samtools_pipeline_collate_fixmate_sort
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_sort -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/samtools/pipeline/nextflow.config
+  tags:
+    - samtools/pipeline
+    - samtools
+  files:
+    - path: output/samtools/test.bam
+      md5sum: 543221828943029864db75bd617b79d1
+    - path: output/samtools/versions.yml
+
+- name: samtools pipeline test_samtools_pipeline_collate_fixmate
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/samtools/pipeline/nextflow.config
+  tags:
+    - samtools/pipeline
+    - samtools
+  files:
+    - path: output/samtools/test.bam
+      md5sum: 37f2c0f510aff13bc73c7ddd6989c1f7
+    - path: output/samtools/versions.yml

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -46,7 +46,7 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.cram
-      md5sum: 61ca3ec27be08646525d083cdc7b3655
+      md5sum: d091d4cd8ee1fbc3c0937296588962a3
     - path: output/samtools/versions.yml
 - name: samtools pipeline test_samtools_pipeline_collate_fixmate_bam2cram
   command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_bam2cram -c ./tests/config/nextflow.config

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -1,5 +1,5 @@
-- name: samtools pipeline test_samtools_pipeline_complete_sormadup
-  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_complete_sormadup -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/samtools/pipeline/nextflow.config
+- name: samtools pipeline test_samtools_pipeline_sormadup
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_sormadup -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/samtools/pipeline/nextflow.config
   tags:
     - samtools/pipeline
     - samtools

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -48,12 +48,3 @@
     - path: output/samtools/test.cram
       md5sum: b71fc2e9b7c04e32b13e6071f955434d
     - path: output/samtools/versions.yml
-- name: samtools pipeline test_samtools_pipeline_collate_fixmate_bam2cram
-  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_bam2cram -c ./tests/config/nextflow.config
-  tags:
-    - samtools
-    - samtools/pipeline
-  files:
-    - path: output/samtools/test.cram
-      md5sum: d091d4cd8ee1fbc3c0937296588962a3
-    - path: output/samtools/versions.yml

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -46,7 +46,7 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.cram
-      md5sum: d091d4cd8ee1fbc3c0937296588962a3
+      md5sum: b71fc2e9b7c04e32b13e6071f955434d
     - path: output/samtools/versions.yml
 - name: samtools pipeline test_samtools_pipeline_collate_fixmate_bam2cram
   command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_bam2cram -c ./tests/config/nextflow.config
@@ -55,5 +55,5 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.cram
-      md5sum: b71fc2e9b7c04e32b13e6071f955434d
+      md5sum: d091d4cd8ee1fbc3c0937296588962a3
     - path: output/samtools/versions.yml

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -5,7 +5,7 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.bam
-      md5sum: 6ffaaac1f4a02cc67eb68027c9bcd997
+      md5sum: de5d6a0d54d580b71c946c13b58c5d66
     - path: output/samtools/versions.yml
 
 - name: samtools pipeline test_samtools_pipeline_collate_fixmate_sort
@@ -15,7 +15,7 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.bam
-      md5sum: e1c8f4b07b535c037694b4ed5dbbacb2
+      md5sum: aab086c3bfc7e32cef9e8e62c6f1f774
     - path: output/samtools/versions.yml
 
 - name: samtools pipeline test_samtools_pipeline_collate_fixmate
@@ -25,7 +25,7 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.bam
-      md5sum: af385ec8b3038bb9ae54b5ea1e87d58f
+      md5sum: e574ac78aef3617888697733a01de8e3
     - path: output/samtools/versions.yml
 
 - name: samtools pipeline test_samtools_pipeline_all
@@ -35,5 +35,5 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.bam
-      md5sum: ca506ea8953682f8409667aa549a9fe3
+      md5sum: 9815772ce3b23468858f1e76a6123dca
     - path: output/samtools/versions.yml

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -15,7 +15,7 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.bam
-      md5sum: aab086c3bfc7e32cef9e8e62c6f1f774
+      md5sum: 4ba760209400274dee8d67961e66a28b
     - path: output/samtools/test.bam.csi
       md5sum: b9378d1e55b1dfecc5610a61cfd80724
     - path: output/samtools/versions.yml
@@ -46,7 +46,7 @@
     - samtools/pipeline
   files:
     - path: output/samtools/test.cram
-      md5sum: b71fc2e9b7c04e32b13e6071f955434d
+      md5sum: 61ca3ec27be08646525d083cdc7b3655
     - path: output/samtools/versions.yml
 - name: samtools pipeline test_samtools_pipeline_collate_fixmate_bam2cram
   command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_bam2cram -c ./tests/config/nextflow.config

--- a/tests/modules/nf-core/samtools/pipeline/test.yml
+++ b/tests/modules/nf-core/samtools/pipeline/test.yml
@@ -37,3 +37,12 @@
     - path: output/samtools/test.bam
       md5sum: 9815772ce3b23468858f1e76a6123dca
     - path: output/samtools/versions.yml
+- name: samtools pipeline test_samtools_pipeline_collate_fixmate_cram
+  command: nextflow run ./tests/modules/nf-core/samtools/pipeline -entry test_samtools_pipeline_collate_fixmate_cram -c ./tests/config/nextflow.config
+  tags:
+    - samtools
+    - samtools/pipeline
+  files:
+    - path: output/samtools/test.cram
+      md5sum: b71fc2e9b7c04e32b13e6071f955434d
+    - path: output/samtools/versions.yml


### PR DESCRIPTION
I've recently spent some time optimising the resource usage of some Nextflow pipelines and I found that the [samtools workflow to mark duplicates](https://www.htslib.org/algorithms/duplicate.html#workflow) takes 5x longer to run and 3x more disk space when implemented the nf-core way, i.e. as 4 modules put together in a sub-workflow, compared to having a single local module with a bash pipeline.

Last time we discussed this sort of module, #3310 and https://nfcore.slack.com/archives/CJRH30T6V/p1682062426042809 , it was decided against though we didn't know the actual improvements. But both @drpatelh and @SPPearce suggested to reopen the discussion after seeing the figures. After all, the nf-core guidelines don't _forbid_ it (bold type mine).
> Software that can be piped together SHOULD be added to separate module files **unless there is a run-time, storage advantage in implementing in this way**.

However, @drpatelh said that there should be options to disable some of the 4 commands, because not anyone may need them. Here is my take on this.

I introduce a new module that can run a [bash _pipeline_](https://www.gnu.org/software/bash/manual/html_node/Pipelines.html) (hence the name) of any commands the user wants in any order, as long as they take BAM/CRAM as inputs as outputs. It wasn't as trivial as I thought it would because samtools commands have different ways of defining the input and output files 🙃 

It works like this:
```nextflow
workflow {
    input = [
        [ id:'test', single_end:false ], // meta map
        file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true)
    ]
    commands = ['collate', 'fixmate', 'sort', 'markdup']
    SAMTOOLS_PIPELINE ( input, [[],[]], commands )
    SAMTOOLS_PIPELINE.out.output
}
process {
    withName: SAMTOOLS_PIPELINE {
        ext.args = [
            fixmate: '-m',
        ]
    }
}
```

What I like about the approach:

- No mulled container involved. Just the regular samtools, which is much easier to understand and update.
- Easy to add more samtools commands to the module.
- Maximum flexibility for the user in terms of chaining samtools commands.

What I dislike about the implementation:

- I couldn't find how to dynamically get the value of `task.ext.args${index}`. So instead I make `ext.args` a map where the key is the command name and the value is the string to add to the command-line. I don't know if/how closures can be used. I would very much prefer to use the regular `task.ext.args`, `task.ext.args2`, etc.
- Because of the above, my implementation doesn't handle the same command being used multiple times in the pipeline with different command-line options.
- The configuration of the module is actually split between the `.nf` (`commands = ['collate', 'fixmate', 'sort', 'markdup']`) and the `.config` (`ext.args = [ ... ]`). Maybe I should move the definition of the commands to the `.config` ?
- Indentation of the resulting `.command.sh` is very fragile. What I've got works but for instance I tried `pipeline_command += "samtools ${this_command} ${all_args[index]} \\ \n" and that caused the `cat <<-END_VERSIONS > versions.yml` to be indented, which broke the generation of the yml.

What it needs:

- [x] testing with CRAM. I'm no sure I put the `--reference` in the right place.
- [ ] migration to nf-test.

What it may need:

- The selected commands often have command-line options to take extra files as inputs or output more files. Those could be added to the module, though to be fair the existing modules often don't list every single possible option either.
- Some samtools-based sub-workflows could be rewritten to use this module, bringing an instant performance boost to their workflows.
- A different name ? I chose "pipeline" because it's a bash pipeline under the hood. @mashehu doesn't like it :) Alternatives: pipe, chain, any, multi, combine. Ideally it should be name that stands out from the already-crowded list of samtools commands
- A simple sub-workflow wrapper so that people looking for samtools sub-workflows still find about this. (they may not think about checking modules)
- Alternatively, only expose this capability as a sub-workflow, either by allowing "local" modules in nf-core sub-workflows and moving the file over there, or by embedding this `process` block in the sub-workflow's `main.nf`.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
