### PR TITLE
Fix tar to always follow symlinks due to nxf staging in work dirs

### DIFF
--- a/modules/nf-core/tar/main.nf
+++ b/modules/nf-core/tar/main.nf
@@ -49,6 +49,7 @@ process TAR {
     """
     tar \\
         -c \\
+        -h \\
         ${compress_flag} \\
         ${args} \\
         -f ${prefix}.tar${compress_type} \\


### PR DESCRIPTION
Forget this bit :sweat_smile: 