### PR TITLE
Set mkfastq reports and stats outputs to optional

### DIFF
--- a/modules/nf-core/cellranger/mkfastq/main.nf
+++ b/modules/nf-core/cellranger/mkfastq/main.nf
@@ -10,8 +10,8 @@ process CELLRANGER_MKFASTQ {
     output:
     tuple val(meta), path("*_outs/outs/fastq_path/**/*.fastq.gz")          , emit: fastq
     tuple val(meta), path("*_outs/outs/fastq_path/Undetermined*.fastq.gz") , optional:true, emit: undetermined_fastq
-    tuple val(meta), path("*_outs/outs/fastq_path/Reports")                , emit: reports
-    tuple val(meta), path("*_outs/outs/fastq_path/Stats")                  , emit: stats
+    tuple val(meta), path("*_outs/outs/fastq_path/Reports")                , optional:true, emit: reports
+    tuple val(meta), path("*_outs/outs/fastq_path/Stats")                  , optional:true, emit: stats
     tuple val(meta), path("*_outs/outs/interop_path/*.bin")                , emit: interop
     path "versions.yml"                                                    , emit: versions
 


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes [mkfastq fails on AWS Batch #281](https://github.com/nf-core/demultiplex/issues/281)

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!

### Description of error reported:

`cellranger/mkfastq` process fails when running `nf-core/demultiplex` on AWS Batch with `-profile test_mkfastq,docker`. 
When running locally, the output folders are created (but without files) hence the process ends succesfully. When running on AWS Batch the process fails with the following error:

``` bash
Missing output file(s) `*_outs/outs/fastq_path/Reports` expected by process `NFCORE_DEMULTIPLEX:DEMULTIPLEX:MKFASTQ_DEMULTIPLEX:CELLRANGER_MKFASTQ (test_sample.1)`
```

Some explanation may come from the following [AWS doc](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html) explaining that S3 is a flat system where files are grouped by common prefixes to simulate folders. It also explains that the S3 folders behave differently than local systems. So, uploading an empty folder to S3 may be the cause of the error reported by @KallyopeComp.

## Changes
* Set `reports` output to `optional: true`.
* Set `stats` output to `optional: true`.

Notes:
* Module snapshot was also tested.
* Module linting throws a warning related to the container version.


  
