### PR TITLE
Do not trigger test on update of master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
 name: Run tests
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
   merge_group:


### PR DESCRIPTION
The CI test was activating when the master branch was updated, causing a wasted and failed nonsensical test. This PR removes that trigger.
