### PR TITLE
Remove cp operation from bclconvert with Nextflow output operation

### DIFF
--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -14,7 +14,7 @@ process BCLCONVERT {
     tuple val(meta), path("**Undetermined_S0*_I?_00?.fastq.gz")   , optional:true, emit: undetermined_idx
     tuple val(meta), path("Reports")                              , emit: reports
     tuple val(meta), path("Logs")                                 , emit: logs
-    tuple val(meta), path("**/InterOp/*.bin"), includeInputs: true, emit: interop
+    tuple val(meta), path("**/InterOp/*.bin", includeInputs: true), emit: interop
     path("versions.yml")                                          , emit: versions
 
     when:

--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -8,14 +8,14 @@ process BCLCONVERT {
     tuple val(meta), path(samplesheet), path(run_dir)
 
     output:
-    tuple val(meta), path("**_S[1-9]*_R?_00?.fastq.gz")          , emit: fastq
-    tuple val(meta), path("**_S[1-9]*_I?_00?.fastq.gz")          , optional:true, emit: fastq_idx
-    tuple val(meta), path("**Undetermined_S0*_R?_00?.fastq.gz")  , optional:true, emit: undetermined
-    tuple val(meta), path("**Undetermined_S0*_I?_00?.fastq.gz")  , optional:true, emit: undetermined_idx
-    tuple val(meta), path("Reports")                             , emit: reports
-    tuple val(meta), path("Logs")                                , emit: logs
-    tuple val(meta), path("InterOp/*.bin")                       , emit: interop
-    path("versions.yml")                                         , emit: versions
+    tuple val(meta), path("**_S[1-9]*_R?_00?.fastq.gz")           , emit: fastq
+    tuple val(meta), path("**_S[1-9]*_I?_00?.fastq.gz")           , optional:true, emit: fastq_idx
+    tuple val(meta), path("**Undetermined_S0*_R?_00?.fastq.gz")   , optional:true, emit: undetermined
+    tuple val(meta), path("**Undetermined_S0*_I?_00?.fastq.gz")   , optional:true, emit: undetermined_idx
+    tuple val(meta), path("Reports")                              , emit: reports
+    tuple val(meta), path("Logs")                                 , emit: logs
+    tuple val(meta), path("**/InterOp/*.bin"), includeInputs: true, emit: interop
+    path("versions.yml")                                          , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -61,8 +61,6 @@ process BCLCONVERT {
         --output-directory . \\
         --bcl-input-directory ${input_dir} \\
         --sample-sheet ${samplesheet}
-
-    cp -r ${input_dir}/InterOp .
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Replaces cp operation with native Nextflow output path handling. This should reduce the amount of storage required to run the bclconvert process.
 
Fixes https://github.com/nf-core/modules/issues/5644

## PR checklist

Closes #5644 

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
