### PR TITLE
POC of new meta.yml structure and ontologies

### DIFF
--- a/modules/nf-core/atlas/splitmerge/meta.yml
+++ b/modules/nf-core/atlas/splitmerge/meta.yml
@@ -7,58 +7,71 @@ keywords:
   - read group
 tools:
   - "atlas":
-      description: "ATLAS, a suite of methods to accurately genotype and estimate genetic diversity"
+      description: "ATLAS, a suite of methods to accurately genotype and estimate genetic
+        diversity"
       homepage: "https://bitbucket.org/wegmannlab/atlas/wiki/Home"
       documentation: "https://bitbucket.org/wegmannlab/atlas/wiki/Home"
       tool_dev_url: "https://bitbucket.org/wegmannlab/atlas"
       doi: "10.1101/105346"
-      licence: "['GPL v3']"
+      licence: ["GPL v3"]
+      identifier: biotools:atlas_db
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - bam:
-      type: file
-      description: Single input BAM file.
-      pattern: "*.bam"
-  - bai:
-      type: file
-      description: The BAI file for the input BAM file
-      pattern: "*.bai"
-  - read_group_setting:
-      type: file
-      description: |
-        TXT file containing the split and merge settings for
-        each readgroup. Each line consist of one readgroup,
-        single/double identifier and the maximum cycle number
-        of the sequencer. e.g. "RG1 single 100"
-      pattern: "*.txt"
-  - blacklist:
-      type: file
-      description: |
-        blacklist.txt (optional), A txt file with blacklisted read names
-        that should be ignored and just written to file, each on a new line
-      pattern: "*.txt"
+  - - meta:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bam:
+        qualifier: path
+        type: file
+        description: Single input BAM file.
+        pattern: "*.bam"
+    - bai:
+        qualifier: path
+        type: file
+        description: The BAI file for the input BAM file
+        pattern: "*.bai"
+    - read_group_settings:
+        type: file
+        description: |
+          TXT file containing the split and merge settings for
+          each readgroup. Each line consist of one readgroup,
+          single/double identifier and the maximum cycle number
+          of the sequencer. e.g. "RG1 single 100"
+        pattern: "*.txt"
+        qualifier: path
+    - blacklist:
+        qualifier: path
+        type: file
+        description: |
+          blacklist.txt (optional), A txt file with blacklisted read names
+          that should be ignored and just written to file, each on a new line
+        pattern: "*.txt"
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
+  - data:
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*_mergedReads.bam":
+          type: file
+          description: A BAM file with suffix_mergedReads.bam
+          pattern: "*_mergedReads.bam"
+          qualifier: path
+      - "*.txt.gz":
+          type: file
+          description: A file listing all reads that were filtered out in the merging process with suffix_ignoredReads.txt.gz
+          pattern: "*.txt.gz"
+          qualifier: path
   - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-  - bam:
-      type: file
-      description: A BAM file with suffix_mergedReads.bam
-      pattern: "*_mergedReads.bam"
-  - filelist:
-      type: file
-      description: A file listing all reads that were filtered out in the merging process with suffix_ignoredReads.txt.gz
-      pattern: "*.txt.gz"
+      - versions.yml:
+          qualifier: path
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@merszym"
 maintainers:

--- a/modules/nf-core/atlas/splitmerge/meta.yml
+++ b/modules/nf-core/atlas/splitmerge/meta.yml
@@ -17,18 +17,15 @@ tools:
       identifier: biotools:atlas_db
 input:
   - - meta:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing sample information
           e.g. [ id:'test', single_end:false ]
     - bam:
-        qualifier: path
         type: file
         description: Single input BAM file.
         pattern: "*.bam"
     - bai:
-        qualifier: path
         type: file
         description: The BAI file for the input BAM file
         pattern: "*.bai"
@@ -40,9 +37,7 @@ input:
           single/double identifier and the maximum cycle number
           of the sequencer. e.g. "RG1 single 100"
         pattern: "*.txt"
-        qualifier: path
     - blacklist:
-        qualifier: path
         type: file
         description: |
           blacklist.txt (optional), A txt file with blacklisted read names
@@ -51,7 +46,6 @@ input:
 output:
   - data:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
@@ -60,15 +54,13 @@ output:
           type: file
           description: A BAM file with suffix_mergedReads.bam
           pattern: "*_mergedReads.bam"
