### PR TITLE
Subworkflow: Publish UMI-tools dedup basic deduplication statistics in "Bam dedup stats samtools umitools"

### DIFF
--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::multiqc=1.21
+  - bioconda::multiqc=1.22.2

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,8 +3,8 @@ process MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.21--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.21--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.22.2--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.22.2--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "multiqc_versions_single": {
         "content": [
             [
-                "versions.yml:md5,21f35ee29416b9b3073c28733efe4b7d"
+                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-02-29T08:48:55.657331"
+        "timestamp": "2024-06-10T11:50:10.874341679"
     },
     "multiqc_stub": {
         "content": [
@@ -17,25 +17,25 @@
                 "multiqc_report.html",
                 "multiqc_data",
                 "multiqc_plots",
-                "versions.yml:md5,21f35ee29416b9b3073c28733efe4b7d"
+                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-02-29T08:49:49.071937"
+        "timestamp": "2024-06-10T11:50:49.271943761"
     },
     "multiqc_versions_config": {
         "content": [
             [
-                "versions.yml:md5,21f35ee29416b9b3073c28733efe4b7d"
+                "versions.yml:md5,ddbc971a8307f9b9b7b973714cde29d0"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-02-29T08:49:25.457567"
+        "timestamp": "2024-06-10T11:50:34.046706025"
     }
 }

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/main.nf
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/main.nf
@@ -44,6 +44,7 @@ workflow BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS {
 
     emit:
     bam      = UMITOOLS_DEDUP.out.bam          // channel: [ val(meta), path(bam) ]
+    deduplog = UMITOOLS_DEDUP.out.log          // channel: [ val(meta), path(log) ]
 
     bai      = SAMTOOLS_INDEX.out.bai          // channel: [ val(meta), path(bai) ]
     csi      = SAMTOOLS_INDEX.out.csi          // channel: [ val(meta), path(csi) ]

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/meta.yml
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/meta.yml
@@ -37,6 +37,10 @@ output:
       description: |
         CSI samtools index
         Structure: [ val(meta), path(csi) ]
+  - deduplog:
+      description: |
+        UMI-tools deduplication log
+        Structure: [ val(meta), path(log) ]
   - stats:
       description: |
         File containing samtools stats output

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/tests/main.nf.test
@@ -40,6 +40,7 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success},
+                { assert workflow.out.deduplog.get(0).get(1) ==~ ".*.log"},
                 { assert workflow.out.bam.get(0).get(1) ==~ ".*.bam"},
                 { assert workflow.out.bai.get(0).get(1) ==~ ".*.bai"},
                 { assert snapshot(workflow.out.stats).match("test_bam_dedup_stats_samtools_umitools_stats") },


### PR DESCRIPTION
As of now, the subworkflow `bam_dedup_stats_samtools_umitools` does emit the UMI-tools deduplication logs. The output channel `UMITOOLS_DEDUP.out.log` of the module is ignored in the subworkflow, but it is needed to generate a summary of the deduplication rate with MultiQC inside a pipeline. Since MultiQC supports the tool, it would be a pity to omit the stats in the report in the future.

This PR thus makes sure that there is also an output channel on the subworkflow level, so the logs can be utilized in a pipeline's MultiQC report. In addition, I have also upgraded the MultiQC module to the latest version.
 
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [] `nf-core modules test <MODULE> --profile docker` (**MultiQC**)
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker` (**bam_dedup_stats_samtools_umitools**)
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
