### PR TITLE
Sentieon/Haplotyper: Recal table is sample specific

### DIFF
--- a/modules/nf-core/sentieon/haplotyper/main.nf
+++ b/modules/nf-core/sentieon/haplotyper/main.nf
@@ -9,12 +9,11 @@ process SENTIEON_HAPLOTYPER {
         'nf-core/sentieon:202308.02--c641bc397cbf79d5' }"
 
     input:
-    tuple val(meta), path(input), path(input_index), path(intervals)
+    tuple val(meta), path(input), path(input_index), path(intervals), path(recal_table)
     tuple val(meta1), path(fasta)
     tuple val(meta2), path(fai)
     tuple val(meta3), path(dbsnp)
     tuple val(meta4), path(dbsnp_tbi)
-    tuple val(meta5), path(recal_table)
     val(emit_vcf)
     val(emit_gvcf)
 

--- a/modules/nf-core/sentieon/haplotyper/meta.yml
+++ b/modules/nf-core/sentieon/haplotyper/meta.yml
@@ -28,6 +28,9 @@ input:
   - intervals:
       type: file
       description: Bed file with the genomic regions included in the library (optional)
+  - recal_table:
+      type: file
+      description: Recalibration table from sentieon/qualcal (optional)
   - fasta:
       type: file
       description: Genome fasta file
@@ -42,9 +45,6 @@ input:
   - dbsnp_tbi:
       type: file
       description: VCF index of dbsnp (optional)
-  - recal_table:
-      type: file
-      description: Recalibration table from sentieon/qualcal (optional)
   - emit_vcf:
       type: string
       description: |

--- a/modules/nf-core/sentieon/haplotyper/tests/main.nf.test
+++ b/modules/nf-core/sentieon/haplotyper/tests/main.nf.test
@@ -19,15 +19,15 @@ nextflow_process {
                 input[0] = [ [ id:'test' ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
-                           []  // no intervals
+                            [],  // no intervals
+                            []   // no recal table
                         ]
                 input[1] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
                 input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
                 input[3] = [[:],[]]
                 input[4] = [[:],[]]
-                input[5] = [[:],[]]
-                input[6] = 'variant'
-                input[7] = false
+                input[5] = 'variant'
+                input[6] = false
                 """
             }
         }
@@ -54,15 +54,15 @@ nextflow_process {
                 input[0] = [ [ id:'test' ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
-                           []  // no intervals
+                            [],  // no intervals
+                            []   // no recal table
                         ]
                 input[1] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
                 input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
                 input[3] = [[:],[]]
                 input[4] = [[:],[]]
-                input[5] = [[:],[]]
-                input[6] = ''
-                input[7] = true
+                input[5] = ''
+                input[6] = true
                 """
             }
         }
@@ -89,15 +89,15 @@ nextflow_process {
                 input[0] = [ [ id:'test' ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
-                           []  // no intervals
+                            [],  // no intervals
+                            []   // no recal table
                         ]
                 input[1] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
                 input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
                 input[3] = [[:],[]]
                 input[4] = [[:],[]]
-                input[5] = [[:],[]]
-                input[6] = 'variant'
-                input[7] = true
+                input[5] = 'variant'
+                input[6] = true
                 """
             }
         }
@@ -126,15 +126,15 @@ nextflow_process {
                 input[0] = [ [ id:'test' ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
-                            file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true),
+                            []
                         ]
                 input[1] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
                 input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
                 input[3] = [[:],[]]
                 input[4] = [[:],[]]
-                input[5] = [[:],[]]
-                input[6] = 'variant'
-                input[7] = true
+                input[5] = 'variant'
+                input[6] = true
                 """
             }
         }
@@ -163,15 +163,15 @@ nextflow_process {
                 input[0] = [ [ id:'test' ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
-                            file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true),
+                            []
                         ]
                 input[1] = [[id: 'test'], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
                 input[2] = [[id: 'test'], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
                 input[3] = [[id: 'test'], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz', checkIfExists: true)]
                 input[4] = [[id: 'test'], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz.tbi', checkIfExists: true)]
-                input[5] = [[:],[]]
-                input[6] = 'variant'
-                input[7] = true
+                input[5] = 'variant'
+                input[6] = true
                 """
             }
         }
@@ -218,18 +218,20 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test' ], // meta map
+                recal_table = SENTIEON_QUALCAL.out.table
+                bam = Channel.of([ [ id:'test' ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
-                           []  // no intervals
-                        ]
+                            []  // no intervals
+
+                        ])
+                input[0] = bam.join(recal_table)
                 input[1] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
                 input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
                 input[3] = [[:],[]]
                 input[4] = [[:],[]]
-                input[5] = SENTIEON_QUALCAL.out.table
-                input[6] = 'variant'
-                input[7] = false
+                input[5] = 'variant'
+                input[6] = false
                 """
             }
         }
@@ -257,15 +259,15 @@ nextflow_process {
                 input[0] = [ [ id:'test' ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
-                           []  // no intervals
+                            [],  // no intervals
+                            []   // no recal table
                         ]
                 input[1] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
                 input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
                 input[3] = [[:],[]]
                 input[4] = [[:],[]]
-                input[5] = [[:],[]]
-                input[6] = 'variant'
-                input[7] = true
+                input[5] = 'variant'
+                input[6] = true
                 """
             }
         }


### PR DESCRIPTION
PR adds recalibration as part of the sample-specific input instead of a general input, since each sample has its own recalibration table generated upstream by sentieon/qualcal. 

Without the changes the recalibration table can't be matched to the sample. 