### PR TITLE
Replace base path for test data with new form

### DIFF
--- a/modules/nf-core/custom/sratoolsncbisettings/tests/main.nf.test
+++ b/modules/nf-core/custom/sratoolsncbisettings/tests/main.nf.test
@@ -21,7 +21,7 @@ nextflow_process {
             process {
                 """
                 file(params.settings_path).mkdirs()
-                def settings = file(params.modules_test_data_base + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                def settings = file(params.testdata_base_path + '/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 settings.copyTo(params.settings_file)
                 """
             }

--- a/modules/nf-core/sratools/fasterqdump/tests/main.nf.test
+++ b/modules/nf-core/sratools/fasterqdump/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
                 script "modules/nf-core/untar/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/genomics/sarscov2/illumina/sra/SRR13255544.tar.gz', checkIfExists: true) ])
+                    input[0] = Channel.of([ [], file(params.testdata_base_path + 'genomics/sarscov2/illumina/sra/SRR13255544.tar.gz', checkIfExists: true) ])
                     """
                 }
             }
@@ -25,7 +25,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR.out.untar.map{ meta, files -> [ [ id:'test_single_end', single_end:true ], files]}
-                input[1] = file(params.testdata_base_path + '/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + 'generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }
@@ -46,7 +46,7 @@ nextflow_process {
                 script "modules/nf-core/untar/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/genomics/sarscov2/illumina/sra/SRR11140744.tar.gz', checkIfExists: true) ])
+                    input[0] = Channel.of([ [], file(params.testdata_base_path + 'genomics/sarscov2/illumina/sra/SRR11140744.tar.gz', checkIfExists: true) ])
                     """
                 }
             }
@@ -56,7 +56,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR.out.untar.map{ meta, files -> [ [ id:'test_paired_end', single_end:false ], files]}
-                input[1] = file(params.testdata_base_path + '/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + 'generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }

--- a/modules/nf-core/sratools/fasterqdump/tests/main.nf.test
+++ b/modules/nf-core/sratools/fasterqdump/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
                 script "modules/nf-core/untar/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([ [], file(params.modules_test_data_base + '/data/genomics/sarscov2/illumina/sra/SRR13255544.tar.gz', checkIfExists: true) ])
+                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/data/genomics/sarscov2/illumina/sra/SRR13255544.tar.gz', checkIfExists: true) ])
                     """
                 }
             }
@@ -25,7 +25,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR.out.untar.map{ meta, files -> [ [ id:'test_single_end', single_end:true ], files]}
-                input[1] = file(params.modules_test_data_base + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }
@@ -46,7 +46,7 @@ nextflow_process {
                 script "modules/nf-core/untar/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([ [], file(params.modules_test_data_base + '/data/genomics/sarscov2/illumina/sra/SRR11140744.tar.gz', checkIfExists: true) ])
+                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/data/genomics/sarscov2/illumina/sra/SRR11140744.tar.gz', checkIfExists: true) ])
                     """
                 }
             }
@@ -56,7 +56,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR.out.untar.map{ meta, files -> [ [ id:'test_paired_end', single_end:false ], files]}
-                input[1] = file(params.modules_test_data_base + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }

--- a/modules/nf-core/sratools/fasterqdump/tests/main.nf.test
+++ b/modules/nf-core/sratools/fasterqdump/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
                 script "modules/nf-core/untar/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/2024-01-11/data/genomics/sarscov2/illumina/sra/SRR13255544.tar.gz', checkIfExists: true) ])
+                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/genomics/sarscov2/illumina/sra/SRR13255544.tar.gz', checkIfExists: true) ])
                     """
                 }
             }
@@ -25,7 +25,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR.out.untar.map{ meta, files -> [ [ id:'test_single_end', single_end:true ], files]}
-                input[1] = file(params.testdata_base_path + '/2024-01-11/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + '/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }
@@ -46,7 +46,7 @@ nextflow_process {
                 script "modules/nf-core/untar/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/2024-01-11/data/genomics/sarscov2/illumina/sra/SRR11140744.tar.gz', checkIfExists: true) ])
+                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/genomics/sarscov2/illumina/sra/SRR11140744.tar.gz', checkIfExists: true) ])
                     """
                 }
             }
@@ -56,7 +56,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR.out.untar.map{ meta, files -> [ [ id:'test_paired_end', single_end:false ], files]}
-                input[1] = file(params.testdata_base_path + '/2024-01-11/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + '/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }

--- a/modules/nf-core/sratools/fasterqdump/tests/main.nf.test
+++ b/modules/nf-core/sratools/fasterqdump/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
                 script "modules/nf-core/untar/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/data/genomics/sarscov2/illumina/sra/SRR13255544.tar.gz', checkIfExists: true) ])
+                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/2024-01-11/data/genomics/sarscov2/illumina/sra/SRR13255544.tar.gz', checkIfExists: true) ])
                     """
                 }
             }
@@ -25,7 +25,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR.out.untar.map{ meta, files -> [ [ id:'test_single_end', single_end:true ], files]}
-                input[1] = file(params.testdata_base_path + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + '/2024-01-11/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }
@@ -46,7 +46,7 @@ nextflow_process {
                 script "modules/nf-core/untar/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/data/genomics/sarscov2/illumina/sra/SRR11140744.tar.gz', checkIfExists: true) ])
+                    input[0] = Channel.of([ [], file(params.testdata_base_path + '/2024-01-11/data/genomics/sarscov2/illumina/sra/SRR11140744.tar.gz', checkIfExists: true) ])
                     """
                 }
             }
