### PR TITLE
mapAD: fix `versions.yml` emission

### DIFF
--- a/modules/nf-core/mapad/index/main.nf
+++ b/modules/nf-core/mapad/index/main.nf
@@ -29,7 +29,7 @@ process MAPAD_INDEX {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        mapad: \$(echo \$(mapad --version) | sed 's/^mapAD //' ))
+        mapad: \$(echo \$(mapad --version) | sed 's/^mapAD //' )
     END_VERSIONS
     """
 }

--- a/modules/nf-core/mapad/index/tests/main.nf.test.snap
+++ b/modules/nf-core/mapad/index/tests/main.nf.test.snap
@@ -20,7 +20,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,7698672e1d4fb0c59ed5cd1c1ee6fc14"
+                    "versions.yml:md5,f1c9a397c29647a2e0f0d12249b5925c"
                 ],
                 "index": [
                     [
@@ -40,7 +40,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,7698672e1d4fb0c59ed5cd1c1ee6fc14"
+                    "versions.yml:md5,f1c9a397c29647a2e0f0d12249b5925c"
                 ]
             }
         ],
@@ -48,6 +48,6 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-10T10:51:54.8419703"
+        "timestamp": "2024-06-24T12:08:46.548614152"
     }
 }

--- a/modules/nf-core/mapad/map/main.nf
+++ b/modules/nf-core/mapad/map/main.nf
@@ -51,7 +51,7 @@ process MAPAD_MAP {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        mapad: \$(echo \$(mapad --version) | sed 's/^mapAD //' ))
+        mapad: \$(echo \$(mapad --version) | sed 's/^mapAD //' )
     END_VERSIONS
     """
 }

--- a/modules/nf-core/mapad/map/tests/main.nf.test.snap
+++ b/modules/nf-core/mapad/map/tests/main.nf.test.snap
@@ -2,13 +2,13 @@
     "Single-End": {
         "content": [
             [
-                "versions.yml:md5,b25aa098d7980fd088c698e1213777ee"
+                "versions.yml:md5,4e43bd89ce3a7829faa14f4b175ba88b"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-10T10:50:31.671167805"
+        "timestamp": "2024-06-24T12:07:08.873803678"
     }
 }

--- a/subworkflows/nf-core/fastq_align_mapad/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_mapad/tests/main.nf.test.snap
@@ -50,9 +50,9 @@
             ],
             [
                 "versions.yml:md5,3520569f44d66ebc2d9256786ea2c946",
+                "versions.yml:md5,5746a9bf098150e85e9babe1e7ec505a",
                 "versions.yml:md5,7950a0717fb509ace2b9a6df8b510644",
                 "versions.yml:md5,8ce93773095b0d41b336a9e322bb38d9",
-                "versions.yml:md5,bf7d72cf2d0b8a787cf5a2adec7c0bae",
                 "versions.yml:md5,c4e1a9063a91a5f19477eac1b4a783b8",
                 "versions.yml:md5,f09c2fd009cb37d09b5ac9be59390688"
             ]
@@ -61,6 +61,6 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-10T10:20:54.004646153"
+        "timestamp": "2024-06-24T12:03:47.456700325"
     }
 }


### PR DESCRIPTION
Remove a stray parenthesis that was not correctly stripped off the version string.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Emit the `versions.yml` file.