### PR TITLE
chore: bump fgbio version

### DIFF
--- a/modules/nf-core/fgbio/callduplexconsensusreads/environment.yml
+++ b/modules/nf-core/fgbio/callduplexconsensusreads/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.2.1
+  - bioconda::fgbio=2.4.0

--- a/modules/nf-core/fgbio/callduplexconsensusreads/main.nf
+++ b/modules/nf-core/fgbio/callduplexconsensusreads/main.nf
@@ -4,8 +4,8 @@ process FGBIO_CALLDUPLEXCONSENSUSREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fgbio:2.2.1--hdfd78af_0' :
-        'biocontainers/fgbio:2.2.1--hdfd78af_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
+        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
 
     input:
     tuple val(meta), path(grouped_bam)

--- a/modules/nf-core/fgbio/callduplexconsensusreads/tests/main.nf.test.snap
+++ b/modules/nf-core/fgbio/callduplexconsensusreads/tests/main.nf.test.snap
@@ -12,7 +12,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,7277dba1bc055b578eb6d8d6af43b128"
+                    "versions.yml:md5,b2c92e1b52c4e42b0b1e74ec828feb04"
                 ],
                 "bam": [
                     [
@@ -24,15 +24,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,7277dba1bc055b578eb6d8d6af43b128"
+                    "versions.yml:md5,b2c92e1b52c4e42b0b1e74ec828feb04"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-07-02T17:44:41.656625835"
+        "timestamp": "2024-11-11T12:21:15.700422"
     },
     "homo_sapiens - bam": {
         "content": [
@@ -47,7 +47,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,7277dba1bc055b578eb6d8d6af43b128"
+                    "versions.yml:md5,b2c92e1b52c4e42b0b1e74ec828feb04"
                 ],
                 "bam": [
                     [
@@ -59,14 +59,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,7277dba1bc055b578eb6d8d6af43b128"
+                    "versions.yml:md5,b2c92e1b52c4e42b0b1e74ec828feb04"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-17T06:05:28.894178772"
+        "timestamp": "2024-11-11T12:21:02.896452"
     }
 }

--- a/modules/nf-core/fgbio/callmolecularconsensusreads/environment.yml
+++ b/modules/nf-core/fgbio/callmolecularconsensusreads/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.2.1
+  - bioconda::fgbio=2.4.0

--- a/modules/nf-core/fgbio/callmolecularconsensusreads/main.nf
+++ b/modules/nf-core/fgbio/callmolecularconsensusreads/main.nf
@@ -4,8 +4,8 @@ process FGBIO_CALLMOLECULARCONSENSUSREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fgbio:2.2.1--hdfd78af_0' :
-        'biocontainers/fgbio:2.2.1--hdfd78af_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
+        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
 
     input:
     tuple val(meta), path(grouped_bam)

--- a/modules/nf-core/fgbio/callmolecularconsensusreads/tests/main.nf.test.snap
+++ b/modules/nf-core/fgbio/callmolecularconsensusreads/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8a39cbc62685ce7afb5ae36609898bde"
+                    "versions.yml:md5,b5ef59a06877dec12426c4c2c02e887c"
                 ],
                 "bam": [
                     [
@@ -22,15 +22,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8a39cbc62685ce7afb5ae36609898bde"
+                    "versions.yml:md5,b5ef59a06877dec12426c4c2c02e887c"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-17T06:01:29.676084265"
+        "timestamp": "2024-11-11T12:22:07.722755"
     },
     "homo_sapiens - bam": {
         "content": [
@@ -44,7 +44,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8a39cbc62685ce7afb5ae36609898bde"
+                    "versions.yml:md5,b5ef59a06877dec12426c4c2c02e887c"
                 ],
                 "bam": [
                     [
@@ -55,14 +55,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8a39cbc62685ce7afb5ae36609898bde"
+                    "versions.yml:md5,b5ef59a06877dec12426c4c2c02e887c"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:34:16.47828891"
+        "timestamp": "2024-11-11T12:21:46.241305"
     }
 }

--- a/modules/nf-core/fgbio/collectduplexseqmetrics/environment.yml
+++ b/modules/nf-core/fgbio/collectduplexseqmetrics/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::fgbio=2.0.2"
-  - "conda-forge::r-ggplot2=3.4.4"
+  - "bioconda::fgbio=2.4.0"
+  - "conda-forge::r-ggplot2=3.5.1"

--- a/modules/nf-core/fgbio/collectduplexseqmetrics/main.nf
+++ b/modules/nf-core/fgbio/collectduplexseqmetrics/main.nf
@@ -4,8 +4,8 @@ process FGBIO_COLLECTDUPLEXSEQMETRICS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-51891ad0b60843e4aade9cde2eb5d40c5ae92b80:72c944cdea5caff7f03b96034968ce2a4f1737bc-0':
-        'biocontainers/mulled-v2-51891ad0b60843e4aade9cde2eb5d40c5ae92b80:72c944cdea5caff7f03b96034968ce2a4f1737bc-0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d6/d65e7c77d89e7e443384d17a94ffe31fe988b05bc7d695f2a75beaf502721925/data':
+        'community.wave.seqera.io/library/fgbio_r-ggplot2:cf2b9a5308d77b67' }"
 
     input:
     tuple val(meta), path(grouped_bam)

--- a/modules/nf-core/fgbio/collectduplexseqmetrics/tests/main.nf.test.snap
+++ b/modules/nf-core/fgbio/collectduplexseqmetrics/tests/main.nf.test.snap
@@ -41,15 +41,15 @@
                 
             ],
             [
-                "versions.yml:md5,637a7384cd910f0e0541a631c52b95e1"
+                "versions.yml:md5,d19c5782883e16da8a29a27d7074c080"
             ],
             "test.duplex_qc.pdf"
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.3"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-07-17T19:26:23.325859809"
+        "timestamp": "2024-11-11T12:22:45.594572"
     },
     "homo_sapiens - bam": {
         "content": [
@@ -93,14 +93,14 @@
                 
             ],
             [
-                "versions.yml:md5,637a7384cd910f0e0541a631c52b95e1"
+                "versions.yml:md5,d19c5782883e16da8a29a27d7074c080"
             ],
             "test.duplex_qc.pdf"
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.3"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-07-17T19:26:03.1373243"
+        "timestamp": "2024-11-11T12:22:30.764995"
     }
 }

