### PR TITLE
Update gnu_sort dependency versions

### DIFF
--- a/modules/nf-core/gnu/sort/environment.yml
+++ b/modules/nf-core/gnu/sort/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::coreutils=8.25
+  - bioconda::coreutils=9.3

--- a/modules/nf-core/gnu/sort/environment.yml
+++ b/modules/nf-core/gnu/sort/environment.yml
@@ -1,7 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 name: gnu_sort
 channels:
   - conda-forge
   - bioconda
   - defaults
 dependencies:
-  - bioconda::coreutils=9.3
+  - conda-forge::coreutils=9.3

--- a/modules/nf-core/gnu/sort/main.nf
+++ b/modules/nf-core/gnu/sort/main.nf
@@ -4,8 +4,8 @@ process GNU_SORT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/coreutils:8.25--1' :
-    'biocontainers/coreutils:8.25--1' }"
+    'https://depot.galaxyproject.org/singularity/coreutils:9.3' :
+    'biocontainers/coreutils:9.3' }"
 
     input:
     tuple val(meta), path(input)

--- a/modules/nf-core/gnu/sort/main.nf
+++ b/modules/nf-core/gnu/sort/main.nf
@@ -1,11 +1,11 @@
 process GNU_SORT {
-    tag "${meta.id}"
+    tag "$meta.id"
     label "process_low"
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/coreutils:9.3' :
-    'biocontainers/coreutils:9.3' }"
+        'https://depot.galaxyproject.org/singularity/coreutils:9.3':
+        'biocontainers/coreutils:9.3' }"
 
     input:
     tuple val(meta), path(input)
@@ -22,7 +22,7 @@ process GNU_SORT {
     def prefix      = task.ext.prefix   ?: "${meta.id}"
     suffix          = task.ext.suffix   ?: "${input.extension}"
     output_file     = "${prefix}.${suffix}"
-    def VERSION     = "9.1"             // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def VERSION     = "9.3"             // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     if ("$input" == "$output_file") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     sort ${args} ${input} > ${output_file}
@@ -37,7 +37,7 @@ process GNU_SORT {
     def prefix      = task.ext.prefix   ?: "${meta.id}"
     suffix          = task.ext.suffix   ?: "${input.extension}"
     output_file     = "${prefix}.${suffix}"
-    def VERSION     = "9.1"
+    def VERSION     = "9.3"
 
     if ("$input" == "$output_file") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """

--- a/modules/nf-core/gnu/sort/tests/main.nf.test.snap
+++ b/modules/nf-core/gnu/sort/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8ebec31a85721157399cb4faab6e0d26"
+                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
                 ],
                 "sorted": [
                     [
@@ -22,17 +22,25 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8ebec31a85721157399cb4faab6e0d26"
+                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
                 ]
             }
         ],
-        "timestamp": "2024-02-22T13:57:33.598003"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-14T11:13:44.714632791"
     },
     "interval_sort": {
         "content": [
             "test.bed.sorted"
         ],
-        "timestamp": "2024-02-22T13:57:25.5442"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-14T11:13:37.962807086"
     },
     "unsorted_csv_sort_stub": {
         "content": [
@@ -46,7 +54,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8ebec31a85721157399cb4faab6e0d26"
+                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
                 ],
                 "sorted": [
                     [
@@ -57,17 +65,25 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8ebec31a85721157399cb4faab6e0d26"
+                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
                 ]
             }
         ],
-        "timestamp": "2024-02-22T13:57:41.490986"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-14T11:13:51.456258705"
     },
     "csv_sort": {
         "content": [
             "test.csv.sorted"
         ],
-        "timestamp": "2024-02-22T13:57:33.62444"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-14T11:13:44.725431761"
     },
     "unsorted_genome_sort": {
         "content": [
@@ -81,7 +97,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8ebec31a85721157399cb4faab6e0d26"
+                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
                 ],
                 "sorted": [
                     [
@@ -92,17 +108,25 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8ebec31a85721157399cb4faab6e0d26"
+                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
                 ]
             }
         ],
-        "timestamp": "2024-02-22T13:57:17.281092"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-14T11:13:31.041778719"
     },
     "genome_sort": {
         "content": [
             "genome_test.bed.sorted"
         ],
-        "timestamp": "2024-02-22T13:57:17.340463"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-14T11:13:31.060201722"
     },
     "unsorted_intervals_sort": {
         "content": [
@@ -116,7 +140,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8ebec31a85721157399cb4faab6e0d26"
+                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
                 ],
                 "sorted": [
                     [
@@ -127,10 +151,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8ebec31a85721157399cb4faab6e0d26"
+                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
                 ]
             }
         ],
-        "timestamp": "2024-02-22T13:57:25.514206"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-14T11:13:37.951397547"
     }
 }


### PR DESCRIPTION
The primary goal is to fix the upcoming problems with old docker images not being compatible with current docker versions. I took inspiration from [gnu_split](https://github.com/nf-core/modules/tree/master/modules/nf-core/gnu/split), which has the same dependencies.