### PR TITLE
Update `modules/gtdbtk_classifywf` to 2.4.0

### DIFF
--- a/modules/nf-core/gtdbtk/classifywf/environment.yml
+++ b/modules/nf-core/gtdbtk/classifywf/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::gtdbtk=2.3.2
+  - bioconda::gtdbtk=2.4.0

--- a/modules/nf-core/gtdbtk/classifywf/main.nf
+++ b/modules/nf-core/gtdbtk/classifywf/main.nf
@@ -5,8 +5,8 @@ process GTDBTK_CLASSIFYWF {
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gtdbtk:2.3.2--pyhdfd78af_0' :
-        'biocontainers/gtdbtk:2.3.2--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/gtdbtk:2.4.0--pyhdfd78af_1' :
+        'biocontainers/gtdbtk:2.4.0--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path("bins/*")


### PR DESCRIPTION
gtdbtk was updated last month from 2.3.2 to 2.4.0+

- `FastANI` has been replaced by `skani` as the primary tool for computing Average Nucleotide Identity (ANI)

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
