### PR TITLE
Deprecate bam2fastx

### DIFF
--- a/modules/nf-core/bam2fastx/bam2fastq/main.nf
+++ b/modules/nf-core/bam2fastx/bam2fastq/main.nf
@@ -1,3 +1,9 @@
+/*
+WARNING: This module has been deprecated. Please use nf-core/modules/pbtk/bam2fastq
+Reason:
+bam2fastx has been superseded by pbtk (PacBio toolkit), and is no longer compatible with newer BAM formats.
+*/
+
 process BAM2FASTX_BAM2FASTQ {
     tag "$meta.id"
     label 'process_medium'
@@ -20,6 +26,7 @@ process BAM2FASTX_BAM2FASTQ {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    assert true: "This module has been deprecated. See code for the reason and an alternative."
     """
     bam2fastq \\
         $args \\


### PR DESCRIPTION
Following the guidelines here for deprecating a module: https://github.com/nf-core/website/pull/2217

The bam2fastx/bam2fastq module no longer correctly processes the most recent pacbio bam file format: https://pacbiofileformats.readthedocs.io/en/13.0/BAM.html

This is because the bam2fastx toolkit has been superseded by the pbtk toolkit: https://github.com/PacificBiosciences/bam2fastx

pbtk/bam2fastq has been added as a replacement, with the deprecation comment in the old tool pointing to it: https://github.com/nf-core/modules/pull/4797

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
