### PR TITLE
new module jvarkit/dict2bed

### DIFF
--- a/modules/nf-core/jvarkit/dict2bed/environment.yml
+++ b/modules/nf-core/jvarkit/dict2bed/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::jvarkit=2024.08.25"
+  - "bioconda:bcftools=1.20"

--- a/modules/nf-core/jvarkit/dict2bed/environment.yml
+++ b/modules/nf-core/jvarkit/dict2bed/environment.yml
@@ -5,4 +5,3 @@ channels:
   - bioconda
 dependencies:
   - "bioconda::jvarkit=2024.08.25"
-  - "bioconda:bcftools=1.20"

--- a/modules/nf-core/jvarkit/dict2bed/main.nf
+++ b/modules/nf-core/jvarkit/dict2bed/main.nf
@@ -1,0 +1,47 @@
+process JVARKIT_DICT2BED {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/jvarkit:2024.08.25--hdfd78af_1':
+        'biocontainers/jvarkit:2024.08.25--hdfd78af_1' }"
+
+    input:
+    tuple val(meta),  path(dict_files)
+
+    output:
+    tuple val(meta), path(dict_files), path("*.bed"), emit: bed
+    path "versions.yml"                             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args1          = task.ext.args1 ?: ''
+    def downstream_cmd = task.ext.downstream_cmd ?: '' /* give a chance to run a command like '| cut -f1,2,3 |sort | uniq' */
+    def prefix         = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir TMP
+
+    jvarkit -Xmx${task.memory.giga}g -XX:-UsePerfData -Djava.io.tmpdir=TMP dict2bed ${args1} ${dict_files} ${downstream_cmd} > ${prefix}.bed
+
+    rm -rf TMP
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        jvarkit: \$(jvarkit -v)
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch "${prefix}.bed"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        jvarkit: \$(jvarkit -v)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/jvarkit/dict2bed/main.nf
+++ b/modules/nf-core/jvarkit/dict2bed/main.nf
@@ -8,7 +8,7 @@ process JVARKIT_DICT2BED {
         'biocontainers/jvarkit:2024.08.25--hdfd78af_1' }"
 
     input:
-    tuple val(meta),  path(dict_files)
+    tuple val(meta), path(dict_files)
 
     output:
     tuple val(meta), path("*.bed"), emit: bed
