### PR TITLE
Set BWA and bwamem2 index memory dynamically

### DIFF
--- a/modules/nf-core/bwa/index/main.nf
+++ b/modules/nf-core/bwa/index/main.nf
@@ -1,6 +1,8 @@
 process BWA_INDEX {
     tag "$fasta"
-    label 'process_single'
+    // NOTE requires 5.37N memory where N is the size of the database
+    // source: https://bio-bwa.sourceforge.net/bwa.shtml#8
+    memory { 5.5.B * fasta.size() }
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/bwa/index/main.nf
+++ b/modules/nf-core/bwa/index/main.nf
@@ -2,7 +2,7 @@ process BWA_INDEX {
     tag "$fasta"
     // NOTE requires 5.37N memory where N is the size of the database
     // source: https://bio-bwa.sourceforge.net/bwa.shtml#8
-    memory { 5.5.B * fasta.size() }
+    memory { 6.B * fasta.size() }
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/bwamem2/index/main.nf
+++ b/modules/nf-core/bwamem2/index/main.nf
@@ -1,7 +1,7 @@
 process BWAMEM2_INDEX {
     tag "$fasta"
     // NOTE Requires 28N GB memory where N is the size of the reference sequence
-    // https://github.com/bwa-mem2/bwa-mem2/issues/9
+    // source: https://github.com/bwa-mem2/bwa-mem2/issues/9
     memory { 28.B * fasta.size() }
 
     conda "${moduleDir}/environment.yml"

--- a/modules/nf-core/bwamem2/index/main.nf
+++ b/modules/nf-core/bwamem2/index/main.nf
@@ -1,6 +1,8 @@
 process BWAMEM2_INDEX {
     tag "$fasta"
-    label 'process_single'
+    // NOTE Requires 28N GB memory where N is the size of the reference sequence
+    // https://github.com/bwa-mem2/bwa-mem2/issues/9
+    memory { 28.B * fasta.size() }
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
Kept having bwamem2 index tasks that ran forever and failed. 
Updated bwamem2 to use 28.B of memory per byte of fasta. Issue for reference: https://github.com/bwa-mem2/bwa-mem2/issues/9

Also tracked down the required memory for bwa index while I was at it. Doesn't seem to fail because most of the genome requirements are under the necessary memory.

Not the first place where people have run into this https://github.com/nf-core/modules/pull/6628
