### PR TITLE
adding log to hifiasm outputs

### DIFF
--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -49,7 +49,7 @@ process HIFIASM {
             -1 $paternal_kmer_dump \\
             -2 $maternal_kmer_dump \\
             $reads \\
-            2> >( tee ${prefix}.stderr.log >&2 ) 
+            2> >( tee ${prefix}.stderr.log >&2 )
 
 
         cat <<-END_VERSIONS > versions.yml
@@ -70,7 +70,7 @@ process HIFIASM {
             --h1 $hic_read1 \\
             --h2 $hic_read2 \\
             $reads \\
-            2> >( tee ${prefix}.stderr.log >&2 ) 
+            2> >( tee ${prefix}.stderr.log >&2 )
 
 
         cat <<-END_VERSIONS > versions.yml
@@ -85,7 +85,7 @@ process HIFIASM {
             -o ${prefix}.asm \\
             -t $task.cpus \\
             $reads \\
-            2> >( tee ${prefix}.stderr.log >&2 ) 
+            2> >( tee ${prefix}.stderr.log >&2 )
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -25,6 +25,7 @@ process HIFIASM {
     tuple val(meta), path("*.asm.a_ctg.gfa")   , emit: alternate_contigs, optional: true
     tuple val(meta), path("*.hap1.p_ctg.gfa")  , emit: paternal_contigs , optional: true
     tuple val(meta), path("*.hap2.p_ctg.gfa")  , emit: maternal_contigs , optional: true
+    tuple val(meta), path("*.log")             , emit: log
     path  "versions.yml"                       , emit: versions
 
     when:
@@ -47,7 +48,9 @@ process HIFIASM {
             -t $task.cpus \\
             -1 $paternal_kmer_dump \\
             -2 $maternal_kmer_dump \\
-            $reads
+            $reads \\
+            2> >( tee ${prefix}.stderr.log >&2 ) 
+
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -66,7 +69,9 @@ process HIFIASM {
             -t $task.cpus \\
             --h1 $hic_read1 \\
             --h2 $hic_read2 \\
-            $reads
+            $reads \\
+            2> >( tee ${prefix}.stderr.log >&2 ) 
+
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -79,7 +84,8 @@ process HIFIASM {
             $args \\
             -o ${prefix}.asm \\
             -t $task.cpus \\
-            $reads
+            $reads \\
+            2> >( tee ${prefix}.stderr.log >&2 ) 
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -93,4 +93,26 @@ process HIFIASM {
         END_VERSIONS
         """
     }
+        stub:
+        def args = task.ext.args ?: ''
+        def prefix = task.ext.prefix ?: "${meta.id}"
+        """
+        touch ${prefix}.asm.r_utg.gfa
+        touch ${prefix}.asm.ec.bin
+        touch ${prefix}.asm.ovlp.source.bin
+        touch ${prefix}.asm.ovlp.reverse.bin
+        touch ${prefix}.asm.bp.p_ctg.gfa
+        touch ${prefix}.asm.p_utg.gfa
+        touch ${prefix}.asm.p_ctg.gfa
+        touch ${prefix}.asm.a_ctg.gfa
+        touch ${prefix}.asm.hap1.p_ctg.gfa
+        touch ${prefix}.asm.hap2.p_ctg.gfa
+        touch ${prefix}.stderr.log
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            hifiasm: \$(hifiasm --version 2>&1)
+        END_VERSIONS
+        """
+
 }

--- a/modules/nf-core/hifiasm/meta.yml
+++ b/modules/nf-core/hifiasm/meta.yml
@@ -93,6 +93,7 @@ output:
 authors:
   - "@sidorov-si"
   - "@scorreard"
+  - "@mbeavitt"
 maintainers:
   - "@sidorov-si"
   - "@scorreard"

--- a/modules/nf-core/hifiasm/meta.yml
+++ b/modules/nf-core/hifiasm/meta.yml
@@ -86,6 +86,10 @@ output:
       type: file
       description: Reverse overlaps
       pattern: "*.ovlp.reverse.bin"
+  - log:
+      type: file
+      description: Stderr log
+      pattern: "*.log"
 authors:
   - "@sidorov-si"
   - "@scorreard"


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`

This change outputs the stderr of hifiasm to a .log file, and adds it to the named emitted files. Log file is compatible with MultiQC, and this module can now be used with it.