### PR TITLE
bump MetaPhlAn to 4.1.1

### DIFF
--- a/modules/nf-core/metaphlan/makedb/environment.yml
+++ b/modules/nf-core/metaphlan/makedb/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::metaphlan=4.0.6
+  - bioconda::metaphlan=4.1.1

--- a/modules/nf-core/metaphlan/makedb/main.nf
+++ b/modules/nf-core/metaphlan/makedb/main.nf
@@ -3,8 +3,8 @@ process METAPHLAN_MAKEDB {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/metaphlan:4.0.6--pyhca03a8a_0' :
-        'biocontainers/metaphlan:4.0.6--pyhca03a8a_0' }"
+        'https://depot.galaxyproject.org/singularity/metaphlan:4.1.1--pyhdfd78af_0' :
+        'biocontainers/metaphlan:4.1.1--pyhdfd78af_0' }"
 
     output:
     path "metaphlan_db_latest"      , emit: db

--- a/modules/nf-core/metaphlan/mergemetaphlantables/environment.yml
+++ b/modules/nf-core/metaphlan/mergemetaphlantables/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::metaphlan=4.0.6
+  - bioconda::metaphlan=4.1.1

--- a/modules/nf-core/metaphlan/mergemetaphlantables/main.nf
+++ b/modules/nf-core/metaphlan/mergemetaphlantables/main.nf
@@ -3,8 +3,8 @@ process METAPHLAN_MERGEMETAPHLANTABLES {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/metaphlan:4.0.6--pyhca03a8a_0' :
-        'biocontainers/metaphlan:4.0.6--pyhca03a8a_0' }"
+        'https://depot.galaxyproject.org/singularity/metaphlan:4.1.1--pyhdfd78af_0' :
+        'biocontainers/metaphlan:4.1.1--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(profiles)

--- a/modules/nf-core/metaphlan/metaphlan/environment.yml
+++ b/modules/nf-core/metaphlan/metaphlan/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::metaphlan=4.0.6
+  - bioconda::metaphlan=4.1.1

--- a/modules/nf-core/metaphlan/metaphlan/main.nf
+++ b/modules/nf-core/metaphlan/metaphlan/main.nf
@@ -4,8 +4,8 @@ process METAPHLAN_METAPHLAN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/metaphlan:4.0.6--pyhca03a8a_0' :
-        'biocontainers/metaphlan:4.0.6--pyhca03a8a_0' }"
+        'https://depot.galaxyproject.org/singularity/metaphlan:4.1.1--pyhdfd78af_0' :
+        'biocontainers/metaphlan:4.1.1--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(input)


### PR DESCRIPTION


## PR checklist

This PR bumps the version of MetaPhlAn to 4.1.1 . There are currently no tests with this module, so I have not run the suggested docker test.

- [x] This comment contains a description of changes (with reason).
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