-          qualifier: path
       - "*.txt.gz":
           type: file
-          description: A file listing all reads that were filtered out in the merging process with suffix_ignoredReads.txt.gz
+          description: A file listing all reads that were filtered out in the merging
+            process with suffix_ignoredReads.txt.gz
           pattern: "*.txt.gz"
-          qualifier: path
   - versions:
       - versions.yml:
-          qualifier: path
           type: file
           description: File containing software versions
           pattern: "versions.yml"

--- a/modules/nf-core/bwa/mem/environment.yml
+++ b/modules/nf-core/bwa/mem/environment.yml
@@ -1,10 +1,11 @@
 name: bwa_mem
+
 channels:
   - conda-forge
   - bioconda
   - defaults
+
 dependencies:
   - bwa=0.7.18
-  # renovate: datasource=conda depName=bioconda/samtools
-  - samtools=1.20
   - htslib=1.20.0
+  - samtools=1.20

--- a/modules/nf-core/bwa/mem/meta.yml
+++ b/modules/nf-core/bwa/mem/meta.yml
@@ -20,92 +20,76 @@ tools:
       identifier: "biotools:bwa"
 input:
   - - meta:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing sample information
           e.g. [ id:'test', single_end:false ]
     - reads:
-        qualifier: path
         type: file
         description: |
           List of input FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively.
   - - meta2:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing reference information.
           e.g. [ id:'test', single_end:false ]
     - index:
-        qualifier: path
         type: file
         description: BWA genome index files
         pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
   - - meta3:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing reference information.
           e.g. [ id:'test', single_end:false ]
     - fasta:
-        qualifier: path
         type: file
         description: Reference genome in FASTA format
         pattern: "*.{fasta,fa}"
   - - sort_bam:
-        qualifier: val
         type: boolean
         description: use samtools sort (true) or samtools view (false)
         pattern: "true or false"
 output:
   - bam:
       - meta:
-          qualifier: val
           type: file
           description: Output BAM file containing read alignments
           pattern: "*.{bam}"
       - "*.bam":
-          qualifier: path
           type: file
           description: Output BAM file containing read alignments
           pattern: "*.{bam}"
   - cram:
       - meta:
-          qualifier: val
           type: file
           description: Output CRAM file containing read alignments
           pattern: "*.{cram}"
       - "*.cram":
-          qualifier: path
           type: file
           description: Output CRAM file containing read alignments
           pattern: "*.{cram}"
   - csi:
       - meta:
-          qualifier: val
           type: file
           description: Optional index file for BAM file
           pattern: "*.{csi}"
       - "*.csi":
-          qualifier: path
           type: file
           description: Optional index file for BAM file
           pattern: "*.{csi}"
   - crai:
       - meta:
-          qualifier: val
           type: file
           description: Optional index file for CRAM file
           pattern: "*.{crai}"
       - "*.crai":
-          qualifier: path
           type: file
           description: Optional index file for CRAM file
           pattern: "*.{crai}"
   - versions:
       - versions.yml:
-          qualifier: path
           type: file
           description: File containing software versions
           pattern: "versions.yml"

--- a/modules/nf-core/bwa/mem/meta.yml
+++ b/modules/nf-core/bwa/mem/meta.yml
@@ -17,55 +17,98 @@ tools:
       documentation: https://bio-bwa.sourceforge.net/bwa.shtml
       arxiv: arXiv:1303.3997
       licence: ["GPL-3.0-or-later"]
+      identifier: "biotools:bwa"
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - reads:
-      type: file
-      description: |
-        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
-        respectively.
-  - meta2:
-      type: map
-      description: |
-        Groovy Map containing reference information.
-        e.g. [ id:'test', single_end:false ]
-  - index:
-      type: file
-      description: BWA genome index files
-      pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
-  - fasta:
-      type: file
-      description: Reference genome in FASTA format
-      pattern: "*.{fasta,fa}"
-  - sort_bam:
-      type: boolean
-      description: use samtools sort (true) or samtools view (false)
-      pattern: "true or false"
+  - - meta:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        qualifier: path
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+  - - meta2:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing reference information.
+          e.g. [ id:'test', single_end:false ]
+    - index:
+        qualifier: path
+        type: file
+        description: BWA genome index files
+        pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
+  - - meta3:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing reference information.
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        qualifier: path
+        type: file
+        description: Reference genome in FASTA format
+        pattern: "*.{fasta,fa}"
+  - - sort_bam:
+        qualifier: val
+        type: boolean
+        description: use samtools sort (true) or samtools view (false)
+        pattern: "true or false"
 output:
   - bam:
