### PR TITLE
Make segemehl outputs more specific

### DIFF
--- a/modules/nf-core/segemehl/align/main.nf
+++ b/modules/nf-core/segemehl/align/main.nf
@@ -15,8 +15,8 @@ process SEGEMEHL_ALIGN {
     output:
     tuple val(meta), path("${prefix}/${prefix}.${suffix}"), emit: alignment
     tuple val(meta), path("${prefix}/${prefix}.trns.txt") , emit: trans_alignments, optional: true
-    tuple val(meta), path("${prefix}/${prefix}.mult.bed") , emit: multibed, optional: true
-    tuple val(meta), path("${prefix}/${prefix}.sngl.bed") , emit: singlebed, optional: true
+    tuple val(meta), path("${prefix}/${prefix}.mult.bed") , emit: multi_bed, optional: true
+    tuple val(meta), path("${prefix}/${prefix}.sngl.bed") , emit: single_bed, optional: true
     path "versions.yml"                                   , emit: versions
 
     when:

--- a/modules/nf-core/segemehl/align/main.nf
+++ b/modules/nf-core/segemehl/align/main.nf
@@ -13,8 +13,11 @@ process SEGEMEHL_ALIGN {
     path(index)
 
     output:
-    tuple val(meta), path("${prefix}/*"), emit: results
-    path "versions.yml"                  , emit: versions
+    tuple val(meta), path("${prefix}/${prefix}.${suffix}"), emit: alignment
+    tuple val(meta), path("${prefix}/${prefix}.trns.txt") , emit: trans_alignments, optional: true
+    tuple val(meta), path("${prefix}/${prefix}.mult.bed") , emit: multibed, optional: true
+    tuple val(meta), path("${prefix}/${prefix}.sngl.bed") , emit: singlebed, optional: true
+    path "versions.yml"                                   , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -23,7 +26,7 @@ process SEGEMEHL_ALIGN {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     def reads = meta.single_end ? "-q ${reads}" : "-q ${reads[0]} -p ${reads[1]}"
-    def suffix = ( args.contains("-b") || args.contains("--bamabafixoida") ) ? "bam" : "sam"
+    suffix = ( args.contains("-b") || args.contains("--bamabafixoida") ) ? "bam" : "sam"
     """
     mkdir -p $prefix
 
@@ -43,7 +46,7 @@ process SEGEMEHL_ALIGN {
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
-    def suffix = ( args.contains("-b") || args.contains("--bamabafixoida") ) ? "bam" : "sam"
+    suffix = ( args.contains("-b") || args.contains("--bamabafixoida") ) ? "bam" : "sam"
     """
     mkdir -p $prefix
     touch ${prefix}/${prefix}.${suffix}

--- a/modules/nf-core/segemehl/align/meta.yml
+++ b/modules/nf-core/segemehl/align/meta.yml
@@ -11,7 +11,7 @@ tools:
       homepage: "https://www.bioinf.uni-leipzig.de/Software/segemehl/"
       documentation: "https://www.bioinf.uni-leipzig.de/Software/segemehl/"
       doi: "10.1186/gb-2014-15-2-r34"
-      licence: "GPL v3"
+      licence: ["GPL v3"]
 input:
   - meta:
       type: map

--- a/modules/nf-core/segemehl/align/meta.yml
+++ b/modules/nf-core/segemehl/align/meta.yml
@@ -36,19 +36,38 @@ output:
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  - results:
-      type: directory
+  - alignment:
+      type: file
       description: |
-        Directory containing genomic alignments in SAM format
+        File containing genomic alignments in SAM format
           (please add "-b" flag to task.ext.args for BAM)
-        In addition to split-read alignments files when -S parameter used.
-          [ *.{sam,bam}, *.trns.txt, *.mult.bed, *.sngl.bed ]
-      pattern: "${meta.id}*"
+      pattern: "*.{sam,bam}"
+  - trans_alignments:
+      type: file
+      description: |
+        Custom text file containing all single split alignments predicted to be in trans
+          (optional, only if -S flag is set in task.ext.args)
+      pattern: "*.trns.txt"
+  - single_bed:
+      type: file
+      description: |
+        Bed file containing all single splice events predicted
+        in the split read alignments.
+          (optional, only if -S flag is set in task.ext.args)
+      pattern: "*.sngl.bed"
+  - multi_bed:
+      type: file
+      description: |
+        Bed file containing all splice events predicted
+        in the split read alignments.
+          (optional, only if -S flag is set in task.ext.args)
+      pattern: "*.mult.bed"
   - versions:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
 authors:
   - "@BarryDigby"
+  - "@nictru"
 maintainers:
-  - "@BarryDigby"
+  - "@nictru"

--- a/modules/nf-core/segemehl/align/tests/main.nf.test
+++ b/modules/nf-core/segemehl/align/tests/main.nf.test
@@ -75,5 +75,66 @@ nextflow_process {
         }
     }
 
+    test("homo_sapiens - split - single_end") {
+        config "./split.config"
 
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true) ]
+                ])
+                input[1] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = SEGEMEHL_INDEX.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alignment[0][1]).exists() },
+                { assert path(process.out.trans_alignments[0][1]).exists() },
+                { assert path(process.out.multi_bed[0][1]).exists() },
+                { assert path(process.out.single_bed[0][1]).exists() },
+                { assert snapshot(process.out.versions).match("homo_sapiens - split - single_end - versions") }
+            )
+        }
+    }
+
+    test("homo_sapiens - split - paired_end") {
+        config "./split.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = SEGEMEHL_INDEX.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alignment[0][1]).exists() },
+                { assert path(process.out.trans_alignments[0][1]).exists() },
+                { assert path(process.out.multi_bed[0][1]).exists() },
+                { assert path(process.out.single_bed[0][1]).exists() },
+                { assert snapshot(process.out.versions).match("homo_sapiens - split - paired_end - versions") }
+            )
+        }
+    }
 }

