### PR TITLE
Add cobs/compactconstruct module

### DIFF
--- a/modules/nf-core/cobs/compactconstruct/environment.yml
+++ b/modules/nf-core/cobs/compactconstruct/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "cobs_compactconstruct"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "bioconda::cobs=0.3.0"

--- a/modules/nf-core/cobs/compactconstruct/main.nf
+++ b/modules/nf-core/cobs/compactconstruct/main.nf
@@ -1,0 +1,50 @@
+process COBS_COMPACTCONSTRUCT {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/cobs:0.3.0--hdcf5f25_1' :
+        'biocontainers/cobs:0.3.0--hdcf5f25_1'}"
+
+    input:
+    tuple val(meta), path(input)
+
+    output:
+    tuple val(meta), path("*.index.cobs_compact"), emit: index
+    path "versions.yml"                          , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def task_memory_in_bytes = task.memory.toBytes()
+    """
+    cobs \\
+        compact-construct \\
+        $args \\
+        --memory $task_memory_in_bytes \\
+        --threads $task.cpus \\
+        $input \\
+        ${prefix}.index.cobs_compact
+
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        cobs: \$(cobs version 2>&1 | awk '{print \$3}')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.index.cobs_compact
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        cobs: \$(cobs version 2>&1 | awk '{print \$3}')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/cobs/compactconstruct/meta.yml
+++ b/modules/nf-core/cobs/compactconstruct/meta.yml
@@ -12,7 +12,6 @@ tools:
       description: "Compact Bit-Sliced Signature Index (for Genomic k-Mer Data or q-Grams)"
       homepage: "https://panthema.net/cobs"
       documentation: "https://github.com/iqbal-lab-org/cobs"
-      tool_dev_url: "https://github.com/iqbal-lab-org/cobs"
       doi: "10.1007/978-3-030-32686-9_21"
       licence: ["MIT"]
 

--- a/modules/nf-core/cobs/compactconstruct/meta.yml
+++ b/modules/nf-core/cobs/compactconstruct/meta.yml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "cobs_compactconstruct"
+description: Builds a compact bloom filter COBS index
+keywords:
+  - COBS
+  - index
+  - k-mer index
+  - bloom filter
+tools:
+  - "cobs":
+      description: "Compact Bit-Sliced Signature Index (for Genomic k-Mer Data or q-Grams)"
+      homepage: "https://panthema.net/cobs"
+      documentation: "https://github.com/iqbal-lab-org/cobs"
+      tool_dev_url: "https://github.com/iqbal-lab-org/cobs"
+      doi: "10.1007/978-3-030-32686-9_21"
+      licence: ["MIT"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1', single_end:false ]`
+
+  - input:
+      type: file
+      description: |
+        The file or directory to be indexed.
+        COBS can read:
+          1. FASTA files (*.fa, *.fasta, *.fna, *.ffn, *.faa, *.frn, *.fa.gz, *.fasta.gz, *.fna.gz, *.ffn.gz, *.faa.gz, *.frn.gz),
+          2. FASTQ files (*.fq, *.fastq, *.fq.gz., *.fastq.gz),
+          3. "Multi-FASTA" and "Multi-FASTQ" files (*.mfasta, *.mfastq),
+          4. McCortex files (*.ctx),
+          5. or text files (*.txt).
+        You can either recursively scan a directory for all files matching any of these files,
+        or pass a *.list file which lists all paths COBS should index.
+      pattern: "*.*"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1', single_end:false ]`
+
+  - index:
+      type: file
+      description: The COBS compact index
+      pattern: "*.index.cobs_compact"
+
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@leoisl"
+maintainers:
+  - "@leoisl"

--- a/modules/nf-core/cobs/compactconstruct/meta.yml
+++ b/modules/nf-core/cobs/compactconstruct/meta.yml
@@ -20,7 +20,7 @@ input:
       type: map
       description: |
         Groovy Map containing sample information
-        e.g. `[ id:'sample1', single_end:false ]`
+        e.g. `[ id:'sample1' ]`
 
   - input:
       type: file
@@ -41,7 +41,7 @@ output:
       type: map
       description: |
         Groovy Map containing sample information
-        e.g. `[ id:'sample1', single_end:false ]`
+        e.g. `[ id:'sample1' ]`
 
   - index:
       type: file

--- a/modules/nf-core/cobs/compactconstruct/meta.yml
+++ b/modules/nf-core/cobs/compactconstruct/meta.yml
@@ -27,13 +27,13 @@ input:
       description: |
         The file or directory to be indexed.
         COBS can read:
-          1. FASTA files (*.fa, *.fasta, *.fna, *.ffn, *.faa, *.frn, *.fa.gz, *.fasta.gz, *.fna.gz, *.ffn.gz, *.faa.gz, *.frn.gz),
-          2. FASTQ files (*.fq, *.fastq, *.fq.gz., *.fastq.gz),
-          3. "Multi-FASTA" and "Multi-FASTQ" files (*.mfasta, *.mfastq),
-          4. McCortex files (*.ctx),
-          5. or text files (*.txt).
+          1. FASTA files (`*.fa`, `*.fasta`, `*.fna`, `*.ffn`, `*.faa`, `*.frn`, `*.fa.gz`, `*.fasta.gz`, `*.fna.gz`, `*.ffn.gz`, `*.faa.gz`, `*.frn.gz`),
+          2. FASTQ files (`*.fq`, `*.fastq`, `*.fq.gz.`, `*.fastq.gz`),
+          3. "Multi-FASTA" and "Multi-FASTQ" files (`*.mfasta`, `*.mfastq`),
+          4. McCortex files (`*.ctx`),
+          5. or text files (`*.txt`).
         You can either recursively scan a directory for all files matching any of these files,
-        or pass a *.list file which lists all paths COBS should index.
+        or pass a `*.list` file which lists all paths COBS should index.
       pattern: "*.*"
 
 output:

--- a/modules/nf-core/cobs/compactconstruct/tests/main.nf.test
+++ b/modules/nf-core/cobs/compactconstruct/tests/main.nf.test
@@ -1,0 +1,49 @@
+nextflow_process {
+    name "Test Process COBS_COMPACTCONSTRUCT"
+    script "../main.nf"
+    process "COBS_COMPACTCONSTRUCT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "cobs"
+    tag "cobs/compactconstruct"
+
+    test("sarscov2 - genome - fasta") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match()}
+            )
+        }
+    }
+
+    test("sarscov2 - genome - fasta - stub") {
+        options "-stub-run"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match()}
+            )
+        }
+    }
+}

--- a/modules/nf-core/cobs/compactconstruct/tests/main.nf.test.snap
+++ b/modules/nf-core/cobs/compactconstruct/tests/main.nf.test.snap
@@ -1,0 +1,60 @@
+{
+    "sarscov2 - genome - fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.index.cobs_compact:md5,56d89956e4c2cb0f5994af9720f2d882"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,6965c5f6acff9fb35d20b520fccc843e"
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.index.cobs_compact:md5,56d89956e4c2cb0f5994af9720f2d882"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,6965c5f6acff9fb35d20b520fccc843e"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-14T16:28:47.082358"
+    },
+    "sarscov2 - genome - fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.index.cobs_compact:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,6965c5f6acff9fb35d20b520fccc843e"
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.index.cobs_compact:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,6965c5f6acff9fb35d20b520fccc843e"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-14T16:28:55.338642"
+    }
+}

--- a/modules/nf-core/cobs/compactconstruct/tests/tags.yml
+++ b/modules/nf-core/cobs/compactconstruct/tests/tags.yml
@@ -1,0 +1,2 @@
+cobs/compactconstruct:
+  - "modules/nf-core/cobs/compactconstruct/**"


### PR DESCRIPTION
Add cobs/compactconstruct module. This subtool is very similar to one previously merged (cobs/classicconstruct: https://github.com/nf-core/modules/pull/4586), but it builds a compact bloom filter instead of a classic one, which is the main innovation of this work. For cobs, see https://github.com/iqbal-lab-org/cobs and https://link.springer.com/chapter/10.1007/978-3-030-32686-9_21

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
