### PR TITLE
ci(renovate): Allow channels in environment.ymls

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,8 +35,8 @@
         //     description: "Upgrade conda dependencies",
         //     fileMatch: ["(^|/)environment(.*).ya?ml$"],
         //     matchStrings: [
-        //         '#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*"?(?<currentValue>.*)"?',
-        //         '# renovate: datasource=conda depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*"?(?<currentValue>.*)"?',
+        //         '#\\s*renovate\\s+datasource=conda\\s+depName=(?<depName>.*?)\\s+-\\s*[\\w-]+:?:?[\\w-]+\\s*==?\\s*"?(?<currentValue>.*)"?',
+        //         '# renovate: datasource=conda depName=(?<depName>.*?)\\s+-\\s*[\\w-]+:?:?[\\w-]+\\s*==?\\s*"?(?<currentValue>.*)"?',
         //     ],
         //     datasourceTemplate: "conda",
         // },


### PR DESCRIPTION
No clue if this will work, it passed locally 🤷🏻 

Adds a regex to fix not finding the dependency if `::` and a channel is in the conda dependency.