### PR TITLE
Fix krakenuniq filename splitting into prefix

### DIFF
--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -107,7 +107,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
         END_VERSIONS
         """
     } else {
-        command_input = sequences.collect { first, second -> "${first} ${second} ${get_paired_prefix(first, second)}" }
+        command_input = sequences.collate(2).collect { first, second -> "${first} ${second} ${get_paired_prefix(first, second)}" }
         """
         cat <<-END_OPTIONS > options.txt
         ${command_input.join('\n')}
@@ -206,7 +206,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
         END_VERSIONS
         """
     } else {
-        command_input = sequences.collect { first, second -> "${first} ${second} ${get_paired_prefix(first, second)}" }
+        command_input = sequences.collate(2).collect { first, second -> "${first} ${second} ${get_paired_prefix(first, second)}" }
         """
         cat <<-END_OPTIONS > options.txt
         ${command_input.join('\n')}

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -1,33 +1,30 @@
-import java.nio.file.Path
-import java.nio.file.Paths
-
-boolean is_compressed(Path filename, Set<String> extensions = ['gz', 'gzip'] as Set<String>) {
+def is_compressed(filename, extensions = ['gz', 'gzip'] as Set<String>) {
     return extensions.contains(filename.extension)
 }
 
-boolean is_sequence(Path filename, Set<String> extensions = ['fasta', 'fa', 'fastq', 'fq'] as Set<String>) {
+def is_sequence(filename, extensions = ['fasta', 'fa', 'fastq', 'fq'] as Set<String>) {
     return extensions.contains(filename.extension)
 }
 
-String get_simple_name(Path filename) {
+def get_simple_name(filename) {
     // If the input has a gzip compression, strip the file extension.
     if (is_compressed(filename)) {
-        filename = Paths.get(filename.baseName)
+        filename = java.nio.file.Paths.get(filename.baseName)
     }
     // Strip an expected sequencing file extension.
     if (is_sequence(filename)) {
-        filename = Paths.get(filename.baseName)
+        filename = java.nio.file.Paths.get(filename.baseName)
     } else {
         throw new Exception("Unrecognized sequencing file extension '${filename.extension}'.")
     }
     return filename.name
 }
 
-String get_single_prefix(Path sequence_file) {
+def get_single_prefix(sequence_file) {
     return get_simple_name(sequence_file)
 }
 
-String get_paired_prefix(Path first, Path second) {
+def get_paired_prefix(first, _second) {
     // Paired sequencing files usually have a suffix of `_1` or `.1` in their name,
     // which we remove.
     return get_simple_name(first) - ~/[._]1$/

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -87,7 +87,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
             --preload-size $ram_chunk_size \\
             --threads $task.cpus
 
-        while IFS= read -r SEQ PREFIX; do
+        while IFS=' ' read -r SEQ PREFIX; do
             krakenuniq \\
                 --db $db \\
                 --threads $task.cpus \\
@@ -97,7 +97,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
                 $classified_option \\
                 $args2 \\
                 "\${SEQ}"
-        done
+        done < options.txt
 
         $compress_reads_command
 
@@ -120,7 +120,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
             --preload-size $ram_chunk_size \\
             --threads $task.cpus
 
-        while IFS= read -r SEQ_1 SEQ_2 PREFIX; do
+        while IFS=' ' read -r SEQ_1 SEQ_2 PREFIX; do
             krakenuniq \\
                 --db $db \\
                 --threads $task.cpus \\
@@ -131,7 +131,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
                 --paired \\
                 $args2 \\
                 "\${SEQ_1}" "\${SEQ_2}"
-        done
+        done < options.txt
 
         $compress_reads_command
 
@@ -178,7 +178,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
             echo '<3 nf-core' | gzip -n > "\$1"
         }
 
-        while IFS= read -r SEQ PREFIX; do
+        while IFS=' ' read -r SEQ PREFIX; do
             echo "\${SEQ}"
             echo "\${PREFIX}"
 
@@ -196,7 +196,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
             create_file "\${PREFIX}.krakenuniq.report.txt"
             create_gzip_file "\${PREFIX}.classified.${sequence_type}.gz"
             create_gzip_file "\${PREFIX}.unclassified.${sequence_type}.gz"
-        done
+        done < options.txt
 
         echo "$compress_reads_command"
 
@@ -227,14 +227,17 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
             echo '<3 nf-core' | gzip -n > "\$1"
         }
 
-        while IFS= read -r SEQ_1 SEQ_2 PREFIX; do
+        while IFS=' ' read -r SEQ_1 SEQ_2 PREFIX; do
             echo "\${SEQ_1} \${SEQ_2}"
             echo "\${PREFIX}"
 
             echo krakenuniq \\
                 --db $db \\
                 --threads $task.cpus \\
-                \${OPTIONS} \\
+                $report \\
+                $output_option \\
+                $unclassified_option \\
+                $classified_option \\
                 --paired \\
                 $args2 \\
                 "\${SEQ_1}" "\${SEQ_2}"
@@ -243,7 +246,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
             create_file "\${PREFIX}.krakenuniq.report.txt"
             create_gzip_file "\${PREFIX}.merged.classified.${sequence_type}.gz"
             create_gzip_file "\${PREFIX}.merged.unclassified.${sequence_type}.gz"
-        done
+        done < options.txt
 
         echo "$compress_reads_command"
 

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.function.nf.test
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.function.nf.test
@@ -1,0 +1,129 @@
+nextflow_function {
+    name "Test Functions in Module KRAKENUNIQ_PRELOADEDKRAKENUNIQ"
+    script "../main.nf"
+    tag "krakenuniq"
+    tag "krakenuniq/preloadedkrakenuniq"
+
+    test("Test Function get_single_prefix with FASTA input") {
+
+        function "get_single_prefix"
+
+        when {
+            function {
+                """
+                input[0] = file('sample.1234.fasta')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result == 'sample.1234' },
+            )
+        }
+    }
+
+    test("Test Function get_single_prefix with compressed FASTA input") {
+
+        function "get_single_prefix"
+
+        when {
+            function {
+                """
+                input[0] = file('sample.1234.fasta.gz')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result == 'sample.1234' },
+            )
+        }
+    }
+
+    test("Test Function get_single_prefix with FASTQ input") {
+
+        function "get_single_prefix"
+
+        when {
+            function {
+                """
+                input[0] = file('sample.1234.fastq')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result == 'sample.1234' },
+            )
+        }
+    }
+
+    test("Test Function get_single_prefix with compressed FASTQ input") {
+
+        function "get_single_prefix"
+
+        when {
+            function {
+                """
+                input[0] = file('sample.1234.fastq.gz')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result == 'sample.1234' },
+            )
+        }
+    }
+
+    test("Test Function get_paired_prefix with compressed FASTA input") {
+
+        function "get_paired_prefix"
+
+        when {
+            function {
+                """
+                input[0] = file('sample.1234.1.fasta.gz')
+                input[1] = file('sample.1234.2.fasta.gz')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result == 'sample.1234' },
+            )
+        }
+    }
+
+    test("Test Function get_paired_prefix with compressed FASTQ input") {
+
+        function "get_paired_prefix"
+
+        when {
+            function {
+                """
+                input[0] = file('sample_1234_1.fasta.gz')
+                input[1] = file('sample_1234_2.fasta.gz')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result == 'sample_1234' },
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test
@@ -32,7 +32,9 @@ nextflow_process {
                 """
                 input[0] = [
                     [id:'test', single_end:true],
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
+                    ]
                 ]
                 input[1] = 'fasta'
                 input[2] = UNTAR.out.untar.map { it[1] }
@@ -69,7 +71,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id:'test', single_end:true],
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true)
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true)]
                 ]
                 input[1] = 'fastq'
                 input[2] = UNTAR.out.untar.map { it[1] }
@@ -148,7 +150,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id:'test', single_end:true],
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)]
                 ]
                 input[1] = 'fasta'
                 input[2] = UNTAR.out.untar.map { it[1] }
@@ -188,7 +190,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id:'test', single_end:true],
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true)
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true)]
                 ]
                 input[1] = 'fastq'
                 input[2] = UNTAR.out.untar.map { it[1] }


### PR DESCRIPTION
Updating the module will address the following bug in the taxprofiler pipeline https://github.com/nf-core/taxprofiler/issues/533
