### PR TITLE
Update deepbgc module: produce `gbk.tsv` file even if no results are found

### DIFF
--- a/modules/nf-core/deepbgc/pipeline/main.nf
+++ b/modules/nf-core/deepbgc/pipeline/main.nf
@@ -12,18 +12,18 @@ process DEEPBGC_PIPELINE {
     path(db)
 
     output:
-    tuple val(meta), path("${prefix}/README.txt")                    ,   optional: true, emit: readme
-    tuple val(meta), path("${prefix}/LOG.txt")                       ,   emit: log
-    tuple val(meta), path("${prefix}/${prefix}.antismash.json")      ,   optional: true, emit: json
-    tuple val(meta), path("${prefix}/${prefix}.bgc.gbk")             ,   optional: true, emit: bgc_gbk
-    tuple val(meta), path("${prefix}/${prefix}.bgc.tsv")             ,   optional: true, emit: bgc_tsv
-    tuple val(meta), path("${prefix}/${prefix}.full.gbk")            ,   optional: true, emit: full_gbk
-    tuple val(meta), path("${prefix}/${prefix}.pfam.tsv")            ,   optional: true, emit: pfam_tsv
-    tuple val(meta), path("${prefix}/evaluation/${prefix}.bgc.png")  ,   optional: true, emit: bgc_png
-    tuple val(meta), path("${prefix}/evaluation/${prefix}.pr.png")   ,   optional: true, emit: pr_png
-    tuple val(meta), path("${prefix}/evaluation/${prefix}.roc.png")  ,   optional: true, emit: roc_png
-    tuple val(meta), path("${prefix}/evaluation/${prefix}.score.png"),   optional: true, emit: score_png
-    path "versions.yml"                                                                    ,   emit: versions
+    tuple val(meta), path("${prefix}/README.txt")                    , optional: true, emit: readme
+    tuple val(meta), path("${prefix}/LOG.txt")                       ,               , emit: log
+    tuple val(meta), path("${prefix}/${prefix}.antismash.json")      , optional: true, emit: json
+    tuple val(meta), path("${prefix}/${prefix}.bgc.gbk")             , optional: true, emit: bgc_gbk
+    tuple val(meta), path("${prefix}/${prefix}.bgc.tsv")             ,               , emit: bgc_tsv
+    tuple val(meta), path("${prefix}/${prefix}.full.gbk")            , optional: true, emit: full_gbk
+    tuple val(meta), path("${prefix}/${prefix}.pfam.tsv")            , optional: true, emit: pfam_tsv
+    tuple val(meta), path("${prefix}/evaluation/${prefix}.bgc.png")  , optional: true, emit: bgc_png
+    tuple val(meta), path("${prefix}/evaluation/${prefix}.pr.png")   , optional: true, emit: pr_png
+    tuple val(meta), path("${prefix}/evaluation/${prefix}.roc.png")  , optional: true, emit: roc_png
+    tuple val(meta), path("${prefix}/evaluation/${prefix}.score.png"), optional: true, emit: score_png
+    path "versions.yml"                                                              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -46,6 +46,11 @@ process DEEPBGC_PIPELINE {
     for i in \$(find -name '${genome.baseName}*' -type f); do
         mv \$i \${i/${genome.baseName}/${prefix}};
     done
+
+    bgc_tsv="${prefix}/${prefix}.bgc.tsv"
+    if [ ! -f \$bgc_tsv ]; then
+        echo "sequence_id\tdetector\tdetector_version\tdetector_label\tbgc_candidate_id\tnucl_start\tnucl_end\tnucl_length\tnum_proteins\tnum_domains\tnum_bio_domains\tdeepbgc_score\tproduct_activity\tantibacterial\tcytotoxic\tinhibitor\tantifungal\tproduct_class\tAlkaloid\tNRP\tOther\tPolyketide\tRiPP\tSaccharide\tTerpene\tprotein_ids\tbio_pfam_ids\tpfam_ids" > \$bgc_tsv
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
This updates the deepbgc/pipeline module to produce `gbk.tsv` output file even if no BGCs are found.

The default behaviour of DeepBGC if no BGCs are found is:
- not produce `bgc.tsv` file
- produce empty `bgc.gbk` file

I would like to adjust this to
- produce empty `bgc.tsv` file
- produce empty `bgc.gbk` file

The `bgc.gbk` file includes then no hits, just the table header of a normal `bgc.tsv` file from DeepBGC.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
