### PR TITLE
Use global SETUP for making index for STAR_ALIGN tests

### DIFF
--- a/modules/nf-core/star/align/tests/main.nf.test
+++ b/modules/nf-core/star/align/tests/main.nf.test
@@ -9,38 +9,38 @@ nextflow_process {
     tag "star/align"
     tag "star/genomegenerate"
 
-    test("homo_sapiens - single_end") {
-        config "./nextflow.config"
-
-        setup {
-            run("STAR_GENOMEGENERATE") {
-                script "../../../star/genomegenerate/main.nf"
-                process {
-                    """
-                    input[0] = Channel.of([
-                        [ id:'test_fasta' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
-                    ])
-                    input[1] = Channel.of([
-                        [ id:'test_gtf' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
-                    ])
-                    """
-                }
+    setup {
+        run("STAR_GENOMEGENERATE") {
+            script "../../../star/genomegenerate/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test_fasta' ],
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
+                ])
+                input[1] = Channel.of([
+                    [ id:'test_gtf' ],
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
+                ])
+                """
             }
         }
+    }
+
+    test("homo_sapiens - single_end") {
+        config "./nextflow.config"
 
         when {
             process {
                 """
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_1_fastq_gz'], checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true) ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
                 input[2] = Channel.of([
                     [ id:'test_gtf' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = false
                 input[4] = 'illumina'
@@ -75,38 +75,20 @@ nextflow_process {
     test("homo_sapiens - paired_end") {
         config "./nextflow.config"
 
-        setup {
-            run("STAR_GENOMEGENERATE") {
-                script "../../../star/genomegenerate/main.nf"
-                process {
-                    """
-                    input[0] = Channel.of([
-                        [ id:'test_fasta' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
-                    ])
-                    input[1] = Channel.of([
-                        [ id:'test_gtf' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
-                    ])
-                    """
-                }
-            }
-        }
-
         when {
             process {
                 """
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
                 input[2] = Channel.of([
                     [ id:'test_gtf' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = false
                 input[4] = 'illumina'
@@ -141,38 +123,20 @@ nextflow_process {
     test("homo_sapiens - paired_end - arriba") {
         config "./nextflow.arriba.config"
 
-        setup {
-            run("STAR_GENOMEGENERATE") {
-                script "../../../star/genomegenerate/main.nf"
-                process {
-                    """
-                    input[0] = Channel.of([
-                        [ id:'test_fasta' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
-                    ])
-                    input[1] = Channel.of([
-                        [ id:'test_gtf' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
-                    ])
-                    """
-                }
-            }
-        }
-
         when {
             process {
                 """
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
                 input[2] = Channel.of([
                     [ id:'test_gtf' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = false
                 input[4] = 'illumina'
@@ -207,38 +171,20 @@ nextflow_process {
     test("homo_sapiens - paired_end - starfusion") {
         config "./nextflow.starfusion.config"
 
-        setup {
-            run("STAR_GENOMEGENERATE") {
-                script "../../../star/genomegenerate/main.nf"
-                process {
-                    """
-                    input[0] = Channel.of([
-                        [ id:'test_fasta' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
-                    ])
-                    input[1] = Channel.of([
-                        [ id:'test_gtf' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
-                    ])
-                    """
-                }
-            }
-        }
-
         when {
             process {
                 """
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
                 input[2] = Channel.of([
                     [ id:'test_gtf' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = false
                 input[4] = 'illumina'
@@ -273,40 +219,22 @@ nextflow_process {
     test("homo_sapiens - paired_end - multiple") {
         config "./nextflow.config"
 
-        setup {
-            run("STAR_GENOMEGENERATE") {
-                script "../../../star/genomegenerate/main.nf"
-                process {
-                    """
-                    input[0] = Channel.of([
-                        [ id:'test_fasta' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
-                    ])
-                    input[1] = Channel.of([
-                        [ id:'test_gtf' ],
-                        [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
-                    ])
-                    """
-                }
-            }
-        }
-
         when {
             process {
                 """
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_2_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_rnaseq_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
                 input[2] = Channel.of([
                     [ id:'test_gtf' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = false
                 input[4] = 'illumina'

--- a/modules/nf-core/star/genomegenerate/tests/main.nf.test
+++ b/modules/nf-core/star/genomegenerate/tests/main.nf.test
@@ -15,11 +15,11 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [ id:'test_fasta' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                 ])
                 input[1] = Channel.of([
                     [ id:'test_gtf' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 """
             }
@@ -43,11 +43,11 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [ id:'test_fasta' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                 ])
                 input[1] = Channel.of([
                     [ id:'test_gtf' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 """
             }
@@ -69,7 +69,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [ id:'test_fasta' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                 ])
                 input[1] = Channel.of([ [], [] ])
                 """
@@ -95,7 +95,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [ id:'test_fasta' ],
-                    [file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)]
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                 ])
                 input[1] = Channel.of([ [], [] ])
                 """


### PR DESCRIPTION
- Adds a global set up so we only run STAR_INDEX once
- Changes to use relative file paths.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
