### PR TITLE
Fix bug in sentieon/qualcal where stubs failed

### DIFF
--- a/modules/nf-core/sentieon/qualcal/main.nf
+++ b/modules/nf-core/sentieon/qualcal/main.nf
@@ -95,10 +95,11 @@ process SENTIEON_QUALCAL {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def file_suffix = input.name.endsWith(".bam") ? "bam" : "cram"
     def recalibrated_bam = generate_recalibrated_bams ? "${prefix}.recalibrated.${file_suffix}" : ""
+    def recalibrated_bam_cmd = generate_recalibrated_bams ? "touch $recalibrated_bam" : ""
     """
     touch ${prefix}.table
     touch ${prefix}.table.post
-    touch ${recalibrated_bam}
+    ${recalibrated_bam_cmd}
     touch ${prefix}.csv
     touch ${prefix}.pdf
 

--- a/modules/nf-core/sentieon/qualcal/tests/main.nf.test
+++ b/modules/nf-core/sentieon/qualcal/tests/main.nf.test
@@ -202,6 +202,36 @@ nextflow_process {
 
     }
 
+    test("no recal BAM - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ]
+                input[1] = [ [ id:'fasta' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                input[2] = [ [ id:'fasta' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true) ]
+
+                input[3] = [ [ id:'knownSites' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true) ]
+                input[4] = [ [ id:'knownSites' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true) ]
+                input[5] = [[:],[]]
+                input[6] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
 
 
 }


### PR DESCRIPTION
If generate_recalibrated_bams is false, sentieon/qualcal stubs would fail with an empty 'touch' command. This PR fixes that bug.
