### PR TITLE
Update dupradar.r according to new MultiQC (>=v1.22) config values

### DIFF
--- a/modules/nf-core/dupradar/templates/dupradar.r
+++ b/modules/nf-core/dupradar/templates/dupradar.r
@@ -88,7 +88,6 @@ line="#id: DupInt
 #        max: 100
 #        min: 0
 #        scale: 'RdYlGn-rev'
-#        format: '{:.2f}%'
 Sample dupRadar_intercept"
 
 write(line,file=paste0(output_prefix, "_dup_intercept_mqc.txt"),append=TRUE)
@@ -115,29 +114,23 @@ line="#id: dupradar
 #    This plot shows the general linear models - a summary of the gene duplication distributions. \"
 #pconfig:
 #    title: 'DupRadar General Linear Model'
-#    xLog: True
+#    xlog: True
 #    xlab: 'expression (reads/kbp)'
 #    ylab: '% duplicate reads'
 #    ymax: 100
 #    ymin: 0
 #    tt_label: '<b>{point.x:.1f} reads/kbp</b>: {point.y:,.2f}% duplicates'
-#    xPlotLines:
+#    x_lines:
 #        - color: 'green'
-#          dashStyle: 'LongDash'
+#          dash: 'LongDash'
 #          label:
-#                style: {color: 'green'}
 #                text: '0.5 RPKM'
-#                verticalAlign: 'bottom'
-#                y: -65
 #          value: 0.5
 #          width: 1
 #        - color: 'red'
-#          dashStyle: 'LongDash'
+#          dash: 'LongDash'
 #          label:
-#                style: {color: 'red'}
 #                text: '1 read/bp'
-#                verticalAlign: 'bottom'
-#                y: -65
 #          value: 1000
 #          width: 1"
 


### PR DESCRIPTION
In the course of working on the upcoming rnaseq 3.15.0 release, we noticed that MultiQC renamed or otherwise changed keywords in the configuration. For compatibility with current and future versions of MultiQC, the module needs updating.

I wonder if there is a point in retaining the old version and enabling switching between the two?

(_This PR is not ready for merging, we might need to add more changes to it when testing is continued with a new MultiQC version._)

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
