### PR TITLE
Pass annotation files to last-dotplot

### DIFF
--- a/modules/nf-core/last/dotplot/main.nf
+++ b/modules/nf-core/last/dotplot/main.nf
@@ -8,8 +8,9 @@ process LAST_DOTPLOT {
         'biocontainers/last:1542--h43eeafb_1' }"
 
     input:
-    tuple val(meta), path(maf)
+    tuple val(meta), path(maf), path(annot_b)
     val(format)
+    path(annot_a)
 
     output:
     tuple val(meta), path("*.gif"), optional:true, emit: gif
@@ -22,9 +23,12 @@ process LAST_DOTPLOT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def annot_a_arg = annot_a ? "-a ${annot_a}" : ''
+    def annot_b_arg = annot_b ? "-b ${annot_b}" : ''
     """
     last-dotplot \\
         $args \\
+        $annot_a_arg $annot_b_arg \\
         $maf \\
         $prefix.$format
 

--- a/modules/nf-core/last/dotplot/main.nf
+++ b/modules/nf-core/last/dotplot/main.nf
@@ -28,7 +28,8 @@ process LAST_DOTPLOT {
     """
     last-dotplot \\
         $args \\
-        $annot_a_arg $annot_b_arg \\
+        $annot_a_arg \\
+        $annot_b_arg \\
         $maf \\
         $prefix.$format
 

--- a/modules/nf-core/last/dotplot/main.nf
+++ b/modules/nf-core/last/dotplot/main.nf
@@ -9,8 +9,8 @@ process LAST_DOTPLOT {
 
     input:
     tuple val(meta), path(maf), path(annot_b)
+    tuple val(meta2), path(annot_a)
     val(format)
-    path(annot_a)
 
     output:
     tuple val(meta), path("*.gif"), optional:true, emit: gif

--- a/modules/nf-core/last/dotplot/meta.yml
+++ b/modules/nf-core/last/dotplot/meta.yml
@@ -28,6 +28,14 @@ input:
   - format:
       type: string
       description: Output format (PNG or GIF).
+  - annot_a:
+      type: file
+      description: Annotation file in BED, Repeamasker, genePred or AGP format for the first (horizontal) sequence
+      pattern: "*.{bed,bed.gz,out,out.gz,rmsk.txt,rmsk.txt.gz,genePred,genePred.gz,gff,gff.gz,gtf,gtf.gz,gap.txt,gap.txt.gz}"
+  - annot_b:
+      type: file
+      description: Annotation file in BED, Repeamasker, genePred or AGP format for the second (vertical) sequence
+      pattern: "*.{bed,bed.gz,out,out.gz,rmsk.txt,rmsk.txt.gz,genePred,genePred.gz,gff,gff.gz,gtf,gtf.gz,gap.txt,gap.txt.gz}"
 output:
   - meta:
       type: map

--- a/modules/nf-core/last/dotplot/tests/main.nf.test
+++ b/modules/nf-core/last/dotplot/tests/main.nf.test
@@ -14,13 +14,17 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [
-                    [ id:'test' ], // meta map
-                    file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true),
-                    []
-                ]
-                input[1] = channel.of("png")
-                input[2] = []
+                input[0] = channel.of('NODE_1_length_20973_cov_191.628754\t2000\t2010')
+                         . collectFile(name: 'dummy_annot_b.bed', newLine: true)
+                         . map { [
+                                   [ id:'test' ], // meta map
+                                   file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true),
+                                   it
+                                 ] }
+                input[1] = channel.of('MT192765.1\t1000\t1010')
+                         . collectFile(name: 'dummy_annot_a.bed', newLine: true)
+                         . map { [ [ id:'test'], it ] }
+                input[2] = channel.of("png")
                 """
             }
         }
@@ -36,7 +40,7 @@ nextflow_process {
     }
 
     test("sarscov2 - contigs - genome - gif") {
-
+    // Test a different output format and absence of annotation files
         when {
             process {
                 """
@@ -45,8 +49,8 @@ nextflow_process {
                     file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true),
                     []
                 ]
-                input[1] = channel.of("gif")
-                input[2] = []
+                input[1] = [ [id: 'test'], [] ]
+                input[2] = "gif"
                 """
             }
         }
@@ -72,8 +76,8 @@ nextflow_process {
                     file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true),
                     []
                 ]
-                input[1] = channel.of("png")
-                input[2] = []
+                input[1] = [ [id: 'test'], [] ]
+                input[2] = "png"
                 """
             }
         }

--- a/modules/nf-core/last/dotplot/tests/main.nf.test
+++ b/modules/nf-core/last/dotplot/tests/main.nf.test
@@ -16,9 +16,11 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
+                    file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true),
+                    []
                 ]
                 input[1] = channel.of("png")
+                input[2] = []
                 """
             }
         }
@@ -40,9 +42,11 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
+                    file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true),
+                    []
                 ]
                 input[1] = channel.of("gif")
+                input[2] = []
                 """
             }
         }
@@ -65,9 +69,11 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true)
+                    file(params.test_data['sarscov2']['genome']['contigs_genome_maf_gz'], checkIfExists: true),
+                    []
                 ]
                 input[1] = channel.of("png")
+                input[2] = []
                 """
             }
         }

--- a/modules/nf-core/last/dotplot/tests/main.nf.test.snap
+++ b/modules/nf-core/last/dotplot/tests/main.nf.test.snap
@@ -9,7 +9,7 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-05T18:40:14.120002"
+        "timestamp": "2024-06-27T09:19:30.116358"
     },
     "sarscov2 - contigs - genome - png - stub": {
         "content": [
@@ -21,7 +21,7 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-05T18:41:15.687306"
+        "timestamp": "2024-06-27T09:19:46.588825"
     },
     "sarscov2 - contigs - genome - png": {
         "content": [
@@ -33,6 +33,6 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-06-05T18:39:17.823555"
+        "timestamp": "2024-06-27T09:19:08.959252"
     }
 }


### PR DESCRIPTION
This adds the capacity to overlay annotations to the dot plots.  In the _pairgenomealign_ pipeline, we will use it to indicate genomic regions containing N stretches that typically mark contig boundaries in scaffold assemblies, like the pink lines in the following example:

![image](https://github.com/nf-core/modules/assets/1834905/74ef93aa-3bdc-47a3-b346-1d6ea8a44811)


## Details

The annotation of the target (plotted horizontally) genome is passed as a new channel.

The annotation of the query (plotted vertically) genome is passed as a new component of the first channel.

This is because this module typically loops on a list of alignments of various query genomes (from samplesheet) to a single target genome.

The annotation files are called `annot_a` and `annot_b` because they are passed to the `-a` and `-b` arguments of `last-dotplot`.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [ x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
