### PR TITLE
[Fix gprofiler] Empty output table is now always added

### DIFF
--- a/modules/nf-core/gprofiler2/gost/main.nf
+++ b/modules/nf-core/gprofiler2/gost/main.nf
@@ -1,5 +1,5 @@
 process GPROFILER2_GOST {
-    tag "$meta"
+    tag "$meta.id"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
@@ -8,21 +8,20 @@ process GPROFILER2_GOST {
         'biocontainers/mulled-v2-3712554873398d849d0d11b22440f41febbc4ede:aa19bb8afc0ec6456a4f3cd650f7577c3bbdd4f3-0' }"
 
     input:
-    tuple val(meta), val(contrast_variable), val(reference), val(target)
-    tuple val(meta1), path(de_file)
+    tuple val(meta), path(de_file)
     path(gmt_file)
     path(background_file)
 
     output:
-    tuple val(meta), path("*gprofiler2.*all_enriched_pathways.tsv") , emit: all_enrich
-    tuple val(meta), path("*gprofiler2.*gost_results.rds")          , emit: rds         , optional: true
-    tuple val(meta), path("*gprofiler2.*gostplot.png")              , emit: plot_png    , optional: true
-    tuple val(meta), path("*gprofiler2.*gostplot.html")             , emit: plot_html   , optional: true
-    tuple val(meta), path("*gprofiler2.*sub_enriched_pathways.tsv") , emit: sub_enrich  , optional: true
-    tuple val(meta), path("*gprofiler2.*sub_enriched_pathways.png") , emit: sub_plot    , optional: true
-    tuple val(meta), path("*ENSG_filtered.gmt")                     , emit: filtered_gmt, optional: true
-    tuple val(meta), path("*R_sessionInfo.log")                     , emit: session_info
-    path "versions.yml"                                             , emit: versions
+    tuple val(meta), path("*.gprofiler2.all_enriched_pathways.tsv")     , emit: all_enrich
+    tuple val(meta), path("*.gprofiler2.gost_results.rds")              , emit: rds         , optional: true
+    tuple val(meta), path("*.gprofiler2.gostplot.png")                  , emit: plot_png    , optional: true
+    tuple val(meta), path("*.gprofiler2.gostplot.html")                 , emit: plot_html   , optional: true
+    tuple val(meta), path("*.gprofiler2.*.sub_enriched_pathways.tsv")   , emit: sub_enrich  , optional: true
+    tuple val(meta), path("*.gprofiler2.*.sub_enriched_pathways.png")   , emit: sub_plot    , optional: true
+    tuple val(meta), path("*ENSG_filtered.gmt")                         , emit: filtered_gmt, optional: true
+    tuple val(meta), path("*R_sessionInfo.log")                         , emit: session_info
+    path "versions.yml"                                                 , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/gprofiler2/gost/templates/gprofiler2_gost.R
+++ b/modules/nf-core/gprofiler2/gost/templates/gprofiler2_gost.R
@@ -214,6 +214,10 @@ if (!is.null(opt\$blocking_variables)) {
     output_prefix <- paste(output_prefix, blocking_variables, sep= '_')
 }
 
+
+# Create empty output table as it is a mandatory output
+file.create(paste(output_prefix, 'all_enriched_pathways', 'tsv', sep = '.'))
+
 if (nrow(de.genes) > 0) {
 
     query <- de.genes[[opt\$de_id_column]]
@@ -430,8 +434,6 @@ if (nrow(de.genes) > 0) {
         }
     }
 } else {
-    # Create empty output table as it is a mandatory output
-    file.create(paste(output_prefix, 'all_enriched_pathways', 'tsv', sep = '.'))
     print("No differential features found, pathway enrichment analysis with gprofiler2 will be skipped.")
 }
 

