### PR TITLE
Updating sentieon to 202308.02

### DIFF
--- a/modules/nf-core/sentieon/applyvarcal/environment.yml
+++ b/modules/nf-core/sentieon/applyvarcal/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/applyvarcal/environment.yml
+++ b/modules/nf-core/sentieon/applyvarcal/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/applyvarcal/main.nf
+++ b/modules/nf-core/sentieon/applyvarcal/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_APPLYVARCAL {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(vcf), path(vcf_tbi), path(recal), path(recal_index), path(tranches)

--- a/modules/nf-core/sentieon/bwaindex/environment.yml
+++ b/modules/nf-core/sentieon/bwaindex/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/bwaindex/environment.yml
+++ b/modules/nf-core/sentieon/bwaindex/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/bwaindex/main.nf
+++ b/modules/nf-core/sentieon/bwaindex/main.nf
@@ -5,8 +5,8 @@ process SENTIEON_BWAINDEX {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/sentieon/bwamem/environment.yml
+++ b/modules/nf-core/sentieon/bwamem/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/bwamem/environment.yml
+++ b/modules/nf-core/sentieon/bwamem/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/bwamem/main.nf
+++ b/modules/nf-core/sentieon/bwamem/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_BWAMEM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/sentieon/datametrics/environment.yml
+++ b/modules/nf-core/sentieon/datametrics/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/datametrics/environment.yml
+++ b/modules/nf-core/sentieon/datametrics/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/datametrics/main.nf
+++ b/modules/nf-core/sentieon/datametrics/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_DATAMETRICS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/sentieon/dedup/environment.yml
+++ b/modules/nf-core/sentieon/dedup/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/dedup/environment.yml
+++ b/modules/nf-core/sentieon/dedup/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/dedup/main.nf
+++ b/modules/nf-core/sentieon/dedup/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_DEDUP {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/sentieon/dnamodelapply/environment.yml
+++ b/modules/nf-core/sentieon/dnamodelapply/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/dnamodelapply/environment.yml
+++ b/modules/nf-core/sentieon/dnamodelapply/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/dnamodelapply/main.nf
+++ b/modules/nf-core/sentieon/dnamodelapply/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_DNAMODELAPPLY {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(vcf), path(idx)

--- a/modules/nf-core/sentieon/dnascope/environment.yml
+++ b/modules/nf-core/sentieon/dnascope/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/dnascope/environment.yml
+++ b/modules/nf-core/sentieon/dnascope/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/dnascope/main.nf
+++ b/modules/nf-core/sentieon/dnascope/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_DNASCOPE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai), path(intervals)

--- a/modules/nf-core/sentieon/gvcftyper/environment.yml
+++ b/modules/nf-core/sentieon/gvcftyper/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/gvcftyper/environment.yml
+++ b/modules/nf-core/sentieon/gvcftyper/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/gvcftyper/main.nf
+++ b/modules/nf-core/sentieon/gvcftyper/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_GVCFTYPER {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(gvcfs), path(tbis), path(intervals)

--- a/modules/nf-core/sentieon/haplotyper/environment.yml
+++ b/modules/nf-core/sentieon/haplotyper/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/haplotyper/environment.yml
+++ b/modules/nf-core/sentieon/haplotyper/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/haplotyper/main.nf
+++ b/modules/nf-core/sentieon/haplotyper/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_HAPLOTYPER {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)

--- a/modules/nf-core/sentieon/readwriter/environment.yml
+++ b/modules/nf-core/sentieon/readwriter/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/readwriter/environment.yml
+++ b/modules/nf-core/sentieon/readwriter/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/readwriter/main.nf
+++ b/modules/nf-core/sentieon/readwriter/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_READWRITER {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(input), path(index)

--- a/modules/nf-core/sentieon/tnfilter/environment.yml
+++ b/modules/nf-core/sentieon/tnfilter/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/tnfilter/environment.yml
+++ b/modules/nf-core/sentieon/tnfilter/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/tnfilter/main.nf
+++ b/modules/nf-core/sentieon/tnfilter/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_TNFILTER {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(vcf), path(vcf_tbi), path(stats), path(contamination), path(segments), path(orientation_priors)

--- a/modules/nf-core/sentieon/tnhaplotyper2/environment.yml
+++ b/modules/nf-core/sentieon/tnhaplotyper2/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/tnhaplotyper2/environment.yml
+++ b/modules/nf-core/sentieon/tnhaplotyper2/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/tnhaplotyper2/main.nf
+++ b/modules/nf-core/sentieon/tnhaplotyper2/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_TNHAPLOTYPER2 {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)

--- a/modules/nf-core/sentieon/tnscope/environment.yml
+++ b/modules/nf-core/sentieon/tnscope/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/tnscope/environment.yml
+++ b/modules/nf-core/sentieon/tnscope/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/tnscope/main.nf
+++ b/modules/nf-core/sentieon/tnscope/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_TNSCOPE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/sentieon/varcal/environment.yml
+++ b/modules/nf-core/sentieon/varcal/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/varcal/environment.yml
+++ b/modules/nf-core/sentieon/varcal/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/varcal/main.nf
+++ b/modules/nf-core/sentieon/varcal/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_VARCAL {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(vcf), path(tbi) // input vcf and tbi of variants to recalibrate

--- a/modules/nf-core/sentieon/wgsmetrics/environment.yml
+++ b/modules/nf-core/sentieon/wgsmetrics/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon:202308.02
+  - bioconda::sentieon=202308.02

--- a/modules/nf-core/sentieon/wgsmetrics/environment.yml
+++ b/modules/nf-core/sentieon/wgsmetrics/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::sentieon=202308.01
+  - bioconda::sentieon:202308.02

--- a/modules/nf-core/sentieon/wgsmetrics/main.nf
+++ b/modules/nf-core/sentieon/wgsmetrics/main.nf
@@ -7,8 +7,8 @@ process SENTIEON_WGSMETRICS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sentieon:202308.01--h43eeafb_0' :
-        'biocontainers/sentieon:202308.01--h43eeafb_0' }"
+        'https://depot.galaxyproject.org/singularity/sentieon:202308.02--h43eeafb_0' :
+        'biocontainers/sentieon:202308.02--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)


### PR DESCRIPTION
Updating Sentieon to version 202308.02.

I don't expect that the CI-tests will run, since - as far as I know - nf-core's test-license server for sentieon is still down.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
