### PR TITLE
Support large databases like NT

### DIFF
--- a/modules/nf-core/blast/blastn/main.nf
+++ b/modules/nf-core/blast/blastn/main.nf
@@ -29,7 +29,12 @@ process BLAST_BLASTN {
         gzip -c -d ${fasta} > ${fasta_name}
     fi
 
-    DB=`find -L ./ -name "*.nin" | sed 's/\\.nin\$//'`
+    DB=`find -L ./ -name "*.nal" | sed 's/\\.nal\$//'`
+    if [ -z "\$DB" ]; then
+        DB=`find -L ./ -name "*.nin" | sed 's/\\.nin\$//'`
+    fi
+    echo Using \$DB
+
     blastn \\
         -num_threads ${task.cpus} \\
         -db \$DB \\

--- a/modules/nf-core/blast/blastn/tests/main.nf.test
+++ b/modules/nf-core/blast/blastn/tests/main.nf.test
@@ -8,6 +8,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "blast"
     tag "blast/blastn"
+    tag "blast/makeblastdb"
 
     setup {
         run("BLAST_MAKEBLASTDB") {

--- a/modules/nf-core/blast/tblastn/main.nf
+++ b/modules/nf-core/blast/tblastn/main.nf
@@ -28,7 +28,12 @@ process BLAST_TBLASTN {
         gzip -c -d ${fasta} > ${fasta_name}
     fi
 
-    DB=`find -L ./ -name "*.nsq" | sed 's/\\.nsq\$//'`
+    DB=`find -L ./ -name "*.nal" | sed 's/\\.nal\$//'`
+    if [ -z "\$DB" ]; then
+        DB=`find -L ./ -name "*.nin" | sed 's/\\.nin\$//'`
+    fi
+    echo Using \$DB
+
     tblastn \\
         -num_threads ${task.cpus} \\
         -db \$DB \\

--- a/modules/nf-core/blast/tblastn/tests/main.nf.test
+++ b/modules/nf-core/blast/tblastn/tests/main.nf.test
@@ -8,6 +8,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "blast"
     tag "blast/tblastn"
+    tag "blast/makeblastdb"
 
     setup {
         run("BLAST_MAKEBLASTDB") {


### PR DESCRIPTION
Very large blast databases, like NT, are split in chunks, and only the individual chunks have `.nin` files.

```
$ wget https://ftp.ncbi.nlm.nih.gov/blast/db/nt.000.tar.gz
$ tar tvzf nt.000.tar.gz
-rw-r--r-- blastadm/blast  962 2024-01-06 03:06 nt.nal
-rw-r--r-- blastadm/blast 5712982016 2024-01-05 06:59 nt.ndb
-rw-r--r-- blastadm/blast 2283727932 2024-01-05 06:54 nt.nos
-rw-r--r-- blastadm/blast 1230513580 2024-01-05 07:00 nt.not
-rw-r--r-- blastadm/blast  189022208 2024-01-05 07:01 nt.ntf
-rw-r--r-- blastadm/blast  421142456 2024-01-05 07:00 nt.nto
-rw-rw-r-- blastadm/blast  164539268 2024-01-08 14:05 taxdb.btd
-rw-rw-r-- blastadm/blast   17292992 2024-01-08 14:05 taxdb.bti
-rw-rw-r-- blastadm/blast   78737408 2024-01-08 14:05 taxonomy4blast.sqlite3
-rw-r--r-- blastadm/blast   27374232 2024-01-06 00:28 nt.000.nin
-rw-r--r-- blastadm/blast  421155020 2024-01-05 04:42 nt.000.nhr
-rw-r--r-- blastadm/blast 2999949176 2024-01-05 04:42 nt.000.nsq
-rw-r--r-- blastadm/blast      83012 2024-01-05 04:42 nt.000.nni
-rw-r--r-- blastadm/blast   21238584 2024-01-05 04:42 nt.000.nnd
-rw-r--r-- blastadm/blast     935870 2024-01-05 04:42 nt.000.nhi
-rw-r--r-- blastadm/blast   41640537 2024-01-05 04:42 nt.000.nhd
-rw-r--r-- blastadm/blast    9124740 2024-01-05 04:42 nt.000.nog
```

The current rule for finding the database name will pick up `nt.000` and `nt.001` and `nt.002`, etc. First of all, there are >100 files these days and the size of the command-line may exceed system limits. But anyway, the right name to put on the command-line is just `nt`.

I thought about trimming trailing digits, but what if someone wants to name their database `beaver.000` ?

My solution is to first look for split databases, which have this `.nal` file:

```
$ cat nt.nal 
#
# Alias file created: Jan 5, 2024  7:22 PM
#
TITLE Nucleotide collection (nt)
DBLIST nt.000 nt.001 nt.002 nt.003 nt.004 nt.005 nt.006 nt.007 nt.008 nt.009 nt.010 nt.011 nt.012 nt.013 nt.014 nt.015 nt.016 nt.017 nt.018 nt.019 nt.020 nt.021 nt.022 nt.023 nt.024 nt.025 nt.026 nt.027 nt.028 nt.029 nt.030 nt.031 nt.032 nt.033 nt.034 nt.035 nt.036 nt.037 nt.038 nt.039 nt.040 nt.041 nt.042 nt.043 nt.044 nt.045 nt.046 nt.047 nt.048 nt.049 nt.050 nt.051 nt.052 nt.053 nt.054 nt.055 nt.056 nt.057 nt.058 nt.059 nt.060 nt.061 nt.062 nt.063 nt.064 nt.065 nt.066 nt.067 nt.068 nt.069 nt.070 nt.071 nt.072 nt.073 nt.074 nt.075 nt.076 nt.077 nt.078 nt.079 nt.080 nt.081 nt.082 nt.083 nt.084 nt.085 nt.086 nt.087 nt.088 nt.089 nt.090 nt.091 nt.092 nt.093 nt.094 nt.095 nt.096 nt.097 nt.098 nt.099 nt.100 nt.101 nt.102 nt.103 nt.104 nt.105 nt.106 nt.107 nt.108 nt.109 nt.110 nt.111 nt.112 nt.113 nt.114 nt.115 nt.116 nt.117 nt.118 nt.119 nt.120 nt.121 nt.122 nt.123 nt.124
```

And if there isn't a `.nal` file, then fall back to the `.nin` search.

I also roll the change out to `tblastn`

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
