### PR TITLE
Add Stimulus analysis-default

### DIFF
--- a/modules/nf-core/stimulus/analysisdefault/environment.yml
+++ b/modules/nf-core/stimulus/analysisdefault/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "YOUR-TOOL-HERE"

--- a/modules/nf-core/stimulus/analysisdefault/environment.yml
+++ b/modules/nf-core/stimulus/analysisdefault/environment.yml
@@ -4,4 +4,14 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "YOUR-TOOL-HERE"
+  - python=3.12
+  - pytorch
+  - matplotlib
+  - pandas
+  - polars
+  - ray
+  - safetensors
+  - scikit-learn
+  # NOTE https://github.com/nf-core/modules/issues/5814
+  - pip:
+      - stimulus-py

--- a/modules/nf-core/stimulus/analysisdefault/environment.yml
+++ b/modules/nf-core/stimulus/analysisdefault/environment.yml
@@ -1,19 +1,13 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda
+
 dependencies:
-  - conda-forge::python=3.12
-  - conda-forge::pytorch=2.4.1
   - conda-forge::matplotlib=3.9.2
   - conda-forge::pandas=2.2.3
   - conda-forge::polars=1.9.0
+  - conda-forge::python=3.12
+  - conda-forge::pytorch=2.4.1
   - conda-forge::ray-core=2.37.0
   - conda-forge::safetensors=0.4.5
   - conda-forge::scikit-learn=1.5.2
-  # NOTE https://github.com/nf-core/modules/issues/5814
-  - pip:
-      # this will not lint, it fails the check with 1 equal sign
-      # and crashes tools with 2
-      - stimulus-py=0.0.9

--- a/modules/nf-core/stimulus/analysisdefault/environment.yml
+++ b/modules/nf-core/stimulus/analysisdefault/environment.yml
@@ -4,14 +4,16 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python=3.12
-  - pytorch
-  - matplotlib
-  - pandas
-  - polars
-  - ray
-  - safetensors
-  - scikit-learn
+  - conda-forge::python=3.12
+  - conda-forge::pytorch=2.4.1
+  - conda-forge::matplotlib=3.9.2
+  - conda-forge::pandas=2.2.3
+  - conda-forge::polars=1.9.0
+  - conda-forge::ray-core=2.37.0
+  - conda-forge::safetensors=0.4.5
+  - conda-forge::scikit-learn=1.5.2
   # NOTE https://github.com/nf-core/modules/issues/5814
   - pip:
-      - stimulus-py
+      # this will not lint, it fails the check with 1 equal sign
+      # and crashes tools with 2
+      - stimulus-py=0.0.9

