### PR TITLE
Sentieon/bwamem: Remove bai if cram is output

### DIFF
--- a/modules/nf-core/sentieon/bwamem/main.nf
+++ b/modules/nf-core/sentieon/bwamem/main.nf
@@ -41,6 +41,11 @@ process SENTIEON_BWAMEM {
         $reads \\
         | sentieon util sort -r $fasta -t $task.cpus -o ${prefix} --sam2bam -
 
+    # Delete *.bai file if prefix ends with .cram
+    if [[ "${prefix}" == *.cram ]]; then
+        rm -f "${prefix}.bai"
+    fi
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         sentieon: \$(echo \$(sentieon driver --version 2>&1) | sed -e "s/sentieon-genomics-//g")

--- a/modules/nf-core/sentieon/bwamem/tests/main.nf.test.snap
+++ b/modules/nf-core/sentieon/bwamem/tests/main.nf.test.snap
@@ -34,7 +34,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-08-14T17:18:41.102940776"
+        "timestamp": "2024-08-19T08:58:40.112926615"
     },
     "Paired-End - stub": {
         "content": [
@@ -71,7 +71,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-08-14T17:19:43.26809832"
+        "timestamp": "2024-08-19T08:59:20.476791905"
     },
     "Paired-End": {
         "content": [
@@ -108,7 +108,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-08-14T17:19:18.693597847"
+        "timestamp": "2024-08-19T08:59:00.346034062"
     },
     "Single-End - stub": {
         "content": [
@@ -145,7 +145,7 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-08-14T17:19:32.371839584"
+        "timestamp": "2024-08-19T08:59:10.054146084"
     },
     "Single-End Output CRAM": {
         "content": [
@@ -157,10 +157,7 @@
                             "single_end": true
                         },
                         "test.cram:md5,04d88bd709dc0bc27ca81a09e80d4a1b",
-                        [
-                            "test.cram.bai:md5,b910904d03ed167d3e2f1017e2257ac9",
-                            "test.cram.crai:md5,ac34c713fe95aa8a1fd6291bdbb76dcf"
-                        ]
+                        "test.cram.crai:md5,ac34c713fe95aa8a1fd6291bdbb76dcf"
                     ]
                 ],
                 "1": [
@@ -173,10 +170,7 @@
                             "single_end": true
                         },
                         "test.cram:md5,04d88bd709dc0bc27ca81a09e80d4a1b",
-                        [
-                            "test.cram.bai:md5,b910904d03ed167d3e2f1017e2257ac9",
-                            "test.cram.crai:md5,ac34c713fe95aa8a1fd6291bdbb76dcf"
-                        ]
+                        "test.cram.crai:md5,ac34c713fe95aa8a1fd6291bdbb76dcf"
                     ]
                 ],
                 "versions": [
@@ -188,6 +182,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-08-14T17:19:01.38682761"
+        "timestamp": "2024-08-19T08:58:49.962693499"
     }
 }


### PR DESCRIPTION
Sentieon bwamem always generates a bai file, even if `cram` is specified as output. In the output channel specification this means that both `bai` and `crai` are provided as indices breaking any downstream tool without further channel magic. Since the `bai` is not needed, if a `crai` exists, it is removed.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
