### PR TITLE
cat/fastq : Using modules_testdata_base_path instead of test_data in nf-test

### DIFF
--- a/modules/nf-core/cat/fastq/tests/main.nf.test
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test
@@ -16,11 +16,11 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [
+                input[0] = Channel.of([
                             [ id:'test', single_end:true ], // meta map
                             [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                             file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true) ]
-                        ]
+                ])
                 """
             }
         }
@@ -42,13 +42,13 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [
+                input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_2.fastq.gz', checkIfExists: true) ]
-                ]
+                ])
                 """
             }
         }
@@ -70,11 +70,11 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [
+                input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
-                ]
+                ])
                 """
             }
         }
@@ -96,13 +96,13 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [
+                input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
-                ]
+                ])
                 """
             }
         }
@@ -124,10 +124,10 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = [
+                input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
-                ]
+                ])
                 """
             }
         }

--- a/modules/nf-core/cat/fastq/tests/main.nf.test
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test
@@ -16,11 +16,11 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = Channel.of([
-                    [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
-                ])
+                input[0] = [
+                            [ id:'test', single_end:true ], // meta map
+                            [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true) ]
+                        ]
                 """
             }
         }
@@ -28,7 +28,8 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.reads).match() },
+                { assert path(process.out.versions.get(0)).getText().contains("cat") }
             )
         }
     }
@@ -41,13 +42,13 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = Channel.of([
+                input[0] = [
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_2.fastq.gz', checkIfExists: true)]
-                ])
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_2.fastq.gz', checkIfExists: true) ]
+                ]
                 """
             }
         }
@@ -55,7 +56,8 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.reads).match() },
+                { assert path(process.out.versions.get(0)).getText().contains("cat") }
             )
         }
     }
@@ -68,11 +70,11 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = Channel.of([
+                input[0] = [
                     [ id:'test', single_end:true ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
-                ])
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                ]
                 """
             }
         }
@@ -80,7 +82,8 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.reads).match() },
+                { assert path(process.out.versions.get(0)).getText().contains("cat") }
             )
         }
     }
@@ -93,13 +96,13 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = Channel.of([
+                input[0] = [
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
-                ])
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                ]
                 """
             }
         }
@@ -107,7 +110,8 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.reads).match() },
+                { assert path(process.out.versions.get(0)).getText().contains("cat") }
             )
         }
     }
@@ -120,10 +124,10 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = Channel.of([
+                input[0] = [
                     [ id:'test', single_end:true ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
-                ])
+                ]
                 """
             }
         }
@@ -131,7 +135,8 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.reads).match() },
+                { assert path(process.out.versions.get(0)).getText().contains("cat") }
             )
         }
     }

--- a/modules/nf-core/cat/fastq/tests/main.nf.test.snap
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test.snap
@@ -1,169 +1,98 @@
 {
     "test_cat_fastq_single_end": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.merged.fastq.gz:md5,ee314a9bd568d06617171b0c85f508da"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
-                ],
-                "reads": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.merged.fastq.gz:md5,ee314a9bd568d06617171b0c85f508da"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22"
                 ]
-            }
+            ]
         ],
-        "timestamp": "2024-01-17T17:30:39.816981"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-26T11:17:05.986894832"
     },
     "test_cat_fastq_single_end_same_name": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
-                ],
-                "reads": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22"
                 ]
-            }
+            ]
         ],
-        "timestamp": "2024-01-17T17:32:35.229332"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-26T11:17:17.745982654"
     },
     "test_cat_fastq_single_end_single_file": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.merged.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
-                ],
-                "reads": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.merged.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.merged.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
                 ]
-            }
+            ]
         ],
-        "timestamp": "2024-01-17T17:34:00.058829"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-26T11:17:29.306357887"
     },
     "test_cat_fastq_paired_end_same_name": {
         "content": [
-            {
-                "0": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
                     [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
-                            "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
-                        ]
+                        "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
+                        "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
                     ]
-                ],
-                "1": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
-                ],
-                "reads": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
-                            "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
-                        ]
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
                 ]
-            }
+            ]
         ],
-        "timestamp": "2024-01-17T17:33:33.031555"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-26T11:17:23.720837002"
     },
     "test_cat_fastq_paired_end": {
         "content": [
-            {
-                "0": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
                     [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
-                            "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
-                        ]
+                        "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
+                        "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
                     ]
-                ],
-                "1": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
-                ],
-                "reads": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
-                            "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
-                        ]
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,d42d6e24d67004608495883e00bd501b"
                 ]
-            }
+            ]
         ],
-        "timestamp": "2024-01-17T17:32:02.270935"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-26T11:17:11.942445051"
     }
 }


### PR DESCRIPTION
Needed for getting nf-tests to run in Sarek.