### PR TITLE
Update MaxBin2: allow multiple abund files

### DIFF
--- a/modules/nf-core/maxbin2/main.nf
+++ b/modules/nf-core/maxbin2/main.nf
@@ -13,6 +13,7 @@ process MAXBIN2 {
     output:
     tuple val(meta), path("*.fasta.gz")   , emit: binned_fastas
     tuple val(meta), path("*.summary")    , emit: summary
+    tuple val(meta), path("*.abundance")  , emit: abundance   , optional: true
     tuple val(meta), path("*.log.gz")     , emit: log
     tuple val(meta), path("*.marker.gz")  , emit: marker_counts
     tuple val(meta), path("*.noclass.gz") , emit: unbinned_fasta
@@ -27,7 +28,15 @@ process MAXBIN2 {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def associate_files = reads ? "-reads $reads" : "-abund $abund"
+    def associate_files = ""
+    if ( reads ) {
+        associate_files = "-reads $reads"
+    } else if ( abund instanceof List ) {
+        associate_files = "-abund ${abund[0]}"
+        for (i in 2..abund.size()) { associate_files += " -abund$i ${abund[i-1]}" }
+    } else {
+        associate_files = "-abund $abund"
+    }
     """
     mkdir input/ && mv $contigs input/
     run_MaxBin.pl \\

--- a/modules/nf-core/maxbin2/main.nf
+++ b/modules/nf-core/maxbin2/main.nf
@@ -28,6 +28,7 @@ process MAXBIN2 {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    if (reads && abund) { error("ERROR: MaxBin2 can only accept one of `reads` or `abund`, no both. Check input.") }
     def associate_files = ""
     if ( reads ) {
         associate_files = "-reads $reads"

--- a/modules/nf-core/maxbin2/meta.yml
+++ b/modules/nf-core/maxbin2/meta.yml
@@ -35,8 +35,8 @@ input:
           supply at the same time as abundance files.
         pattern: "*.fasta"
     - abund:
-        type: file or list of files
-        description: Contig abundance files, i.e. reads against each contig. See MaxBin2
+        type: list
+        description: One or more contig abundance files, i.e. average depth of reads against each contig. See MaxBin2
           README for details. Do not supply at the same time as read files.
 output:
   - binned_fastas:

--- a/modules/nf-core/maxbin2/meta.yml
+++ b/modules/nf-core/maxbin2/meta.yml
@@ -35,7 +35,7 @@ input:
           supply at the same time as abundance files.
         pattern: "*.fasta"
     - abund:
-        type: file
+        type: file or list of files
         description: Contig abundance files, i.e. reads against each contig. See MaxBin2
           README for details. Do not supply at the same time as read files.
 output:
@@ -60,6 +60,17 @@ output:
           description: Summary file describing which contigs are being classified into
             which bin
           pattern: "*.summary"
+  - abundance:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.abundance":
+          type: file
+          description: Abundance of each bin if multiple abundance files were supplied
+            which bin
+          pattern: "*.abundance"
   - log:
       - meta:
           type: map


### PR DESCRIPTION
Currently this modules allows the input of only one abundance file with one abundance column. This adds a possibility to use multiple abundance files (each with the contig abundance of one sample).
Related to https://github.com/nf-core/mag/pull/690

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
