### PR TITLE
Updating samtools in bwamem

### DIFF
--- a/modules/nf-core/bwa/mem/environment.yml
+++ b/modules/nf-core/bwa/mem/environment.yml
@@ -6,5 +6,5 @@ channels:
 dependencies:
   - bwa=0.7.17
   # renovate: datasource=conda depName=bioconda/samtools
-  - samtools=1.18
-  - htslib=1.18
+  - samtools=1.19.2
+  - htslib=1.19.1

--- a/modules/nf-core/bwa/mem/main.nf
+++ b/modules/nf-core/bwa/mem/main.nf
@@ -4,8 +4,8 @@ process BWA_MEM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:9c0128851101dafef65cef649826d2dbe6bedd7e-0' :
-        'biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:9c0128851101dafef65cef649826d2dbe6bedd7e-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:a34558545ae1413d94bde4578787ebef08027945-0' :
+        'biocontainers/mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:a34558545ae1413d94bde4578787ebef08027945-0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/bwa/mem/tests/main.nf.test.snap
+++ b/modules/nf-core/bwa/mem/tests/main.nf.test.snap
@@ -8,11 +8,11 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.bam:md5,df203d7c7e8fef351408a909570c7952"
+                        "test.bam:md5,a74710a0345b4717bb4431bf9c257120"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,a18ac8ef8cfcc7b2cc262c49d4c064f9"
+                    "versions.yml:md5,c32f719a68bb2966c8511d808154d42d"
                 ],
                 "bam": [
                     [
@@ -20,15 +20,19 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.bam:md5,df203d7c7e8fef351408a909570c7952"
+                        "test.bam:md5,a74710a0345b4717bb4431bf9c257120"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a18ac8ef8cfcc7b2cc262c49d4c064f9"
+                    "versions.yml:md5,c32f719a68bb2966c8511d808154d42d"
                 ]
             }
         ],
-        "timestamp": "2023-12-04T11:01:22.483594641"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-19T11:11:48.440661587"
     },
     "Single-End Sort": {
         "content": [
@@ -39,11 +43,11 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.bam:md5,8a52bd78fdcecb994c1f63897d5b431c"
+                        "test.bam:md5,cb1e038bc4d990683fa485d632550b54"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,a18ac8ef8cfcc7b2cc262c49d4c064f9"
+                    "versions.yml:md5,c32f719a68bb2966c8511d808154d42d"
                 ],
                 "bam": [
                     [
@@ -51,15 +55,19 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.bam:md5,8a52bd78fdcecb994c1f63897d5b431c"
+                        "test.bam:md5,cb1e038bc4d990683fa485d632550b54"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a18ac8ef8cfcc7b2cc262c49d4c064f9"
+                    "versions.yml:md5,c32f719a68bb2966c8511d808154d42d"
                 ]
             }
         ],
-        "timestamp": "2023-12-04T11:01:30.180783483"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-19T11:11:56.086493265"
     },
     "Paired-End": {
         "content": [
@@ -70,11 +78,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.bam:md5,9815aef9ec763a60c53c3879be2d73ae"
+                        "test.bam:md5,aea123a3828a99da1906126355f15a12"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,a18ac8ef8cfcc7b2cc262c49d4c064f9"
+                    "versions.yml:md5,c32f719a68bb2966c8511d808154d42d"
                 ],
                 "bam": [
                     [
@@ -82,15 +90,19 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.bam:md5,9815aef9ec763a60c53c3879be2d73ae"
+                        "test.bam:md5,aea123a3828a99da1906126355f15a12"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a18ac8ef8cfcc7b2cc262c49d4c064f9"
+                    "versions.yml:md5,c32f719a68bb2966c8511d808154d42d"
                 ]
             }
         ],
-        "timestamp": "2023-12-04T11:01:38.761983007"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-19T11:12:03.474974773"
     },
     "Paired-End Sort": {
         "content": [
@@ -101,11 +113,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.bam:md5,0f0cda73704c4f7ba08af482edcbbe88"
+                        "test.bam:md5,4682087bcdc3617384b375093fecd8dd"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,a18ac8ef8cfcc7b2cc262c49d4c064f9"
+                    "versions.yml:md5,c32f719a68bb2966c8511d808154d42d"
                 ],
                 "bam": [
                     [
@@ -113,14 +125,18 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.bam:md5,0f0cda73704c4f7ba08af482edcbbe88"
+                        "test.bam:md5,4682087bcdc3617384b375093fecd8dd"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a18ac8ef8cfcc7b2cc262c49d4c064f9"
+                    "versions.yml:md5,c32f719a68bb2966c8511d808154d42d"
                 ]
             }
         ],
-        "timestamp": "2023-12-04T11:01:46.284587802"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-19T11:12:10.721510817"
     }
 }

--- a/modules/nf-core/samblaster/environment.yml
+++ b/modules/nf-core/samblaster/environment.yml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - bioconda::samblaster=0.1.26
   - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/svdb/merge/environment.yml
+++ b/modules/nf-core/svdb/merge/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - svdb=2.8.1
   # renovate: datasource=conda depName=bioconda/samtools
   - samtools=1.19.2
+  - htslib=1.19.1

--- a/modules/nf-core/umicollapse/tests/main.nf.test.snap
+++ b/modules/nf-core/umicollapse/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.dedup.bam:md5,4e86d60aa82242889ab5f9031418ab2e"
+                    "test.dedup.bam:md5,05c5331185263cbee6f508c0669be864"
                 ]
             ],
             [
@@ -16,9 +16,9 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-01-30T10:45:28.352669757"
+        "timestamp": "2024-02-19T11:24:31.850566925"
     },
     "umicollapse fastq tests": {
         "content": [
@@ -108,7 +108,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.dedup.bam:md5,54be836ec246073e60212445b4369a91"
+                    "test.dedup.bam:md5,f4f05467cb456309fe22851d8b4d4387"
                 ]
             ],
             [
@@ -117,8 +117,8 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nextflow": "24.01.0"
         },
-        "timestamp": "2024-01-30T10:45:44.961261065"
+        "timestamp": "2024-02-19T11:24:44.166029769"
     }
 }


### PR DESCRIPTION
Updating samtools to v1.19.2 in bwamem.

Also pinning version of htslib in `environment.yml` to v1.19.2 for modules `bwa/mem`, `samblaster` and `svdb/merge`.