### PR TITLE
Switch from oras to https in phantompeakqualtools module

### DIFF
--- a/modules/nf-core/phantompeakqualtools/main.nf
+++ b/modules/nf-core/phantompeakqualtools/main.nf
@@ -5,7 +5,7 @@ process PHANTOMPEAKQUALTOOLS {
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://community.wave.seqera.io/library/phantompeakqualtools:1.2.2--50be7727b2a72700' :
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4a/4a1cddfad5b503ee347cc5de17d172e1876c547fca00aa844559c9e764fb400f/data' :
         'community.wave.seqera.io/library/phantompeakqualtools:1.2.2--f8026fe2526a5e18' }"
 
     input:


### PR DESCRIPTION
Do not use `oras` in `phantompeakqualtools` module.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`

