### PR TITLE
Fix stack size for collapse tool

### DIFF
--- a/modules/nf-core/umicollapse/main.nf
+++ b/modules/nf-core/umicollapse/main.nf
@@ -29,7 +29,7 @@ process UMICOLLAPSE {
     // umicollapse. We set the stack size to 5% of the available memory, the heap size to 90%
     // which leaves 5% for stuff happening outside of java without the scheduler killing the process.
     def max_heap_size_mega = (task.memory.toMega() * 0.9).intValue()
-    def max_stack_size_mega = (task.memory.toMega() * 0.05).intValue()
+    def max_stack_size_mega = 999 //most java jdks will not allow Xss > 1GB, so fixing this to the allowed max
     if ( mode !in [ 'fastq', 'bam' ] ) {
         error "Mode must be one of 'fastq' or 'bam'."
     }


### PR DESCRIPTION
The Java `-Xss` parameter was automatically derived from the amount of available / supplied memory to the task. However, this resulted in e.g. `-Xss6553M` which is larger than the allowed > 1GB limit that most Java systems allowed when running this in production, thus creating failures. 

This fixes this to the allowed maximum of Xss999M, which should be fine given that most people will run umicollapse with > 4GB of memory which will result in a default of `-Xmx3800M` that is still higher than 999M for Xss as it should be. 