### PR TITLE
CHORES: Update sortmerna modules to use path rather than map

### DIFF
--- a/modules/nf-core/sortmerna/main.nf
+++ b/modules/nf-core/sortmerna/main.nf
@@ -31,7 +31,7 @@ process SORTMERNA {
     } else {
         mv_cmd = """
         mv non_rRNA_reads_fwd.f*q.gz ${prefix}_1.non_rRNA.fastq.gz
-        mv non_rRNA_reads_rev.f*q.gz ${prefix}_2.non_rRNA.fastq.gz"
+        mv non_rRNA_reads_rev.f*q.gz ${prefix}_2.non_rRNA.fastq.gz
         """.stripIndent()
         paired_cmd = "--paired_in"
         out2_cmd   = "--out2"

--- a/modules/nf-core/sortmerna/main.nf
+++ b/modules/nf-core/sortmerna/main.nf
@@ -20,77 +20,64 @@ process SORTMERNA {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    if (meta.single_end) {
-        """
-        sortmerna \\
-            ${'--ref '+fastas.join(' --ref ')} \\
-            --reads $reads \\
-            --threads $task.cpus \\
-            --workdir . \\
-            --aligned rRNA_reads \\
-            --fastx \\
-            --other non_rRNA_reads \\
-            $args
-
-        mv non_rRNA_reads.f*q.gz ${prefix}.non_rRNA.fastq.gz
-        mv rRNA_reads.log ${prefix}.sortmerna.log
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            sortmerna: \$(echo \$(sortmerna --version 2>&1) | sed 's/^.*SortMeRNA version //; s/ Build Date.*\$//')
-        END_VERSIONS
-        """
+    def args        = task.ext.args  ?: ''
+    def prefix       = task.ext.prefix ?: "${meta.id}"
+    def reads_input = reads instanceof List ? reads.collect{"--reads $it"}.join(' ') : "--reads $reads"
+    def n_fastq     = reads instanceof List ? reads.size() : 1
+    if ( n_fastq == 1 ) {
+        mv_cmd = "mv non_rRNA_reads.f*q.gz ${prefix}.non_rRNA.fastq.gz"
+        paired_cmd = ''
+        out2_cmd   = ''
     } else {
-        """
-        sortmerna \\
-            ${'--ref '+fastas.join(' --ref ')} \\
-            --reads ${reads[0]} \\
-            --reads ${reads[1]} \\
-            --threads $task.cpus \\
-            --workdir . \\
-            --aligned rRNA_reads \\
-            --fastx \\
-            --other non_rRNA_reads \\
-            --paired_in \\
-            --out2 \\
-            $args
-
+        mv_cmd = """
         mv non_rRNA_reads_fwd.f*q.gz ${prefix}_1.non_rRNA.fastq.gz
-        mv non_rRNA_reads_rev.f*q.gz ${prefix}_2.non_rRNA.fastq.gz
-        mv rRNA_reads.log ${prefix}.sortmerna.log
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            sortmerna: \$(echo \$(sortmerna --version 2>&1) | sed 's/^.*SortMeRNA version //; s/ Build Date.*\$//')
-        END_VERSIONS
-        """
+        mv non_rRNA_reads_rev.f*q.gz ${prefix}_2.non_rRNA.fastq.gz"
+        """.stripIndent()
+        paired_cmd = "--paired_in"
+        out2_cmd   = "--out2"
     }
+    """
+    sortmerna \\
+        ${'--ref '+fastas.join(' --ref ')} \\
+        $reads_input \\
+        --threads $task.cpus \\
+        --workdir . \\
+        --aligned rRNA_reads \\
+        --fastx \\
+        --other non_rRNA_reads \\
+        $paired_cmd \\
+        $out2_cmd \\
+        $args
+
+    $mv_cmd
+    mv rRNA_reads.log ${prefix}.sortmerna.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sortmerna: \$(echo \$(sortmerna --version 2>&1) | sed 's/^.*SortMeRNA version //; s/ Build Date.*\$//')
+    END_VERSIONS
+    """
 
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if (meta.single_end) {
-        """
-        touch ${prefix}.non_rRNA.fastq.gz
-        touch ${prefix}.sortmerna.log
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            sortmerna: \$(echo \$(sortmerna --version 2>&1) | sed 's/^.*SortMeRNA version //; s/ Build Date.*\$//')
-        END_VERSIONS
-        """
+    def reads_input = reads instanceof List ? reads.collect{"--reads $it"}.join(' ') : "--reads $reads"
+    def n_fastq     = reads instanceof List ? reads.size() : 1
+    if ( n_fastq == 1 ) {
+        mv_cmd = "touch ${prefix}.non_rRNA.fastq.gz"
     } else {
-        """
+        mv_cmd = """
         touch ${prefix}_1.non_rRNA.fastq.gz
         touch ${prefix}_2.non_rRNA.fastq.gz
-        touch ${prefix}.sortmerna.log
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            sortmerna: \$(echo \$(sortmerna --version 2>&1) | sed 's/^.*SortMeRNA version //; s/ Build Date.*\$//')
-        END_VERSIONS
-        """
+        """.stripIndent()
     }
+    """
+    $mv_cmd
+    touch ${prefix}.sortmerna.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sortmerna: \$(echo \$(sortmerna --version 2>&1) | sed 's/^.*SortMeRNA version //; s/ Build Date.*\$//')
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/sortmerna/tests/main.nf.test
+++ b/modules/nf-core/sortmerna/tests/main.nf.test
@@ -13,7 +13,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
                 ]
                 input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
                 """
@@ -48,7 +48,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
                 ]
                 input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
                 """
@@ -80,8 +80,8 @@ nextflow_process {
                 """
                 input[0] = [ [ id:'test', single_end:true ], // meta map
                     [ 
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
+                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
+                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
                     ]
                 ]
                 input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
@@ -118,8 +118,8 @@ nextflow_process {
                 """
                 input[0] = [ [ id:'test', single_end:true ], // meta map
                     [ 
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
+                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
+                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
                     ]
                 ]
                 input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]

--- a/modules/nf-core/sortmerna/tests/main.nf.test
+++ b/modules/nf-core/sortmerna/tests/main.nf.test
@@ -78,7 +78,8 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:true ], // meta map
+                input[0] = [ 
+                    [ id:'test', single_end:true ], // meta map
                     [ 
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)

--- a/modules/nf-core/sortmerna/tests/main.nf.test
+++ b/modules/nf-core/sortmerna/tests/main.nf.test
@@ -12,7 +12,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:true ], // meta map
+                input[0] = [ [ id:'test' ], // meta map
                     [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
                 ]
                 input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
@@ -47,7 +47,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:true ], // meta map
+                input[0] = [ [ id:'test' ], // meta map
                     [ file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
                 ]
                 input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
@@ -79,7 +79,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [ 
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test' ], // meta map
                     [ 
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
@@ -117,7 +117,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:false ], // meta map
+                input[0] = [ [ id:'test' ], // meta map
                     [ 
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)

--- a/modules/nf-core/sortmerna/tests/main.nf.test
+++ b/modules/nf-core/sortmerna/tests/main.nf.test
@@ -13,9 +13,9 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id:'test', single_end:true ], // meta map
-                             [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
-                           ]
-                input[1] = [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
+                ]
+                input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
                 """
             }
         }
@@ -48,9 +48,9 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id:'test', single_end:true ], // meta map
-                             [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
-                           ]
-                input[1] = [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true) ]
+                ]
+                input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
                 """
             }
         }
@@ -78,11 +78,13 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:false ], // meta map
-                             [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                               file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
-                           ]
-                input[1] = [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+                input[0] = [ [ id:'test', single_end:true ], // meta map
+                    [ 
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
+                    ]
+                ]
+                input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
                 """
             }
         }
