### PR TITLE
remove pre-commit config validator hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,6 @@ repos:
         files: ^subworkflows/nf-core/.*/meta\.yml$
         args: ["--schemafile", "subworkflows/yaml-schema.json"]
       - id: check-github-workflows
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 39.0.0
-    hooks:
-      - id: renovate-config-validator
   # use ruff for python files
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.2


### PR DESCRIPTION
I thought we did this already... it's just too noisy with updates and we don't need to update the config that often.