### PR TITLE
Replace bedtools sort with unix sort in BEDTOOLS_GENOMECOV

### DIFF
--- a/modules/nf-core/bedtools/genomecov/main.nf
+++ b/modules/nf-core/bedtools/genomecov/main.nf
@@ -27,7 +27,7 @@ process BEDTOOLS_GENOMECOV {
     if (!args_list.contains('-bg') && (scale > 0 && scale != 1)) {
         args += " -bg"
     }
-    def sort_cmd = sort ? '| bedtools sort' : ''
+    def sort_cmd = sort ? '| sort -k1,1 -k2,2n' : ''
 
     def prefix = task.ext.prefix ?: "${meta.id}"
     if (intervals.name =~ /\.bam/) {

--- a/modules/nf-core/bedtools/genomecov/main.nf
+++ b/modules/nf-core/bedtools/genomecov/main.nf
@@ -28,7 +28,7 @@ process BEDTOOLS_GENOMECOV {
     if (!args_list.contains('-bg') && (scale > 0 && scale != 1)) {
         args += " -bg"
     }
-    def sort_cmd = sort ? '| sort $args2 -k1,1 -k2,2n' : ''
+    def sort_cmd = sort ? "| sort $args2 -k1,1 -k2,2n" : ''
 
     def prefix = task.ext.prefix ?: "${meta.id}"
     if (intervals.name =~ /\.bam/) {

--- a/modules/nf-core/bedtools/genomecov/main.nf
+++ b/modules/nf-core/bedtools/genomecov/main.nf
@@ -21,17 +21,16 @@ process BEDTOOLS_GENOMECOV {
     task.ext.when == null || task.ext.when
 
     script:
-    def args  = task.ext.args  ?: ''
-    def args2 = task.ext.args2 ?: ''
+    def args      = task.ext.args  ?: ''
     def args_list = args.tokenize()
-    def buffer = task.memory.toGiga().intdiv(2)
     args += (scale > 0 && scale != 1) ? " -scale $scale" : ""
     if (!args_list.contains('-bg') && (scale > 0 && scale != 1)) {
         args += " -bg"
     }
     // Sorts output file by chromosome and position using additional options for performance and consistency
     // See https://www.biostars.org/p/66927/ for further details
-    def sort_cmd = sort ? "| LC_ALL=C sort --parallel=$task.cpus --buffer-size=${buffer}G -k1,1 -k2,2n" : ''
+    def buffer   = task.memory ? "--buffer-size=${task.memory.toGiga().intdiv(2)}G" : ''
+    def sort_cmd = sort ? "| LC_ALL=C sort --parallel=$task.cpus $buffer -k1,1 -k2,2n" : ''
 
     def prefix = task.ext.prefix ?: "${meta.id}"
     if (intervals.name =~ /\.bam/) {

--- a/modules/nf-core/bedtools/genomecov/main.nf
+++ b/modules/nf-core/bedtools/genomecov/main.nf
@@ -21,13 +21,14 @@ process BEDTOOLS_GENOMECOV {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
+    def args  = task.ext.args  ?: ''
+    def args2 = task.ext.args2 ?: ''
     def args_list = args.tokenize()
     args += (scale > 0 && scale != 1) ? " -scale $scale" : ""
     if (!args_list.contains('-bg') && (scale > 0 && scale != 1)) {
         args += " -bg"
     }
-    def sort_cmd = sort ? '| sort -k1,1 -k2,2n' : ''
+    def sort_cmd = sort ? '| sort $args2 -k1,1 -k2,2n' : ''
 
     def prefix = task.ext.prefix ?: "${meta.id}"
     if (intervals.name =~ /\.bam/) {

--- a/modules/nf-core/bedtools/genomecov/tests/tags.yml
+++ b/modules/nf-core/bedtools/genomecov/tests/tags.yml
@@ -1,2 +1,0 @@
-bedtools/genomecov:
-  - "modules/nf-core/bedtools/genomecov/**"


### PR DESCRIPTION
`bedtools sort` uses a large amount of CPUs and memory, but when using it here it doesn't require the  additional genome based features of `bedtools`. Replacing it should speed up the process and make it many times more efficient.

First discovered by @pabloaledo 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
