### PR TITLE
bugfix: the file was not compressed

### DIFF
--- a/modules/nf-core/samtools/fasta/main.nf
+++ b/modules/nf-core/samtools/fasta/main.nf
@@ -24,7 +24,7 @@ process SAMTOOLS_FASTA {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def output = ( interleave && ! meta.single_end ) ? "> ${prefix}_interleaved.fasta.gz" :
+    def output = ( interleave && ! meta.single_end ) ? "| gzip > ${prefix}_interleaved.fasta.gz" :
         meta.single_end ? "-1 ${prefix}_1.fasta.gz -s ${prefix}_singleton.fasta.gz" :
         "-1 ${prefix}_1.fasta.gz -2 ${prefix}_2.fasta.gz -s ${prefix}_singleton.fasta.gz"
     """

--- a/tests/modules/nf-core/samtools/fasta/test.yml
+++ b/tests/modules/nf-core/samtools/fasta/test.yml
@@ -21,7 +21,7 @@
     - samtools/fasta
   files:
     - path: output/samtools/test_interleaved.fasta.gz
-      md5sum: 02d7f0389745d9d274d091cf8bf3b8a1
+      md5sum: c0b1732bbe267dfe84ee6fdf56f5b1b4
     - path: output/samtools/test_other.fasta.gz
       md5sum: 709872fc2910431b1e8b7074bfe38c67
     - path: output/samtools/versions.yml


### PR DESCRIPTION
The standard output of `samtools fasta` is _uncompressed_ Fasta. Need to add `gzip` to compress it

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
