### PR TITLE
fq lint module update: exit on failed validation

### DIFF
--- a/modules/nf-core/fq/lint/main.nf
+++ b/modules/nf-core/fq/lint/main.nf
@@ -1,7 +1,6 @@
 process FQ_LINT {
     tag "$meta.id"
     label 'process_low'
-    errorStrategy 'terminate'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -30,10 +29,5 @@ process FQ_LINT {
     "${task.process}":
         fq: \$(echo \$(fq lint --version | sed 's/fq-lint //g'))
     END_VERSIONS
-
-    if ! tail -n 1 ${prefix}.fq_lint.txt | grep -q 'fq-lint end'; then
-        echo "ERROR: Linting failure detected for ${meta.id}. See ${prefix}.fq_lint.txt for details."
-        exit 1 
-    fi
     """
 }

--- a/modules/nf-core/fq/lint/main.nf
+++ b/modules/nf-core/fq/lint/main.nf
@@ -1,6 +1,7 @@
 process FQ_LINT {
     tag "$meta.id"
     label 'process_low'
+    errorStrategy 'terminate'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -29,5 +30,10 @@ process FQ_LINT {
     "${task.process}":
         fq: \$(echo \$(fq lint --version | sed 's/fq-lint //g'))
     END_VERSIONS
+
+    if ! tail -n 1 ${prefix}.fq_lint.txt | grep -q 'fq-lint end'; then
+        echo "ERROR: Linting failure detected for ${meta.id}. See ${prefix}.fq_lint.txt for details."
+        exit 1 
+    fi
     """
 }

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -124,6 +124,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
             ch_fastq_lint.map{ meta, fastqs -> [meta, fastqs.flatten()] }
         )
         ch_versions = ch_versions.mix(FQ_LINT.out.versions.first())
+        ch_lint_log = FQ_LINT.out.lint
     }
 
     ch_reads
@@ -324,6 +325,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
 
     emit:
 
+    lint_log        = ch_lint_log
     reads           = ch_strand_inferred_fastq
     trim_read_count = ch_trim_read_count
 

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -4,6 +4,7 @@ include { BBMAP_BBSPLIT                   } from '../../../modules/nf-core/bbmap
 include { CAT_FASTQ                       } from '../../../modules/nf-core/cat/fastq/main'
 include { SORTMERNA                       } from '../../../modules/nf-core/sortmerna/main'
 include { SORTMERNA as SORTMERNA_INDEX    } from '../../../modules/nf-core/sortmerna/main'
+include { FQ_LINT                         } from '../../../modules/nf-core/fq/lint/main'
 
 include { FASTQ_SUBSAMPLE_FQ_SALMON        } from '../fastq_subsample_fq_salmon'
 include { FASTQ_FASTQC_UMITOOLS_TRIMGALORE } from '../fastq_fastqc_umitools_trimgalore'
@@ -106,6 +107,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     umi_discard_read     // integer: 0, 1 or 2
     stranded_threshold   // float: The fraction of stranded reads that must be assigned to a strandedness for confident assignment. Must be at least 0.5
     unstranded_threshold // float: The difference in fraction of stranded reads assigned to 'forward' and 'reverse' below which a sample is classified as 'unstranded'
+    skip_linting         // boolean: true/false
 
     main:
 
@@ -113,6 +115,16 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     ch_filtered_reads  = Channel.empty()
     ch_trim_read_count = Channel.empty()
     ch_multiqc_files   = Channel.empty()
+
+    //
+    // MODULE: Lint FastQ files
+    //
+    if(!skip_linting) {
+        FQ_LINT (
+            ch_fastq_lint.map{ meta, fastqs -> [meta, fastqs.flatten()] }
+        )
+        ch_versions = ch_versions.mix(FQ_LINT.out.versions.first())
+    }
 
     ch_reads
         .branch {


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

I am proposing a change to the nf-core [fq lint module](https://nf-co.re/modules/fq_lint/), such that the process will exit if a FastQ file fails validation. This will allow us to add this module into nf-core pipelines like rnaseq (see relevant PR [here](https://github.com/nf-core/rnaseq/pull/1453)) and validate FastQ files early in the workflow, preventing pipelines from continuing and running more computationally-heavy steps on corrupted FastQ files.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