-      type: file
-      description: Output BAM file containing read alignments
-      pattern: "*.{bam}"
+      - meta:
+          qualifier: val
+          type: file
+          description: Output BAM file containing read alignments
+          pattern: "*.{bam}"
+      - "*.bam":
+          qualifier: path
+          type: file
+          description: Output BAM file containing read alignments
+          pattern: "*.{bam}"
   - cram:
-      type: file
-      description: Output CRAM file containing read alignments
-      pattern: "*.{cram}"
+      - meta:
+          qualifier: val
+          type: file
+          description: Output CRAM file containing read alignments
+          pattern: "*.{cram}"
+      - "*.cram":
+          qualifier: path
+          type: file
+          description: Output CRAM file containing read alignments
+          pattern: "*.{cram}"
   - csi:
-      type: file
-      description: Optional index file for BAM file
-      pattern: "*.{csi}"
+      - meta:
+          qualifier: val
+          type: file
+          description: Optional index file for BAM file
+          pattern: "*.{csi}"
+      - "*.csi":
+          qualifier: path
+          type: file
+          description: Optional index file for BAM file
+          pattern: "*.{csi}"
   - crai:
-      type: file
-      description: Optional index file for CRAM file
-      pattern: "*.{crai}"
+      - meta:
+          qualifier: val
+          type: file
+          description: Optional index file for CRAM file
+          pattern: "*.{crai}"
+      - "*.crai":
+          qualifier: path
+          type: file
+          description: Optional index file for CRAM file
+          pattern: "*.{crai}"
   - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
+      - versions.yml:
+          qualifier: path
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@drpatelh"
   - "@jeremy1805"

--- a/modules/nf-core/bwa/mem/meta.yml
+++ b/modules/nf-core/bwa/mem/meta.yml
@@ -29,6 +29,8 @@ input:
         description: |
           List of input FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively.
+        ontologies:
+          - edam: http://edamontology.org/format_1930
   - - meta2:
         type: map
         description: |
@@ -36,8 +38,7 @@ input:
           e.g. [ id:'test', single_end:false ]
     - index:
         type: file
-        description: BWA genome index files
-        pattern: "Directory containing BWA index *.{amb,ann,bwt,pac,sa}"
+        description: BWA genome index files. Directory containing BWA index *.{amb,ann,bwt,pac,sa}
   - - meta3:
         type: map
         description: |
@@ -47,43 +48,47 @@ input:
         type: file
         description: Reference genome in FASTA format
         pattern: "*.{fasta,fa}"
+        ontologies:
+          - edam: http://edamontology.org/format_1929
   - - sort_bam:
         type: boolean
         description: use samtools sort (true) or samtools view (false)
         pattern: "true or false"
+        ontologies:
+          - edam: http://edamontology.org/format_2572
 output:
   - bam:
       - meta:
-          type: file
-          description: Output BAM file containing read alignments
-          pattern: "*.{bam}"
+          type: map
+          description: Groovy map
       - "*.bam":
           type: file
           description: Output BAM file containing read alignments
           pattern: "*.{bam}"
+          ontologies:
+            - edam: http://edamontology.org/format_2572
   - cram:
       - meta:
-          type: file
-          description: Output CRAM file containing read alignments
-          pattern: "*.{cram}"
+          type: map
+          description: Groovy map
       - "*.cram":
           type: file
           description: Output CRAM file containing read alignments
           pattern: "*.{cram}"
+          ontologies:
+            - edam: http://edamontology.org/format_3462
   - csi:
       - meta:
-          type: file
-          description: Optional index file for BAM file
-          pattern: "*.{csi}"
+          type: map
+          description: Groovy map
       - "*.csi":
           type: file
           description: Optional index file for BAM file
           pattern: "*.{csi}"
   - crai:
       - meta:
-          type: file
-          description: Optional index file for CRAM file
-          pattern: "*.{crai}"
+          type: map
+          description: Groovy map
       - "*.crai":
           type: file
           description: Optional index file for CRAM file