--- a/modules/nf-core/fgbio/fastqtobam/environment.yml
+++ b/modules/nf-core/fgbio/fastqtobam/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.2.1
+  - bioconda::fgbio=2.4.0

--- a/modules/nf-core/fgbio/fastqtobam/main.nf
+++ b/modules/nf-core/fgbio/fastqtobam/main.nf
@@ -4,8 +4,8 @@ process FGBIO_FASTQTOBAM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fgbio:2.2.1--hdfd78af_0' :
-        'biocontainers/fgbio:2.2.1--hdfd78af_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
+        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/fgbio/fastqtobam/tests/main.nf.test.snap
+++ b/modules/nf-core/fgbio/fastqtobam/tests/main.nf.test.snap
@@ -6,14 +6,14 @@
             ],
             "test.cram",
             [
-                "versions.yml:md5,f6c3db3a20ce5e11c96e0ddd8ccd51de"
+                "versions.yml:md5,5f78e5611a92d4bd41337180b6d071b3"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:35:16.955213727"
+        "timestamp": "2024-11-11T12:23:19.214068"
     },
     "homo_sapiens - fastq1": {
         "content": [
@@ -22,14 +22,14 @@
                 
             ],
             [
-                "versions.yml:md5,f6c3db3a20ce5e11c96e0ddd8ccd51de"
+                "versions.yml:md5,5f78e5611a92d4bd41337180b6d071b3"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:35:50.320465546"
+        "timestamp": "2024-11-11T12:23:52.501663"
     },
     "homo_sapiens - [fastq1, fastq2] - default": {
         "content": [
@@ -38,14 +38,14 @@
                 
             ],
             [
-                "versions.yml:md5,f6c3db3a20ce5e11c96e0ddd8ccd51de"
+                "versions.yml:md5,5f78e5611a92d4bd41337180b6d071b3"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:34:53.093519753"
+        "timestamp": "2024-11-11T12:23:02.561152"
     },
     "homo_sapiens - [fastq1, fastq2] - umi": {
         "content": [
@@ -54,14 +54,14 @@
                 
             ],
             [
-                "versions.yml:md5,f6c3db3a20ce5e11c96e0ddd8ccd51de"
+                "versions.yml:md5,5f78e5611a92d4bd41337180b6d071b3"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:36:07.216840033"
+        "timestamp": "2024-11-11T12:24:09.020635"
     },
     "homo_sapiens - [fastq1, fastq2] - bam": {
         "content": [
@@ -70,14 +70,14 @@
                 
             ],
             [
-                "versions.yml:md5,f6c3db3a20ce5e11c96e0ddd8ccd51de"
+                "versions.yml:md5,5f78e5611a92d4bd41337180b6d071b3"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:35:33.666898844"
+        "timestamp": "2024-11-11T12:23:35.97054"
     },
     "homo_sapiens - [fastq1, fastq2] - custom sample": {
         "content": [
@@ -86,14 +86,14 @@
                 
             ],
             [
-                "versions.yml:md5,f6c3db3a20ce5e11c96e0ddd8ccd51de"
+                "versions.yml:md5,5f78e5611a92d4bd41337180b6d071b3"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:36:24.905643178"
+        "timestamp": "2024-11-11T12:24:25.692023"
     },
     "homo_sapiens - [fastq1, fastq2] - stub": {
         "content": [
@@ -102,13 +102,13 @@
                 
             ],
             [
-                "versions.yml:md5,f6c3db3a20ce5e11c96e0ddd8ccd51de"
+                "versions.yml:md5,5f78e5611a92d4bd41337180b6d071b3"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:36:38.954087571"
+        "timestamp": "2024-11-11T12:24:37.828713"
     }
 }

--- a/modules/nf-core/fgbio/filterconsensusreads/environment.yml
+++ b/modules/nf-core/fgbio/filterconsensusreads/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.2.1
+  - bioconda::fgbio=2.4.0

--- a/modules/nf-core/fgbio/filterconsensusreads/main.nf
+++ b/modules/nf-core/fgbio/filterconsensusreads/main.nf
@@ -4,8 +4,8 @@ process FGBIO_FILTERCONSENSUSREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fgbio:2.2.1--hdfd78af_0' :
-        'biocontainers/fgbio:2.2.1--hdfd78af_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
+        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/fgbio/filterconsensusreads/tests/main.nf.test.snap
+++ b/modules/nf-core/fgbio/filterconsensusreads/tests/main.nf.test.snap
@@ -12,7 +12,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,63ca8ca45ef2080260cc973288239e7b"
+                    "versions.yml:md5,851cc03732cb4307aa499b822bb80b33"
                 ],
                 "bam": [
                     [
@@ -24,15 +24,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,63ca8ca45ef2080260cc973288239e7b"
+                    "versions.yml:md5,851cc03732cb4307aa499b822bb80b33"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T06:05:27.436987863"
+        "timestamp": "2024-11-11T12:25:06.750465"
     },
     "sarscov2 - bam": {
         "content": [
@@ -47,7 +47,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,63ca8ca45ef2080260cc973288239e7b"
+                    "versions.yml:md5,851cc03732cb4307aa499b822bb80b33"
                 ],
                 "bam": [
                     [
@@ -59,14 +59,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,63ca8ca45ef2080260cc973288239e7b"
+                    "versions.yml:md5,851cc03732cb4307aa499b822bb80b33"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T06:08:24.799849173"
+        "timestamp": "2024-11-11T12:24:54.71894"
     }
 }

--- a/modules/nf-core/fgbio/groupreadsbyumi/environment.yml
+++ b/modules/nf-core/fgbio/groupreadsbyumi/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.2.1
+  - bioconda::fgbio=2.4.0

--- a/modules/nf-core/fgbio/groupreadsbyumi/main.nf
+++ b/modules/nf-core/fgbio/groupreadsbyumi/main.nf
@@ -4,8 +4,8 @@ process FGBIO_GROUPREADSBYUMI {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fgbio:2.2.1--hdfd78af_0' :
-        'biocontainers/fgbio:2.2.1--hdfd78af_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
+        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/fgbio/groupreadsbyumi/tests/main.nf.test.snap
+++ b/modules/nf-core/fgbio/groupreadsbyumi/tests/main.nf.test.snap
@@ -21,7 +21,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e293eed3614f921114b3bd5b0e1ada10"
+                    "versions.yml:md5,3951d85671eb08c5731449a16bd9a229"
                 ],
                 "bam": [
                     [
@@ -42,15 +42,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,e293eed3614f921114b3bd5b0e1ada10"
+                    "versions.yml:md5,3951d85671eb08c5731449a16bd9a229"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:48:29.108067677"
+        "timestamp": "2024-11-11T12:25:36.897639"
     },
     "sarscov2 - bam": {
         "content": [
@@ -74,7 +74,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e293eed3614f921114b3bd5b0e1ada10"
+                    "versions.yml:md5,3951d85671eb08c5731449a16bd9a229"
                 ],
                 "bam": [
                     [
@@ -95,14 +95,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,e293eed3614f921114b3bd5b0e1ada10"
+                    "versions.yml:md5,3951d85671eb08c5731449a16bd9a229"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:48:14.269677258"
+        "timestamp": "2024-11-11T12:25:25.077144"
     }
 }

--- a/modules/nf-core/fgbio/sortbam/environment.yml
+++ b/modules/nf-core/fgbio/sortbam/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.2.1
+  - bioconda::fgbio=2.4.0

--- a/modules/nf-core/fgbio/sortbam/main.nf
+++ b/modules/nf-core/fgbio/sortbam/main.nf
@@ -4,8 +4,8 @@ process FGBIO_SORTBAM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fgbio:2.2.1--hdfd78af_0' :
-        'biocontainers/fgbio:2.2.1--hdfd78af_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
+        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/fgbio/sortbam/tests/main.nf.test.snap
+++ b/modules/nf-core/fgbio/sortbam/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,384c5398cae017e4fe0df8cb8f004017"
+                    "versions.yml:md5,2d127286141b26c7cf87e99f2875d10e"
                 ],
                 "bam": [
                     [
@@ -22,15 +22,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,384c5398cae017e4fe0df8cb8f004017"
+                    "versions.yml:md5,2d127286141b26c7cf87e99f2875d10e"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T05:37:31.605753331"
+        "timestamp": "2024-11-11T12:26:05.650691"
     },
     "sarscov2 - bam": {
         "content": [
@@ -44,7 +44,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,384c5398cae017e4fe0df8cb8f004017"
+                    "versions.yml:md5,2d127286141b26c7cf87e99f2875d10e"
                 ],
                 "bam": [
                     [
@@ -55,14 +55,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,384c5398cae017e4fe0df8cb8f004017"
+                    "versions.yml:md5,2d127286141b26c7cf87e99f2875d10e"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:48:47.945706955"
+        "timestamp": "2024-11-11T12:25:53.613141"
     }
 }

--- a/modules/nf-core/fgbio/zipperbams/environment.yml
+++ b/modules/nf-core/fgbio/zipperbams/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fgbio=2.2.1
+  - bioconda::fgbio=2.4.0

--- a/modules/nf-core/fgbio/zipperbams/main.nf
+++ b/modules/nf-core/fgbio/zipperbams/main.nf
@@ -4,8 +4,8 @@ process FGBIO_ZIPPERBAMS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fgbio:2.2.1--hdfd78af_0' :
-        'biocontainers/fgbio:2.2.1--hdfd78af_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/87626ef674e2f19366ae6214575a114fe80ce598e796894820550731706a84be/data' :
+        'community.wave.seqera.io/library/fgbio:2.4.0--913bad9d47ff8ddc' }"
 
     input:
     tuple val(meta), path(unmapped_bam)

--- a/modules/nf-core/fgbio/zipperbams/tests/main.nf.test.snap
+++ b/modules/nf-core/fgbio/zipperbams/tests/main.nf.test.snap
@@ -12,7 +12,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,febce3e93c176534d546b12a8766778c"
+                    "versions.yml:md5,14c9cd3297b43902a9a0cb60aea4def4"
                 ],
                 "bam": [
                     [
@@ -24,15 +24,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,febce3e93c176534d546b12a8766778c"
+                    "versions.yml:md5,14c9cd3297b43902a9a0cb60aea4def4"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:29:48.140540051"
+        "timestamp": "2024-11-11T12:26:44.653937"
     },
     "sarscov2 - bam": {
         "content": [
@@ -43,11 +43,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_zipped.bam:md5,b309c59ad774142b42c48b122d1f38bb"
+                        "test_zipped.bam:md5,1980b44177f4720f1005c9be62b09f79"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,febce3e93c176534d546b12a8766778c"
+                    "versions.yml:md5,14c9cd3297b43902a9a0cb60aea4def4"
                 ],
                 "bam": [
                     [
@@ -55,18 +55,18 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_zipped.bam:md5,b309c59ad774142b42c48b122d1f38bb"
+                        "test_zipped.bam:md5,1980b44177f4720f1005c9be62b09f79"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,febce3e93c176534d546b12a8766778c"
+                    "versions.yml:md5,14c9cd3297b43902a9a0cb60aea4def4"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
         },
-        "timestamp": "2024-05-21T10:31:35.808757537"
+        "timestamp": "2024-11-11T12:26:29.680188"
     }
 }


### PR DESCRIPTION
This PR updates the version of fgbio used in all fgbio modules to version 2.4.0. It also switches from biocontainers to Seqera containers.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] Use Seqera Containers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
