### PR TITLE
umicollapse module: Set initial heap size and modificaitons to log file creation

### DIFF
--- a/modules/nf-core/umicollapse/main.nf
+++ b/modules/nf-core/umicollapse/main.nf
@@ -26,13 +26,10 @@ process UMICOLLAPSE {
     """
     umicollapse \\
         bam \\
-        -Xms${String.format("%.0f", Math.rint(0.2 * task.memory.toGiga()))}g  \\
         -Xmx${task.memory.toGiga()}g  \\
         -i $bam \\
         -o ${prefix}.bam \\
-        $args
-
-    mv .command.log ${prefix}_UMICollapse.log
+        $args | tee ${prefix}_UMICollapse.log
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/umicollapse/main.nf
+++ b/modules/nf-core/umicollapse/main.nf
@@ -26,6 +26,8 @@ process UMICOLLAPSE {
     """
     umicollapse \\
         bam \\
+        -Xms${String.format("%.0f", Math.rint(0.2 * task.memory.toGiga()))}g  \\
+        -Xmx${task.memory.toGiga()}g  \\
         -i $bam \\
         -o ${prefix}.bam \\
         $args

--- a/modules/nf-core/umicollapse/main.nf
+++ b/modules/nf-core/umicollapse/main.nf
@@ -33,7 +33,7 @@ process UMICOLLAPSE {
     # by conda that allows to set the heap size (Xmx), but not the stack size (Xss).
     # `which` allows us to get the directory that contains `umicollapse`, independent of wheather we
     # are in a container or conda environment.
-    UMICOLLAPSE_JAR=$(dirname $(which umicollapse))/../share/umicollapse-${VERSION}/umicollapse.jar
+    UMICOLLAPSE_JAR=\$(dirname \$(which umicollapse))/../share/umicollapse-${VERSION}/umicollapse.jar
     java \\
         -Xmx${max_heap_size_mega}M \\
         -Xss${max_stack_size_mega}M \\

--- a/modules/nf-core/umicollapse/main.nf
+++ b/modules/nf-core/umicollapse/main.nf
@@ -1,5 +1,6 @@
 process UMICOLLAPSE {
     tag "$meta.id"
+    label "process_high"
     label "process_high_memory"
 
     conda "${moduleDir}/environment.yml"
@@ -12,7 +13,7 @@ process UMICOLLAPSE {
 
     output:
     tuple val(meta), path("*.bam"), emit: bam
-    tuple val(meta), path("*.log"), emit: log
+    tuple val(meta), path("*_UMICollapse.log"), emit: log
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/umicollapse/main.nf
+++ b/modules/nf-core/umicollapse/main.nf
@@ -39,7 +39,6 @@ process UMICOLLAPSE {
         -Xss${max_stack_size_mega}M \\
         -jar \$UMICOLLAPSE_JAR \\
         bam \\
-        -Xmx${task.memory.toGiga()}g  \\
         -i $bam \\
         -o ${prefix}.bam \\
         $args | tee ${prefix}_UMICollapse.log

--- a/modules/nf-core/umicollapse/meta.yml
+++ b/modules/nf-core/umicollapse/meta.yml
@@ -39,6 +39,10 @@ output:
       type: file
       description: BAM file with deduplicated UMIs.
       pattern: "*.{bam}"
+  - log:
+      type: file
+      description: A log file with the deduplication statistics.
+      pattern: "*_{UMICollapse.log}"
   - versions:
       type: file
       description: File containing software versions


### PR DESCRIPTION
This PR suggests two changes to the upstream nf-core module that I had to introduce to make it work [within an evaluation version the rnaseq pipeline using this module](https://github.com/MatthiasZepper/rnaseq/tree/eval_umicollapse).

The first modification adds a `-Xmx` parameter to the command that specifies the maximum heap size of the virtual machine. The parameter is used exactly as it is found in several other nf-core modules wrapping Java tools.

The second modification writes a logfile from stdout, since moving the `.command.log` doesn't seem to be a valid approach. The file seemingly does not yet exist in the work directory when the command is about to be executed.

For me, it was fine to not set an explicit stack size with `-Xss`, but @grst [apparently had to do it for the smrnaseq pipeline](https://github.com/nf-core/smrnaseq/blob/d5192d48a3491504b41fe1af51860d1d9773c632/modules/nf-core/umicollapse/main.nf), so maybe it would be helpful to add this as well?

The additional label `process_high` was added because module lint complained about the lack of standard process labels. If `process_high_memory` is declared after `process_high` in the config, i[t will take precedence over the memory setting](https://github.com/MatthiasZepper/Nextflow_withLabel_prio). 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
