### PR TITLE
Improve FASTQC/FASTP/UMI subworkflow

### DIFF
--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
@@ -17,10 +17,9 @@ def getFastpReadsAfterFiltering(json_file) {
     return json['after_filtering']['total_reads'].toLong()
 }
 
-String getFastpAdapterSequence(json_file){
-    return new JsonSlurper().parseText(json_file.text)
-    ?.get('adapter_cutting')
-    ?.get('read1_adapter_sequence')
+def getFastpAdapterSequence(json_file){
+    def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('adapter_cutting')
+    return json['read1_adapter_sequence']
 }
 
 workflow FASTQ_FASTQC_UMITOOLS_FASTP {
@@ -116,7 +115,7 @@ workflow FASTQ_FASTQC_UMITOOLS_FASTP {
 
         trim_json.
             .map { meta, json -> [meta, getFastpAdapterSequence(json)] }
-            .set { adapterseq }
+            .set { adapter_seq }
 
         if (!skip_fastqc) {
             FASTQC_TRIM (
@@ -135,7 +134,7 @@ workflow FASTQ_FASTQC_UMITOOLS_FASTP {
     fastqc_raw_zip     // channel: [ val(meta), [ zip ] ]
 
     umi_log            // channel: [ val(meta), [ log ] ]
-    adapterseq         // channel: [ val(meta), [ adapterseq] ]
+    adapter_seq        // channel: [ val(meta), [ adapter_seq] ]
 
     trim_json          // channel: [ val(meta), [ json ] ]
     trim_html          // channel: [ val(meta), [ html ] ]

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
@@ -80,6 +80,8 @@ workflow FASTQ_FASTQC_UMITOOLS_FASTP {
     fastqc_trim_html  = Channel.empty()
     fastqc_trim_zip   = Channel.empty()
     trim_read_count   = Channel.empty()
+    adapter_seq       = Channel.empty()
+
     if (!skip_trimming) {
         FASTP (
             umi_reads,

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
@@ -115,7 +115,7 @@ workflow FASTQ_FASTQC_UMITOOLS_FASTP {
             .map { meta, reads, num_reads -> [ meta, num_reads ] }
             .set { trim_read_count }
 
-        trim_json.
+        trim_json
             .map { meta, json -> [meta, getFastpAdapterSequence(json)] }
             .set { adapter_seq }
 

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/meta.yml
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/meta.yml
@@ -43,7 +43,7 @@ input:
   - skip_trimming:
       type: boolean
       description: |
-        Allows to skip trimgalore execution
+        Allows to skip FastP execution
   - adapter_fasta:
       type: file
       description: |

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/meta.yml
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/meta.yml
@@ -70,10 +70,7 @@ output:
       type: file
       description: >
         Extracted FASTQ files. | For single-end reads, pattern is \${prefix}.umi_extract.fastq.gz. |
-
-
-
-          For paired-end reads, pattern is \${prefix}.umi_extract_{1,2}.fastq.gz.
+        For paired-end reads, pattern is \${prefix}.umi_extract_{1,2}.fastq.gz.
       pattern: "*.{fastq.gz}"
   - fastqc_html:
       type: file
@@ -118,6 +115,10 @@ output:
       type: file
       description: FastQC report archive
       pattern: "*_{fastqc.zip}"
+  - adapter_seq:
+      type: string
+      description: |
+        Adapter Sequence found in read1
   - versions:
       type: file
       description: File containing software versions

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test
@@ -45,6 +45,7 @@ nextflow_workflow {
                 { assert snapshot(workflow.out.trim_json).match("trim_json") },
                 { assert snapshot(workflow.out.trim_reads_fail).match("trim_reads_fail") },
                 { assert snapshot(workflow.out.trim_reads_merged).match("trim_reads_merged") },
+                { assert snapshot(workflow.out.adapter_seq).match("adapter_seq") },
                 { assert snapshot(workflow.out.trim_read_count).match("trim_read_count") },
                 { assert snapshot(workflow.out.versions).match("versions") },
 

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test.snap
@@ -2,18 +2,18 @@
     "trim_reads_merged": {
         "content": [
             [
-
+                
             ]
         ],
-        "timestamp": "2023-11-26T02:28:26.26920982"
+        "timestamp": "2024-01-12T08:38:50.041635573"
     },
     "trim_reads_fail": {
         "content": [
             [
-
+                
             ]
         ],
-        "timestamp": "2023-11-26T02:28:26.25861515"
+        "timestamp": "2024-01-12T08:38:50.033284693"
     },
     "versions": {
         "content": [
@@ -23,7 +23,7 @@
                 "versions.yml:md5,f3dcaae948e8eed92b4a5557b4c6668e"
             ]
         ],
-        "timestamp": "2023-11-26T02:28:26.30891403"
+        "timestamp": "2024-01-12T08:38:50.121510557"
     },
     "trim_json": {
         "content": [
@@ -37,7 +37,21 @@
                 ]
             ]
         ],
-        "timestamp": "2023-11-26T02:28:26.24768259"
+        "timestamp": "2024-01-12T08:38:50.024410724"
+    },
+    "adapter_seq": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "unspecified"
+                ]
+            ]
+        ],
+        "timestamp": "2024-01-12T08:38:50.08674429"
     },
     "reads": {
         "content": [
@@ -54,23 +68,15 @@
                 ]
             ]
         ],
-        "timestamp": "2023-12-04T11:30:32.061644815"
+        "timestamp": "2024-01-12T08:38:49.994419936"
     },
     "umi_log": {
         "content": [
             [
-
+                
             ]
         ],
-        "timestamp": "2023-11-26T02:28:26.238536"
-    },
-    "adapter_seq": {
-        "content": [
-            [
-
-            ]
-        ],
-        "timestamp": "2023-11-26T02:28:26.238536"
+        "timestamp": "2024-01-12T08:38:50.017720214"
     },
     "trim_read_count": {
         "content": [
@@ -84,6 +90,6 @@
                 ]
             ]
         ],
-        "timestamp": "2023-11-26T02:28:26.27984169"
+        "timestamp": "2024-01-12T08:38:50.102326089"
     }
 }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "trim_reads_merged": {
         "content": [
             [
-                
+
             ]
         ],
         "timestamp": "2023-11-26T02:28:26.26920982"
@@ -10,7 +10,7 @@
     "trim_reads_fail": {
         "content": [
             [
-                
+
             ]
         ],
         "timestamp": "2023-11-26T02:28:26.25861515"
@@ -59,7 +59,15 @@
     "umi_log": {
         "content": [
             [
-                
+
+            ]
+        ],
+        "timestamp": "2023-11-26T02:28:26.238536"
+    },
+    "adapter_seq": {
+        "content": [
+            [
+
             ]
         ],
         "timestamp": "2023-11-26T02:28:26.238536"


### PR DESCRIPTION
This improves the FASTQ_FASTQC_UMITOOLS_FASTP subworkflow by adding in the output of detected adapter sequence(s) per sample. Needed in https://github.com/nf-core/smrnaseq/pull/303 to enable mirtrace to get the adapter sequence. I ditched the previously used subworkflow in favor of this one (thank you for making this already cover 95%!)

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
