### PR TITLE
Bump checkm/qa version

### DIFF
--- a/modules/nf-core/checkm/lineagewf/main.nf
+++ b/modules/nf-core/checkm/lineagewf/main.nf
@@ -4,8 +4,8 @@ process CHECKM_LINEAGEWF {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/checkm-genome:1.2.3--pyhdfd78af_0' :
-        'biocontainers/checkm-genome:1.2.3--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/checkm-genome:1.2.3--pyhdfd78af_1' :
+        'biocontainers/checkm-genome:1.2.3--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(fasta, stageAs: "input_bins/*")

--- a/modules/nf-core/checkm/qa/environment.yml
+++ b/modules/nf-core/checkm/qa/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::checkm-genome=1.2.2
+  - bioconda::checkm-genome=1.2.3

--- a/modules/nf-core/checkm/qa/main.nf
+++ b/modules/nf-core/checkm/qa/main.nf
@@ -4,8 +4,8 @@ process CHECKM_QA {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/checkm-genome:1.2.1--pyhdfd78af_0' :
-        'biocontainers/checkm-genome:1.2.2--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/checkm-genome:1.2.3--pyhdfd78af_1' :
+        'biocontainers/checkm-genome:1.2.3--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(analysis_dir), path(marker_file), path(coverage_file)
@@ -23,8 +23,8 @@ process CHECKM_QA {
     def args     = task.ext.args ?: ''
     prefix       = task.ext.prefix ?: "${meta.id}"
     suffix       = task.ext.args?.matches(".*-o 9.*|.*--out_file 9.*") ? "fasta" : "txt"
-    def coverage = coverage_file                                   ? "--coverage_file ${coverage_file}"  : ""
-    def exclude  = exclude_marker_file                             ? "--exclude_markers ${marker_filer}" : ""
+    def coverage = coverage_file.isFile()                              ? "--coverage_file ${coverage_file}"  : ""
+    def exclude  = exclude_marker_file                                 ? "--exclude_markers ${exclude_marker_file}" : ""
     """
     checkm \\
         qa \\
@@ -33,7 +33,6 @@ process CHECKM_QA {
         $marker_file \\
         $analysis_dir \\
         $coverage \\
-        $exclude \\
         $args
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/checkm/qa/tests/main.nf.test
+++ b/modules/nf-core/checkm/qa/tests/main.nf.test
@@ -1,0 +1,51 @@
+nextflow_process {
+
+    name "Test Process CHECKM_QA"
+    script "../main.nf"
+    process "CHECKM_QA"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "checkm"
+    tag "checkm/qa"
+    tag "checkm/lineagewf"
+
+    test("Test CheckM QA") {
+
+        setup {
+            run("CHECKM_LINEAGEWF") {
+                script "../../lineagewf/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test', single_end:false ], // meta map
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true)
+                    ]
+                    input[1] = 'fasta'
+                    input[2] = [] // Download CheckM database
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = CHECKM_LINEAGEWF.out.checkm_output.join(CHECKM_LINEAGEWF.out.marker_file)
+                             .map { v -> v + [file('NO_FILE')] }
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(
+                process.out.output,
+                process.out.fasta,
+                process.out.versions
+            ).match()
+        }
+
+    }
+
+}

--- a/modules/nf-core/checkm/qa/tests/main.nf.test.snap
+++ b/modules/nf-core/checkm/qa/tests/main.nf.test.snap
@@ -1,0 +1,26 @@
+{
+    "Test CheckM QA": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.txt:md5,645f4282569afb4b171396732b2d2582"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,7a0683a78cbf54a6a69ee64055c584a6"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.1",
+            "nextflow": "24.10.0"
+        },
+        "timestamp": "2024-11-01T03:05:13.944833026"
+    }
+}

--- a/modules/nf-core/checkm/qa/tests/tags.yml
+++ b/modules/nf-core/checkm/qa/tests/tags.yml
@@ -1,0 +1,3 @@
+checkm/qa:
+  - modules/nf-core/checkm/lineagewf/**
+  - modules/nf-core/checkm/qa/**


### PR DESCRIPTION
This PR includes:

- Fixes how `coverage_file` file is checked
- Fixes how `exclude` is defined
- Bump checkm version in checkm/qa module to 1.2.3
- Add tests for this module.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
