### PR TITLE
Update main.nf

### DIFF
--- a/modules/nf-core/ensemblvep/vep/main.nf
+++ b/modules/nf-core/ensemblvep/vep/main.nf
@@ -20,7 +20,7 @@ process ENSEMBLVEP_VEP {
     tuple val(meta), path("*.vcf.gz")  , optional:true, emit: vcf
     tuple val(meta), path("*.tab.gz")  , optional:true, emit: tab
     tuple val(meta), path("*.json.gz") , optional:true, emit: json
-    path "*.summary.html"              , optional:true, emit: report
+    path "*_summary.html"              , optional:true, emit: report
     path "versions.yml"                , emit: versions
 
     when:
@@ -60,7 +60,7 @@ process ENSEMBLVEP_VEP {
     echo "" | gzip > ${prefix}.vcf.gz
     echo "" | gzip > ${prefix}.tab.gz
     echo "" | gzip > ${prefix}.json.gz
-    touch ${prefix}.summary.html
+    touch ${prefix}_summary.html
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
VEP html report is missing when publishing results because by default vep html file is `_summary.html` instead of `.summary.html`. This changes just adjust the module to the vep defaults to avoid the issue.