@@ -114,11 +116,13 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:false ], // meta map
-                             [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                               file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]
-                           ]
-                input[1] = [ file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true) ]
+                input[0] = [ [ id:'test', single_end:true ], // meta map
+                    [ 
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
+                    ]
+                ]
+                input[1] = [ file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true) ]
                 """
             }
         }

--- a/modules/nf-core/sortmerna/tests/main.nf.test
+++ b/modules/nf-core/sortmerna/tests/main.nf.test
@@ -79,7 +79,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [ 
-                    [ id:'test', single_end:true ], // meta map
+                    [ id:'test', single_end:false ], // meta map
                     [ 
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
@@ -117,7 +117,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test', single_end:true ], // meta map
+                input[0] = [ [ id:'test', single_end:false ], // meta map
                     [ 
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
                         file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)

--- a/modules/nf-core/sortmerna/tests/main.nf.test.snap
+++ b/modules/nf-core/sortmerna/tests/main.nf.test.snap
@@ -33,26 +33,26 @@
     "versions_paired_end_stub": {
         "content": [
             [
-                "versions.yml:md5,7df9d50209f351e1f75e05a1fad6ba4b"
+                "versions.yml:md5,5a099f3eea59b9deee96deffcf3387f5"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-02-01T12:10:57.850054063"
+        "timestamp": "2024-02-07T12:27:11.223149"
     },
     "versions_paired_end": {
         "content": [
             [
-                "versions.yml:md5,7df9d50209f351e1f75e05a1fad6ba4b"
+                "versions.yml:md5,5a099f3eea59b9deee96deffcf3387f5"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-02-01T12:10:47.066657228"
+        "timestamp": "2024-02-07T12:27:04.517155"
     },
     "versions_single_end": {
         "content": [

--- a/modules/nf-core/sortmerna/tests/main.nf.test.snap
+++ b/modules/nf-core/sortmerna/tests/main.nf.test.snap
@@ -4,31 +4,31 @@
             [
                 "test.non_rRNA.fastq.gz",
                 "test.sortmerna.log",
-                "{id=test, single_end=true}"
+                "{id=test}"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2023-12-21T11:56:00.15356"
+        "timestamp": "2024-02-07T12:28:29.197913"
     },
     "sarscov2 paired_end_match": {
         "content": [
             [
+                "{id=test}",
                 [
                     "test_1.non_rRNA.fastq.gz",
                     "test_2.non_rRNA.fastq.gz"
                 ],
-                "test.sortmerna.log",
-                "{id=test, single_end=false}"
+                "test.sortmerna.log"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-02-01T12:16:08.266820184"
+        "timestamp": "2024-02-07T12:28:49.914992"
     },
     "versions_paired_end_stub": {
         "content": [
@@ -83,30 +83,30 @@
             [
                 "test.non_rRNA.fastq.gz",
                 "test.sortmerna.log",
-                "{id=test, single_end=true}"
+                "{id=test}"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-02-01T12:15:30.47928718"
+        "timestamp": "2024-02-07T12:28:23.20327"
     },
     "sarscov2 paired_end-for_stub_match": {
         "content": [
             [
+                "{id=test}",
                 [
                     "test_1.non_rRNA.fastq.gz",
                     "test_2.non_rRNA.fastq.gz"
                 ],
-                "test.sortmerna.log",
-                "{id=test, single_end=false}"
+                "test.sortmerna.log"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2023-12-21T12:00:47.879193"
+        "timestamp": "2024-02-07T12:28:56.063579"
     }
 }

--- a/subworkflows/nf-core/preprocess_rnaseq/tests/main.nf.test
+++ b/subworkflows/nf-core/preprocess_rnaseq/tests/main.nf.test
@@ -23,13 +23,16 @@ nextflow_workflow {
         when {
             workflow {
                 """
