### PR TITLE
Fixed sort_bam description in meta.yml

### DIFF
--- a/subworkflows/nf-core/fastq_align_bowtie2/meta.yml
+++ b/subworkflows/nf-core/fastq_align_bowtie2/meta.yml
@@ -37,7 +37,7 @@ input:
   - sort_bam:
       type: boolean
       description: |
-        Save reads that do not map to the reference (true) or discard them (false)
+        Use samtools sort (true) or samtools view (false)
       default: false
   - ch_fasta:
       type: file


### PR DESCRIPTION
In the [fastq_align_bowtie2/meta.yml](subworkflows/nf-core/fastq_align_bowtie2/meta.yml) the sort_bam description was a duplicated from save_unaligned, I just replaced it with the description from the [bowtie2 module](https://nf-co.re/modules/bowtie2_align)

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
