### PR TITLE
Add support for Kallisto h5 format to tximeta-tximport

### DIFF
--- a/modules/nf-core/tximeta/tximport/environment.yml
+++ b/modules/nf-core/tximeta/tximport/environment.yml
@@ -6,4 +6,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - "bioconda::bioconductor-tximeta=1.20.1"
+  - "bioconda::bioconductor-tximeta=1.20.1=r43hdfd78af_1"

--- a/modules/nf-core/tximeta/tximport/environment.yml
+++ b/modules/nf-core/tximeta/tximport/environment.yml
@@ -6,4 +6,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - "bioconda::bioconductor-tximeta=1.20.1=r43hdfd78af_1"
+  - "bioconda::bioconductor-tximeta=1.20.1"

--- a/modules/nf-core/tximeta/tximport/main.nf
+++ b/modules/nf-core/tximeta/tximport/main.nf
@@ -3,8 +3,8 @@ process TXIMETA_TXIMPORT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bioconductor-tximeta%3A1.20.1--r43hdfd78af_0' :
-        'biocontainers/bioconductor-tximeta:1.20.1--r43hdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/bioconductor-tximeta%3A1.20.1--r43hdfd78af_1' :
+        'biocontainers/bioconductor-tximeta:1.20.1--r43hdfd78af_1' }"
 
     input:
     tuple val(meta), path("quants/*")

--- a/modules/nf-core/tximeta/tximport/templates/tximport.r
+++ b/modules/nf-core/tximeta/tximport/templates/tximport.r
@@ -118,14 +118,16 @@ create_summarized_experiment <- function(counts, abundance, length, col_data, ro
 ################################################
 
 # Define pattern for file names based on quantification type
-pattern <- ifelse('$quant_type' == "kallisto", "abundance.tsv", "quant.sf")
+pattern <- ifelse('$quant_type' == "kallisto",
+                ifelse(file.exists("quants/abundance.h5"), "abundance.h5", "abundance.tsv"),
+                "quant.sf")
+
 fns <- list.files('quants', pattern = pattern, recursive = T, full.names = T)
 names <- basename(dirname(fns))
 names(fns) <- names
-dropInfReps <- '$quant_type' == "kallisto"
 
 # Import transcript-level quantifications
-txi <- tximport(fns, type = '$quant_type', txOut = TRUE, dropInfReps = dropInfReps)
+txi <- tximport(fns, type = '$quant_type', txOut = TRUE)
 
 # Read transcript and sample data
 transcript_info <- read_transcript_info('$tx2gene')


### PR DESCRIPTION
This change allows the usage of inferential replicates in Kallisto. Handling them was not previously possible, since each replicate is saved in a separate plaintext file, but there is a single `h5` file which contains all of them. 

The according bioconda package was updated via [this PR](https://github.com/bioconda/bioconda-recipes/pull/47286)