-                input[0] = Channel.of([ [ id:'test', single_end:false, strandedness:'auto' ], // meta map
-                        [file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
-                        ]]) // ch_reads
-                input[1] = Channel.of(file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)) // ch_fasta
-                input[2] = Channel.of(file(params.test_data['homo_sapiens']['genome']['transcriptome_fasta'], checkIfExists: true)) // ch_transcript_fasta
-                input[3] = Channel.of(file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)) // ch_gtf
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false, strandedness:'auto' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]) // ch_reads
+                input[1] = Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)) // ch_fasta
+                input[2] = Channel.of(file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/transcriptome.fasta", checkIfExists: true)) // ch_transcript_fasta
+                input[3] = Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)) // ch_gtf
                 input[4] = []              // ch_salmon_index
                 input[5] = []              // ch_bbsplit_index
                 input[6] = []              // ch_ribo_db
@@ -69,13 +72,16 @@ nextflow_workflow {
         when {
             workflow {
                 """
-                input[0] = Channel.of([ [ id:'test', single_end:false, strandedness:'auto' ], // meta map
-                        [file(params.test_data['homo_sapiens']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['homo_sapiens']['illumina']['test_2_fastq_gz'], checkIfExists: true)
-                        ]]) // ch_reads
-                input[1] = Channel.of(file(params.test_data['homo_sapiens']['genome']['genome_fasta'], checkIfExists: true)) // ch_fasta
-                input[2] = Channel.of(file(params.test_data['homo_sapiens']['genome']['transcriptome_fasta'], checkIfExists: true)) // ch_transcript_fasta
-                input[3] = Channel.of(file(params.test_data['homo_sapiens']['genome']['genome_gtf'], checkIfExists: true)) // ch_gtf
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false, strandedness:'auto' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]) // ch_reads
+                input[1] = Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)) // ch_fasta
+                input[2] = Channel.of(file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/transcriptome.fasta", checkIfExists: true)) // ch_transcript_fasta
+                input[3] = Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)) // ch_gtf
                 input[4] = []              // ch_salmon_index
                 input[5] = []              // ch_bbsplit_index
                 input[6] = []              // ch_ribo_db

--- a/subworkflows/nf-core/preprocess_rnaseq/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/preprocess_rnaseq/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                         "single_end": false,
                         "strandedness": "auto"
                     },
-                    31828
+                    3022
                 ]
             ]
         ],
@@ -16,79 +16,79 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T17:03:17.65199684"
+        "timestamp": "2024-02-07T11:05:51.060371"
     },
     "trimgalore_test_pe_reads_2_lines": {
-        "content": "1fb3f17574c8d4bc147054efc370705a",
+        "content": "eccf3e9e74589ff01c77fce7f4548e41",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T20:34:36.937705622"
+        "timestamp": "2024-02-07T11:16:44.427598"
     },
     "fastp_test_pe_reads_1_size": {
         "content": [
-            939632
+            4508
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T17:03:12.664499082"
+        "timestamp": "2024-02-07T11:05:51.019935"
     },
     "trimgalore_test_pe_reads_1_size": {
         "content": [
-            939632
+            4508
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T20:34:32.674462193"
+        "timestamp": "2024-02-07T11:16:44.398923"
     },
     "trimgalore_test_pe_reads_1_lines": {
-        "content": "c505f587d2864e41499d4f7546c0a777",
+        "content": "3868fc1caf09367141d2bbf47e158823",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T20:34:32.668662623"
+        "timestamp": "2024-02-07T11:16:44.395858"
     },
     "fastp_test_pe_reads_2_lines": {
-        "content": "1fb3f17574c8d4bc147054efc370705a",
+        "content": "eccf3e9e74589ff01c77fce7f4548e41",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T17:03:17.648440471"
+        "timestamp": "2024-02-07T11:05:51.05632"
     },
     "fastp_test_pe_reads_2_size": {
         "content": [
-            939632
+            4508
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T17:03:17.650545591"
+        "timestamp": "2024-02-07T11:05:51.058326"
     },
     "trimgalore_test_pe_reads_2_size": {
         "content": [
-            939632
+            4508
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T20:34:36.942171292"
+        "timestamp": "2024-02-07T11:16:44.430226"
     },
     "fastp_test_pe_reads_1_lines": {
-        "content": "c505f587d2864e41499d4f7546c0a777",
+        "content": "3868fc1caf09367141d2bbf47e158823",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T17:03:12.660913832"
+        "timestamp": "2024-02-07T11:05:51.015562"
     },
     "trimgalore_read_count": {
         "content": [
@@ -99,7 +99,7 @@
                         "single_end": false,
                         "strandedness": "auto"
                     },
-                    31828
+                    3022
                 ]
             ]
         ],
@@ -107,6 +107,6 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-01-31T20:34:36.947394381"
+        "timestamp": "2024-02-07T11:16:44.432645"
     }
 }


### PR DESCRIPTION
- Removes requirement for `meta.single_end` from meta map. Infers the information from the FASTQs directly
- Replace config map with relative paths in sortmerna tests.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - [ ] `PROFILE=docker pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=singularity pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
  - [ ] `PROFILE=conda pytest --tag <MODULE> --symlink --keep-workflow-wd --git-aware`
