### PR TITLE
Maximises Sentieon BWA Mem memory usage

### DIFF
--- a/modules/nf-core/sentieon/bwamem/main.nf
+++ b/modules/nf-core/sentieon/bwamem/main.nf
@@ -30,6 +30,7 @@ process SENTIEON_BWAMEM {
 
     """
     $sentieonLicense
+    export bwt_max_mem="${(task.memory * 0.9).toGiga()}G"
 
     INDEX=`find -L ./ -name "*.amb" | sed 's/.amb//'`
 

--- a/modules/nf-core/sentieon/bwamem/meta.yml
+++ b/modules/nf-core/sentieon/bwamem/meta.yml
@@ -57,14 +57,10 @@ output:
       description: |
         Groovy Map containing reference information.
         e.g. [ id:'test', single_end:false ]
-  - bam:
+  - bam_and_bai:
       type: file
-      description: BAM file.
-      pattern: "*.bam"
-  - bai:
-      type: file
-      description: BAI file
-      pattern: "*.bai"
+      description: BAM file with corresponding index.
+      pattern: "*.{bam,bai}"
   - versions:
       type: file
       description: File containing software versions

--- a/modules/nf-core/sentieon/bwamem/tests/tags.yml
+++ b/modules/nf-core/sentieon/bwamem/tests/tags.yml
@@ -1,0 +1,2 @@
+sentieon/bwamem:
+  - "modules/nf-core/sentieon/bwamem/**"


### PR DESCRIPTION
- Sentieon uses an environment variable to estimate the maximum memory usage.
- This PR sets the environment variable to 90% of the task memory, which should be a safe value for most cases.
- This will speed up the Sentieon BWA mem throughput considerably.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
