### PR TITLE
Add Ruff to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,11 @@ repos:
     rev: 37.236.0
     hooks:
       - id: renovate-config-validator
+  # use ruff for python files
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
+    hooks:
+      - id: ruff
+        files: \.py$
+        args: [--fix, --exit-non-zero-on-fix, "--select", "I,E1,E4,E7,E9,F,UP,N"] # sort imports and fix (rules taken from nf-core/tools)
+      - id: ruff-format # formatter


### PR DESCRIPTION
Adds Ruff to pre-commit hook for linting any Python. 

Formatting rules reflect the rules in nf-core/tools.

Authored by @mashehu