--- a/modules/nf-core/fastp/meta.yml
+++ b/modules/nf-core/fastp/meta.yml
@@ -14,113 +14,94 @@ tools:
       identifier: biotools:fastp
 input:
   - - meta:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing sample information. Use 'single_end: true' to specify single ended or interleaved FASTQs. Use 'single_end: false' for paired-end reads.
           e.g. [ id:'test', single_end:false ]
     - reads:
-        qualifier: path
         type: file
         description: |
           List of input FastQ files of size 1 and 2 for single-end and paired-end data,
           respectively. If you wish to run interleaved paired-end data,  supply as single-end data
           but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
   - - adapter_fasta:
-        qualifier: path
         type: file
         description: File in FASTA format containing possible adapters to remove.
         pattern: "*.{fasta,fna,fas,fa}"
   - - discard_trimmed_pass:
-        qualifier: val
         type: boolean
         description: Specify true to not write any reads that pass trimming thresholds.
           | This can be used to use fastp for the output report only.
   - - save_trimmed_fail:
-        qualifier: val
         type: boolean
         description: Specify true to save files that failed to pass trimming thresholds
           ending in `*.fail.fastq.gz`
   - - save_merged:
-        qualifier: val
         type: boolean
         description: Specify true to save all merged reads to a file ending in `*.merged.fastq.gz`
 output:
   - reads:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.fastp.fastq.gz":
-          qualifier: path
           type: file
           description: The trimmed/modified/unmerged fastq reads
           pattern: "*fastp.fastq.gz"
   - json:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.json":
-          qualifier: path
           type: file
           description: Results in JSON format
           pattern: "*.json"
   - html:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.html":
-          qualifier: path
           type: file
           description: Results in HTML format
           pattern: "*.html"
   - log:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.log":
-          qualifier: path
           type: file
           description: fastq log file
           pattern: "*.log"
   - reads_fail:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.fail.fastq.gz":
-          qualifier: path
           type: file
           description: Reads the failed the preprocessing
           pattern: "*fail.fastq.gz"
   - reads_merged:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.merged.fastq.gz":
-          qualifier: path
           type: file
           description: Reads that were successfully merged
           pattern: "*.{merged.fastq.gz}"
   - versions:
       - versions.yml:
-          qualifier: path
           type: file
           description: File containing software versions
           pattern: "versions.yml"

--- a/modules/nf-core/fastp/meta.yml
+++ b/modules/nf-core/fastp/meta.yml
@@ -11,66 +11,119 @@ tools:
       documentation: https://github.com/OpenGene/fastp
       doi: 10.1093/bioinformatics/bty560
       licence: ["MIT"]
+      identifier: biotools:fastp
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information. Use 'single_end: true' to specify single ended or interleaved FASTQs. Use 'single_end: false' for paired-end reads.
-        e.g. [ id:'test', single_end:false ]
-  - reads:
-      type: file
-      description: |
-        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
-        respectively. If you wish to run interleaved paired-end data,  supply as single-end data
-        but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
-  - adapter_fasta:
-      type: file
-      description: File in FASTA format containing possible adapters to remove.
-      pattern: "*.{fasta,fna,fas,fa}"
-  - discard_trimmed_pass:
-      type: boolean
-      description: Specify true to not write any reads that pass trimming thresholds. |
-        This can be used to use fastp for the output report only.
-  - save_trimmed_fail:
-      type: boolean
-      description: Specify true to save files that failed to pass trimming thresholds ending in `*.fail.fastq.gz`
-  - save_merged:
-      type: boolean
-      description: Specify true to save all merged reads to a file ending in `*.merged.fastq.gz`
+  - - meta:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing sample information. Use 'single_end: true' to specify single ended or interleaved FASTQs. Use 'single_end: false' for paired-end reads.
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        qualifier: path
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively. If you wish to run interleaved paired-end data,  supply as single-end data
+          but with `--interleaved_in` in your `modules.conf`'s `ext.args` for the module.
+  - - adapter_fasta:
+        qualifier: path
+        type: file
+        description: File in FASTA format containing possible adapters to remove.
+        pattern: "*.{fasta,fna,fas,fa}"
+  - - discard_trimmed_pass:
+        qualifier: val
+        type: boolean
+        description: Specify true to not write any reads that pass trimming thresholds.
+          | This can be used to use fastp for the output report only.
+  - - save_trimmed_fail:
+        qualifier: val
+        type: boolean
+        description: Specify true to save files that failed to pass trimming thresholds
+          ending in `*.fail.fastq.gz`
+  - - save_merged:
+        qualifier: val
+        type: boolean
+        description: Specify true to save all merged reads to a file ending in `*.merged.fastq.gz`
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
   - reads:
