### PR TITLE
Skip wave if the PR is from a fork

### DIFF
--- a/.github/workflows/wave.yml
+++ b/.github/workflows/wave.yml
@@ -13,9 +13,10 @@ env:
   NFTEST_VER: "0.9.1"
 
 jobs:
-  gen-matrix:
+  generate-matrix:
     name: generate-matrix
     runs-on: ubuntu-latest
+    if: github.repository == 'nf-core/modules'
 
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
@@ -39,6 +40,7 @@ jobs:
 
   build:
     if: "${{ fromJson(needs.gen-matrix.outputs.matrix) }}"
+    # if: github.repository == 'nf-core/modules'
     needs: gen-matrix
     name: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because it doesn't expose our tower workspace and tower token if it's from a fork.

https://github.com/nf-core/modules/pull/6917