### PR TITLE
Stop nf-test complaining about missing dependency

### DIFF
--- a/modules/nf-core/ltrfinder/tests/main.nf.test
+++ b/modules/nf-core/ltrfinder/tests/main.nf.test
@@ -7,7 +7,7 @@ nextflow_process {
     tag "modules"
     tag "modules_nfcore"
     tag "ltrfinder"
-    tag "gunzip/main"
+    tag "gunzip"
 
     test("actinidia_chinensis-genome_21_fasta_gz-success") {
 

--- a/modules/nf-core/ltrfinder/tests/main.nf.test
+++ b/modules/nf-core/ltrfinder/tests/main.nf.test
@@ -13,7 +13,7 @@ nextflow_process {
 
         setup {
             run('GUNZIP') {
-                script "../../gunzip/main"
+                script "../../gunzip/main.nf"
 
                 process {
                     """

--- a/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test
+++ b/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test
@@ -19,7 +19,7 @@ nextflow_process {
         setup {
 
             run("LTRHARVEST") {
-                script "../../../ltrharvest"
+                script "../../../ltrharvest/main.nf"
 
                 process {
                     """
@@ -32,7 +32,7 @@ nextflow_process {
             }
 
             run("LTRFINDER") {
-                script "../../../ltrfinder"
+                script "../../../ltrfinder/main.nf"
 
                 process {
                     """
@@ -45,7 +45,7 @@ nextflow_process {
             }
 
             run("CAT_CAT") {
-                script "../../../cat/cat"
+                script "../../../cat/cat/main.nf"
 
                 process {
                     """
@@ -85,7 +85,7 @@ nextflow_process {
         setup {
 
             run('GUNZIP') {
-                script "../../../gunzip/main"
+                script "../../../gunzip/main.nf"
 
                 process {
                     """
@@ -98,7 +98,7 @@ nextflow_process {
             }
 
             run("LTRHARVEST") {
-                script "../../../ltrharvest"
+                script "../../../ltrharvest/main.nf"
 
                 process {
                     """
@@ -108,7 +108,7 @@ nextflow_process {
             }
 
             run("LTRFINDER") {
-                script "../../../ltrfinder"
+                script "../../../ltrfinder/main.nf"
 
                 process {
                     """
@@ -118,7 +118,7 @@ nextflow_process {
             }
 
             run("CAT_CAT") {
-                script "../../../cat/cat"
+                script "../../../cat/cat/main.nf"
 
                 process {
                     """

--- a/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test
+++ b/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test
@@ -9,7 +9,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "ltrretriever"
     tag "ltrretriever/ltrretriever"
-    tag "gunzip/main"
+    tag "gunzip"
     tag "ltrharvest"
     tag "ltrfinder"
     tag "cat/cat"


### PR DESCRIPTION
For a little while nf-test has been producing a warning for every test:
```
│ Warning: Module /workspace/modules/modules/nf-core/ltrfinder/tests/main.nf.test: Dependency '/workspace/modules/modules/nf-core/ltrfinder/tests/../../gunzip/main' not found.                   │
│ Warning: Module /workspace/modules/modules/nf-core/ltrretriever/ltrretriever/tests/main.nf.test: Dependency                                                                                     │
│ '/workspace/modules/modules/nf-core/ltrretriever/ltrretriever/tests/../../../gunzip/main' not found.        
```
This PR fixes this by providing full file paths to them modules.