-      type: file
-      description: The trimmed/modified/unmerged fastq reads
-      pattern: "*fastp.fastq.gz"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fastp.fastq.gz":
+          qualifier: path
+          type: file
+          description: The trimmed/modified/unmerged fastq reads
+          pattern: "*fastp.fastq.gz"
   - json:
-      type: file
-      description: Results in JSON format
-      pattern: "*.json"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.json":
+          qualifier: path
+          type: file
+          description: Results in JSON format
+          pattern: "*.json"
   - html:
-      type: file
-      description: Results in HTML format
-      pattern: "*.html"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.html":
+          qualifier: path
+          type: file
+          description: Results in HTML format
+          pattern: "*.html"
   - log:
-      type: file
-      description: fastq log file
-      pattern: "*.log"
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          qualifier: path
+          type: file
+          description: fastq log file
+          pattern: "*.log"
   - reads_fail:
-      type: file
-      description: Reads the failed the preprocessing
-      pattern: "*fail.fastq.gz"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fail.fastq.gz":
+          qualifier: path
+          type: file
+          description: Reads the failed the preprocessing
+          pattern: "*fail.fastq.gz"
   - reads_merged:
-      type: file
-      description: Reads that were successfully merged
-      pattern: "*.{merged.fastq.gz}"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.merged.fastq.gz":
+          qualifier: path
+          type: file
+          description: Reads that were successfully merged
+          pattern: "*.{merged.fastq.gz}"
+  - versions:
+      - versions.yml:
+          qualifier: path
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@drpatelh"
   - "@kevinmenden"

--- a/modules/nf-core/multiqc/meta.yml
+++ b/modules/nf-core/multiqc/meta.yml
@@ -1,5 +1,6 @@
 name: multiqc
-description: Aggregate results from bioinformatics analyses across many samples into a single report
+description: Aggregate results from bioinformatics analyses across many samples into
+  a single report
 keywords:
   - QC
   - bioinformatics tools
@@ -12,40 +13,54 @@ tools:
       homepage: https://multiqc.info/
       documentation: https://multiqc.info/docs/
       licence: ["GPL-3.0-or-later"]
+      identifier: biotools:multiqc
 input:
-  - multiqc_files:
-      type: file
-      description: |
-        List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
-  - multiqc_config:
-      type: file
-      description: Optional config yml for MultiQC
-      pattern: "*.{yml,yaml}"
-  - extra_multiqc_config:
-      type: file
-      description: Second optional config yml for MultiQC. Will override common sections in multiqc_config.
-      pattern: "*.{yml,yaml}"
-  - multiqc_logo:
-      type: file
-      description: Optional logo file for MultiQC
-      pattern: "*.{png}"
+  - - multiqc_files:
+        qualifier: path
+        type: file
+        description: |
+          List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
+  - - multiqc_config:
+        qualifier: path
+        type: file
+        description: Optional config yml for MultiQC
+        pattern: "*.{yml,yaml}"
+  - - extra_multiqc_config:
+        qualifier: path
+        type: file
+        description: Second optional config yml for MultiQC. Will override common sections
+          in multiqc_config.
+        pattern: "*.{yml,yaml}"
+  - - multiqc_logo:
+        qualifier: path
+        type: file
+        description: Optional logo file for MultiQC
+        pattern: "*.{png}"
 output:
   - report:
-      type: file
-      description: MultiQC report file
-      pattern: "multiqc_report.html"
+      - "*multiqc_report.html":
+          qualifier: path
+          type: file
+          description: MultiQC report file
+          pattern: "multiqc_report.html"
   - data:
-      type: directory
-      description: MultiQC data dir
-      pattern: "multiqc_data"
+      - "*_data":
+          qualifier: path
+          type: directory
+          description: MultiQC data dir
+          pattern: "multiqc_data"
   - plots:
-      type: file
-      description: Plots created by MultiQC
-      pattern: "*_data"
+      - "*_plots":
+          qualifier: path
+          type: file
+          description: Plots created by MultiQC
+          pattern: "*_data"
   - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
