### PR TITLE
Remove redundant tximport outputs

### DIFF
--- a/modules/nf-core/tximeta/tximport/main.nf
+++ b/modules/nf-core/tximeta/tximport/main.nf
@@ -13,8 +13,6 @@ process TXIMETA_TXIMPORT {
 
     output:
     tuple val(meta), path("*gene_tpm.tsv")                 , emit: tpm_gene
-    tuple val(meta), path("*gene_tpm_scaled.tsv")          , emit: tpm_gene_scaled
-    tuple val(meta), path("*gene_tpm_length_scaled.tsv")   , emit: tpm_gene_length_scaled
     tuple val(meta), path("*gene_counts.tsv")              , emit: counts_gene
     tuple val(meta), path("*gene_counts_length_scaled.tsv"), emit: counts_gene_length_scaled
     tuple val(meta), path("*gene_counts_scaled.tsv")       , emit: counts_gene_scaled
@@ -33,8 +31,6 @@ process TXIMETA_TXIMPORT {
     stub:
     """
     touch ${meta.id}.gene_tpm.tsv
-    touch ${meta.id}.gene_tpm_scaled.tsv
-    touch ${meta.id}.gene_tpm_length_scaled.tsv
     touch ${meta.id}.gene_counts.tsv
     touch ${meta.id}.gene_counts_length_scaled.tsv
     touch ${meta.id}.gene_counts_scaled.tsv

--- a/modules/nf-core/tximeta/tximport/templates/tximport.r
+++ b/modules/nf-core/tximeta/tximport/templates/tximport.r
@@ -169,9 +169,7 @@ if ("tx2gene" %in% names(transcript_info) && !is.null(transcript_info\$tx2gene))
         list(obj = gse, slot = "length", suffix = "gene_lengths.tsv"),
         list(obj = gse, slot = "abundance", suffix = "gene_tpm.tsv"),
         list(obj = gse, slot = "counts", suffix = "gene_counts.tsv"),
-        list(obj = gse.ls, slot = "abundance", suffix = "gene_tpm_length_scaled.tsv"),
         list(obj = gse.ls, slot = "counts", suffix = "gene_counts_length_scaled.tsv"),
-        list(obj = gse.s, slot = "abundance", suffix = "gene_tpm_scaled.tsv"),
         list(obj = gse.s, slot = "counts", suffix = "gene_counts_scaled.tsv")
     ))
 }

--- a/modules/nf-core/tximeta/tximport/tests/main.nf.test
+++ b/modules/nf-core/tximeta/tximport/tests/main.nf.test
@@ -64,8 +64,6 @@ nextflow_process {
                 { assert snapshot(process.out.lengths_gene).match('lengths_gene_kallisto') },
                 { assert snapshot(process.out.lengths_transcript).match('lengths_transcript_kallisto') },
                 { assert snapshot(process.out.tpm_gene).match('tpm_gene_kallisto') },
-                { assert snapshot(process.out.tpm_gene_scaled).match('tpm_gene_scaled_kallisto') },
-                { assert snapshot(process.out.tpm_gene_length_scaled).match('tpm_gene_length_scaled_kallisto') },
                 { assert snapshot(process.out.tpm_transcript).match('tpm_transcript_kallisto') },
                 { assert snapshot(process.out.versions).match('versions_kallisto') }
             )
@@ -96,8 +94,6 @@ nextflow_process {
                 { assert snapshot(process.out.lengths_gene).match('lengths_gene_kallisto - stub') },
                 { assert snapshot(process.out.lengths_transcript).match('lengths_transcript_kallisto - stub') },
                 { assert snapshot(process.out.tpm_gene).match('tpm_gene_kallisto - stub') },
-                { assert snapshot(process.out.tpm_gene_scaled).match('tpm_gene_scaled_kallisto - stub') },
-                { assert snapshot(process.out.tpm_gene_length_scaled).match('tpm_gene_length_scaled_kallisto - stub') },
                 { assert snapshot(process.out.tpm_transcript).match('tpm_transcript_kallisto - stub') },
                 { assert snapshot(process.out.versions).match('versions_kallisto - stub') }
             )
@@ -157,8 +153,6 @@ nextflow_process {
                 { assert snapshot(process.out.lengths_gene).match('lengths_gene_salmon') },
                 { assert snapshot(process.out.lengths_transcript).match('lengths_transcript_salmon') },
                 { assert snapshot(process.out.tpm_gene).match('tpm_gene_salmon') },
-                { assert snapshot(process.out.tpm_gene_scaled).match('tpm_gene_scaled_salmon') },
-                { assert snapshot(process.out.tpm_gene_length_scaled).match('tpm_gene_length_scaled_salmon') },
                 { assert snapshot(process.out.tpm_transcript).match('tpm_transcript_salmon') },
                 { assert snapshot(process.out.versions).match('versions_salmon') }
             )
@@ -190,8 +184,6 @@ nextflow_process {
                 { assert snapshot(process.out.lengths_gene).match('lengths_gene_salmon - stub') },
                 { assert snapshot(process.out.lengths_transcript).match('lengths_transcript_salmon - stub') },
                 { assert snapshot(process.out.tpm_gene).match('tpm_gene_salmon - stub') },
-                { assert snapshot(process.out.tpm_gene_scaled).match('tpm_gene_scaled_salmon - stub') },
-                { assert snapshot(process.out.tpm_gene_length_scaled).match('tpm_gene_length_scaled_salmon - stub') },
                 { assert snapshot(process.out.tpm_transcript).match('tpm_transcript_salmon - stub') },
                 { assert snapshot(process.out.versions).match('versions_salmon - stub') }
             )

--- a/modules/nf-core/tximeta/tximport/tests/main.nf.test.snap
+++ b/modules/nf-core/tximeta/tximport/tests/main.nf.test.snap
@@ -1,21 +1,4 @@
 {
-    "tpm_gene_scaled_salmon - stub": {
-        "content": [
-            [
-                [
-                    [
-                        
-                    ],
-                    "[].gene_tpm_scaled.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-05-15T17:06:10.039734"
-    },
     "tpm_transcript_salmon - stub": {
         "content": [
             [
@@ -31,7 +14,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:10.054273"
+        "timestamp": "2024-05-28T12:35:50.683744"
     },
     "lengths_gene_kallisto - stub": {
         "content": [
@@ -48,7 +31,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.844905"
+        "timestamp": "2024-05-28T12:35:16.126128"
     },
     "counts_gene_scaled_salmon - stub": {
         "content": [
@@ -65,7 +48,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:10.004285"
+        "timestamp": "2024-05-28T12:35:50.654405"
     },
     "counts_gene_kallisto - stub": {
         "content": [
@@ -82,7 +65,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.830142"
+        "timestamp": "2024-05-28T12:35:16.112898"
     },
     "lengths_transcript_salmon - stub": {
         "content": [
@@ -99,7 +82,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:10.024984"
+        "timestamp": "2024-05-28T12:35:50.67148"
     },
     "versions_salmon - stub": {
         "content": [
@@ -111,7 +94,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:10.06179"
+        "timestamp": "2024-05-28T12:35:50.690592"
     },
     "counts_gene_length_scaled_kallisto": {
         "content": [
@@ -128,7 +111,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.069055"
+        "timestamp": "2024-05-28T12:34:59.621599"
     },
     "lengths_transcript_salmon": {
         "content": [
@@ -145,7 +128,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.926442"
+        "timestamp": "2024-05-28T12:35:32.876208"
     },
     "counts_transcript_kallisto": {
         "content": [
@@ -162,24 +145,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.072017"
-    },
-    "tpm_gene_scaled_salmon": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.gene_tpm_scaled.tsv:md5,6076364cc78741a4f8bc8935a045d13d"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-05-15T17:05:51.939292"
+        "timestamp": "2024-05-28T12:34:59.62725"
     },
     "counts_transcript_kallisto - stub": {
         "content": [
@@ -196,7 +162,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.841028"
+        "timestamp": "2024-05-28T12:35:16.122852"
     },
     "counts_transcript_salmon": {
         "content": [
@@ -213,7 +179,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.914566"
+        "timestamp": "2024-05-28T12:35:32.866731"
     },
     "lengths_gene_salmon - stub": {
         "content": [
@@ -230,7 +196,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:10.017072"
+        "timestamp": "2024-05-28T12:35:50.6654"
     },
     "tpm_gene_salmon": {
         "content": [
@@ -247,24 +213,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.932867"
-    },
-    "tpm_gene_length_scaled_salmon": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.gene_tpm_length_scaled.tsv:md5,6076364cc78741a4f8bc8935a045d13d"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-05-15T17:05:51.946446"
+        "timestamp": "2024-05-28T12:35:32.881193"
     },
     "tpm_transcript_salmon": {
         "content": [
@@ -281,7 +230,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.953143"
+        "timestamp": "2024-05-28T12:35:32.886363"
     },
     "tpm_gene_salmon - stub": {
         "content": [
@@ -298,7 +247,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:10.032111"
+        "timestamp": "2024-05-28T12:35:50.677538"
     },
     "lengths_transcript_kallisto": {
         "content": [
@@ -315,7 +264,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.075618"
+        "timestamp": "2024-05-28T12:34:59.632822"
     },
     "counts_gene_length_scaled_kallisto - stub": {
         "content": [
@@ -332,24 +281,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.833979"
-    },
-    "tpm_gene_scaled_kallisto - stub": {
-        "content": [
-            [
-                [
-                    [
-                        
-                    ],
-                    "[].gene_tpm_scaled.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-05-15T17:05:34.85604"
+        "timestamp": "2024-05-28T12:35:16.11652"
     },
     "tpm_gene_kallisto - stub": {
         "content": [
@@ -366,41 +298,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.852369"
-    },
-    "tpm_gene_length_scaled_salmon - stub": {
-        "content": [
-            [
-                [
-                    [
-                        
-                    ],
-                    "[].gene_tpm_length_scaled.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-05-15T17:06:10.046936"
-    },
-    "tpm_gene_length_scaled_kallisto": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.gene_tpm_length_scaled.tsv:md5,85d108269769ae0d841247b9b9ed922d"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-05-15T17:05:18.083493"
+        "timestamp": "2024-05-28T12:35:16.133742"
     },
     "counts_transcript_salmon - stub": {
         "content": [
@@ -417,7 +315,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:10.010515"
+        "timestamp": "2024-05-28T12:35:50.660144"
     },
     "counts_gene_scaled_kallisto": {
         "content": [
@@ -434,7 +332,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.070165"
+        "timestamp": "2024-05-28T12:34:59.624732"
     },
     "counts_gene_salmon": {
         "content": [
@@ -451,7 +349,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.897485"
+        "timestamp": "2024-05-28T12:35:32.852188"
     },
     "versions_salmon": {
         "content": [
@@ -463,7 +361,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.960123"
+        "timestamp": "2024-05-28T12:35:32.892224"
     },
     "counts_gene_length_scaled_salmon": {
         "content": [
@@ -480,24 +378,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.903299"
-    },
-    "tpm_gene_scaled_kallisto": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.gene_tpm_scaled.tsv:md5,85d108269769ae0d841247b9b9ed922d"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-05-15T17:05:18.080714"
+        "timestamp": "2024-05-28T12:35:32.857451"
     },
     "tpm_gene_kallisto": {
         "content": [
@@ -514,7 +395,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.078242"
+        "timestamp": "2024-05-28T12:34:59.636454"
     },
     "lengths_transcript_kallisto - stub": {
         "content": [
@@ -531,7 +412,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.848752"
+        "timestamp": "2024-05-28T12:35:16.129712"
     },
     "lengths_gene_kallisto": {
         "content": [
@@ -548,7 +429,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.073669"
+        "timestamp": "2024-05-28T12:34:59.630042"
     },
     "counts_gene_scaled_kallisto - stub": {
         "content": [
@@ -565,24 +446,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.837599"
-    },
-    "tpm_gene_length_scaled_kallisto - stub": {
-        "content": [
-            [
-                [
-                    [
-                        
-                    ],
-                    "[].gene_tpm_length_scaled.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-05-15T17:05:34.859965"
+        "timestamp": "2024-05-28T12:35:16.119638"
     },
     "tpm_transcript_kallisto": {
         "content": [
@@ -599,7 +463,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.086227"
+        "timestamp": "2024-05-28T12:34:59.639525"
     },
     "lengths_gene_salmon": {
         "content": [
@@ -616,7 +480,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.920866"
+        "timestamp": "2024-05-28T12:35:32.871162"
     },
     "counts_gene_length_scaled_salmon - stub": {
         "content": [
@@ -633,7 +497,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:09.998062"
+        "timestamp": "2024-05-28T12:35:50.605613"
     },
     "counts_gene_kallisto": {
         "content": [
@@ -650,7 +514,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.066975"
+        "timestamp": "2024-05-28T12:34:59.61832"
     },
     "versions_kallisto": {
         "content": [
@@ -662,7 +526,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:18.089743"
+        "timestamp": "2024-05-28T12:34:59.642751"
     },
     "counts_gene_salmon - stub": {
         "content": [
@@ -679,7 +543,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:06:09.989799"
+        "timestamp": "2024-05-28T12:35:50.598457"
     },
     "versions_kallisto - stub": {
         "content": [
@@ -691,7 +555,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.86895"
+        "timestamp": "2024-05-28T12:35:16.141689"
     },
     "tpm_transcript_kallisto - stub": {
         "content": [
@@ -708,7 +572,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:34.864527"
+        "timestamp": "2024-05-28T12:35:16.137716"
     },
     "counts_gene_scaled_salmon": {
         "content": [
@@ -725,6 +589,6 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-15T17:05:51.908075"
+        "timestamp": "2024-05-28T12:35:32.862272"
     }
 }

--- a/subworkflows/nf-core/quantify_pseudo_alignment/main.nf
+++ b/subworkflows/nf-core/quantify_pseudo_alignment/main.nf
@@ -106,8 +106,6 @@ workflow QUANTIFY_PSEUDO_ALIGNMENT {
     multiqc                       = ch_pseudo_multiqc                              // channel: [ val(meta), files_for_multiqc ]
 
     tpm_gene                      = TXIMETA_TXIMPORT.out.tpm_gene                  //    path: *gene_tpm.tsv
-    tpm_gene_scaled               = TXIMETA_TXIMPORT.out.tpm_gene_scaled           //    path: *gene_tpm_scaled.tsv
-    tpm_gene_length_scaled        = TXIMETA_TXIMPORT.out.tpm_gene_length_scaled    //    path: *gene_tpm_length_scaled.tsv
     counts_gene                   = TXIMETA_TXIMPORT.out.counts_gene               //    path: *gene_counts.tsv
     lengths_gene                  = TXIMETA_TXIMPORT.out.lengths_gene              //    path: *gene_lengths.tsv
     counts_gene_length_scaled     = TXIMETA_TXIMPORT.out.counts_gene_length_scaled //    path: *gene_counts_length_scaled.tsv

--- a/subworkflows/nf-core/quantify_pseudo_alignment/tests/main.nf.test
+++ b/subworkflows/nf-core/quantify_pseudo_alignment/tests/main.nf.test
@@ -63,8 +63,6 @@ nextflow_workflow {
                 { assert workflow.success },
                 { assert snapshot(
                         workflow.out.tpm_gene,
-                        workflow.out.tpm_gene_scaled,
-                        workflow.out.tpm_gene_length_scaled,
                         workflow.out.counts_gene,
                         workflow.out.lengths_gene,
                         workflow.out.counts_gene_length_scaled,
@@ -134,8 +132,6 @@ nextflow_workflow {
                 { assert workflow.success },
                 { assert snapshot(
                         workflow.out.tpm_gene,
-                        workflow.out.tpm_gene_scaled,
-                        workflow.out.tpm_gene_length_scaled,
                         workflow.out.counts_gene,
                         workflow.out.lengths_gene,
                         workflow.out.counts_gene_length_scaled,

--- a/subworkflows/nf-core/quantify_pseudo_alignment/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/quantify_pseudo_alignment/tests/main.nf.test.snap
@@ -14,22 +14,6 @@
                     {
                         "id": "all_samples"
                     },
-                    "all_samples.gene_tpm_scaled.tsv:md5,23fa0c64cfbd198806b53897de791b8b"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "all_samples"
-                    },
-                    "all_samples.gene_tpm_length_scaled.tsv:md5,23fa0c64cfbd198806b53897de791b8b"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "all_samples"
-                    },
                     "all_samples.gene_counts.tsv:md5,4ba44e5ebc9ed0ca2ca008d10a1dddc3"
                 ]
             ],
@@ -80,7 +64,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-16T11:00:38.264567"
+        "timestamp": "2024-05-28T12:54:12.855884"
     },
     "salmon": {
         "content": [
@@ -90,22 +74,6 @@
                         "id": "all_samples"
                     },
                     "all_samples.gene_tpm.tsv:md5,9711ed8364c3a1ea4fc87bd5e0780835"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "all_samples"
-                    },
-                    "all_samples.gene_tpm_scaled.tsv:md5,9711ed8364c3a1ea4fc87bd5e0780835"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "all_samples"
-                    },
-                    "all_samples.gene_tpm_length_scaled.tsv:md5,9711ed8364c3a1ea4fc87bd5e0780835"
                 ]
             ],
             [
@@ -165,6 +133,6 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-16T11:00:09.117121"
+        "timestamp": "2024-05-28T12:53:39.46319"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

Effectively undo https://github.com/nf-core/modules/pull/5619 and https://github.com/nf-core/modules/pull/5610. The abundance estimates of Salmon/ Kallisto are unaffected by tximport processing (unlike the counts) so there's no point writing them out multiple times.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
