### PR TITLE
ADD argNorm module

### DIFF
--- a/modules/nf-core/argnorm/environment.yml
+++ b/modules/nf-core/argnorm/environment.yml
@@ -1,0 +1,7 @@
+name: "argnorm"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "bioconda::argnorm=0.5.0"

--- a/modules/nf-core/argnorm/main.nf
+++ b/modules/nf-core/argnorm/main.nf
@@ -44,4 +44,25 @@ process ARGNORM {
         argnorm: $VERSION
     END_VERSIONS
     """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION = '0.5.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    if (!tool) {
+        error 'Tool not provided.'
+    }
+    if ((tool in ["abricate"]) && !db) {
+        error "$tool requires a database but <db> not provided."
+    }
+
+    """
+    touch ${prefix}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        argnorm: $VERSION
+    END_VERSIONS
+    """
+
 }

--- a/modules/nf-core/argnorm/main.nf
+++ b/modules/nf-core/argnorm/main.nf
@@ -14,7 +14,7 @@ process ARGNORM {
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    path "versions.yml", emit: versions
+    path "versions.yml"           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -23,7 +23,7 @@ process ARGNORM {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.5.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
-     if ((tool in ["abricate"]) && !db) {
+    if ((tool in ["abricate"]) && !db) {
         error "$tool requires a database but <db> not provided."
     }
     db = db ? ("--db " + db) : ""

--- a/modules/nf-core/argnorm/main.nf
+++ b/modules/nf-core/argnorm/main.nf
@@ -24,6 +24,9 @@ process ARGNORM {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.5.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     def db_args = db ? "--db ${db}" : ""
+    if (!tool) {
+        error 'Tool not provided.'
+    }
     if ((tool in ["abricate"]) && !db) {
         error "$tool requires a database but <db> not provided."
     }

--- a/modules/nf-core/argnorm/main.nf
+++ b/modules/nf-core/argnorm/main.nf
@@ -1,0 +1,40 @@
+process ARGNORM {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/argnorm:0.5.0--pyhdfd78af_0':
+        'biocontainers/argnorm:0.5.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(input_tsv)
+    val(db)
+    val(hamronized)
+    val(tool)
+
+    output:
+    tuple val(meta), path("*.tsv"), emit: tsv
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def VERSION = '0.5.0'
+    """
+    argnorm \\
+        $tool \\
+        -i $input_tsv \\
+        -o $prefix \\
+        --db $db \\
+        $hamronized
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        argnorm: $VERSION
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/argnorm/main.nf
+++ b/modules/nf-core/argnorm/main.nf
@@ -9,13 +9,13 @@ process ARGNORM {
 
     input:
     tuple val(meta), path(input_tsv)
-    val(db)
-    val(hamronized)
-    val(tool)
+    val db
+    val hamronized
+    val tool
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    path "versions.yml"           , emit: versions
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,6 +24,8 @@ process ARGNORM {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.5.0'
+    hamronized = hamronized ? "--hamronized" : ""
+
     """
     argnorm \\
         $tool \\

--- a/modules/nf-core/argnorm/main.nf
+++ b/modules/nf-core/argnorm/main.nf
@@ -1,7 +1,7 @@
 process ARGNORM {
     tag "$meta.id"
     label 'process_low'
-    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions. 
+    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/argnorm:0.5.0--pyhdfd78af_0':
@@ -22,11 +22,11 @@ process ARGNORM {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '0.5.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.  
-     if ((tool in ["abricate"]) && !db) {  
-        error "$tool requires a database but <db> not provided."  
-    }   
-    db = db ? ("--db " + db) : ""  
+    def VERSION = '0.5.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+     if ((tool in ["abricate"]) && !db) {
+        error "$tool requires a database but <db> not provided."
+    }
+    db = db ? ("--db " + db) : ""
 
     """
     argnorm \\

--- a/modules/nf-core/argnorm/main.nf
+++ b/modules/nf-core/argnorm/main.nf
@@ -1,7 +1,7 @@
 process ARGNORM {
     tag "$meta.id"
     label 'process_low'
-
+    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions. 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/argnorm:0.5.0--pyhdfd78af_0':
@@ -9,9 +9,8 @@ process ARGNORM {
 
     input:
     tuple val(meta), path(input_tsv)
-    val db
-    val hamronized
     val tool
+    val db
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
@@ -23,16 +22,19 @@ process ARGNORM {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '0.5.0'
-    hamronized = hamronized ? "--hamronized" : ""
+    def VERSION = '0.5.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.  
+     if ((tool in ["abricate"]) && !db) {  
+        error "$tool requires a database but <db> not provided."  
+    }   
+    db = db ? ("--db " + db) : ""  
 
     """
     argnorm \\
         $tool \\
         -i $input_tsv \\
         -o $prefix \\
-        --db $db \\
-        $hamronized
+        $db \\
+        $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/argnorm/main.nf
+++ b/modules/nf-core/argnorm/main.nf
@@ -23,17 +23,17 @@ process ARGNORM {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.5.0' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def db_args = db ? "--db ${db}" : ""
     if ((tool in ["abricate"]) && !db) {
         error "$tool requires a database but <db> not provided."
     }
-    db = db ? ("--db " + db) : ""
 
     """
     argnorm \\
         $tool \\
         -i $input_tsv \\
         -o $prefix \\
-        $db \\
+        $db_args \\
         $args
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/argnorm/meta.yml
+++ b/modules/nf-core/argnorm/meta.yml
@@ -29,15 +29,15 @@ input:
       description: ARG annotation output
       pattern: "*.tsv"
 
-  - db:
-      type: string
-      description: Database used for ARG annotation
-      pattern: "sarg|ncbi|resfinder|deeparg|megares|argannot|resfinderfg"
-
   - tool:
       type: string
       description: ARG annotation tool used
       pattern: "argsoap|abricate|deeparg|resfinder|amrfinderplus"
+
+  - db:
+      type: string
+      description: Database used for ARG annotation
+      pattern: "sarg|ncbi|resfinder|deeparg|megares|argannot|resfinderfg"
 
 output:
   - meta:
@@ -45,14 +45,14 @@ output:
       description: |
         Groovy Map containing sample information
         e.g. `[ id:'sample1', single_end:false ]`
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
   - tsv:
       type: file
       description: Normalized argNorm output
       pattern: "*.tsv"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
 
 authors:
   - "@Vedanth-Ramji"

--- a/modules/nf-core/argnorm/meta.yml
+++ b/modules/nf-core/argnorm/meta.yml
@@ -35,9 +35,9 @@ input:
       pattern: "sarg|ncbi|resfinder|deeparg|megares|argannot|resfinderfg"
 
   - hamronized:
-      type: string
+      type: boolean
       description: Indicate ARG annotation output has been processed by hAMRonization
-      pattern: "|--hamronized"
+      pattern: "true|false"
 
   - tool:
       type: string

--- a/modules/nf-core/argnorm/meta.yml
+++ b/modules/nf-core/argnorm/meta.yml
@@ -34,11 +34,6 @@ input:
       description: Database used for ARG annotation
       pattern: "sarg|ncbi|resfinder|deeparg|megares|argannot|resfinderfg"
 
-  - hamronized:
-      type: boolean
-      description: Indicate ARG annotation output has been processed by hAMRonization
-      pattern: "true|false"
-
   - tool:
       type: string
       description: ARG annotation tool used

--- a/modules/nf-core/argnorm/meta.yml
+++ b/modules/nf-core/argnorm/meta.yml
@@ -1,0 +1,65 @@
+name: "argnorm"
+description: Normalize antibiotic resistance genes (ARGs) using the ARO ontology (developed by CARD).
+keywords:
+  - amr
+  - antimicrobial resistance
+  - arg
+  - antimicrobial resistance genes
+  - genomics
+  - metagenomics
+  - normalization
+  - drug categorization
+tools:
+  - "argnorm":
+      description: "Normalize antibiotic resistance genes (ARGs) using the ARO ontology (developed by CARD)."
+      homepage: "https://argnorm.readthedocs.io/en/latest/"
+      documentation: "https://argnorm.readthedocs.io/en/latest/"
+      tool_dev_url: "https://github.com/BigDataBiology/argNorm"
+      licence: ["MIT"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1', single_end:false ]`
+
+  - input_tsv:
+      type: file
+      description: ARG annotation output
+      pattern: "*.tsv"
+
+  - db:
+      type: string
+      description: Database used for ARG annotation
+      pattern: "sarg|ncbi|resfinder|deeparg|megares|argannot|resfinderfg"
+
+  - hamronized:
+      type: string
+      description: Indicate ARG annotation output has been processed by hAMRonization
+      pattern: "|--hamronized"
+
+  - tool:
+      type: string
+      description: ARG annotation tool used
+      pattern: "argsoap|abricate|deeparg|resfinder|amrfinderplus"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1', single_end:false ]`
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - tsv:
+      type: file
+      description: Normalized argNorm output
+      pattern: "*.tsv"
+
+authors:
+  - "@Vedanth-Ramji"
+maintainers:
+  - "@Vedanth-Ramji"

--- a/modules/nf-core/argnorm/tests/argnorm_hamronized.config
+++ b/modules/nf-core/argnorm/tests/argnorm_hamronized.config
@@ -1,0 +1,5 @@
+process {
+    withName: ARGNORM {
+        ext.args = '--hamronized'
+    }
+}

--- a/modules/nf-core/argnorm/tests/argnorm_raw.config
+++ b/modules/nf-core/argnorm/tests/argnorm_raw.config
@@ -1,0 +1,5 @@
+process {
+    withName: ARGNORM {
+        ext.args = ''
+    }
+}

--- a/modules/nf-core/argnorm/tests/main.nf.test
+++ b/modules/nf-core/argnorm/tests/main.nf.test
@@ -78,6 +78,29 @@ nextflow_process {
         }
     }
 
+    test("argnorm - missing db") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'argnorm_raw.tsv' ], // meta map
+                    file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/amrfinderplus/test_output.tsv", checkIfExists: true)
+                ]
+                input[1] = "abricate"
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("abricate requires a database but <db> not provided.") }
+            )
+        }
+    }
+
     test("argnorm - amrfinderplus_ncbi_hamronized - tsv - stub") {
         options "-stub"
         config './argnorm_hamronized.config'

--- a/modules/nf-core/argnorm/tests/main.nf.test
+++ b/modules/nf-core/argnorm/tests/main.nf.test
@@ -8,16 +8,17 @@ nextflow_process {
     tag "argnorm"
 
     test("argnorm - amrfinderplus_ncbi_raw - tsv") {
+        config './argnorm_raw.config'
+
         when {
             process {
                 """                
                 input[0] = [
-                    [ id:'test.tsv', single_end:false ], // meta map                                                                                                                           
+                    [ id:'argnorm_raw.tsv' ], // meta map                                                                                                                           
                     file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/amrfinderplus/test_output.tsv", checkIfExists: true)                              
                 ]
-                input[1] = 'ncbi'
-                input[2] = ''
-                input[3] = 'amrfinderplus'
+                input[1] = 'amrfinderplus'
+                input[2] = 'ncbi'
                 """
             }
         }
@@ -31,16 +32,17 @@ nextflow_process {
     }
     
     test("argnorm - amrfinderplus_ncbi_hamronized - tsv") {
+        config './argnorm_hamronized.config'
+
         when {
             process {
                 """                
                 input[0] = [
-                    [ id:'test.tsv', single_end:false ], // meta map                                                                                                                           
+                    [ id:'argnorm_hamronized.tsv' ], // meta map                                                                                                                           
                     file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
                 ]
-                input[1] = 'ncbi'
-                input[2] = '--hamronized'
-                input[3] = 'amrfinderplus'
+                input[1] = 'amrfinderplus'
+                input[2] = 'ncbi'
                 """
             }
         }
@@ -55,17 +57,17 @@ nextflow_process {
     
     test("argnorm - amrfinderplus_ncbi_hamronized - tsv - stub") {
         options "-stub"
-    
+        config './argnorm_hamronized.config'
+
         when {
             process {
                 """                
                 input[0] = [
-                    [ id:'test.tsv', single_end:false ], // meta map                                                                                                                           
+                    [ id:'argnorm_hamronized_stub.tsv'  ], // meta map                                                                                                                           
                     file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
                 ]
-                input[1] = 'ncbi'
-                input[2] = '--hamronized'
-                input[3] = 'amrfinderplus'
+                input[1] = 'amrfinderplus'
+                input[2] = 'ncbi'
                 """
             }
         }
@@ -81,17 +83,17 @@ nextflow_process {
     test("argnorm - amrfinderplus_ncbi - tsv - stub") {
 
         options "-stub"
+        config './argnorm_raw.config' 
 
         when {
             process {
                 """                
                 input[0] = [
-                    [ id:'test.tsv', single_end:false ], // meta map                                                                                                                           
+                    [ id:'argnorm_raw_stub.tsv', single_end:false ], // meta map                                                                                                                           
                     file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/raw/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
                 ]
-                input[1] = 'ncbi'
-                input[2] = ''
-                input[3] = 'amrfinderplus'
+                input[1] = 'amrfinderplus'
+                input[2] = 'ncbi'
                 """
             }
         }
@@ -104,5 +106,4 @@ nextflow_process {
         }
 
     }
-
 }

--- a/modules/nf-core/argnorm/tests/main.nf.test
+++ b/modules/nf-core/argnorm/tests/main.nf.test
@@ -16,8 +16,8 @@ nextflow_process {
                     file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/amrfinderplus/test_output.tsv", checkIfExists: true)                              
                 ]
                 input[1] = 'ncbi'
-                input[2] = 'amrfinderplus'
-                input[3] = ''
+                input[2] = ''
+                input[3] = 'amrfinderplus'
                 """
             }
         }
@@ -39,8 +39,8 @@ nextflow_process {
                     file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
                 ]
                 input[1] = 'ncbi'
-                input[2] = 'amrfinderplus'
-                input[3] = '--hamronized'
+                input[2] = '--hamronized'
+                input[3] = 'amrfinderplus'
                 """
             }
         }
@@ -64,8 +64,8 @@ nextflow_process {
                     file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
                 ]
                 input[1] = 'ncbi'
-                input[2] = 'amrfinderplus'
-                input[3] = '--hamronized'
+                input[2] = '--hamronized'
+                input[3] = 'amrfinderplus'
                 """
             }
         }
@@ -90,8 +90,8 @@ nextflow_process {
                     file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/raw/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
                 ]
                 input[1] = 'ncbi'
-                input[2] = 'amrfinderplus'
-                input[3] = ''
+                input[2] = ''
+                input[3] = 'amrfinderplus'
                 """
             }
         }

--- a/modules/nf-core/argnorm/tests/main.nf.test
+++ b/modules/nf-core/argnorm/tests/main.nf.test
@@ -89,7 +89,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'argnorm_raw_stub.tsv', single_end:false ], // meta map
+                    [ id:'argnorm_raw_stub.tsv' ], // meta map
                     file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/raw/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)
                 ]
                 input[1] = 'amrfinderplus'

