### PR TITLE
Fix gtffilter output definition

### DIFF
--- a/modules/nf-core/custom/gtffilter/main.nf
+++ b/modules/nf-core/custom/gtffilter/main.nf
@@ -12,8 +12,8 @@ process CUSTOM_GTFFILTER {
     tuple val(meta2), path(fasta)
 
     output:
-    tuple val(meta), path("*.gtf"), emit: gtf
-    path "versions.yml"           , emit: versions
+    tuple val(meta), path("${prefix}.${suffix}"), emit: gtf
+    path "versions.yml"                         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when


### PR DESCRIPTION
Make the output definition more general, as the extension won't always be "gtf"