### PR TITLE
Changed tag from single quotes to double quotes

### DIFF
--- a/modules/nf-core/ucsc/gtftogenepred/main.nf
+++ b/modules/nf-core/ucsc/gtftogenepred/main.nf
@@ -1,5 +1,5 @@
 process UCSC_GTFTOGENEPRED {
-    tag '${meta.id}'
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"


### PR DESCRIPTION
### PR regarding the quotes of the tag of ucsc/gtftogenepred
The use of single quotes around `${meta.id}` prevents variable evaluation, outputting the literal string "${meta.id}". This is resolved by switching to double quotes, aligning the module with the other ucsc modules.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
