### PR TITLE
Conda remove defaults channel - structural changes

### DIFF
--- a/.github/env-template.yml
+++ b/.github/env-template.yml
@@ -1,4 +1,3 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -452,7 +452,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3
         with:
           miniconda-version: "latest"
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda
           python-version: ${{ matrix.python-version }}
 
       - name: Conda setup
@@ -693,7 +693,7 @@ jobs:
         with:
           miniconda-version: "latest"
           auto-update-conda: true
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda
 
       - name: Conda setup
         run: |

--- a/modules/environment-schema.json
+++ b/modules/environment-schema.json
@@ -16,12 +16,9 @@
                 },
                 {
                     "enum": ["bioconda"]
-                },
-                {
-                    "enum": ["defaults"]
                 }
             ],
-            "minItems": 3
+            "minItems": 2
         },
         "dependencies": {
             "type": "array",

--- a/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
@@ -102,7 +102,7 @@ def checkCondaChannels() {
 
     // Check that all channels are present
     // This channel list is ordered by required channel priority.
-    def required_channels_in_order = ['conda-forge', 'bioconda', 'defaults']
+    def required_channels_in_order = ['conda-forge', 'bioconda']
     def channels_missing = ((required_channels_in_order as Set) - (channels as Set)) as Boolean
 
     // Check that they are in the right order


### PR DESCRIPTION
Structural changes to schema and other files for removing the `defaults` channel.

See https://github.com/nf-core/modules/issues/5829