### PR TITLE
Update custom/sratoolsncbisettings to only run when sra ids are provided

### DIFF
--- a/modules/nf-core/custom/sratoolsncbisettings/main.nf
+++ b/modules/nf-core/custom/sratoolsncbisettings/main.nf
@@ -7,6 +7,9 @@ process CUSTOM_SRATOOLSNCBISETTINGS {
         'https://depot.galaxyproject.org/singularity/sra-tools:3.0.8--h9f5acd7_0' :
         'biocontainers/sra-tools:3.0.8--h9f5acd7_0' }"
 
+    input:
+    val ids
+
     output:
     path('*.mkfg')     , emit: ncbi_settings
     path 'versions.yml', emit: versions

--- a/modules/nf-core/custom/sratoolsncbisettings/tests/main.nf.test
+++ b/modules/nf-core/custom/sratoolsncbisettings/tests/main.nf.test
@@ -15,11 +15,12 @@ nextflow_process {
             params {
                 settings_path = '/tmp/.ncbi'
                 settings_file  = "${params.settings_path}/user-settings.mkfg"
-                outdir        = "$outputDir"
+                outdir         = "$outputDir"
             }
 
             process {
                 """
+                input[0] = ["SRX6725035"]
                 file(params.settings_path).mkdirs()
                 def settings = file(params.modules_testdata_base_path + 'generic/config/ncbi_user_settings.mkfg', checkIfExists: true)
                 settings.copyTo(params.settings_file)

--- a/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/main.nf
+++ b/subworkflows/nf-core/fastq_download_prefetch_fasterqdump_sratools/main.nf
@@ -17,7 +17,7 @@ workflow FASTQ_DOWNLOAD_PREFETCH_FASTERQDUMP_SRATOOLS {
     //
     // Detect existing NCBI user settings or create new ones.
     //
-    CUSTOM_SRATOOLSNCBISETTINGS()
+    CUSTOM_SRATOOLSNCBISETTINGS ( ch_sra_ids.collect() )
     ch_ncbi_settings = CUSTOM_SRATOOLSNCBISETTINGS.out.ncbi_settings
     ch_versions = ch_versions.mix(CUSTOM_SRATOOLSNCBISETTINGS.out.versions)
 


### PR DESCRIPTION
This is to prevent the `FASTQ_DOWNLOAD_PREFETCH_FASTERQDUMP_SRATOOLS:CUSTOM_SRATOOLSNCBISETTINGS` process from running unnecessarily when no sra ids are provided to the workflow. If the sra ids channel is empty that process will no longer be run.