@@ -18,13 +18,13 @@ process JVARKIT_DICT2BED {
     task.ext.when == null || task.ext.when
 
     script:
-    def args           = task.ext.args ?: ''
-    def downstream_cmd = task.ext.downstream_cmd ?: '' /* give a chance to run a command like '| cut -f1,2,3 |sort | uniq' */
-    def prefix         = task.ext.prefix ?: "${meta.id}"
+    def args   = task.ext.args ?: ''
+    def args2  = task.ext.args2 ?: '' /* give a chance to run a command like '| cut -f1,2,3 |sort | uniq' */
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     mkdir TMP
 
-    jvarkit -Xmx${task.memory.giga}g -XX:-UsePerfData -Djava.io.tmpdir=TMP dict2bed ${args} ${dict_files} ${downstream_cmd} > ${prefix}.bed
+    jvarkit -Xmx${task.memory.giga}g -XX:-UsePerfData -Djava.io.tmpdir=TMP dict2bed ${args} ${dict_files} ${args2} > ${prefix}.bed
 
     rm -rf TMP
 

--- a/modules/nf-core/jvarkit/dict2bed/main.nf
+++ b/modules/nf-core/jvarkit/dict2bed/main.nf
@@ -11,8 +11,8 @@ process JVARKIT_DICT2BED {
     tuple val(meta),  path(dict_files)
 
     output:
-    tuple val(meta), path(dict_files), path("*.bed"), emit: bed
-    path "versions.yml"                             , emit: versions
+    tuple val(meta), path("*.bed"), emit: bed
+    path "versions.yml"           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/jvarkit/dict2bed/main.nf
+++ b/modules/nf-core/jvarkit/dict2bed/main.nf
@@ -18,13 +18,13 @@ process JVARKIT_DICT2BED {
     task.ext.when == null || task.ext.when
 
     script:
-    def args1          = task.ext.args1 ?: ''
+    def args           = task.ext.args ?: ''
     def downstream_cmd = task.ext.downstream_cmd ?: '' /* give a chance to run a command like '| cut -f1,2,3 |sort | uniq' */
     def prefix         = task.ext.prefix ?: "${meta.id}"
     """
     mkdir TMP
 
-    jvarkit -Xmx${task.memory.giga}g -XX:-UsePerfData -Djava.io.tmpdir=TMP dict2bed ${args1} ${dict_files} ${downstream_cmd} > ${prefix}.bed
+    jvarkit -Xmx${task.memory.giga}g -XX:-UsePerfData -Djava.io.tmpdir=TMP dict2bed ${args} ${dict_files} ${downstream_cmd} > ${prefix}.bed
 
     rm -rf TMP
 

--- a/modules/nf-core/jvarkit/dict2bed/meta.yml
+++ b/modules/nf-core/jvarkit/dict2bed/meta.yml
@@ -17,7 +17,7 @@ tools:
       tool_dev_url: "https://github.com/lindenb/jvarkit"
       doi: "10.1093/bioinformatics/btx734 "
       licence: ["MIT License"]
-      args_id: ["$args1","$args2"]
+      args_id: "$args1"
       identifier: ""
 input:
   - - meta:

--- a/modules/nf-core/jvarkit/dict2bed/meta.yml
+++ b/modules/nf-core/jvarkit/dict2bed/meta.yml
@@ -25,7 +25,7 @@ input:
         description: |
           Groovy Map containing dict file information
           e.g. [ id:'test_reference' ]
-    - dict_file:
+    - dict_files:
         type: file
         description: File(s) containing a dictionary VCF/BCF/BAM/DICT etc...
         pattern: "*.{vcf,bcf,vcf.gz,bcf.gz,dict,fai,bam,cram,interval_list}"
@@ -36,7 +36,7 @@ output:
           description: |
             Groovy Map containing VCF information
             e.g. [ id:'test', single_end:false ]
-      - dict_file:
+      - dict_files:
         type: file
         description: Input dict file(s)
         pattern: "*.{vcf,bcf,vcf.gz,bcf.gz,dict,fai,bam,cram,interval_list}"

--- a/modules/nf-core/jvarkit/dict2bed/meta.yml
+++ b/modules/nf-core/jvarkit/dict2bed/meta.yml
@@ -15,7 +15,7 @@ tools:
       homepage: "https://github.com/lindenb/jvarkit"
       documentation: "https://jvarkit.readthedocs.io/"
       tool_dev_url: "https://github.com/lindenb/jvarkit"
-      doi: "10.1093/bioinformatics/btx734 "
+      doi: "10.6084/m9.figshare.1425030"
       licence: ["MIT License"]
       args_id: "$args"
       identifier: ""
@@ -36,10 +36,6 @@ output:
           description: |
             Groovy Map containing VCF information
             e.g. [ id:'test', single_end:false ]
-      - dict_files:
-        type: file
-        description: Input dict file(s)
-        pattern: "*.{vcf,bcf,vcf.gz,bcf.gz,dict,fai,bam,cram,interval_list}"
       - "*.bed":
           type: file
           description: BED output file

--- a/modules/nf-core/jvarkit/dict2bed/meta.yml
+++ b/modules/nf-core/jvarkit/dict2bed/meta.yml
@@ -17,7 +17,7 @@ tools:
       tool_dev_url: "https://github.com/lindenb/jvarkit"
       doi: "10.1093/bioinformatics/btx734 "
       licence: ["MIT License"]
-      args_id: "$args1"
+      args_id: "$args"
       identifier: ""
 input:
   - - meta:

--- a/modules/nf-core/jvarkit/dict2bed/meta.yml
+++ b/modules/nf-core/jvarkit/dict2bed/meta.yml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "jvarkit_dict2xml"
+description: Extract BED file from hts files containing a dictionary (VCF,BAM, CRAM, DICT, etc...)
+keywords:
+  - vcf
+  - bcf
+  - bed
+  - dict
+  - dictionary
+  - fasta
+  - fai
+tools:
+  - "jvarkit":
+      description: "Java utilities for Bioinformatics."
+      homepage: "https://github.com/lindenb/jvarkit"
+      documentation: "https://jvarkit.readthedocs.io/"
+      tool_dev_url: "https://github.com/lindenb/jvarkit"
+      doi: "10.1093/bioinformatics/btx734 "
+      licence: ["MIT License"]
+      args_id: ["$args1","$args2"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing dict file information
+          e.g. [ id:'test_reference' ]
+    - dict_file:
+        type: file
+        description: File(s) containing a dictionary VCF/BCF/BAM/DICT etc...
+        pattern: "*.{vcf,bcf,vcf.gz,bcf.gz,dict,fai,bam,cram,interval_list}"
+output:
+  - bed:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing VCF information
+            e.g. [ id:'test', single_end:false ]
+      - dict_file:
+        type: file
+        description: Input dict file(s)
+        pattern: "*.{vcf,bcf,vcf.gz,bcf.gz,dict,fai,bam,cram,interval_list}"
+      - "*.bed":
+          type: file
+          description: BED output file
+          pattern: "*.{vcf,bcf,vcf.gz,bcf.gz}"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@lindenb"
+maintainers:
+  - "@lindenb"

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
@@ -33,7 +33,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    path(process.out.bed[0][1]),
+                    process.out.versions
+                    ).match()
+                }
             )
         }
 
@@ -62,7 +66,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    path(process.out.bed[0][1]),
+                    process.out.versions
+                    ).match()
+                }
             )
         }
 

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
@@ -33,11 +33,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-                    path(process.out.bed[0][1]),
-                    process.out.versions
-                    ).match()
-                }
+                { assert snapshot(path(process.out).match() }
             )
         }
 
@@ -66,11 +62,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-                    path(process.out.bed[0][1]),
-                    process.out.versions
-                    ).match()
-                }
+                { assert snapshot(path(process.out).match() }
             )
         }
 

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
@@ -33,7 +33,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(path(process.out).match() }
+                { assert snapshot(path(process.out)).match() }
             )
         }
 
@@ -62,7 +62,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(path(process.out).match() }
+                { assert snapshot(path(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
@@ -1,0 +1,80 @@
+// nf-core modules test jvarkit/dict2bed
+nextflow_process {
+
+    name "Test Process JVARKIT_DICT2BED"
+    script "../main.nf"
+    process "JVARKIT_DICT2BED"
+    config "./nextflow.config"
+
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "jvarkit"
+    tag "jvarkit/dict2bed"
+
+    test("sarscov2 - dict") {
+
+        when {
+            process {
+                """
+                input[0] =[
+                    [id:"dict_test"],
+                    [
+                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true),
+                     file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true),
+                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    path(process.out.vcf[0][2]),
+                    process.out.versions
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("sarscov2 - stub") {
+
+        options  "-stub"
+
+        when {
+            process {
+                """
+                input[0] =[
+                    [id:"dict_stub"],
+                    [
+                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true),
+                     file(params.test_data['sarscov2']['genome']['genome_dict'], checkIfExists: true),
+                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    path(process.out.vcf[0][2]),
+                    process.out.versions
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+
+}

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
@@ -34,7 +34,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    path(process.out.bed[0][2]),
+                    path(process.out.bed[0][1]),
                     process.out.versions
                     ).match()
                 }
@@ -67,7 +67,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    path(process.out.bed[0][2]),
+                    path(process.out.bed[0][1]),
                     process.out.versions
                     ).match()
                 }
@@ -75,6 +75,4 @@ nextflow_process {
         }
 
     }
-
-
 }

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
@@ -34,7 +34,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    path(process.out.vcf[0][2]),
+                    path(process.out.bed[0][2]),
                     process.out.versions
                     ).match()
                 }
@@ -67,7 +67,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    path(process.out.vcf[0][2]),
+                    path(process.out.bed[0][2]),
                     process.out.versions
                     ).match()
                 }

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test
@@ -33,7 +33,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(path(process.out)).match() }
+                { assert snapshot(process.out).match() }
             )
         }
 
@@ -62,7 +62,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(path(process.out)).match() }
+                { assert snapshot(process.out).match() }
             )
         }
 

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test.snap
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test.snap
@@ -2,9 +2,9 @@
 
     "sarscov2 - dict": {
         "content": [
-           "dict_test.bed:md5,d41d8cd98f00b204e9800998ecf8427e",
+           "dict_test.bed:md5,296a58ee6d26a13ceed194d3f5286c64",
            [
-           "versions.yml:md5,3601751995727e2ee7102d8ef18e5304"
+           "versions.yml:md5,53252028d7bd745cb0720a242d7851d7"
            ] 
         ],
         "meta": {
@@ -17,7 +17,7 @@
         "content": [
            "dict_stub.bed:md5,d41d8cd98f00b204e9800998ecf8427e",
            [
-           "versions.yml:md5,3601751995727e2ee7102d8ef18e5304"
+           "versions.yml:md5,53252028d7bd745cb0720a242d7851d7"
            ] 
         ],
         "meta": {

--- a/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test.snap
+++ b/modules/nf-core/jvarkit/dict2bed/tests/main.nf.test.snap
@@ -1,0 +1,30 @@
+{
+
+    "sarscov2 - dict": {
+        "content": [
+           "dict_test.bed:md5,d41d8cd98f00b204e9800998ecf8427e",
+           [
+           "versions.yml:md5,3601751995727e2ee7102d8ef18e5304"
+           ] 
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-03T14:00:13.118369362"
+    },
+    "sarscov2 - stub": {
+        "content": [
+           "dict_stub.bed:md5,d41d8cd98f00b204e9800998ecf8427e",
+           [
+           "versions.yml:md5,3601751995727e2ee7102d8ef18e5304"
+           ] 
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-03T14:00:13.118369362"
+    }
+
+}

--- a/modules/nf-core/jvarkit/dict2bed/tests/nextflow.config
+++ b/modules/nf-core/jvarkit/dict2bed/tests/nextflow.config
@@ -1,5 +1,5 @@
 process {
     withName: JVARKIT_DICT2BED {
-        ext.downstream_cmd =" | cut -f1,2,3 "
+        ext.args2 =" | cut -f1,2,3 "
     }
 }

--- a/modules/nf-core/jvarkit/dict2bed/tests/nextflow.config
+++ b/modules/nf-core/jvarkit/dict2bed/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: JVARKIT_DICT2BED {
+        ext.downstream_cmd =" | cut -f1,2,3 "
+    }
+}

--- a/modules/nf-core/jvarkit/dict2bed/tests/tags.yml
+++ b/modules/nf-core/jvarkit/dict2bed/tests/tags.yml
@@ -1,0 +1,2 @@
+jvarkit/dict2bed:
+  - "modules/nf-core/jvarkit/dict2bed/**"


### PR DESCRIPTION
this is a PR for jvarkit/vcf2table  which convert files containing a dictionary like cram/bam/dict/etc.. to bed: https://jvarkit.readthedocs.io/en/latest/DictToBed/

```
$ java -jar dist/jvarkit.jar dict2bed ~/src/jvarkit-git/src/test/resources/*.bam |  head | column -t
chrom  start  end        path                                                                         tid  buildName  AS  M5  SP  UR
chr1   0      248956422  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  0    GRCh38     .   .   .   .
chr2   0      242193529  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  1    GRCh38     .   .   .   .
chr3   0      198295559  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  2    GRCh38     .   .   .   .
chr4   0      190214555  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  3    GRCh38     .   .   .   .
chr5   0      181538259  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  4    GRCh38     .   .   .   .
chr6   0      170805979  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  5    GRCh38     .   .   .   .
chr7   0      159345973  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  6    GRCh38     .   .   .   .
chr8   0      145138636  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  7    GRCh38     .   .   .   .
chr9   0      138394717  /home/lindenb/src/jvarkit-git/src/test/resources/ENCFF331CGL.rnaseq.b38.bam  8    GRCh38     .   .   .   .
```



## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [X] If necessary, include test data in your PR.
- [X] Remove all TODO statements.
- [X] Emit the `versions.yml` file.
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [X] Add a resource `label`
- [X] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [X] `nf-core modules test <MODULE> --profile docker`
    - [X] `nf-core modules test <MODULE> --profile singularity`
    - [X] `nf-core modules test <MODULE> --profile conda`
