### PR TITLE
New subworkflow: Bam dedup stats samtools umicollapse

### DIFF
--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/main.nf
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/main.nf
@@ -1,0 +1,36 @@
+// TODO nf-core: If in doubt look at other nf-core/subworkflows to see how we are doing things! :)
+//               https://github.com/nf-core/modules/tree/master/subworkflows
+//               You can also ask for help via your pull request or on the #subworkflows channel on the nf-core Slack workspace:
+//               https://nf-co.re/join
+// TODO nf-core: A subworkflow SHOULD import at least two modules
+
+include { SAMTOOLS_SORT      } from '../../../modules/nf-core/samtools/sort/main'
+include { SAMTOOLS_INDEX     } from '../../../modules/nf-core/samtools/index/main'
+
+workflow BAM_DEDUP_STATS_SAMTOOLS_UMICOLLAPSE {
+
+    take:
+    // TODO nf-core: edit input (take) channels
+    ch_bam // channel: [ val(meta), [ bam ] ]
+
+    main:
+
+    ch_versions = Channel.empty()
+
+    // TODO nf-core: substitute modules here for the modules of your subworkflow
+
+    SAMTOOLS_SORT ( ch_bam )
+    ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions.first())
+
+    SAMTOOLS_INDEX ( SAMTOOLS_SORT.out.bam )
+    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions.first())
+
+    emit:
+    // TODO nf-core: edit emitted channels
+    bam      = SAMTOOLS_SORT.out.bam           // channel: [ val(meta), [ bam ] ]
+    bai      = SAMTOOLS_INDEX.out.bai          // channel: [ val(meta), [ bai ] ]
+    csi      = SAMTOOLS_INDEX.out.csi          // channel: [ val(meta), [ csi ] ]
+
+    versions = ch_versions                     // channel: [ versions.yml ]
+}
+

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/main.nf
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/main.nf
@@ -17,7 +17,7 @@ workflow BAM_DEDUP_STATS_SAMTOOLS_UMICOLLAPSE {
     //
     // umicollapse in bam mode (thus hardcode mode input channel to 'bam')
     //
-    UMICOLLAPSE ( ch_bam_bai, "bam" )
+    UMICOLLAPSE ( ch_bam_bai, channel.value( 'bam' ))
     ch_versions = ch_versions.mix(UMICOLLAPSE.out.versions.first())
 
     //

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/meta.yml
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/meta.yml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "bam_dedup_stats_samtools_umicollapse"
+description: umicollapse, index BAM file and run samtools stats, flagstat and idxstats
+keywords:
+  - umi
+  - dedup
+  - index
+  - bam
+  - sam
+  - cram
+components:
+  - umicollapse
+  - samtools/index
+  - samtools/stats
+  - samtools/idxstats
+  - samtools/flagstat
+  - bam_stats_samtools
+input:
+  - ch_bam_bai:
+      description: |
+        input BAM file
+        Structure: [ val(meta), path(bam), path(bai) ]
+  - val_get_dedup_stats:
+      type: boolean
+      description: |
+        Generate output stats when running "umi_tools dedup"
+output:
+  - bam:
+      description: |
+        Umi deduplicated BAM/SAM file
+        Structure: [ val(meta), path(bam) ]
+  - bai:
+      description: |
+        Umi deduplicated BAM/SAM samtools index
+        Structure: [ val(meta), path(bai) ]
+  - csi:
+      description: |
+        CSI samtools index
+        Structure: [ val(meta), path(csi) ]
+  - stats:
+      description: |
+        File containing samtools stats output
+        Structure: [ val(meta), path(stats) ]
+  - flagstat:
+      description: |
+        File containing samtools flagstat output
+        Structure: [ val(meta), path(flagstat) ]
+  - idxstats:
+      description: |
+        File containing samtools idxstats output
+        Structure: [ val(meta), path(idxstats) ]
+  - versions:
+      description: |
+        Files containing software versions
+        Structure: [ path(versions.yml) ]
+authors:
+  - "@MatthiasZepper"
+maintainers:
+  - "@MatthiasZepper"

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/meta.yml
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/meta.yml
@@ -20,10 +20,6 @@ input:
       description: |
         input BAM file
         Structure: [ val(meta), path(bam), path(bai) ]
-  - val_get_dedup_stats:
-      type: boolean
-      description: |
-        Generate output stats when running "umi_tools dedup"
 output:
   - bam:
       description: |
@@ -37,6 +33,10 @@ output:
       description: |
         CSI samtools index
         Structure: [ val(meta), path(csi) ]
+  - dedupstats:
+      description: |
+        File containing umicollapse deduplication stats
+        Structure: [ val(meta), path(stats) ]
   - stats:
       description: |
         File containing samtools stats output

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
@@ -1,4 +1,3 @@
-// TODO nf-core: Once you have added the required tests, please run the following command to build this file:
 // nf-core subworkflows test bam_dedup_stats_samtools_umicollapse
 nextflow_workflow {
 
@@ -9,35 +8,47 @@ nextflow_workflow {
     tag "subworkflows"
     tag "subworkflows_nfcore"
     tag "subworkflows/bam_dedup_stats_samtools_umicollapse"
-    // TODO nf-core: Add tags for all modules used within this subworkflow. Example:
+    tag "subworkflows/bam_stats_samtools"
+    tag "bam_stats_samtools"
     tag "samtools"
-    tag "samtools/sort"
     tag "samtools/index"
+    tag "samtools/stats"
+    tag "samtools/idxstats"
+    tag "samtools/flagstat"
+    tag "umicollapse"
 
+    test("sarscov2_bam_bai") {
 
-    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used
-    test("sarscov2 - bam - single_end") {
-
-        when {
-            workflow {
-                """
-                // TODO nf-core: define inputs of the workflow here. Example:
-                input[0] = [ [ id:'test', single_end:false ], // meta map
-                        file(params.test_data['sarscov2']['illumina']['test_single_end_bam'], checkIfExists: true)
-                        ]
-                input[1] = [ [ id:'genome' ],
-                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
-                        ]
-                """
-            }
+    when {
+        params {
+            outdir   = "$outputDir"
         }
+        workflow {
+            """
 
-        then {
-            assertAll(
-                { assert workflow.success},
-                { assert snapshot(workflow.out).match()}
-                //TODO nf-core: Add all required assertions to verify the test output.
-            )
+            input[0] = Channel.of([
+                [ id:'test'], // meta map
+                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+            ])
+
+            """
         }
     }
+
+    then {
+        assertAll(
+            { assert workflow.success},
+            { assert workflow.out.bam.get(0).get(1) ==~ ".*.bam"},
+            { assert workflow.out.bai.get(0).get(1) ==~ ".*.bai"},
+            { assert workflow.out.dedup_stats.get(0).get(1) ==~ ".*_UMICollapse.log"},
+            { assert snapshot(workflow.out.dedup_stats).match("test_bam_dedup_stats_samtools_umicollapse_dedup_stats") },
+            { assert snapshot(workflow.out.stats).match("test_bam_dedup_stats_samtools_umicollapse_stats") },
+            { assert snapshot(workflow.out.flagstat).match("test_bam_dedup_stats_samtools_umicollapse_flagstats") },
+            { assert snapshot(workflow.out.idxstats).match("test_bam_dedup_stats_samtools_umicollapse_idxstats") }
+        )
+    }
+
 }
+}
+

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
@@ -10,12 +10,15 @@ nextflow_workflow {
     tag "subworkflows/bam_dedup_stats_samtools_umicollapse"
     tag "subworkflows/bam_stats_samtools"
     tag "bam_stats_samtools"
+    tag "bwa/index"
+    tag "bwa/mem"
     tag "samtools"
     tag "samtools/index"
     tag "samtools/stats"
     tag "samtools/idxstats"
     tag "samtools/flagstat"
     tag "umicollapse"
+    tag "umitools/extract"
 
     test("sarscov2_bam_bai") {
 

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
@@ -1,0 +1,43 @@
+// TODO nf-core: Once you have added the required tests, please run the following command to build this file:
+// nf-core subworkflows test bam_dedup_stats_samtools_umicollapse
+nextflow_workflow {
+
+    name "Test Subworkflow BAM_DEDUP_STATS_SAMTOOLS_UMICOLLAPSE"
+    script "../main.nf"
+    workflow "BAM_DEDUP_STATS_SAMTOOLS_UMICOLLAPSE"
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/bam_dedup_stats_samtools_umicollapse"
+    // TODO nf-core: Add tags for all modules used within this subworkflow. Example:
+    tag "samtools"
+    tag "samtools/sort"
+    tag "samtools/index"
+
+
+    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used
+    test("sarscov2 - bam - single_end") {
+
+        when {
+            workflow {
+                """
+                // TODO nf-core: define inputs of the workflow here. Example:
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                        file(params.test_data['sarscov2']['illumina']['test_single_end_bam'], checkIfExists: true)
+                        ]
+                input[1] = [ [ id:'genome' ],
+                        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                        ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+                //TODO nf-core: Add all required assertions to verify the test output.
+            )
+        }
+    }
+}

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
@@ -58,7 +58,7 @@ nextflow_workflow {
                         """
                     }
                 }
-                run("SAMTOOLS_INDEX"){  
+                run("SAMTOOLS_INDEX"){
                     script "../../../../modules/nf-core/samtools/index/main.nf"
                     process{
                         """
@@ -85,11 +85,10 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success},
-                { assert snapshot(workflow.out.bam, workflow.out.out.versions).match() },
+                { assert snapshot(workflow.out.bam, workflow.out.versions).match() },
                 { assert workflow.out.bam.get(0).get(1) ==~ ".*.bam"},
                 { assert workflow.out.bai.get(0).get(1) ==~ ".*.bai"},
                 { assert workflow.out.dedup_stats.get(0).get(1) ==~ ".*_UMICollapse.log"},
-                { assert snapshot(workflow.out.dedup_stats).match("test_bam_dedup_stats_samtools_umicollapse_dedup_stats") },
                 { assert snapshot(workflow.out.stats).match("test_bam_dedup_stats_samtools_umicollapse_stats") },
                 { assert snapshot(workflow.out.flagstat).match("test_bam_dedup_stats_samtools_umicollapse_flagstats") },
                 { assert snapshot(workflow.out.idxstats).match("test_bam_dedup_stats_samtools_umicollapse_idxstats") }

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test
@@ -19,35 +19,82 @@ nextflow_workflow {
 
     test("sarscov2_bam_bai") {
 
-    when {
-        params {
-            outdir   = "$outputDir"
+        setup{
+                run("UMITOOLS_EXTRACT"){
+                    script "../../../../modules/nf-core/umitools/extract/main.nf"
+                    config "./paired-end-umis.config"
+                    process{
+                        """
+                        input[0] = [
+                        [ id:'test', single_end:false ], // meta map
+                        [
+                            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        ]
+                        ]
+                        """
+                    }
+                }
+
+                run("BWA_INDEX"){
+                    script "../../../../modules/nf-core/bwa/index/main.nf"
+                    process{
+                        """
+                        input[0] = [
+                                [ id:'sarscov2'],
+                                file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                                ]
+                        """
+                    }
+                }
+                run("BWA_MEM"){
+                    script "../../../../modules/nf-core/bwa/mem/main.nf"
+                    process{
+                        """
+                        input[0] = UMITOOLS_EXTRACT.out.reads
+                        input[1] = BWA_INDEX.out.index
+                        input[2] = [[ id:'sarscov2'],file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)]
+                        input[3] = true
+                        """
+                    }
+                }
+                run("SAMTOOLS_INDEX"){  
+                    script "../../../../modules/nf-core/samtools/index/main.nf"
+                    process{
+                        """
+                        input[0] = BWA_MEM.out.bam
+                        """
+                    }
+                }
+            }
+
+        when {
+            config "./paired-end-umis.config"
+            params {
+                outdir   = "$outputDir"
+            }
+            workflow {
+                """
+
+                    input[0] =  BWA_MEM.out.bam.join(SAMTOOLS_INDEX.out.bai, by: [0])
+
+                """
+            }
         }
-        workflow {
-            """
 
-            input[0] = Channel.of([
-                [ id:'test'], // meta map
-                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
-                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
-            ])
-
-            """
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out.bam, workflow.out.out.versions).match() },
+                { assert workflow.out.bam.get(0).get(1) ==~ ".*.bam"},
+                { assert workflow.out.bai.get(0).get(1) ==~ ".*.bai"},
+                { assert workflow.out.dedup_stats.get(0).get(1) ==~ ".*_UMICollapse.log"},
+                { assert snapshot(workflow.out.dedup_stats).match("test_bam_dedup_stats_samtools_umicollapse_dedup_stats") },
+                { assert snapshot(workflow.out.stats).match("test_bam_dedup_stats_samtools_umicollapse_stats") },
+                { assert snapshot(workflow.out.flagstat).match("test_bam_dedup_stats_samtools_umicollapse_flagstats") },
+                { assert snapshot(workflow.out.idxstats).match("test_bam_dedup_stats_samtools_umicollapse_idxstats") }
+            )
         }
-    }
-
-    then {
-        assertAll(
-            { assert workflow.success},
-            { assert workflow.out.bam.get(0).get(1) ==~ ".*.bam"},
-            { assert workflow.out.bai.get(0).get(1) ==~ ".*.bai"},
-            { assert workflow.out.dedup_stats.get(0).get(1) ==~ ".*_UMICollapse.log"},
-            { assert snapshot(workflow.out.dedup_stats).match("test_bam_dedup_stats_samtools_umicollapse_dedup_stats") },
-            { assert snapshot(workflow.out.stats).match("test_bam_dedup_stats_samtools_umicollapse_stats") },
-            { assert snapshot(workflow.out.flagstat).match("test_bam_dedup_stats_samtools_umicollapse_flagstats") },
-            { assert snapshot(workflow.out.idxstats).match("test_bam_dedup_stats_samtools_umicollapse_idxstats") }
-        )
-    }
 
 }
 }

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test.snap
@@ -2,23 +2,12 @@
     "test_bam_dedup_stats_samtools_umicollapse_stats": {
         "content": [
             [
-                
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T16:13:21.286009"
-    },
-    "test_bam_dedup_stats_samtools_umicollapse_dedup_stats": {
-        "content": [
-            [
                 [
                     {
-                        "id": "test"
+                        "id": "test",
+                        "single_end": false
                     },
-                    "test_UMICollapse.log:md5,4d68bd25c3159559c71fc9921bc43d7e"
+                    "test.stats:md5,8ae0b86daa5e217cd3eb2b14e5c45889"
                 ]
             ]
         ],
@@ -26,30 +15,67 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-20T16:13:21.271945"
+        "timestamp": "2024-04-09T17:05:48.651300504"
     },
     "test_bam_dedup_stats_samtools_umicollapse_flagstats": {
         "content": [
             [
-                
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.flagstat:md5,18d602435a02a4d721b78d1812622159"
+                ]
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-20T16:13:21.290561"
+        "timestamp": "2024-04-09T17:05:48.69612524"
+    },
+    "sarscov2_bam_bai": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.dedup.bam:md5,f4f05467cb456309fe22851d8b4d4387"
+                ]
+            ],
+            [
+                "versions.yml:md5,268e43f34038d4c6146ed050630f95b4",
+                "versions.yml:md5,4d7f2fa6d88636249b0facef20ca8488",
+                "versions.yml:md5,55e0888af101bd1179280b929b5d28ce",
+                "versions.yml:md5,998ea4e7011dcf30ce452cda788459c4",
+                "versions.yml:md5,a584305b5057f7c72b9d6e2bfac37f57"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-09T17:05:48.588766659"
     },
     "test_bam_dedup_stats_samtools_umicollapse_idxstats": {
         "content": [
             [
-                
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.idxstats:md5,85d20a901eef23ca50c323638a2eb602"
+                ]
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-03-20T16:13:21.293779"
+        "timestamp": "2024-04-09T17:05:48.740441747"
     }
 }

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test.snap
@@ -1,0 +1,55 @@
+{
+    "test_bam_dedup_stats_samtools_umicollapse_stats": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T16:13:21.286009"
+    },
+    "test_bam_dedup_stats_samtools_umicollapse_dedup_stats": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_UMICollapse.log:md5,4d68bd25c3159559c71fc9921bc43d7e"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T16:13:21.271945"
+    },
+    "test_bam_dedup_stats_samtools_umicollapse_flagstats": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T16:13:21.290561"
+    },
+    "test_bam_dedup_stats_samtools_umicollapse_idxstats": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-20T16:13:21.293779"
+    }
+}

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/paired-end-umis.config
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/paired-end-umis.config
@@ -1,0 +1,10 @@
+process {
+
+    withName: UMITOOLS_EXTRACT {
+        ext.args = '--bc-pattern="NNNN" --bc-pattern2="NNNN"'
+    }
+
+    withName: UMICOLLAPSE {
+        ext.prefix = { "${meta.id}.dedup" }
+    }
+}

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/tags.yml
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/tags.yml
@@ -1,0 +1,2 @@
+subworkflows/bam_dedup_stats_samtools_umicollapse:
+  - subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/**


### PR DESCRIPTION
This PR proposes the addition of the `bam_dedup_stats_samtools_umicollapse` subworkflow. It is closely modelled after the [`bam_dedup_stats_samtools_umitools`](https://nf-co.re/subworkflows/bam_dedup_stats_samtools_umitools) and essentially copies most if its code - minus one input channel, plus one additional output channel. 

It is meant as an alternative/drop-in replacement of the former to use the more performant tool `umicollapse` instead of `umi-tools`. 

Regarding the tests I am unfortunately in a Catch22 situation: nf-tests do not run on my local machine and also not on Gitpod. They seem to work on the Github runner, but I can't update the snapshot to reflect the latest changes.

## PR checklist

Closes #5184

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
 (**_Only on the Github runners, it neither works on Gitpod nor on my local machine. So best to double check!!_**)
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