--- a/modules/nf-core/argnorm/tests/main.nf.test
+++ b/modules/nf-core/argnorm/tests/main.nf.test
@@ -12,10 +12,10 @@ nextflow_process {
 
         when {
             process {
-                """                
+                """
                 input[0] = [
-                    [ id:'argnorm_raw.tsv' ], // meta map                                                                                                                           
-                    file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/amrfinderplus/test_output.tsv", checkIfExists: true)                              
+                    [ id:'argnorm_raw.tsv' ], // meta map
+                    file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/amrfinderplus/test_output.tsv", checkIfExists: true)
                 ]
                 input[1] = 'amrfinderplus'
                 input[2] = 'ncbi'
@@ -30,16 +30,16 @@ nextflow_process {
             )
         }
     }
-    
+
     test("argnorm - amrfinderplus_ncbi_hamronized - tsv") {
         config './argnorm_hamronized.config'
 
         when {
             process {
-                """                
+                """
                 input[0] = [
-                    [ id:'argnorm_hamronized.tsv' ], // meta map                                                                                                                           
-                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
+                    [ id:'argnorm_hamronized.tsv' ], // meta map
+                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)
                 ]
                 input[1] = 'amrfinderplus'
                 input[2] = 'ncbi'
@@ -54,17 +54,17 @@ nextflow_process {
             )
         }
     }
-    
+
     test("argnorm - amrfinderplus_ncbi_hamronized - tsv - stub") {
         options "-stub"
         config './argnorm_hamronized.config'
 
         when {
             process {
-                """                
+                """
                 input[0] = [
-                    [ id:'argnorm_hamronized_stub.tsv'  ], // meta map                                                                                                                           
-                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
+                    [ id:'argnorm_hamronized_stub.tsv'  ], // meta map
+                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)
                 ]
                 input[1] = 'amrfinderplus'
                 input[2] = 'ncbi'
@@ -83,14 +83,14 @@ nextflow_process {
     test("argnorm - amrfinderplus_ncbi - tsv - stub") {
 
         options "-stub"
-        config './argnorm_raw.config' 
+        config './argnorm_raw.config'
 
         when {
             process {
-                """                
+                """
                 input[0] = [
-                    [ id:'argnorm_raw_stub.tsv', single_end:false ], // meta map                                                                                                                           
-                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/raw/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
+                    [ id:'argnorm_raw_stub.tsv', single_end:false ], // meta map
+                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/raw/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)
                 ]
                 input[1] = 'amrfinderplus'
                 input[2] = 'ncbi'

--- a/modules/nf-core/argnorm/tests/main.nf.test
+++ b/modules/nf-core/argnorm/tests/main.nf.test
@@ -104,6 +104,6 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
-
     }
+
 }

--- a/modules/nf-core/argnorm/tests/main.nf.test
+++ b/modules/nf-core/argnorm/tests/main.nf.test
@@ -55,6 +55,29 @@ nextflow_process {
         }
     }
 
+    test("argnorm - missing tool") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'argnorm_raw.tsv' ], // meta map
+                    file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/amrfinderplus/test_output.tsv", checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("Tool not provided") }
+            )
+        }
+    }
+
     test("argnorm - amrfinderplus_ncbi_hamronized - tsv - stub") {
         options "-stub"
         config './argnorm_hamronized.config'

--- a/modules/nf-core/argnorm/tests/main.nf.test
+++ b/modules/nf-core/argnorm/tests/main.nf.test
@@ -1,0 +1,108 @@
+nextflow_process {
+    name "Test Process ARGNORM"
+    script "../main.nf"
+    process "ARGNORM"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "argnorm"
+
+    test("argnorm - amrfinderplus_ncbi_raw - tsv") {
+        when {
+            process {
+                """                
+                input[0] = [
+                    [ id:'test.tsv', single_end:false ], // meta map                                                                                                                           
+                    file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/amrfinderplus/test_output.tsv", checkIfExists: true)                              
+                ]
+                input[1] = 'ncbi'
+                input[2] = 'amrfinderplus'
+                input[3] = ''
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+    
+    test("argnorm - amrfinderplus_ncbi_hamronized - tsv") {
+        when {
+            process {
+                """                
+                input[0] = [
+                    [ id:'test.tsv', single_end:false ], // meta map                                                                                                                           
+                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
+                ]
+                input[1] = 'ncbi'
+                input[2] = 'amrfinderplus'
+                input[3] = '--hamronized'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+    
+    test("argnorm - amrfinderplus_ncbi_hamronized - tsv - stub") {
+        options "-stub"
+    
+        when {
+            process {
+                """                
+                input[0] = [
+                    [ id:'test.tsv', single_end:false ], // meta map                                                                                                                           
+                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/hamronized/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
+                ]
+                input[1] = 'ncbi'
+                input[2] = 'amrfinderplus'
+                input[3] = '--hamronized'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("argnorm - amrfinderplus_ncbi - tsv - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """                
+                input[0] = [
+                    [ id:'test.tsv', single_end:false ], // meta map                                                                                                                           
+                    file("https://raw.githubusercontent.com/BigDataBiology/argNorm/main/examples/raw/amrfinderplus.ncbi.orfs.tsv", checkIfExists: true)                              
+                ]
+                input[1] = 'ncbi'
+                input[2] = 'amrfinderplus'
+                input[3] = ''
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/argnorm/tests/main.nf.test.snap
+++ b/modules/nf-core/argnorm/tests/main.nf.test.snap
@@ -73,7 +73,7 @@
                         {
                             "id": "argnorm_hamronized_stub.tsv"
                         },
-                        "argnorm_hamronized_stub.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                        "argnorm_hamronized_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -84,7 +84,7 @@
                         {
                             "id": "argnorm_hamronized_stub.tsv"
                         },
-                        "argnorm_hamronized_stub.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                        "argnorm_hamronized_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -106,7 +106,7 @@
                         {
                             "id": "argnorm_raw_stub.tsv"
                         },
-                        "argnorm_raw_stub.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
+                        "argnorm_raw_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -117,7 +117,7 @@
                         {
                             "id": "argnorm_raw_stub.tsv"
                         },
-                        "argnorm_raw_stub.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
+                        "argnorm_raw_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [

--- a/modules/nf-core/argnorm/tests/main.nf.test.snap
+++ b/modules/nf-core/argnorm/tests/main.nf.test.snap
@@ -104,8 +104,7 @@
                 "0": [
                     [
                         {
-                            "id": "argnorm_raw_stub.tsv",
-                            "single_end": false
+                            "id": "argnorm_raw_stub.tsv"
                         },
                         "argnorm_raw_stub.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
                     ]
@@ -116,8 +115,7 @@
                 "tsv": [
                     [
                         {
-                            "id": "argnorm_raw_stub.tsv",
-                            "single_end": false
+                            "id": "argnorm_raw_stub.tsv"
                         },
                         "argnorm_raw_stub.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
                     ]

--- a/modules/nf-core/argnorm/tests/main.nf.test.snap
+++ b/modules/nf-core/argnorm/tests/main.nf.test.snap
@@ -5,10 +5,9 @@
                 "0": [
                     [
                         {
-                            "id": "test.tsv",
-                            "single_end": false
+                            "id": "argnorm_raw.tsv"
                         },
-                        "test.tsv:md5,f870c239182592a065d9f80732b39bba"
+                        "argnorm_raw.tsv:md5,f870c239182592a065d9f80732b39bba"
                     ]
                 ],
                 "1": [
@@ -17,10 +16,9 @@
                 "tsv": [
                     [
                         {
-                            "id": "test.tsv",
-                            "single_end": false
+                            "id": "argnorm_raw.tsv"
                         },
-                        "test.tsv:md5,f870c239182592a065d9f80732b39bba"
+                        "argnorm_raw.tsv:md5,f870c239182592a065d9f80732b39bba"
                     ]
                 ],
                 "versions": [
@@ -32,7 +30,7 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-07-02T14:56:50.742114812"
+        "timestamp": "2024-07-05T17:46:00.195868976"
     },
     "argnorm - amrfinderplus_ncbi_hamronized - tsv": {
         "content": [
@@ -40,10 +38,9 @@
                 "0": [
                     [
                         {
-                            "id": "test.tsv",
-                            "single_end": false
+                            "id": "argnorm_hamronized.tsv"
                         },
-                        "test.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                        "argnorm_hamronized.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
                     ]
                 ],
                 "1": [
@@ -52,10 +49,9 @@
                 "tsv": [
                     [
                         {
-                            "id": "test.tsv",
-                            "single_end": false
+                            "id": "argnorm_hamronized.tsv"
                         },
-                        "test.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                        "argnorm_hamronized.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
                     ]
                 ],
                 "versions": [
@@ -67,7 +63,7 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-07-02T14:57:19.694510786"
+        "timestamp": "2024-07-05T17:46:31.856263885"
     },
     "argnorm - amrfinderplus_ncbi_hamronized - tsv - stub": {
         "content": [
@@ -75,10 +71,9 @@
                 "0": [
                     [
                         {
-                            "id": "test.tsv",
-                            "single_end": false
+                            "id": "argnorm_hamronized_stub.tsv"
                         },
-                        "test.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                        "argnorm_hamronized_stub.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
                     ]
                 ],
                 "1": [
@@ -87,10 +82,9 @@
                 "tsv": [
                     [
                         {
-                            "id": "test.tsv",
-                            "single_end": false
+                            "id": "argnorm_hamronized_stub.tsv"
                         },
-                        "test.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                        "argnorm_hamronized_stub.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
                     ]
                 ],
                 "versions": [
@@ -102,7 +96,7 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-07-02T14:57:47.422476341"
+        "timestamp": "2024-07-05T17:47:03.088627445"
     },
     "argnorm - amrfinderplus_ncbi - tsv - stub": {
         "content": [
@@ -110,10 +104,10 @@
                 "0": [
                     [
                         {
-                            "id": "test.tsv",
+                            "id": "argnorm_raw_stub.tsv",
                             "single_end": false
                         },
-                        "test.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
+                        "argnorm_raw_stub.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
                     ]
                 ],
                 "1": [
@@ -122,10 +116,10 @@
                 "tsv": [
                     [
                         {
-                            "id": "test.tsv",
+                            "id": "argnorm_raw_stub.tsv",
                             "single_end": false
                         },
-                        "test.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
+                        "argnorm_raw_stub.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
                     ]
                 ],
                 "versions": [
@@ -137,6 +131,6 @@
             "nf-test": "0.8.4",
             "nextflow": "24.04.2"
         },
-        "timestamp": "2024-07-02T14:58:14.950164297"
+        "timestamp": "2024-07-05T17:47:34.346622776"
     }
 }

--- a/modules/nf-core/argnorm/tests/main.nf.test.snap
+++ b/modules/nf-core/argnorm/tests/main.nf.test.snap
@@ -1,0 +1,142 @@
+{
+    "argnorm - amrfinderplus_ncbi_raw - tsv": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test.tsv",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,f870c239182592a065d9f80732b39bba"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,e200075d98a6f59137f105efceea0426"
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test.tsv",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,f870c239182592a065d9f80732b39bba"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e200075d98a6f59137f105efceea0426"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-02T14:56:50.742114812"
+    },
+    "argnorm - amrfinderplus_ncbi_hamronized - tsv": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test.tsv",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,e200075d98a6f59137f105efceea0426"
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test.tsv",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e200075d98a6f59137f105efceea0426"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-02T14:57:19.694510786"
+    },
+    "argnorm - amrfinderplus_ncbi_hamronized - tsv - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test.tsv",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,e200075d98a6f59137f105efceea0426"
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test.tsv",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,1f9a3820f09fd6a818af372dfe5cf322"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e200075d98a6f59137f105efceea0426"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-02T14:57:47.422476341"
+    },
+    "argnorm - amrfinderplus_ncbi - tsv - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test.tsv",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,e200075d98a6f59137f105efceea0426"
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test.tsv",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,e41b52c1213d8833c37472e3efb24db4"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e200075d98a6f59137f105efceea0426"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-07-02T14:58:14.950164297"
+    }
+}

--- a/modules/nf-core/argnorm/tests/tags.yml
+++ b/modules/nf-core/argnorm/tests/tags.yml
@@ -1,0 +1,2 @@
+argnorm:
+  - "modules/nf-core/argnorm/**"


### PR DESCRIPTION
[argNorm](https://github.com/BigDataBiology/argNorm) is a tool to normalize antibiotic resistance genes (ARGs) by mapping them to the [antibiotic resistance ontology (ARO)](https://obofoundry.org/ontology/aro.html) created by the [CARD database](https://card.mcmaster.ca/).
 

argNorm also enhances antibiotic resistance gene annotations by providing drug categorization of the drugs that antibiotic resistance genes confer resistance to.

argNorm takes the outputs of the [hAMRonization](https://nf-co.re/modules/hamronization_abricate) module as well as ARG annotation tools (DeepARG, ARGs-OAP, ABRicate, ResFinder, and AMRFinderPlus) to normalize them to the antibiotic resistance ontology.