### PR TITLE
5236 update cellrangermulti output directives to match work in nf core scrnaseq

### DIFF
--- a/modules/nf-core/cellranger/multi/main.nf
+++ b/modules/nf-core/cellranger/multi/main.nf
@@ -27,9 +27,11 @@ process CELLRANGER_MULTI {
     val skip_renaming
 
     output:
-    tuple val(meta), path("cellranger_multi_config.csv"), emit: config
-    tuple val(meta), path("**/outs/**")                 , emit: outs
-    path "versions.yml"                                 , emit: versions
+    tuple val(meta), path("cellranger_multi_config.csv")            , emit: config
+    tuple val(meta), path("**/outs/**")                             , emit: outs
+    tuple val(meta), path("**/outs/**/filtered_feature_bc_matrix**"), emit: filtered, optional: true
+    tuple val(meta), path("**/outs/**/raw_feature_bc_matrix**")     , emit: raw
+    path "versions.yml"                                             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/cellranger/multi/meta.yml
+++ b/modules/nf-core/cellranger/multi/meta.yml
@@ -100,6 +100,14 @@ output:
       type: file
       description: Files containing the outputs of Cell Ranger
       pattern: "${meta.id}/outs/*"
+  - filtered:
+      type: file
+      description: Files containing the filtered outputs of Cell Ranger
+      pattern: "${meta.id}/outs/**/filtered_feature_bc_matrix**"
+  - raw:
+      type: file
+      description: Files containing the raw outputs of Cell Ranger
+      pattern: "${meta.id}/outs/**/raw_feature_bc_matrix**"
   - versions:
       type: file
       description: File containing software versions


### PR DESCRIPTION
Work related to https://github.com/nf-core/scrnaseq/pull/276
Adding two new output directives so it can be seamlessly coupled in scrnaseq.