+      - versions.yml:
+          qualifier: path
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@abhi18av"
   - "@bunop"

--- a/modules/nf-core/multiqc/meta.yml
+++ b/modules/nf-core/multiqc/meta.yml
@@ -16,48 +16,40 @@ tools:
       identifier: biotools:multiqc
 input:
   - - multiqc_files:
-        qualifier: path
         type: file
         description: |
           List of reports / files recognised by MultiQC, for example the html and zip output of FastQC
   - - multiqc_config:
-        qualifier: path
         type: file
         description: Optional config yml for MultiQC
         pattern: "*.{yml,yaml}"
   - - extra_multiqc_config:
-        qualifier: path
         type: file
         description: Second optional config yml for MultiQC. Will override common sections
           in multiqc_config.
         pattern: "*.{yml,yaml}"
   - - multiqc_logo:
-        qualifier: path
         type: file
         description: Optional logo file for MultiQC
         pattern: "*.{png}"
 output:
   - report:
       - "*multiqc_report.html":
-          qualifier: path
           type: file
           description: MultiQC report file
           pattern: "multiqc_report.html"
   - data:
       - "*_data":
-          qualifier: path
           type: directory
           description: MultiQC data dir
           pattern: "multiqc_data"
   - plots:
       - "*_plots":
-          qualifier: path
           type: file
           description: Plots created by MultiQC
           pattern: "*_data"
   - versions:
       - versions.yml:
-          qualifier: path
           type: file
           description: File containing software versions
           pattern: "versions.yml"

--- a/modules/nf-core/pear/meta.yml
+++ b/modules/nf-core/pear/meta.yml
@@ -14,61 +14,51 @@ tools:
       identifier: biotools:pear
 input:
   - - meta:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing sample information
           e.g. [ id:'test' ]
     - reads:
-        qualifier: path
         type: file
         description: |
           List of input FastQ files with paired-end reads forward and reverse.
 output:
   - assembled:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
       - "*.assembled.fastq.gz":
-          qualifier: path
           type: file
           description: FastQ file containing Assembled reads.
           pattern: "*.{fastq.gz}"
   - unassembled:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
       - "*.unassembled.forward.fastq.gz":
-          qualifier: path
           type: file
           description: FastQ files containing Unassembled forward and reverse reads.
           pattern: "*.{fastq.gz}"
       - "*.unassembled.reverse.fastq.gz":
-          qualifier: path
           type: file
           description: FastQ files containing Unassembled forward and reverse reads.
           pattern: "*.{fastq.gz}"
   - discarded:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
       - "*.discarded.fastq.gz":
-          qualifier: path
           type: file
           description: FastQ file containing discarded reads.
           pattern: "*.{fastq.gz}"
   - versions:
       - versions.yml:
-          qualifier: path
           type: file
           description: File containing software versions
           pattern: "versions.yml"

--- a/modules/nf-core/pear/meta.yml
+++ b/modules/nf-core/pear/meta.yml
@@ -1,5 +1,6 @@
 name: "pear"
-description: PEAR is an ultrafast, memory-efficient and highly accurate pair-end read merger.
+description: PEAR is an ultrafast, memory-efficient and highly accurate pair-end read
+  merger.
 keywords:
   - pair-end
   - read
@@ -10,38 +11,67 @@ tools:
       homepage: "https://cme.h-its.org/exelixis/web/software/pear/"
       documentation: "https://cme.h-its.org/exelixis/web/software/pear/doc.html"
       licence: ["Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported"]
+      identifier: biotools:pear
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test' ]
-  - reads:
-      type: file
-      description: |
-        List of input FastQ files with paired-end reads forward and reverse.
+  - - meta:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - reads:
+        qualifier: path
+        type: file
+        description: |
+          List of input FastQ files with paired-end reads forward and reverse.
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test' ]
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
   - assembled:
-      type: file
-      description: FastQ file containing Assembled reads.
-      pattern: "*.{fastq.gz}"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.assembled.fastq.gz":
+          qualifier: path
+          type: file
+          description: FastQ file containing Assembled reads.
+          pattern: "*.{fastq.gz}"
   - unassembled:
