### PR TITLE
Fix for #4692 added double quotes for find command in gtdbtk/classifywf

### DIFF
--- a/modules/nf-core/gtdbtk/classifywf/main.nf
+++ b/modules/nf-core/gtdbtk/classifywf/main.nf
@@ -61,7 +61,7 @@ process GTDBTK_CLASSIFYWF {
 
     mv gtdbtk.warnings.log "gtdbtk.${prefix}.warnings.log"
 
-    find -name gtdbtk.${prefix}.*.classify.tree | xargs -r gzip # do not fail if .tree is missing
+    find -name "gtdbtk.${prefix}.*.classify.tree" | xargs -r gzip # do not fail if .tree is missing
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist
Simple fix by adding double quotes to find command pattern in `gtdbtk/classifywf/main.nf`. 
Closes #4692  <!-- If this PR fixes an issue, please link it here! -->
