### PR TITLE
[FIX] Make output compression in TCOFFEE/ALIGN more robust

### DIFF
--- a/modules/nf-core/tcoffee/align/main.nf
+++ b/modules/nf-core/tcoffee/align/main.nf
@@ -27,7 +27,7 @@ process TCOFFEE_ALIGN {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def tree_args = tree ? "-usetree $tree" : ""
     def template_args = template ? "-template_file $template" : ""
-    def write_output = compress ? " >(pigz -cp ${task.cpus} > ${prefix}.aln.gz)" : "> ${prefix}.aln"
+    def write_output = compress ? " >(pigz -cp ${task.cpus} > ${prefix}.aln.gz)" : "${prefix}.aln"
     // using >() is necessary to preserve the tcoffee return value,
     // so nextflow knows to display an error when it failed
     """
@@ -38,7 +38,7 @@ process TCOFFEE_ALIGN {
         $args \
         -thread ${task.cpus} \
         -outfile stdout \
-        $write_output
+        > $write_output
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/tcoffee/align/main.nf
+++ b/modules/nf-core/tcoffee/align/main.nf
@@ -28,9 +28,12 @@ process TCOFFEE_ALIGN {
     def tree_args = tree ? "-usetree $tree" : ""
     def template_args = template ? "-template_file $template" : ""
     def write_output = compress ? " | pigz -cp ${task.cpus} > ${prefix}.aln.gz" : " > ${prefix}.aln"
-    // using >() is necessary to preserve the tcoffee return value,
-    // so nextflow knows to display an error when it failed
     """
+    # set pipefail
+    # otherwise the pipe would swallow tcoffees error code if there is an issue
+    # this should work on all modern shells, as opposed to $PIPESTATUS, which is a bashism
+    set -o pipefail
+
     export TEMP='./'
     t_coffee -seq ${fasta} \
         $tree_args \

--- a/modules/nf-core/tcoffee/align/main.nf
+++ b/modules/nf-core/tcoffee/align/main.nf
@@ -27,7 +27,7 @@ process TCOFFEE_ALIGN {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def tree_args = tree ? "-usetree $tree" : ""
     def template_args = template ? "-template_file $template" : ""
-    def write_output = compress ? " >(pigz -cp ${task.cpus} > ${prefix}.aln.gz)" : "${prefix}.aln"
+    def write_output = compress ? " | pigz -cp ${task.cpus} > ${prefix}.aln.gz" : " > ${prefix}.aln"
     // using >() is necessary to preserve the tcoffee return value,
     // so nextflow knows to display an error when it failed
     """
@@ -38,7 +38,7 @@ process TCOFFEE_ALIGN {
         $args \
         -thread ${task.cpus} \
         -outfile stdout \
-        > $write_output
+        ${write_output}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Came across an issue with how some bash shells handle anonymous named pipes that causes tcoffee to interpret it as a parameter and fail.
This commit should make it a bit more robust.