-      type: file
-      description: FastQ files containing Unassembled forward and reverse reads.
-      pattern: "*.{fastq.gz}"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.unassembled.forward.fastq.gz":
+          qualifier: path
+          type: file
+          description: FastQ files containing Unassembled forward and reverse reads.
+          pattern: "*.{fastq.gz}"
+      - "*.unassembled.reverse.fastq.gz":
+          qualifier: path
+          type: file
+          description: FastQ files containing Unassembled forward and reverse reads.
+          pattern: "*.{fastq.gz}"
   - discarded:
-      type: file
-      description: FastQ file containing discarded reads.
-      pattern: "*.{fastq.gz}"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.discarded.fastq.gz":
+          qualifier: path
+          type: file
+          description: FastQ file containing discarded reads.
+          pattern: "*.{fastq.gz}"
+  - versions:
+      - versions.yml:
+          qualifier: path
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@mirpedrol"
 maintainers:

--- a/modules/nf-core/samtools/index/environment.yml
+++ b/modules/nf-core/samtools/index/environment.yml
@@ -1,8 +1,10 @@
 name: samtools_index
+
 channels:
   - conda-forge
   - bioconda
   - defaults
+
 dependencies:
-  - bioconda::samtools=1.20
   - bioconda::htslib=1.20
+  - bioconda::samtools=1.20

--- a/modules/nf-core/samtools/index/meta.yml
+++ b/modules/nf-core/samtools/index/meta.yml
@@ -18,7 +18,6 @@ tools:
       identifier: biotools:samtools
 input:
   - - meta:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing sample information
@@ -27,47 +26,39 @@ input:
         type: file
         description: BAM/CRAM/SAM file
         pattern: "*.{bam,cram,sam}"
-        qualifier: path
 output:
   - bai:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.bai":
-          qualifier: path
           type: file
           description: BAM/CRAM/SAM index file
           pattern: "*.{bai,crai,sai}"
   - csi:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.csi":
-          qualifier: path
           type: file
           description: CSI index file
           pattern: "*.{csi}"
   - crai:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.crai":
-          qualifier: path
           type: file
           description: BAM/CRAM/SAM index file
           pattern: "*.{bai,crai,sai}"
   - versions:
       - versions.yml:
-          qualifier: path
           type: file
           description: File containing software versions
           pattern: "versions.yml"

--- a/modules/nf-core/samtools/index/meta.yml
+++ b/modules/nf-core/samtools/index/meta.yml
@@ -15,38 +15,62 @@ tools:
       documentation: http://www.htslib.org/doc/samtools.html
       doi: 10.1093/bioinformatics/btp352
       licence: ["MIT"]
+      identifier: biotools:samtools
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - bam:
-      type: file
-      description: BAM/CRAM/SAM file
-      pattern: "*.{bam,cram,sam}"
+  - - meta:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - input:
+        type: file
+        description: BAM/CRAM/SAM file
+        pattern: "*.{bam,cram,sam}"
+        qualifier: path
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
   - bai:
-      type: file
-      description: BAM/CRAM/SAM index file
-      pattern: "*.{bai,crai,sai}"
-  - crai:
-      type: file
-      description: BAM/CRAM/SAM index file
-      pattern: "*.{bai,crai,sai}"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bai":
+          qualifier: path
+          type: file
+          description: BAM/CRAM/SAM index file
+          pattern: "*.{bai,crai,sai}"
   - csi:
-      type: file
-      description: CSI index file
-      pattern: "*.{csi}"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.csi":
+          qualifier: path
+          type: file
+          description: CSI index file
+          pattern: "*.{csi}"
+  - crai:
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.crai":
+          qualifier: path
+          type: file
+          description: BAM/CRAM/SAM index file
+          pattern: "*.{bai,crai,sai}"
   - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
+      - versions.yml:
+          qualifier: path
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@drpatelh"
   - "@ewels"

--- a/modules/nf-core/samtools/sort/environment.yml
+++ b/modules/nf-core/samtools/sort/environment.yml
@@ -1,8 +1,10 @@
 name: samtools_sort
+
 channels:
   - conda-forge
   - bioconda
   - defaults
+
 dependencies:
-  - bioconda::samtools=1.20
   - bioconda::htslib=1.20
+  - bioconda::samtools=1.20

