### PR TITLE
Fix bakta: amrfinder database issue

### DIFF
--- a/modules/nf-core/bakta/bakta/main.nf
+++ b/modules/nf-core/bakta/bakta/main.nf
@@ -34,7 +34,10 @@ process BAKTA_BAKTA {
     prefix   = task.ext.prefix ?: "${meta.id}"
     def proteins_opt = proteins ? "--proteins ${proteins[0]}" : ""
     def prodigal_tf = prodigal_tf ? "--prodigal-tf ${prodigal_tf[0]}" : ""
+    db_cmd = ( session.config.conda && session.config.conda.enabled ) ? "amrfinder_update --force_update --database $db/amrfinderplus-db" : ""
     """
+    $db_cmd
+
     bakta \\
         $fasta \\
         $args \\

--- a/modules/nf-core/bakta/bakta/main.nf
+++ b/modules/nf-core/bakta/bakta/main.nf
@@ -34,9 +34,8 @@ process BAKTA_BAKTA {
     prefix   = task.ext.prefix ?: "${meta.id}"
     def proteins_opt = proteins ? "--proteins ${proteins[0]}" : ""
     def prodigal_tf = prodigal_tf ? "--prodigal-tf ${prodigal_tf[0]}" : ""
-    db_cmd = ( session.config.conda && session.config.conda.enabled ) ? "amrfinder_update --force_update --database $db/amrfinderplus-db" : ""
     """
-    $db_cmd
+    amrfinder_update --force_update --database $db/amrfinderplus-db
 
     bakta \\
         $fasta \\

--- a/modules/nf-core/bakta/bakta/tests/main.nf.test.snap
+++ b/modules/nf-core/bakta/bakta/tests/main.nf.test.snap
@@ -1,4 +1,16 @@
 {
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,4b299fc4976606c2b553dab8f670cd42"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-02-27T12:34:11.256486043"
+    },
     "Bakta - stub": {
         "content": [
             {

--- a/modules/nf-core/bakta/bakta/tests/nextflow.config
+++ b/modules/nf-core/bakta/bakta/tests/nextflow.config
@@ -5,7 +5,7 @@ process {
     }
 
     withName: 'BAKTA_BAKTA' {
-        memory = 15.4.GB
+        memory = 7.GB
     }
 
 }


### PR DESCRIPTION
This fixes a crash of bakta when using the automatically downloaded database with bakta (reported [here](https://github.com/nf-core/modules/pull/4847#discussion_r1499767614)).
It does not seem to be a conda-only issue. I could reproduce it with singularity as well, that's why I execute the `amrfinder_update` line regard of the profile.

(The memory requirement in the config file was decreased only because GHA complained.)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
