### PR TITLE
cat/fastq: update snapshot using nf-test v0.8.3

### DIFF
--- a/modules/nf-core/cat/fastq/tests/main.nf.test.snap
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test.snap
@@ -7,11 +7,11 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.merged.fastq.gz:md5,f9cf5e375f7de81a406144a2c70cc64d"
+                    "test.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22"
                 ]
             ]
         ],
-        "timestamp": "2023-10-17T23:19:12.990284837"
+        "timestamp": "2024-01-12T14:02:54.278243"
     },
     "test_cat_fastq_single_end_same_name": {
         "content": [
@@ -21,11 +21,11 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.merged.fastq.gz:md5,63f817db7a29a03eb538104495556f66"
+                    "test.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22"
                 ]
             ]
         ],
-        "timestamp": "2023-10-17T23:19:31.554568147"
+        "timestamp": "2024-01-12T14:03:01.765432"
     },
     "test_cat_fastq_single_end_single_file": {
         "content": [
@@ -35,11 +35,11 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.merged.fastq.gz:md5,e325ef7deb4023447a1f074e285761af"
+                    "test.merged.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
                 ]
             ]
         ],
-        "timestamp": "2023-10-17T23:19:49.629360033"
+        "timestamp": "2024-01-12T14:03:08.858654"
     },
     "test_cat_fastq_paired_end_same_name": {
         "content": [
@@ -50,13 +50,13 @@
                         "single_end": false
                     },
                     [
-                        "test_1.merged.fastq.gz:md5,63f817db7a29a03eb538104495556f66",
-                        "test_2.merged.fastq.gz:md5,fe9f266f43a6fc3dcab690a18419a56e"
+                        "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
+                        "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
                     ]
                 ]
             ]
         ],
-        "timestamp": "2023-10-17T23:19:40.711617539"
+        "timestamp": "2024-01-12T14:03:05.494631"
     },
     "test_cat_fastq_paired_end": {
         "content": [
@@ -67,12 +67,12 @@
                         "single_end": false
                     },
                     [
-                        "test_1.merged.fastq.gz:md5,f9cf5e375f7de81a406144a2c70cc64d",
-                        "test_2.merged.fastq.gz:md5,77c8e966e130d8c6b6ec9be52fcb2bda"
+                        "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
+                        "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
                     ]
                 ]
             ]
         ],
-        "timestamp": "2023-10-18T07:53:20.923560211"
+        "timestamp": "2024-01-12T14:02:58.35062"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->
In nf-test [v0.8.2](https://github.com/askimed/nf-test/releases/tag/v0.8.2), the way md5s are generated for `.gz` files has changed, such that it is now the equivalent of running `gunzip -c file.gz | md5sum` (as opposed to, `md5sum file.gz`). The snapshot in the nf-core modules `master` branch contains the md5s generated for the compressed merged FASTQ, as opposed to the uncompressed. This PR updates the test snapshot using nf-test v0.8.3 and the command `nf-test test --tag cat/fastq --update-snapshot`.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
