### PR TITLE
Fix: Sentieon CoverageMetrics error in meta values

### DIFF
--- a/modules/nf-core/sentieon/coveragemetrics/main.nf
+++ b/modules/nf-core/sentieon/coveragemetrics/main.nf
@@ -10,10 +10,10 @@ process SENTIEON_COVERAGEMETRICS {
 
     input:
     tuple val(meta) , path(bam), path(bai)
-    tuple val(meta) , path(interval)
-    tuple val(meta2), path(fasta)
-    tuple val(meta3), path(fai)
-    tuple val(meta4), path(gene_list)
+    tuple val(meta2), path(interval)
+    tuple val(meta3), path(fasta)
+    tuple val(meta4), path(fai)
+    tuple val(meta5), path(gene_list)
 
     output:
     tuple val(meta), path("$prefix")                                                       , optional: true, emit: per_locus


### PR DESCRIPTION
I accidentally used `meta` twice which caused the `tag` to be null. This PR fixes it.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
