### PR TITLE
fix annoying PRESEQ failure for methylseq

### DIFF
--- a/modules/nf-core/preseq/lcextrap/main.nf
+++ b/modules/nf-core/preseq/lcextrap/main.nf
@@ -1,7 +1,7 @@
 process PRESEQ_LCEXTRAP {
     tag "$meta.id"
     label 'process_single'
-    label 'error_ignore'
+    label 'error_retry'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -21,6 +21,7 @@ process PRESEQ_LCEXTRAP {
 
     script:
     def args = task.ext.args ?: ''
+    args = task.attempt > 1 ? args.join(' -defects') : args
     def prefix = task.ext.prefix ?: "${meta.id}"
     def paired_end = meta.single_end ? '' : '-pe'
     """

--- a/modules/nf-core/preseq/lcextrap/main.nf
+++ b/modules/nf-core/preseq/lcextrap/main.nf
@@ -21,7 +21,7 @@ process PRESEQ_LCEXTRAP {
 
     script:
     def args = task.ext.args ?: ''
-    args = task.attempt > 1 ? args.join(' -defects') : args
+    args = task.attempt > 1 ? args.join(' -defects') : args  // Disable testing for defects
     def prefix = task.ext.prefix ?: "${meta.id}"
     def paired_end = meta.single_end ? '' : '-pe'
     """


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
