### PR TITLE
CHORES: Update rsem/calculateexpression to use path rather than map

### DIFF
--- a/modules/nf-core/rsem/calculateexpression/tests/main.nf.test
+++ b/modules/nf-core/rsem/calculateexpression/tests/main.nf.test
@@ -16,8 +16,8 @@ nextflow_process {
                 script "../../../rsem/preparereference/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)])
-                    input[1] = Channel.of([file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)])
+                    input[0] = Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true))
+                    input[1] = Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true))
                     """
                 }
             }
@@ -32,8 +32,8 @@ nextflow_process {
                 input[0] = Channel.of([
                     [ id:'test', strandedness: 'forward' ], // meta map
                     [
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
                     ]
                 ])
                 input[1] = RSEM_PREPAREREFERENCE.out.index

--- a/modules/nf-core/rsem/calculateexpression/tests/main.nf.test
+++ b/modules/nf-core/rsem/calculateexpression/tests/main.nf.test
@@ -8,6 +8,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "rsem"
     tag "rsem/calculateexpression"
+    tag "rsem/preparereference"
 
     test("homo_sapiens") {
 


### PR DESCRIPTION
Updates rsem/calculateexpression to use a relative path instead of config map.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
