### PR TITLE
Update ashlar to 1.18 and improve staging

### DIFF
--- a/modules/nf-core/ashlar/environment.yml
+++ b/modules/nf-core/ashlar/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::ashlar=1.17.0
+  - bioconda::ashlar=1.18.0

--- a/modules/nf-core/ashlar/main.nf
+++ b/modules/nf-core/ashlar/main.nf
@@ -4,13 +4,13 @@ process ASHLAR {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ashlar:1.17.0--pyh5e36f6f_0' :
-        'biocontainers/ashlar:1.17.0--pyh5e36f6f_0' }"
+        'https://depot.galaxyproject.org/singularity/ashlar:1.18.0--pyhdfd78af_0' :
+        'biocontainers/ashlar:1.18.0--pyhdfd78af_0' }"
 
     input:
-    tuple val(meta), path(images)
-    path(opt_dfp)
-    path(opt_ffp)
+    tuple val(meta), path(images, stageAs: 'image*/*')
+    path(opt_dfp, stageAs: 'dfp*/*')
+    path(opt_ffp, stageAs: 'ffp*/*')
 
     output:
     tuple val(meta), path("*.ome.tif"), emit: tif

--- a/tests/modules/nf-core/ashlar/test.yml
+++ b/tests/modules/nf-core/ashlar/test.yml
@@ -4,7 +4,7 @@
     - ashlar
   files:
     - path: output/ashlar/test_all.ome.tif
-      md5sum: ae98ac74e3c818bb26c99ba4b9c2dd51
+      md5sum: 988bbb2c74d47dc22a9f3ac348f53ef5
     - path: output/ashlar/versions.yml
 
 - name: ashlar test_ashlar_all_files
@@ -13,7 +13,7 @@
     - ashlar
   files:
     - path: output/ashlar/test_all.ome.tif
-      md5sum: 5f4165203545b7efe04ed5f4a6d5ac9d
+      md5sum: c01dda923325588ea34a4fe341b17e6e
     - path: output/ashlar/versions.yml
 
 - name: ashlar test_ashlar_all_files_tile_size
@@ -22,7 +22,7 @@
     - ashlar
   files:
     - path: output/ashlar/test_all.ome.tif
-      md5sum: acee3aeaf7ea088062b2c15eff72dfb4
+      md5sum: 6d9573d40a93e38356ebc8b257f8dfb9
     - path: output/ashlar/versions.yml
 
 - name: ashlar test_ashlar_all_files_dfp_ffp
@@ -31,7 +31,7 @@
     - ashlar
   files:
     - path: output/ashlar/test_all.ome.tif
-      md5sum: 5f4165203545b7efe04ed5f4a6d5ac9d
+      md5sum: c01dda923325588ea34a4fe341b17e6e
     - path: output/ashlar/versions.yml
 
 - name: ashlar test_ashlar_1_file_dfp_ffp
@@ -40,5 +40,5 @@
     - ashlar
   files:
     - path: output/ashlar/test_all.ome.tif
-      md5sum: ae98ac74e3c818bb26c99ba4b9c2dd51
+      md5sum: 988bbb2c74d47dc22a9f3ac348f53ef5
     - path: output/ashlar/versions.yml


### PR DESCRIPTION
Some microscope file formats will break if files are renamed, so we can't change the staged filenames to avoid collisions. Instead we will stage each input without renaming into its own unique subdirectory.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