--- a/tests/modules/nf-core/gprofiler2/gost/main.nf
+++ b/tests/modules/nf-core/gprofiler2/gost/main.nf
@@ -7,12 +7,11 @@ include { GPROFILER2_GOST } from '../../../../../modules/nf-core/gprofiler2/gost
 workflow test_gprofiler2_gost {
     contrasts = [ [ id:'test', reference:'r', target:'t' ], 'test', 'r', 't' ]
     input = [
-        [ id:'test', reference:'r', target:'t' ], // meta map
+        [ id:'test_r_t', reference:'r', target:'t' ], // meta map
         file(params.test_data['mus_musculus']['genome']['deseq_results'], checkIfExists: true)
     ]
 
     GPROFILER2_GOST (
-        contrasts,
         input,
         [],
         []
@@ -22,13 +21,12 @@ workflow test_gprofiler2_gost {
 workflow test_gprofiler2_gost_backgroundmatrix {
     contrasts = [ [ id:'test', reference:'r', target:'t' ], 'test', 'r', 't' ]
     input = [
-        [ id:'test', reference:'r', target:'t' ], // meta map
+        [ id:'test_r_t', reference:'r', target:'t' ], // meta map
         file(params.test_data['mus_musculus']['genome']['deseq_results'], checkIfExists: true)
     ]
     ch_background = Channel.from(file(params.test_data['mus_musculus']['genome']['rnaseq_matrix'], checkIfExists: true))
 
     GPROFILER2_GOST (
-        contrasts,
         input,
         [],
         ch_background

--- a/tests/modules/nf-core/gprofiler2/gost/test.yml
+++ b/tests/modules/nf-core/gprofiler2/gost/test.yml
@@ -6,25 +6,25 @@
   files:
     - path: output/gprofiler2/R_sessionInfo.log
       contains: ["ggplot2_3.4.3", "gprofiler2_0.2.2"]
-    - path: output/gprofiler2/gprofiler2.test_r_t.CORUM.sub_enriched_pathways.png
-    - path: output/gprofiler2/gprofiler2.test_r_t.CORUM.sub_enriched_pathways.tsv
+    - path: output/gprofiler2/test_r_t.gprofiler2.CORUM.sub_enriched_pathways.png
+    - path: output/gprofiler2/test_r_t.gprofiler2.CORUM.sub_enriched_pathways.tsv
       md5sum: b0619e5e1424ac18f6cb52dac87248aa
-    - path: output/gprofiler2/gprofiler2.test_r_t.REAC.sub_enriched_pathways.png
-    - path: output/gprofiler2/gprofiler2.test_r_t.REAC.sub_enriched_pathways.tsv
+    - path: output/gprofiler2/test_r_t.gprofiler2.REAC.sub_enriched_pathways.png
+    - path: output/gprofiler2/test_r_t.gprofiler2.REAC.sub_enriched_pathways.tsv
       md5sum: 0e4f2887e74e00fe8d0ad93771342f4b
-    - path: output/gprofiler2/gprofiler2.test_r_t.all_enriched_pathways.tsv
-      md5sum: 231bdf9e12394dbb37d9bd427da36fb5
-    - path: output/gprofiler2/gprofiler2.test_r_t.gostplot.html
+    - path: output/gprofiler2/test_r_t.gprofiler2.all_enriched_pathways.tsv
+      md5sum: bbfa48be9e30e9898ecf63709bb99331
+    - path: output/gprofiler2/test_r_t.gprofiler2.gostplot.html
       contains:
         [
           "Neurotransmitter receptors and postsynaptic signal transmission",
           "The phototransduction cascade",
           "Muscle contraction",
         ]
-    - path: output/gprofiler2/gprofiler2.test_r_t.gostplot.png
+    - path: output/gprofiler2/test_r_t.gprofiler2.gostplot.png
     - path: output/gprofiler2/gprofiler_full_mmusculus.CORUM_REAC.ENSG_filtered.gmt
       md5sum: 455f9b94af175e78cc551cf7f79c3203
-    - path: output/gprofiler2/test.gprofiler2.gost_results.rds
+    - path: output/gprofiler2/test_r_t.gprofiler2.gost_results.rds
     - path: output/gprofiler2/versions.yml
 
 - name: gprofiler2 gost test_gprofiler2_gost_backgroundmatrix
@@ -35,13 +35,13 @@
   files:
     - path: output/gprofiler2/R_sessionInfo.log
       contains: ["ggplot2_3.4.3", "gprofiler2_0.2.2"]
-    - path: output/gprofiler2/gprofiler2.test_r_t.KEGG.sub_enriched_pathways.png
-    - path: output/gprofiler2/gprofiler2.test_r_t.KEGG.sub_enriched_pathways.tsv
+    - path: output/gprofiler2/test_r_t.gprofiler2.KEGG.sub_enriched_pathways.png
+    - path: output/gprofiler2/test_r_t.gprofiler2.KEGG.sub_enriched_pathways.tsv
       md5sum: fa7c0457da981ca00b209fadafe419bd
-    - path: output/gprofiler2/gprofiler2.test_r_t.all_enriched_pathways.tsv
-      md5sum: 6eeff6d8067f161425184039d68d5d1f
-    - path: output/gprofiler2/gprofiler2.test_r_t.gostplot.html # This plot is empty, will not add contains
-    - path: output/gprofiler2/gprofiler2.test_r_t.gostplot.png
+    - path: output/gprofiler2/test_r_t.gprofiler2.all_enriched_pathways.tsv
+      md5sum: fd611ba563ed8ec2c27dbf8d99b869dd
+    - path: output/gprofiler2/test_r_t.gprofiler2.gostplot.html # This plot is empty, will not add contains
+    - path: output/gprofiler2/test_r_t.gprofiler2.gostplot.png
     - path: output/gprofiler2/gprofiler_full_mmusculus.KEGG.ENSG_filtered.gmt
-    - path: output/gprofiler2/test.gprofiler2.gost_results.rds
+    - path: output/gprofiler2/test_r_t.gprofiler2.gost_results.rds
     - path: output/gprofiler2/versions.yml


### PR DESCRIPTION
A little bug caused the empty output to be created only if no DE genes were input, not if the enrichment analysis itself failed, this is now fixed. Also changed the contrast params into a single prefix param

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