--- a/modules/nf-core/stimulus/analysisdefault/main.nf
+++ b/modules/nf-core/stimulus/analysisdefault/main.nf
@@ -1,43 +1,18 @@
-// TODO nf-core: If in doubt look at other nf-core/modules to see how we are doing things! :)
-//               https://github.com/nf-core/modules/tree/master/modules/nf-core/
-//               You can also ask for help via your pull request or on the #modules channel on the nf-core Slack workspace:
-//               https://nf-co.re/join
-// DONE nf-core: A module file SHOULD only define input and output files as command-line parameters.
-//               All other parameters MUST be provided using the "task.ext" directive, see here:
-//               https://www.nextflow.io/docs/latest/process.html#ext
-//               where "task.ext" is a string.
-//               Any parameters that need to be evaluated in the context of a particular sample
-//               e.g. single-end/paired-end data MUST also be defined and evaluated appropriately.
-// DONE nf-core: Software that can be piped together SHOULD be added to separate module files
-//               unless there is a run-time, storage advantage in implementing in this way
-//               e.g. it's ok to have a single module for bwa to output BAM instead of SAM:
-//                 bwa mem | samtools view -B -T ref.fasta
-// DONE nf-core: Optional inputs are not currently supported by Nextflow. However, using an empty
-//               list (`[]`) instead of a file can be used to work around this issue.
-
 process STIMULUS_ANALYSISDEFAULT {
     tag "$meta.id"
     label 'process_medium'
 
-    // DONE nf-core: List required Conda package(s).
-    //               Software MUST be pinned to channel (i.e. "bioconda"), version (i.e. "1.10").
-    //               For Conda, the build (i.e. "h9402c20_2") must be EXCLUDED to support installation on different operating systems.
-    // DONE nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
-    // conda "${moduleDir}/environment.yml"
+    // TODO: Add singularity support
     // container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     //     'https://depot.galaxyproject.org/singularity/YOUR-TOOL-HERE':
     //     'biocontainers/YOUR-TOOL-HERE' }"
+
+    conda "${moduleDir}/environment.yml"
     container "docker.io/mathysgrapotte/stimulus-py:latest"
 
     input:
-    // TODO nf-core: Where applicable all sample-specific information e.g. "id", "single_end", "read_group"
-    //               MUST be provided as an input via a Groovy Map called "meta".
-    //               This information may not be required in some instances e.g. indexing reference genome files:
-    //               https://github.com/nf-core/modules/blob/master/modules/nf-core/bwa/index/main.nf
-    // TODO nf-core: Where applicable please provide/convert compressed files as input/output
-    //               e.g. "*.fastq.gz" and NOT "*.fastq", "*.bam" and NOT "*.sam" etc.
     path(data)
-    path(experiment_config)
+    tuple val(meta), path(experiment_config)
     path(model_config)
     path(weights)
     path(optimizer)
@@ -45,9 +20,7 @@ process STIMULUS_ANALYSISDEFAULT {
     path(model)
 
     output:
-    // TODO nf-core: Named file extensions MUST be emitted for ALL output channels
-    tuple val(meta), path("*_modelcheck.log"), path("performance_tune_train/"), path("performance_robustness/"), emit: analysis
-    // DONE nf-core: List additional required output channels/values here
+    tuple val(meta), path("performance_tune_train/"), path("performance_robustness/"), emit: analysis
     path "versions.yml"           , emit: versions
 
     when:
@@ -56,15 +29,7 @@ process STIMULUS_ANALYSISDEFAULT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    // DONE nf-core: Where possible, a command MUST be provided to obtain the version number of the software e.g. 1.10
-    //               If the software is unable to output a version number on the command-line then it can be manually specified
-    //               e.g. https://github.com/nf-core/modules/blob/master/modules/nf-core/homer/annotatepeaks/main.nf
-    //               Each software used MUST provide the software name and version number in the YAML version file (versions.yml)
-    // DONE nf-core: It MUST be possible to pass additional parameters to the tool as a command-line string via the "task.ext.args" directive
-    // DONE nf-core: If the tool supports multi-threading then you MUST provide the appropriate parameter
-    //               using the Nextflow "task" variable e.g. "--threads $task.cpus"
-    // DONE nf-core: Please replace the example samtools command below with your module's command
-    // DONE nf-core: Please indent the command appropriately (4 spaces!!) to help with readability ;)
+
     """
     stimulus-analysis-default \\
         $args \\
@@ -78,15 +43,18 @@ process STIMULUS_ANALYSISDEFAULT {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        stimulus: \$(samtools --version |& sed '1!d ; s/samtools //')
+        Python: \$(python --version | cut -d ' ' -f 2)
+        Stimulus-py: \$( pip show stimulus-py | grep Version)
     END_VERSIONS
     """
 
     stub:
     def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
     def STIMULUS_VER = '0.0.9' // container not used in stub, change manually
     """
-    touch ${meta.id}_modelcheck.log
+    mkdir performance_tune_train/
+    mkdir performance_robustness/
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/stimulus/analysisdefault/main.nf
+++ b/modules/nf-core/stimulus/analysisdefault/main.nf
@@ -7,17 +7,17 @@ process STIMULUS_ANALYSISDEFAULT {
     //     'https://depot.galaxyproject.org/singularity/YOUR-TOOL-HERE':
     //     'biocontainers/YOUR-TOOL-HERE' }"
 
-    conda "${moduleDir}/environment.yml"
+    // TODO: Enable when stimulus is on conda-forge
+    // conda "${moduleDir}/environment.yml"
     container "docker.io/mathysgrapotte/stimulus-py:latest"
 
     input:
-    path(data)
+    path(model)
+    path(weights)
+    path(metrics)
     tuple val(meta), path(experiment_config)
     path(model_config)
-    path(weights)
-    path(optimizer)
-    path(metrics)
-    path(model)
+    path(data)
 
     output:
     tuple val(meta), path("performance_tune_train/"), path("performance_robustness/"), emit: analysis
@@ -29,7 +29,7 @@ process STIMULUS_ANALYSISDEFAULT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-
+    def STIMULUS_VER = '0.0.9'
     """
     stimulus-analysis-default \\
         $args \\
@@ -44,7 +44,7 @@ process STIMULUS_ANALYSISDEFAULT {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         Python: \$(python --version | cut -d ' ' -f 2)
-        Stimulus-py: \$( pip show stimulus-py | grep Version)
+        Stimulus-py: ${STIMULUS_VER}
     END_VERSIONS
     """
 

--- a/modules/nf-core/stimulus/analysisdefault/main.nf
+++ b/modules/nf-core/stimulus/analysisdefault/main.nf
@@ -2,31 +2,32 @@
 //               https://github.com/nf-core/modules/tree/master/modules/nf-core/
 //               You can also ask for help via your pull request or on the #modules channel on the nf-core Slack workspace:
 //               https://nf-co.re/join
-// TODO nf-core: A module file SHOULD only define input and output files as command-line parameters.
+// DONE nf-core: A module file SHOULD only define input and output files as command-line parameters.
 //               All other parameters MUST be provided using the "task.ext" directive, see here:
 //               https://www.nextflow.io/docs/latest/process.html#ext
 //               where "task.ext" is a string.
 //               Any parameters that need to be evaluated in the context of a particular sample
 //               e.g. single-end/paired-end data MUST also be defined and evaluated appropriately.
-// TODO nf-core: Software that can be piped together SHOULD be added to separate module files
+// DONE nf-core: Software that can be piped together SHOULD be added to separate module files
 //               unless there is a run-time, storage advantage in implementing in this way
 //               e.g. it's ok to have a single module for bwa to output BAM instead of SAM:
 //                 bwa mem | samtools view -B -T ref.fasta
-// TODO nf-core: Optional inputs are not currently supported by Nextflow. However, using an empty
+// DONE nf-core: Optional inputs are not currently supported by Nextflow. However, using an empty
 //               list (`[]`) instead of a file can be used to work around this issue.
 
 process STIMULUS_ANALYSISDEFAULT {
     tag "$meta.id"
     label 'process_medium'
 
-    // TODO nf-core: List required Conda package(s).
+    // DONE nf-core: List required Conda package(s).
     //               Software MUST be pinned to channel (i.e. "bioconda"), version (i.e. "1.10").
     //               For Conda, the build (i.e. "h9402c20_2") must be EXCLUDED to support installation on different operating systems.
-    // TODO nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
-    conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/YOUR-TOOL-HERE':
-        'biocontainers/YOUR-TOOL-HERE' }"
+    // DONE nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
+    // conda "${moduleDir}/environment.yml"
+    // container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    //     'https://depot.galaxyproject.org/singularity/YOUR-TOOL-HERE':
+    //     'biocontainers/YOUR-TOOL-HERE' }"
+    container "docker.io/mathysgrapotte/stimulus-py:latest"
 
     input:
     // TODO nf-core: Where applicable all sample-specific information e.g. "id", "single_end", "read_group"
@@ -35,12 +36,18 @@ process STIMULUS_ANALYSISDEFAULT {
     //               https://github.com/nf-core/modules/blob/master/modules/nf-core/bwa/index/main.nf
     // TODO nf-core: Where applicable please provide/convert compressed files as input/output
     //               e.g. "*.fastq.gz" and NOT "*.fastq", "*.bam" and NOT "*.sam" etc.
-    tuple val(meta), path(bam)
+    path(data)
+    path(experiment_config)
+    path(model_config)
+    path(weights)
+    path(optimizer)
+    path(metrics)
+    path(model)
 
     output:
     // TODO nf-core: Named file extensions MUST be emitted for ALL output channels
-    tuple val(meta), path("*.bam"), emit: bam
-    // TODO nf-core: List additional required output channels/values here
+    tuple val(meta), path("*_modelcheck.log"), path("performance_tune_train/"), path("performance_robustness/"), emit: analysis
+    // DONE nf-core: List additional required output channels/values here
     path "versions.yml"           , emit: versions
 
     when:
@@ -49,23 +56,25 @@ process STIMULUS_ANALYSISDEFAULT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    // TODO nf-core: Where possible, a command MUST be provided to obtain the version number of the software e.g. 1.10
+    // DONE nf-core: Where possible, a command MUST be provided to obtain the version number of the software e.g. 1.10
     //               If the software is unable to output a version number on the command-line then it can be manually specified
     //               e.g. https://github.com/nf-core/modules/blob/master/modules/nf-core/homer/annotatepeaks/main.nf
     //               Each software used MUST provide the software name and version number in the YAML version file (versions.yml)
-    // TODO nf-core: It MUST be possible to pass additional parameters to the tool as a command-line string via the "task.ext.args" directive
-    // TODO nf-core: If the tool supports multi-threading then you MUST provide the appropriate parameter
+    // DONE nf-core: It MUST be possible to pass additional parameters to the tool as a command-line string via the "task.ext.args" directive
+    // DONE nf-core: If the tool supports multi-threading then you MUST provide the appropriate parameter
     //               using the Nextflow "task" variable e.g. "--threads $task.cpus"
-    // TODO nf-core: Please replace the example samtools command below with your module's command
-    // TODO nf-core: Please indent the command appropriately (4 spaces!!) to help with readability ;)
+    // DONE nf-core: Please replace the example samtools command below with your module's command
+    // DONE nf-core: Please indent the command appropriately (4 spaces!!) to help with readability ;)
     """
-    samtools \\
-        sort \\
+    stimulus-analysis-default \\
         $args \\
-        -@ $task.cpus \\
-        -o ${prefix}.bam \\
-        -T $prefix \\
-        $bam
+        -m ${model} \\
+        -w ${weights} \\
+        -me ${metrics} \\
+        -ec ${experiment_config} \\
+        -mc ${model_config} \\
+        -d ${data} \\
+        -o .
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -75,17 +84,14 @@ process STIMULUS_ANALYSISDEFAULT {
 
     stub:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    // TODO nf-core: A stub section should mimic the execution of the original module as best as possible
-    //               Have a look at the following examples:
-    //               Simple example: https://github.com/nf-core/modules/blob/818474a292b4860ae8ff88e149fbcda68814114d/modules/nf-core/bcftools/annotate/main.nf#L47-L63
-    //               Complex example: https://github.com/nf-core/modules/blob/818474a292b4860ae8ff88e149fbcda68814114d/modules/nf-core/bedtools/split/main.nf#L38-L54
+    def STIMULUS_VER = '0.0.9' // container not used in stub, change manually
     """
-    touch ${prefix}.bam
+    touch ${meta.id}_modelcheck.log
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        stimulus: \$(samtools --version |& sed '1!d ; s/samtools //')
+        Python: \$(python --version | cut -d ' ' -f 2)
+        Stimulus-py: ${STIMULUS_VER}
     END_VERSIONS
     """
 }

--- a/modules/nf-core/stimulus/analysisdefault/main.nf
+++ b/modules/nf-core/stimulus/analysisdefault/main.nf
@@ -1,0 +1,91 @@
+// TODO nf-core: If in doubt look at other nf-core/modules to see how we are doing things! :)
+//               https://github.com/nf-core/modules/tree/master/modules/nf-core/
+//               You can also ask for help via your pull request or on the #modules channel on the nf-core Slack workspace:
+//               https://nf-co.re/join
+// TODO nf-core: A module file SHOULD only define input and output files as command-line parameters.
+//               All other parameters MUST be provided using the "task.ext" directive, see here:
+//               https://www.nextflow.io/docs/latest/process.html#ext
+//               where "task.ext" is a string.
+//               Any parameters that need to be evaluated in the context of a particular sample
+//               e.g. single-end/paired-end data MUST also be defined and evaluated appropriately.
+// TODO nf-core: Software that can be piped together SHOULD be added to separate module files
+//               unless there is a run-time, storage advantage in implementing in this way
+//               e.g. it's ok to have a single module for bwa to output BAM instead of SAM:
+//                 bwa mem | samtools view -B -T ref.fasta
+// TODO nf-core: Optional inputs are not currently supported by Nextflow. However, using an empty
+//               list (`[]`) instead of a file can be used to work around this issue.
+
+process STIMULUS_ANALYSISDEFAULT {
+    tag "$meta.id"
+    label 'process_medium'
+
+    // TODO nf-core: List required Conda package(s).
+    //               Software MUST be pinned to channel (i.e. "bioconda"), version (i.e. "1.10").
+    //               For Conda, the build (i.e. "h9402c20_2") must be EXCLUDED to support installation on different operating systems.
+    // TODO nf-core: See section in main README for further information regarding finding and adding container addresses to the section below.
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/YOUR-TOOL-HERE':
+        'biocontainers/YOUR-TOOL-HERE' }"
+
+    input:
+    // TODO nf-core: Where applicable all sample-specific information e.g. "id", "single_end", "read_group"
+    //               MUST be provided as an input via a Groovy Map called "meta".
+    //               This information may not be required in some instances e.g. indexing reference genome files:
+    //               https://github.com/nf-core/modules/blob/master/modules/nf-core/bwa/index/main.nf
+    // TODO nf-core: Where applicable please provide/convert compressed files as input/output
+    //               e.g. "*.fastq.gz" and NOT "*.fastq", "*.bam" and NOT "*.sam" etc.
+    tuple val(meta), path(bam)
+
+    output:
+    // TODO nf-core: Named file extensions MUST be emitted for ALL output channels
+    tuple val(meta), path("*.bam"), emit: bam
+    // TODO nf-core: List additional required output channels/values here
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    // TODO nf-core: Where possible, a command MUST be provided to obtain the version number of the software e.g. 1.10
+    //               If the software is unable to output a version number on the command-line then it can be manually specified
+    //               e.g. https://github.com/nf-core/modules/blob/master/modules/nf-core/homer/annotatepeaks/main.nf
+    //               Each software used MUST provide the software name and version number in the YAML version file (versions.yml)
+    // TODO nf-core: It MUST be possible to pass additional parameters to the tool as a command-line string via the "task.ext.args" directive
+    // TODO nf-core: If the tool supports multi-threading then you MUST provide the appropriate parameter
+    //               using the Nextflow "task" variable e.g. "--threads $task.cpus"
+    // TODO nf-core: Please replace the example samtools command below with your module's command
+    // TODO nf-core: Please indent the command appropriately (4 spaces!!) to help with readability ;)
+    """
+    samtools \\
+        sort \\
+        $args \\
+        -@ $task.cpus \\
+        -o ${prefix}.bam \\
+        -T $prefix \\
+        $bam
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        stimulus: \$(samtools --version |& sed '1!d ; s/samtools //')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    // TODO nf-core: A stub section should mimic the execution of the original module as best as possible
+    //               Have a look at the following examples:
+    //               Simple example: https://github.com/nf-core/modules/blob/818474a292b4860ae8ff88e149fbcda68814114d/modules/nf-core/bcftools/annotate/main.nf#L47-L63
+    //               Complex example: https://github.com/nf-core/modules/blob/818474a292b4860ae8ff88e149fbcda68814114d/modules/nf-core/bedtools/split/main.nf#L38-L54
+    """
+    touch ${prefix}.bam
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        stimulus: \$(samtools --version |& sed '1!d ; s/samtools //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/stimulus/analysisdefault/meta.yml
+++ b/modules/nf-core/stimulus/analysisdefault/meta.yml
@@ -1,22 +1,23 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "stimulus_analysisdefault"
-## TODO nf-core: Add a description of the module and list keywords
-description: write your description here
+## DONE nf-core: Add a description of the module and list keywords
+description: Model robustness analysis and reporting from the stimulus package.
 keywords:
-  - sort
-  - example
-  - genomics
+  - reporting
+  - machine learning
+  - hyperparameters
+  - optimisation
 tools:
   - "stimulus":
-      ## TODO nf-core: Add a description and other details for the software below
-      description: ""
-      homepage: ""
-      documentation: ""
-      tool_dev_url: ""
+      ## DONE nf-core: Add a description and other details for the software below
+      description: "Python package for processing deep learning models"
+      homepage: "https://github.com/mathysgrapotte/stimulus-py"
+      documentation: "https://github.com/mathysgrapotte/stimulus-py"
+      tool_dev_url: "https://github.com/mathysgrapotte/stimulus-py"
       doi: ""
-      licence: 
-      identifier: 
+      licence: ["MIT License"]
+      identifier: ""
 
 ## TODO nf-core: Add a description of all of the variables used as input
 input:

--- a/modules/nf-core/stimulus/analysisdefault/meta.yml
+++ b/modules/nf-core/stimulus/analysisdefault/meta.yml
@@ -1,62 +1,62 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "stimulus_analysisdefault"
-## DONE nf-core: Add a description of the module and list keywords
 description: Model robustness analysis and reporting from the stimulus package.
 keywords:
-  - reporting
   - machine learning
-  - hyperparameters
-  - optimisation
+  - neural network
+  - unit test
 tools:
   - "stimulus":
-      ## DONE nf-core: Add a description and other details for the software below
-      description: "Python package for processing deep learning models"
+      description: "Stochastic Testing and Input Manipulation for Unbiased Learning Systems"
       homepage: "https://github.com/mathysgrapotte/stimulus-py"
       documentation: "https://github.com/mathysgrapotte/stimulus-py"
       tool_dev_url: "https://github.com/mathysgrapotte/stimulus-py"
-      doi: ""
-      licence: ["MIT License"]
-      identifier: ""
+      licence: ["MIT"]
 
-## TODO nf-core: Add a description of all of the variables used as input
 input:
-  # Only when we have meta
+  - - model:
+        type: file
+        description: "The model .py file."
+        pattern: "*.py"
+  - - weights:
+        type: file
+        description: "Model weights .pt file."
+        pattern: "*.pt"
+  - - metrics:
+        type: file
+        description: "The file path for the metrics file obtained during tuning."
   - - meta:
         type: map
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'sample1', single_end:false ]`
-  
-  ## TODO nf-core: Delete / customise this example input
-    - bam:
+    - experiment_config:
         type: file
-        description: Sorted BAM/CRAM/SAM file
-        pattern: "*.{bam,cram,sam}"
-        ontologies:
-          - edam: "http://edamontology.org/format_25722"
-          - edam: "http://edamontology.org/format_2573"
-          - edam: "http://edamontology.org/format_3462"
-          
+        description: "The experiment config used to modify the data."
+        pattern: "*.yml"
+  - - model_config:
+        type: file
+        description: "The tune config file."
+        pattern: "*.yml"
+  - - data:
+        type: file
+        description: "List of data files to be used for the analysis."
 
 ## TODO nf-core: Add a description of all of the variables used as output
-output:
-  - bam:
-  #Only when we have meta
+output:        
+  - analysis:
     - meta:
         type: map
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'sample1', single_end:false ]`
-  ## TODO nf-core: Delete / customise this example output
-    - "*.bam":
-        type: file
-        description: Sorted BAM/CRAM/SAM file
-        pattern: "*.{bam,cram,sam}"
-        ontologies:
-          - edam: "http://edamontology.org/format_25722"
-          - edam: "http://edamontology.org/format_2573"
-          - edam: "http://edamontology.org/format_3462"
+    - "performance_tune_train/":
+        type: directory
+        description: "Output directory with images detailing performance during tuning/training."
+    - "performance_robustness/":
+        type: directory
+        description: "Output directory with images detailing model robustness."
           
   - versions:
     - "versions.yml":

--- a/modules/nf-core/stimulus/analysisdefault/meta.yml
+++ b/modules/nf-core/stimulus/analysisdefault/meta.yml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "stimulus_analysisdefault"
+## TODO nf-core: Add a description of the module and list keywords
+description: write your description here
+keywords:
+  - sort
+  - example
+  - genomics
+tools:
+  - "stimulus":
+      ## TODO nf-core: Add a description and other details for the software below
+      description: ""
+      homepage: ""
+      documentation: ""
+      tool_dev_url: ""
+      doi: ""
+      licence: 
+      identifier: 
+
+## TODO nf-core: Add a description of all of the variables used as input
+input:
+  # Only when we have meta
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+  
+  ## TODO nf-core: Delete / customise this example input
+    - bam:
+        type: file
+        description: Sorted BAM/CRAM/SAM file
+        pattern: "*.{bam,cram,sam}"
+        ontologies:
+          - edam: "http://edamontology.org/format_25722"
+          - edam: "http://edamontology.org/format_2573"
+          - edam: "http://edamontology.org/format_3462"
+          
+
+## TODO nf-core: Add a description of all of the variables used as output
+output:
+  - bam:
+  #Only when we have meta
+    - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+  ## TODO nf-core: Delete / customise this example output
+    - "*.bam":
+        type: file
+        description: Sorted BAM/CRAM/SAM file
+        pattern: "*.{bam,cram,sam}"
+        ontologies:
+          - edam: "http://edamontology.org/format_25722"
+          - edam: "http://edamontology.org/format_2573"
+          - edam: "http://edamontology.org/format_3462"
+          
+  - versions:
+    - "versions.yml":
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+
+authors:
+  - "@tombch"
+maintainers:
+  - "@tombch"

--- a/modules/nf-core/stimulus/analysisdefault/tests/main.nf.test
+++ b/modules/nf-core/stimulus/analysisdefault/tests/main.nf.test
@@ -1,0 +1,74 @@
+// TODO nf-core: Once you have added the required tests, please run the following command to build this file:
+// nf-core modules test stimulus/analysisdefault
+nextflow_process {
+
+    name "Test Process STIMULUS_ANALYSISDEFAULT"
+    script "../main.nf"
+    process "STIMULUS_ANALYSISDEFAULT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "stimulus"
+    tag "stimulus/analysisdefault"
+
+    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used
+    test("sarscov2 - bam") {
+
+        // TODO nf-core: If you are created a test for a chained module
+        // (the module requires running more than one process to generate the required output)
+        // add the 'setup' method here.
+        // You can find more information about how to use a 'setup' method in the docs (https://nf-co.re/docs/contributing/modules#steps-for-creating-nf-test-for-chained-modules).
+
+        when {
+            process {
+                """
+                // TODO nf-core: define inputs of the process here. Example:
+                
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+                //TODO nf-core: Add all required assertions to verify the test output.
+                // See https://nf-co.re/docs/contributing/tutorials/nf-test_assertions for more information and examples.
+            )
+        }
+
+    }
+
+    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used but keep the " - stub" suffix.
+    test("sarscov2 - bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                // TODO nf-core: define inputs of the process here. Example:
+                
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+                //TODO nf-core: Add all required assertions to verify the test output.
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/stimulus/analysisdefault/tests/main.nf.test
+++ b/modules/nf-core/stimulus/analysisdefault/tests/main.nf.test
@@ -1,5 +1,3 @@
-// TODO nf-core: Once you have added the required tests, please run the following command to build this file:
-// nf-core modules test stimulus/analysisdefault
 nextflow_process {
 
     name "Test Process STIMULUS_ANALYSISDEFAULT"
@@ -11,23 +9,16 @@ nextflow_process {
     tag "stimulus"
     tag "stimulus/analysisdefault"
 
-    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used
-    test("sarscov2 - bam") {
-
-        // TODO nf-core: If you are created a test for a chained module
-        // (the module requires running more than one process to generate the required output)
-        // add the 'setup' method here.
-        // You can find more information about how to use a 'setup' method in the docs (https://nf-co.re/docs/contributing/modules#steps-for-creating-nf-test-for-chained-modules).
+    test("analysis_default") {
 
         when {
             process {
                 """
-                // TODO nf-core: define inputs of the process here. Example:
-                
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
-                ]
+                    [ id:'test'], // meta map
+                    file(params.modules_testdata_base_path + "../../deepmodeloptim/testdata/dna_experiment/experiment_config.json", checkIfExists: true)
+                    ]
+                input[1] = file(params.modules_testdata_base_path + "../../deepmodeloptim/testdata/dna_experiment/input_data_with_split.csv", checkIfExists: true)
                 """
             }
         }
@@ -36,27 +27,23 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out).match() }
-                //TODO nf-core: Add all required assertions to verify the test output.
-                // See https://nf-co.re/docs/contributing/tutorials/nf-test_assertions for more information and examples.
             )
         }
 
     }
 
-    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used but keep the " - stub" suffix.
-    test("sarscov2 - bam - stub") {
+    test("analysis_default - stub") {
 
         options "-stub"
 
         when {
             process {
                 """
-                // TODO nf-core: define inputs of the process here. Example:
-                
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
-                ]
+                    [ id:'test'], // meta map
+                    file(params.modules_testdata_base_path + "../../deepmodeloptim/testdata/dna_experiment/experiment_config.json", checkIfExists: true)
+                    ]
+                input[1] = file(params.modules_testdata_base_path + "../../deepmodeloptim/testdata/dna_experiment/input_data_with_split.csv", checkIfExists: true)
                 """
             }
         }
@@ -65,7 +52,6 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out).match() }
-                //TODO nf-core: Add all required assertions to verify the test output.
             )
         }
 


### PR DESCRIPTION
Add module to run analysis function of stimulus.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
