### PR TITLE
Allow sorting inputs to SVDB

### DIFF
--- a/modules/nf-core/svdb/merge/main.nf
+++ b/modules/nf-core/svdb/merge/main.nf
@@ -29,17 +29,18 @@ process SVDB_MERGE {
 
     if (sort_inputs && vcfs.collect().size() > 1) {
         if (priority) {
-            // If there are more than one input, make vcf-prioprity pairs
-            // pair them and sort on VCF name, so priority is also sorted the same
+            // make vcf-prioprity pairs and sort on VCF name, so priority is also sorted the same
             def pairs = vcfs.indices.collect { [vcfs[it], priority[it]] }
             pairs = pairs.sort { a, b -> a[0].name <=> b[0].name }
             vcfs = pairs.collect { it[0] }
             priority = pairs.collect { it[1] }
         } else {
+            // if there's no priority input just sort the vcfs by name
             vcfs = vcfs.sort { it.name }
         }
     }
 
+    // If there's only one input VCF the code above is not executed, and that VCF becomes the input
     input = vcfs
 
     def prio = ""

--- a/modules/nf-core/svdb/merge/main.nf
+++ b/modules/nf-core/svdb/merge/main.nf
@@ -20,7 +20,7 @@ process SVDB_MERGE {
     script:
     def args   = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input  = "${vcfs.join(" ")}"
+    def input = (vcfs.collect().size() > 1) ? vcfs.sort{ it.name } : vcfs
     def prio   = ""
     if(priority) {
         prio = "--priority ${priority.join(',')}"

--- a/modules/nf-core/svdb/merge/meta.yml
+++ b/modules/nf-core/svdb/merge/meta.yml
@@ -19,15 +19,22 @@ input:
           e.g. [ id:'test' ]
     - vcfs:
         type: list
-        description: Two or more VCF files. Order of files should correspond to the
-          order of tags used for priority.
+        description: |
+          One or more VCF files. The order and number of files should correspond to
+          the order and number of tags in the `priority` input channel.
         pattern: "*.{vcf,vcf.gz}"
   - - priority:
         type: list
-        description: prioritise the input VCF files according to this list, e.g ['tiddit','cnvnator']
+        description: |
+          Prioritize the input VCF files according to this list,
+          e.g ['tiddit','cnvnator']. The order and number of tags should correspond to
+          the order and number of VCFs in the `vcfs` input channel.
   - - sort_inputs:
         type: boolean
-        description: Should the input VCF files be sorted by name or not
+        description: |
+          Should the input files be sorted by name. The priority tag will be sorted
+          together with it's corresponding VCF file.
+
 output:
   - vcf:
       - meta:

--- a/modules/nf-core/svdb/merge/meta.yml
+++ b/modules/nf-core/svdb/merge/meta.yml
@@ -24,7 +24,10 @@ input:
         pattern: "*.{vcf,vcf.gz}"
   - - priority:
         type: list
-        description: prioritise the input vcf files according to this list, e.g ['tiddit','cnvnator']
+        description: prioritise the input VCF files according to this list, e.g ['tiddit','cnvnator']
+  - - sort_inputs:
+        type: boolean
+        description: Should the input VCF files be sorted by name or not
 output:
   - vcf:
       - meta:

--- a/modules/nf-core/svdb/merge/tests/main.nf.test
+++ b/modules/nf-core/svdb/merge/tests/main.nf.test
@@ -30,7 +30,6 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf") }, // SVDB command line
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test") }, // #CHROM line
                 { assert snapshot(
                     path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
@@ -61,7 +60,6 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf") }, // SVDB command line
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test") }, // #CHROM line
                 { assert snapshot(
                     path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
@@ -92,7 +90,6 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf:tiddit") }, // SVDB command line
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test") }, // #CHROM line
                 { assert snapshot(
                     path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
@@ -123,7 +120,6 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf:tiddit") }, // SVDB command line
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test") }, // #CHROM line
                 { assert snapshot(
                     path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
@@ -155,7 +151,6 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test2.vcf test.vcf") }, // SVDB command line
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test2\ttest") }, // #CHROM line
                 { assert snapshot(
                     path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
@@ -187,7 +182,6 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf test2.vcf") }, // SVDB command line
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test\ttest2") }, // #CHROM line
                 { assert snapshot(
                     path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
@@ -219,7 +213,6 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test2.vcf:tiddit test.vcf:cnvnator") }, // SVDB command line
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test2\ttest") }, // #CHROM line
                 { assert snapshot(
                     path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
@@ -230,7 +223,7 @@ nextflow_process {
     }
 
     test("2 samples, ['tiddit', 'cnvnator'], true") {
-        
+
         when {
             process {
                 """
@@ -251,7 +244,6 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf:cnvnator test2.vcf:tiddit") }, // SVDB command line
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test\ttest2") }, // #CHROM line
                 { assert snapshot(
                     path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,

--- a/modules/nf-core/svdb/merge/tests/main.nf.test
+++ b/modules/nf-core/svdb/merge/tests/main.nf.test
@@ -2,50 +2,26 @@ nextflow_process {
 
     name "Test Process SVDB_MERGE"
     script "modules/nf-core/svdb/merge/main.nf"
+    config "./nextflow.config"
     process "SVDB_MERGE"
     tag "modules"
     tag "modules_nfcore"
     tag "svdb"
     tag "svdb/merge"
 
-    test("test_svdb_merge") {
+    test("1 sample, [], []") {
 
         when {
             process {
                 """
                 input[0] = Channel.of([
                     [ id:'test' ], // meta map
-                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true) ]
-                ])
-                input[1] = [ 'tiddit', 'cnvnator']
-                """
-            }
-        }
-
-        then {
-            assertAll (
-                { assert process.success },
-                { assert snapshot(
-                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
-                    process.out.versions
-                ).match() }
-            )
-        }
-
-    }
-
-    test("test_svdb_merge_noprio") {
-
-        when {
-            process {
-                """
-                input[0] = Channel.of([
-                    [ id:'test' ], // meta map
-                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true) ]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
                 ])
                 input[1] = []
+                input[2] = []
                 """
             }
         }
@@ -53,16 +29,239 @@ nextflow_process {
         then {
             assertAll (
                 { assert process.success },
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf") }, // SVDB command line
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test") }, // #CHROM line
                 { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
                     path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
                     process.out.versions
                 ).match() }
             )
         }
-
     }
 
-    test("test_svdb_merge - stub") {
+    test("1 sample, [], true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = []
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf") }, // SVDB command line
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test") }, // #CHROM line
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("1 sample, ['tiddit'], []") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = ['tiddit']
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf:tiddit") }, // SVDB command line
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test") }, // #CHROM line
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("1 sample, ['tiddit'], true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = ['tiddit']
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf:tiddit") }, // SVDB command line
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test") }, // #CHROM line
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("2 samples, [], []") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = []
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test2.vcf test.vcf") }, // SVDB command line
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test2\ttest") }, // #CHROM line
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("2 samples, [], true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = []
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf test2.vcf") }, // SVDB command line
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test\ttest2") }, // #CHROM line
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("2 samples, ['tiddit', 'cnvnator'], []") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = ['tiddit', 'cnvnator']
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test2.vcf:tiddit test.vcf:cnvnator") }, // SVDB command line
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test2\ttest") }, // #CHROM line
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("2 samples, ['tiddit', 'cnvnator'], true") {
+        
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = ['tiddit', 'cnvnator']
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[2].contains("--vcf test.vcf:cnvnator test2.vcf:tiddit") }, // SVDB command line
+                { assert path(process.out.vcf.get(0).get(1)).linesGzip[51].contains("test\ttest2") }, // #CHROM line
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.summary,
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("2 samples, [], [] - stub") {
 
         options "-stub"
 
@@ -71,10 +270,13 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [ id:'test' ], // meta map
-                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true) ]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
                 ])
-                input[1] = [ 'tiddit', 'cnvnator']
+                input[1] = []
+                input[2] = []
                 """
             }
         }
@@ -85,10 +287,9 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
-
     }
 
-    test("test_svdb_merge_noprio - stub") {
+    test("2 samples, [], true - stub") {
 
         options "-stub"
 
@@ -97,10 +298,13 @@ nextflow_process {
                 """
                 input[0] = Channel.of([
                     [ id:'test' ], // meta map
-                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true) ]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
                 ])
                 input[1] = []
+                input[2] = true
                 """
             }
         }
@@ -111,7 +315,62 @@ nextflow_process {
                 { assert snapshot(process.out).match() }
             )
         }
+    }
 
+    test("2 samples, ['tiddit', 'cnvnator'], [] - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = ['tiddit', 'cnvnator']
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("2 samples, ['tiddit', 'cnvnator'], true - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true)
+                    ]
+                ])
+                input[1] = ['tiddit', 'cnvnator']
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
     }
 
 }

--- a/modules/nf-core/svdb/merge/tests/main.nf.test
+++ b/modules/nf-core/svdb/merge/tests/main.nf.test
@@ -26,7 +26,10 @@ nextflow_process {
         then {
             assertAll (
                 { assert process.success },
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip.contains("##fileformat=VCFv4.1") }
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
             )
         }
 
@@ -50,7 +53,10 @@ nextflow_process {
         then {
             assertAll (
                 { assert process.success },
-                { assert path(process.out.vcf.get(0).get(1)).linesGzip.contains("##fileformat=VCFv4.1") }
+                { assert snapshot(
+                    path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
+                    process.out.versions
+                ).match() }
             )
         }
 

--- a/modules/nf-core/svdb/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/svdb/merge/tests/main.nf.test.snap
@@ -1,4 +1,17 @@
 {
+    "test_svdb_merge": {
+        "content": [
+            "d4bd31b08ca81354569f2b1c26847e2f",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-16T12:32:01.319355008"
+    },
     "test_svdb_merge - stub": {
         "content": [
             {
@@ -64,5 +77,18 @@
             "nextflow": "24.04.4"
         },
         "timestamp": "2024-10-16T09:00:49.58223306"
+    },
+    "test_svdb_merge_noprio": {
+        "content": [
+            "8c5898148b927658b29f844c39c2cc7f",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-16T12:32:09.697420841"
     }
 }

--- a/modules/nf-core/svdb/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/svdb/merge/tests/main.nf.test.snap
@@ -1,7 +1,8 @@
 {
-    "test_svdb_merge": {
+    "1 sample, [], []": {
         "content": [
-            "d4bd31b08ca81354569f2b1c26847e2f",
+            "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=9, phased=false, phasedAutodetect=false]",
+            "60fb4cab2aa891bebef8ffdbd0e41bc3",
             [
                 "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
             ]
@@ -10,9 +11,9 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-16T12:32:01.319355008"
+        "timestamp": "2024-10-17T08:30:08.029708713"
     },
-    "test_svdb_merge - stub": {
+    "2 samples, ['tiddit', 'cnvnator'], true - stub": {
         "content": [
             {
                 "0": [
@@ -20,7 +21,7 @@
                         {
                             "id": "test"
                         },
-                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "merged.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "1": [
@@ -31,7 +32,7 @@
                         {
                             "id": "test"
                         },
-                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "merged.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "versions": [
@@ -43,9 +44,107 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-16T09:00:41.058996433"
+        "timestamp": "2024-10-17T08:32:10.741546957"
     },
-    "test_svdb_merge_noprio - stub": {
+    "2 samples, ['tiddit', 'cnvnator'], []": {
+        "content": [
+            "VcfFile [chromosomes=[MT192765.1], sampleCount=2, variantCount=9, phased=false, phasedAutodetect=false]",
+            "254e56e4fc8356d68424828438da66e3",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-17T08:31:15.105041662"
+    },
+    "2 samples, [], []": {
+        "content": [
+            "VcfFile [chromosomes=[MT192765.1], sampleCount=2, variantCount=9, phased=false, phasedAutodetect=false]",
+            "7ad648266e57d405b5b01aaea4613d1c",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-17T08:41:54.793936976"
+    },
+    "2 samples, ['tiddit', 'cnvnator'], true": {
+        "content": [
+            "VcfFile [chromosomes=[MT192765.1], sampleCount=2, variantCount=9, phased=false, phasedAutodetect=false]",
+            "74ed58e115db54f30036bfd68a7dc432",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-17T08:31:29.320496992"
+    },
+    "1 sample, ['tiddit'], []": {
+        "content": [
+            "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=9, phased=false, phasedAutodetect=false]",
+            "9dd588cd870672b78192f48ad440b5d",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-17T08:30:30.590239659"
+    },
+    "1 sample, [], true": {
+        "content": [
+            "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=9, phased=false, phasedAutodetect=false]",
+            "60fb4cab2aa891bebef8ffdbd0e41bc3",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-17T08:30:22.670145479"
+    },
+    "1 sample, ['tiddit'], true": {
+        "content": [
+            "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=9, phased=false, phasedAutodetect=false]",
+            "9dd588cd870672b78192f48ad440b5d",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-17T08:30:40.958649472"
+    },
+    "2 samples, [], true": {
+        "content": [
+            "VcfFile [chromosomes=[MT192765.1], sampleCount=2, variantCount=9, phased=false, phasedAutodetect=false]",
+            "de0a3b56cdee89e4c9cd4fbb4ad3391d",
+            [
+                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-17T08:31:01.933044815"
+    },
+    "2 samples, ['tiddit', 'cnvnator'], [] - stub": {
         "content": [
             {
                 "0": [
@@ -53,7 +152,7 @@
                         {
                             "id": "test"
                         },
-                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "merged.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "1": [
@@ -64,7 +163,7 @@
                         {
                             "id": "test"
                         },
-                        "test.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "merged.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "versions": [
@@ -76,19 +175,72 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-16T09:00:49.58223306"
+        "timestamp": "2024-10-17T08:31:59.830493054"
     },
-    "test_svdb_merge_noprio": {
+    "2 samples, [], [] - stub": {
         "content": [
-            "8c5898148b927658b29f844c39c2cc7f",
-            [
-                "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
-            ]
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "merged.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "merged.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-10-16T12:32:09.697420841"
+        "timestamp": "2024-10-17T08:41:07.289491939"
+    },
+    "2 samples, [], true - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "merged.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "merged.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,772f39343052d54d9bcb21d4892da203"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-10-17T08:31:48.40721064"
     }
 }

--- a/modules/nf-core/svdb/merge/tests/nextflow.config
+++ b/modules/nf-core/svdb/merge/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'SVDB_MERGE' {
+        ext.prefix = "merged"
+    }
+}


### PR DESCRIPTION
This PR adds functionality for sorting the input files to SVDB. This allows the output to be snapshot when this module is included in a subworkflow, since the sample order in the output files will be fixed. The priority tags are sorted together with the VCFs, so the priority order is unchanged.

It also adds a check to make sure there are as many priority tags as input VCFs.

Tests should cover all usages.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