--- a/modules/nf-core/samtools/sort/meta.yml
+++ b/modules/nf-core/samtools/sort/meta.yml
@@ -18,24 +18,20 @@ tools:
       identifier: biotools:samtools
 input:
   - - meta:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing sample information
           e.g. [ id:'test', single_end:false ]
     - bam:
-        qualifier: path
         type: file
         description: BAM/CRAM/SAM file(s)
         pattern: "*.{bam,cram,sam}"
   - - meta2:
-        qualifier: val
         type: map
         description: |
           Groovy Map containing reference information
           e.g. [ id:'genome' ]
     - fasta:
-        qualifier: path
         type: file
         description: Reference genome FASTA file
         pattern: "*.{fa,fasta,fna}"
@@ -43,55 +39,46 @@ input:
 output:
   - bam:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.bam":
-          qualifier: path
           type: file
           description: Sorted BAM file
           pattern: "*.{bam}"
   - cram:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.cram":
-          qualifier: path
           type: file
           description: Sorted CRAM file
           pattern: "*.{cram}"
   - crai:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.crai":
-          qualifier: path
           type: file
           description: CRAM index file (optional)
           pattern: "*.crai"
   - csi:
       - meta:
-          qualifier: val
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.csi":
-          qualifier: path
           type: file
           description: BAM index file (optional)
           pattern: "*.csi"
   - versions:
       - versions.yml:
-          qualifier: path
           type: file
           description: File containing software versions
           pattern: "versions.yml"

--- a/modules/nf-core/samtools/sort/meta.yml
+++ b/modules/nf-core/samtools/sort/meta.yml
@@ -15,52 +15,86 @@ tools:
       documentation: http://www.htslib.org/doc/samtools.html
       doi: 10.1093/bioinformatics/btp352
       licence: ["MIT"]
+      identifier: biotools:samtools
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - bam:
-      type: file
-      description: BAM/CRAM/SAM file(s)
-      pattern: "*.{bam,cram,sam}"
-  - meta2:
-      type: map
-      description: |
-        Groovy Map containing reference information
-        e.g. [ id:'genome' ]
-  - fasta:
-      type: file
-      description: Reference genome FASTA file
-      pattern: "*.{fa,fasta,fna}"
-      optional: true
+  - - meta:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bam:
+        qualifier: path
+        type: file
+        description: BAM/CRAM/SAM file(s)
+        pattern: "*.{bam,cram,sam}"
+  - - meta2:
+        qualifier: val
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome' ]
+    - fasta:
+        qualifier: path
+        type: file
+        description: Reference genome FASTA file
+        pattern: "*.{fa,fasta,fna}"
+        optional: true
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
   - bam:
-      type: file
-      description: Sorted BAM file
-      pattern: "*.{bam}"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bam":
+          qualifier: path
+          type: file
+          description: Sorted BAM file
+          pattern: "*.{bam}"
   - cram:
-      type: file
-      description: Sorted CRAM file
-      pattern: "*.{cram}"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.cram":
+          qualifier: path
+          type: file
+          description: Sorted CRAM file
+          pattern: "*.{cram}"
   - crai:
-      type: file
-      description: CRAM index file (optional)
-      pattern: "*.crai"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.crai":
+          qualifier: path
+          type: file
+          description: CRAM index file (optional)
+          pattern: "*.crai"
   - csi:
-      type: file
-      description: BAM index file (optional)
-      pattern: "*.csi"
+      - meta:
+          qualifier: val
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.csi":
+          qualifier: path
+          type: file
+          description: BAM index file (optional)
+          pattern: "*.csi"
   - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
+      - versions.yml:
+          qualifier: path
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@drpatelh"
   - "@ewels"


### PR DESCRIPTION
POC for https://github.com/nf-core/tools/pull/3028 and https://github.com/nf-core/tools/pull/3032

Run `nf-core modules lint <module_name> --fix` for modules: 
- `fastp`
- `samtools/sort`
- `samtools/index` 
- `atlas/splitmerge`
- `pear`
- `multiqc`
- `bwa/mem`

Note that linting won't pass until https://github.com/nf-core/modules/pull/5837 is merged

ℹ️ The bio.tools ID was not automatically found for `bwa`. 
ℹ️ The modules `samtools/index`, `atlas/splitmerge` and `bwa/mem` had wrong channels specified or missing inputs/outputs, thus the resulting modified `meta.yml` had to be fixed manually.

Ontology for input and output files were added for `bwa/mem` as an example.