### PR TITLE
Use relative test data for multiqc module

### DIFF
--- a/modules/nf-core/multiqc/tests/main.nf.test
+++ b/modules/nf-core/multiqc/tests/main.nf.test
@@ -3,6 +3,9 @@ nextflow_process {
     name "Test Process MULTIQC"
     script "../main.nf"
     process "MULTIQC"
+
+    tag "modules"
+    tag "modules_nfcore"
     tag "multiqc"
 
     test("sarscov2 single-end [fastqc]") {
@@ -23,7 +26,7 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
                 { assert process.out.data[0] ==~ ".*/multiqc_data" },
-                { assert snapshot(process.out.versions).match("versions") }
+                { assert snapshot(process.out.versions).match("versions_2") }
             )
         }
 
@@ -47,7 +50,7 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
                 { assert process.out.data[0] ==~ ".*/multiqc_data" },
-                { assert snapshot(process.out.versions).match("versions") }
+                { assert snapshot(process.out.versions).match("versions_1") }
             )
         }
     }
@@ -73,7 +76,7 @@ nextflow_process {
                 { assert snapshot(process.out.report.collect { file(it).getName() } +
                                 process.out.data.collect { file(it).getName() } +
                                 process.out.plots.collect { file(it).getName() } +
-                                process.out.versions ).match() }
+                                process.out.versions ).match("stub") }
             )
         }
 

--- a/modules/nf-core/multiqc/tests/main.nf.test
+++ b/modules/nf-core/multiqc/tests/main.nf.test
@@ -26,7 +26,7 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
                 { assert process.out.data[0] ==~ ".*/multiqc_data" },
-                { assert snapshot(process.out.versions).match("versions_2") }
+                { assert snapshot(process.out.versions).match("multiqc_versions_single") }
             )
         }
 
@@ -50,7 +50,7 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
                 { assert process.out.data[0] ==~ ".*/multiqc_data" },
-                { assert snapshot(process.out.versions).match("versions_1") }
+                { assert snapshot(process.out.versions).match("multiqc_versions_config") }
             )
         }
     }
@@ -76,7 +76,7 @@ nextflow_process {
                 { assert snapshot(process.out.report.collect { file(it).getName() } +
                                 process.out.data.collect { file(it).getName() } +
                                 process.out.plots.collect { file(it).getName() } +
-                                process.out.versions ).match("stub") }
+                                process.out.versions ).match("multiqc_stub") }
             )
         }
 

--- a/modules/nf-core/multiqc/tests/main.nf.test
+++ b/modules/nf-core/multiqc/tests/main.nf.test
@@ -3,8 +3,6 @@ nextflow_process {
     name "Test Process MULTIQC"
     script "../main.nf"
     process "MULTIQC"
-    tag "modules"
-    tag "modules_nfcore"
     tag "multiqc"
 
     test("sarscov2 single-end [fastqc]") {
@@ -12,7 +10,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = Channel.of([file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz_fastqc_zip'], checkIfExists: true)])
+                input[0] = Channel.of(file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastqc/test_fastqc.zip', checkIfExists: true))
                 input[1] = []
                 input[2] = []
                 input[3] = []
@@ -36,7 +34,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = Channel.of([file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz_fastqc_zip'], checkIfExists: true)])
+                input[0] = Channel.of(file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastqc/test_fastqc.zip', checkIfExists: true))
                 input[1] = Channel.of(file("https://github.com/nf-core/tools/raw/dev/nf_core/pipeline-template/assets/multiqc_config.yml", checkIfExists: true))
                 input[2] = []
                 input[3] = []
@@ -61,7 +59,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = Channel.of([file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz_fastqc_zip'], checkIfExists: true)])
+                input[0] = Channel.of(file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastqc/test_fastqc.zip', checkIfExists: true))
                 input[1] = []
                 input[2] = []
                 input[3] = []

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "versions_1": {
+    "multiqc_versions_single": {
         "content": [
             [
                 "versions.yml:md5,14e9a2661241abd828f4f06a7b5c222d"
@@ -9,21 +9,9 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T17:22:08.655326"
+        "timestamp": "2024-01-31T17:43:40.529579"
     },
-    "versions_2": {
-        "content": [
-            [
-                "versions.yml:md5,14e9a2661241abd828f4f06a7b5c222d"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-01-31T17:20:56.283679"
-    },
-    "stub": {
+    "multiqc_stub": {
         "content": [
             [
                 "multiqc_report.html",
@@ -36,6 +24,18 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T17:22:23.779587"
+        "timestamp": "2024-01-31T17:45:09.605359"
+    },
+    "multiqc_versions_config": {
+        "content": [
+            [
+                "versions.yml:md5,14e9a2661241abd828f4f06a7b5c222d"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-01-31T17:44:53.535994"
     }
 }

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -1,13 +1,29 @@
 {
-    "versions": {
+    "versions_1": {
         "content": [
             [
                 "versions.yml:md5,14e9a2661241abd828f4f06a7b5c222d"
             ]
         ],
-        "timestamp": "2024-01-09T23:02:49.911994"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-01-31T17:22:08.655326"
     },
-    "sarscov2 single-end [fastqc] - stub": {
+    "versions_2": {
+        "content": [
+            [
+                "versions.yml:md5,14e9a2661241abd828f4f06a7b5c222d"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-01-31T17:20:56.283679"
+    },
+    "stub": {
         "content": [
             [
                 "multiqc_report.html",
@@ -16,6 +32,10 @@
                 "versions.yml:md5,14e9a2661241abd828f4f06a7b5c222d"
             ]
         ],
-        "timestamp": "2024-01-09T23:03:14.524346"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-01-31T17:22:23.779587"
     }
 }


### PR DESCRIPTION
Replaces config based path with relative path in test data for MultiQC module.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [x] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [x] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
