### PR TITLE
antismashlite: Update pattern of output path

### DIFF
--- a/modules/nf-core/antismash/antismashlite/main.nf
+++ b/modules/nf-core/antismash/antismashlite/main.nf
@@ -29,7 +29,7 @@ process ANTISMASH_ANTISMASHLITE {
     tuple val(meta), path("${prefix}/knownclusterblast/*_c*.txt")            , optional: true, emit: knownclusterblast_txt
     tuple val(meta), path("${prefix}/svg/clusterblast*.svg")                 , optional: true, emit: svg_files_clusterblast
     tuple val(meta), path("${prefix}/svg/knownclusterblast*.svg")            , optional: true, emit: svg_files_knownclusterblast
-    tuple val(meta), path("${prefix}/*.gbk")                                 , emit: gbk_input
+    tuple val(meta), path("${prefix}/${prefix}.gbk")                         , emit: gbk_input
     tuple val(meta), path("${prefix}/*.json")                                , emit: json_results
     tuple val(meta), path("${prefix}/*.log")                                 , emit: log
     tuple val(meta), path("${prefix}/*.zip")                                 , emit: zip


### PR DESCRIPTION
This updates the paths of the output channel `gbk_input` which is relevant for filtering the output files. Since antiSMASH produces several GBK files, the channel `gbk_input` should only contain the `<sample>.gbk` and not the GBK files of individual BGCs (`*region*.gbk`).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
