### PR TITLE
Fix AMRFinderPlus

### DIFF
--- a/modules/nf-core/amrfinderplus/run/main.nf
+++ b/modules/nf-core/amrfinderplus/run/main.nf
@@ -43,7 +43,7 @@ process AMRFINDERPLUS_RUN {
         mkdir amrfinderdb
         tar xzvf $db -C amrfinderdb
     else
-        cp $db amrfinderdb
+        mv $db amrfinderdb
     fi
 
     amrfinder \\


### PR DESCRIPTION
This fixes the renaming of the AMRFinderPlus database folder. The `cp` command does not work as is (only as `cp -r`, but this copies the >220MB db folder within the work dir). It makes more sense to rename it instead.
Tested and works now as intended.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