--- a/modules/nf-core/segemehl/align/tests/main.nf.test
+++ b/modules/nf-core/segemehl/align/tests/main.nf.test
@@ -1,0 +1,79 @@
+nextflow_process {
+
+    name "Test Process SEGEMEHL_ALIGN"
+    script "../main.nf"
+    process "SEGEMEHL_ALIGN"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "segemehl"
+    tag "segemehl/align"
+    tag "segemehl/index"
+
+    setup {
+        run("SEGEMEHL_INDEX") {
+            script "../../../segemehl/index/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens - single_end") {
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true) ]
+                ])
+                input[1] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = SEGEMEHL_INDEX.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alignment[0][1]).exists() },
+                { assert snapshot(process.out.versions).match("homo_sapiens - single_end - versions") }
+            )
+        }
+    }
+
+    test("homo_sapiens - paired_end") {
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = Channel.of([
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = SEGEMEHL_INDEX.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.alignment[0][1]).exists() },
+                { assert snapshot(process.out.versions).match("homo_sapiens - paired_end - versions") }
+            )
+        }
+    }
+
+
+}

--- a/modules/nf-core/segemehl/align/tests/main.nf.test.snap
+++ b/modules/nf-core/segemehl/align/tests/main.nf.test.snap
@@ -1,0 +1,26 @@
+{
+    "homo_sapiens - paired_end - versions": {
+        "content": [
+            [
+                "versions.yml:md5,0c6afcd6ae65e27a0ea87f5b42c853eb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-05-30T12:58:05.434115758"
+    },
+    "homo_sapiens - single_end - versions": {
+        "content": [
+            [
+                "versions.yml:md5,0c6afcd6ae65e27a0ea87f5b42c853eb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-05-30T12:57:56.488707635"
+    }
+}

--- a/modules/nf-core/segemehl/align/tests/main.nf.test.snap
+++ b/modules/nf-core/segemehl/align/tests/main.nf.test.snap
@@ -22,5 +22,29 @@
             "nextflow": "24.04.2"
         },
         "timestamp": "2024-05-30T12:57:56.488707635"
+    },
+    "homo_sapiens - split - single_end - versions": {
+        "content": [
+            [
+                "versions.yml:md5,0c6afcd6ae65e27a0ea87f5b42c853eb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-05-30T13:06:11.217385877"
+    },
+    "homo_sapiens - split - paired_end - versions": {
+        "content": [
+            [
+                "versions.yml:md5,0c6afcd6ae65e27a0ea87f5b42c853eb"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-05-30T13:06:29.757385118"
     }
 }

--- a/modules/nf-core/segemehl/align/tests/split.config
+++ b/modules/nf-core/segemehl/align/tests/split.config
@@ -1,0 +1,5 @@
+process{
+    withName: SEGEMEHL_ALIGN {
+        ext.args = "-S"
+    }
+}

--- a/modules/nf-core/segemehl/align/tests/tags.yml
+++ b/modules/nf-core/segemehl/align/tests/tags.yml
@@ -1,0 +1,2 @@
+segemehl/align:
+  - modules/nf-core/segemehl/align/**


### PR DESCRIPTION
Currently, the output files of this module are all provided as a single channel containing the output directory.
This makes selecting individual files for further analysis inconvenient. 

This was not a problem before, as the only nf-core pipeline using this module (circrna) had a specific process for handling this. Recently, we switched to using the nf-core `GAWK` module, which makes it necessary to provide only the relevant file to the process.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Follow the input/output options guidelines.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
