### PR TITLE
Add stubs for minimap2 modules

### DIFF
--- a/modules/nf-core/minimap2/align/main.nf
+++ b/modules/nf-core/minimap2/align/main.nf
@@ -46,4 +46,16 @@ process MINIMAP2_ALIGN {
         minimap2: \$(minimap2 --version 2>&1)
     END_VERSIONS
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def output_file = bam_format ? "${prefix}.bam" : "${prefix}.paf"
+    """
+    touch $output_file
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        minimap2: \$(minimap2 --version 2>&1)
+    END_VERSIONS
+    """
 }

--- a/modules/nf-core/minimap2/align/tests/main.nf.test
+++ b/modules/nf-core/minimap2/align/tests/main.nf.test
@@ -142,4 +142,38 @@ nextflow_process {
 
     }
 
+    test("sarscov2 - fastq, fasta, false, false, false - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test_ref' ], // meta map
+                    file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                ]
+                input[2] = false
+                input[3] = false
+                input[4] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.paf[0][1]).name,
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
 }

--- a/modules/nf-core/minimap2/align/tests/main.nf.test.snap
+++ b/modules/nf-core/minimap2/align/tests/main.nf.test.snap
@@ -6,6 +6,10 @@
                 "versions.yml:md5,9e9eeae0002d466d580a9d6e0d003eb1"
             ]
         ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.0"
+        },
         "timestamp": "2023-12-04T12:07:06.01315354"
     },
     "sarscov2 - fastq, fasta, true, false, false - stub": {
@@ -15,7 +19,24 @@
                 "versions.yml:md5,9e9eeae0002d466d580a9d6e0d003eb1"
             ]
         ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.0"
+        },
         "timestamp": "2023-12-04T12:07:24.487175659"
+    },
+    "sarscov2 - fastq, fasta, false, false, false - stub": {
+        "content": [
+            "test.paf",
+            [
+                "versions.yml:md5,9e9eeae0002d466d580a9d6e0d003eb1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.0"
+        },
+        "timestamp": "2024-03-01T11:06:54.090105"
     },
     "sarscov2 - [fastq1, fastq2], fasta, true, false, false": {
         "content": [
@@ -24,6 +45,10 @@
                 "versions.yml:md5,9e9eeae0002d466d580a9d6e0d003eb1"
             ]
         ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.0"
+        },
         "timestamp": "2023-12-04T12:07:12.50816279"
     },
     "sarscov2 - fastq, [], true, false, false": {
@@ -33,6 +58,10 @@
                 "versions.yml:md5,9e9eeae0002d466d580a9d6e0d003eb1"
             ]
         ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.0"
+        },
         "timestamp": "2023-12-04T12:07:18.414974788"
     }
 }

--- a/modules/nf-core/minimap2/index/main.nf
+++ b/modules/nf-core/minimap2/index/main.nf
@@ -31,4 +31,14 @@ process MINIMAP2_INDEX {
         minimap2: \$(minimap2 --version 2>&1)
     END_VERSIONS
     """
+
+    stub:
+    """
+    touch ${fasta.baseName}.mmi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        minimap2: \$(minimap2 --version 2>&1)
+    END_VERSIONS
+    """
 }


### PR DESCRIPTION
## PR checklist

Adds stubs for:
- `minimap2/align`
- `minimap2/index`

Updates `nf-test` tests for:
- `minimap2/align`

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
