### PR TITLE
Add tbi index as an output to lofreq callparallel

### DIFF
--- a/modules/nf-core/lofreq/callparallel/main.nf
+++ b/modules/nf-core/lofreq/callparallel/main.nf
@@ -13,8 +13,9 @@ process LOFREQ_CALLPARALLEL {
     tuple val(meta3), path(fai)
 
     output:
-    tuple val(meta), path("*.vcf.gz"), emit: vcf
-    path "versions.yml"              , emit: versions
+    tuple val(meta), path("*.vcf.gz")    , emit: vcf
+    tuple val(meta), path("*.vcf.gz.tbi"), emit: tbi
+    path "versions.yml"                  , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -33,8 +34,8 @@ process LOFREQ_CALLPARALLEL {
     samtools_cram_convert += alignment_cram ? "    samtools index ${alignment_out}\n" : ''
 
     def samtools_cram_remove = ''
-    samtools_cram_remove += alignment_cram ? "     rm ${alignment_out}\n" : ''
-    samtools_cram_remove += alignment_cram ? "     rm ${alignment_out}.bai\n " : ''
+    samtools_cram_remove += alignment_cram ? "    rm ${alignment_out}\n" : ''
+    samtools_cram_remove += alignment_cram ? "    rm ${alignment_out}.bai\n " : ''
     """
     $samtools_cram_convert
 
@@ -59,6 +60,7 @@ process LOFREQ_CALLPARALLEL {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     echo "" | gzip > ${prefix}.vcf.gz
+    echo "" | gzip > ${prefix}.vcf.gz.tbi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/lofreq/callparallel/meta.yml
+++ b/modules/nf-core/lofreq/callparallel/meta.yml
@@ -62,6 +62,10 @@ output:
       type: file
       description: Predicted variants file
       pattern: "*.{vcf}"
+  - tbi:
+      type: file
+      description: Index of vcf file
+      pattern: "*.{vcf.gz.tbi}"
 authors:
   - "@kaurravneet4123"
   - "@bjohnnyd"

--- a/modules/nf-core/lofreq/callparallel/tests/main.nf.test
+++ b/modules/nf-core/lofreq/callparallel/tests/main.nf.test
@@ -32,7 +32,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.versions).match() },
+                { assert snapshot(
+                    process.out.versions,
+                    process.out.tbi.collect { file(it[1]).getName() }
+                    ).match() },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip.contains('##INFO=<ID=CONSVAR,Number=0,Type=Flag,Description="Indicates that the variant is a consensus variant (as opposed to a low frequency variant).">') }
             )
         }
@@ -62,7 +65,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.versions).match() },
+                { assert snapshot(
+                    process.out.versions,
+                    process.out.tbi.collect { file(it[1]).getName() }
+                    ).match() },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip.contains('##INFO=<ID=CONSVAR,Number=0,Type=Flag,Description="Indicates that the variant is a consensus variant (as opposed to a low frequency variant).">') }
             )
         }

--- a/modules/nf-core/lofreq/callparallel/tests/main.nf.test.snap
+++ b/modules/nf-core/lofreq/callparallel/tests/main.nf.test.snap
@@ -11,7 +11,23 @@
                     ]
                 ],
                 "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.tbi:md5,1a60c330fb42841e8dcf3cd507a70bfc"
+                    ]
+                ],
+                "2": [
                     "versions.yml:md5,56d45e0015add277b2689f071a4fe3e4"
+                ],
+                "tbi": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.vcf.gz.tbi:md5,1a60c330fb42841e8dcf3cd507a70bfc"
+                    ]
                 ],
                 "vcf": [
                     [
@@ -28,32 +44,38 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nextflow": "23.04.0"
         },
-        "timestamp": "2024-07-10T12:57:00.731035"
+        "timestamp": "2024-08-28T12:01:24.268196316"
     },
     "sarscov2 - bam": {
         "content": [
             [
                 "versions.yml:md5,56d45e0015add277b2689f071a4fe3e4"
+            ],
+            [
+                "test.vcf.gz.tbi"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nextflow": "23.04.0"
         },
-        "timestamp": "2024-07-10T12:59:23.105421"
+        "timestamp": "2024-08-28T12:28:18.229899904"
     },
     "sarscov2 - bam - bed": {
         "content": [
             [
                 "versions.yml:md5,56d45e0015add277b2689f071a4fe3e4"
+            ],
+            [
+                "test.vcf.gz.tbi"
             ]
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nextflow": "23.04.0"
         },
-        "timestamp": "2024-07-10T12:59:28.355632"
+        "timestamp": "2024-08-28T12:28:35.27599355"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #6426 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

`tbi` index has been added as an output to `lofreq callparallel` since it is already generated in the variant calling process. It might (and probably will) used downstream in the pipelines. With this change it doesn't have to be generated again.