@@ -56,7 +56,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR.out.untar.map{ meta, files -> [ [ id:'test_paired_end', single_end:false ], files]}
-                input[1] = file(params.testdata_base_path + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + '/2024-01-11/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }

--- a/modules/nf-core/sratools/prefetch/tests/main.nf.test
+++ b/modules/nf-core/sratools/prefetch/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
             process {
                 """
                 input[0] = Channel.of([ [ id:'test', single_end:false ], 'DRR000774' ])
-                input[1] = file(params.modules_test_data_base + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + '/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }
@@ -39,7 +39,7 @@ nextflow_process {
             process {
                 """
                 input[0] = Channel.of([ [ id:'test', single_end:false ], 'SRR1170046' ])
-                input[1] = file(params.modules_test_data_base + '/data/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
+                input[1] = file(params.testdata_base_path + '/generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 input[2] = []
                 """
             }

--- a/modules/nf-core/untar/tests/main.nf.test
+++ b/modules/nf-core/untar/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [ [], file(params.testdata_base_path + '/2024-01-11/data/genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
+                input[0] = [ [], file(params.testdata_base_path + '/genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
                 """
             }
         }
@@ -38,7 +38,7 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [ [], file(params.testdata_base_path + '/2024-01-11/data/generic/tar/hello.tar.gz', checkIfExists: true) ]
+                input[0] = [ [], file(params.testdata_base_path + '/generic/tar/hello.tar.gz', checkIfExists: true) ]
                 """
             }
         }

--- a/modules/nf-core/untar/tests/main.nf.test
+++ b/modules/nf-core/untar/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [ [], file(params.modules_test_data_base + '/data/genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
+                input[0] = [ [], file(params.testdata_base_path + '/data/genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
                 """
             }
         }
@@ -38,7 +38,7 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [ [], file(params.modules_test_data_base + '/data/generic/tar/hello.tar.gz', checkIfExists: true) ]
+                input[0] = [ [], file(params.testdata_base_path + '/data/generic/tar/hello.tar.gz', checkIfExists: true) ]
                 """
             }
         }

--- a/modules/nf-core/untar/tests/main.nf.test
+++ b/modules/nf-core/untar/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [ [], file(params.testdata_base_path + '/genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
+                input[0] = [ [], file(params.testdata_base_path + 'genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
                 """
             }
         }
@@ -38,7 +38,7 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [ [], file(params.testdata_base_path + '/generic/tar/hello.tar.gz', checkIfExists: true) ]
+                input[0] = [ [], file(params.testdata_base_path + 'generic/tar/hello.tar.gz', checkIfExists: true) ]
                 """
             }
         }

--- a/modules/nf-core/untar/tests/main.nf.test
+++ b/modules/nf-core/untar/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [ [], file(params.testdata_base_path + '/data/genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
+                input[0] = [ [], file(params.testdata_base_path + '/2024-01-11/data/genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true) ]
                 """
             }
         }
@@ -38,7 +38,7 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [ [], file(params.testdata_base_path + '/data/generic/tar/hello.tar.gz', checkIfExists: true) ]
+                input[0] = [ [], file(params.testdata_base_path + '/2024-01-11/data/generic/tar/hello.tar.gz', checkIfExists: true) ]
                 """
             }
         }

--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -2,7 +2,7 @@ params {
     publish_dir_mode = "copy"
     singularity_pull_docker_container = false
     test_data_base = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules'
-    modules_test_data_base = 'https://raw.githubusercontent.com/nf-core/test-datasets/3e79d4b5fbed8c6ef7546d50696b343ab9a95fbe/'
+    testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/3e79d4b5fbed8c6ef7546d50696b343ab9a95fbe/'
 }
 
 process {

--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -2,7 +2,7 @@ params {
     publish_dir_mode = "copy"
     singularity_pull_docker_container = false
     test_data_base = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules'
-    testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/3e79d4b5fbed8c6ef7546d50696b343ab9a95fbe/'
+    testdata_base_path = 's3://ngi-igenomes/nf-core/modules'
 }
 
 process {

--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -2,7 +2,7 @@ params {
     publish_dir_mode = "copy"
     singularity_pull_docker_container = false
     test_data_base = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules'
-    testdata_base_path = 's3://ngi-igenomes/nf-core/modules'
+    testdata_base_path = 's3://ngi-igenomes/testdata/nf-core/modules/'
 }
 
 process {

--- a/tests/modules/nf-core/bases2fastq/test.yml
+++ b/tests/modules/nf-core/bases2fastq/test.yml
@@ -7,7 +7,7 @@
     - path: output/bases2fastq/output/Metrics.csv
       md5sum: a8094b308b5653071ac029a27733e4a6
     - path: output/bases2fastq/output/RunManifest.json
-      md5sum: a07dce8ee25c2a6f9355b677c26b53e2
+      md5sum: bb22faef28dfb0b3b106bd5cc320bf09
     - path: output/bases2fastq/output/RunStats.json
     - path: output/bases2fastq/output/UnassignedSequences.csv
       md5sum: 11c1693830ce941b8cfb8d2431a59097

--- a/tests/modules/nf-core/bases2fastq/test.yml
+++ b/tests/modules/nf-core/bases2fastq/test.yml
@@ -7,7 +7,6 @@
     - path: output/bases2fastq/output/Metrics.csv
       md5sum: a8094b308b5653071ac029a27733e4a6
     - path: output/bases2fastq/output/RunManifest.json
-      md5sum: bb22faef28dfb0b3b106bd5cc320bf09
     - path: output/bases2fastq/output/RunStats.json
     - path: output/bases2fastq/output/UnassignedSequences.csv
       md5sum: 11c1693830ce941b8cfb8d2431a59097


### PR DESCRIPTION
Changes:
 - Base path for test data is now replaced with a more logical form based on discussions on Slack
 - from modules_test_data_base to testdata_base_path
 - Should be more explicit and reduce confusion with 'database'

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist


- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
