### PR TITLE
improve workflow logic for `fastq_align_dedup_bismark`

### DIFF
--- a/subworkflows/nf-core/fastq_align_dedup_bismark/main.nf
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/main.nf
@@ -129,12 +129,12 @@ workflow FASTQ_ALIGN_DEDUP_BISMARK {
     /*
      * Collect MultiQC inputs
      */
-    ch_multiqc_files = BISMARK_SUMMARY.out.summary
-                        .mix(ch_alignment_reports.collect{ meta, align_report, dedup_report -> align_report })
-                        .mix(ch_alignment_reports.collect{ meta, align_report, dedup_report -> dedup_report })
-                        .mix(ch_methylation_report.collect{ meta, report -> report })
-                        .mix(ch_methylation_mbias.collect{ meta, mbias -> mbias })
-                        .mix(ch_bismark_report.collect{ meta, report -> report })
+    ch_multiqc_files = ch_bismark_summary
+                            .mix(ch_alignment_reports.collect{ meta, align_report, dedup_report -> align_report })
+                            .mix(ch_alignment_reports.collect{ meta, align_report, dedup_report -> dedup_report })
+                            .mix(ch_methylation_report.collect{ meta, report -> report })
+                            .mix(ch_methylation_mbias.collect{ meta, mbias -> mbias })
+                            .mix(ch_bismark_report.collect{ meta, report -> report })
 
     emit:
     bam                        = SAMTOOLS_SORT.out.bam         // channel: [ val(meta), [ bam ] ]

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/main.nf
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/main.nf
@@ -1,11 +1,11 @@
-include { BISMARK_ALIGN                                 } from '../../../modules/nf-core/bismark/align/main'
-include { BISMARK_DEDUPLICATE                           } from '../../../modules/nf-core/bismark/deduplicate/main'
-include { BISMARK_METHYLATIONEXTRACTOR                  } from '../../../modules/nf-core/bismark/methylationextractor/main'
-include { BISMARK_COVERAGE2CYTOSINE                     } from '../../../modules/nf-core/bismark/coverage2cytosine/main'
-include { BISMARK_REPORT                                } from '../../../modules/nf-core/bismark/report/main'
-include { BISMARK_SUMMARY                               } from '../../../modules/nf-core/bismark/summary/main'
-include { SAMTOOLS_SORT as SAMTOOLS_SORT_DEDUPLICATED   } from '../../../modules/nf-core/samtools/sort/main'
-include { SAMTOOLS_INDEX as SAMTOOLS_INDEX_DEDUPLICATED } from '../../../modules/nf-core/samtools/index/main'
+include { BISMARK_ALIGN                } from '../../../modules/nf-core/bismark/align/main'
+include { BISMARK_DEDUPLICATE          } from '../../../modules/nf-core/bismark/deduplicate/main'
+include { SAMTOOLS_SORT                } from '../../../modules/nf-core/samtools/sort/main'
+include { SAMTOOLS_INDEX               } from '../../../modules/nf-core/samtools/index/main'
+include { BISMARK_METHYLATIONEXTRACTOR } from '../../../modules/nf-core/bismark/methylationextractor/main'
+include { BISMARK_COVERAGE2CYTOSINE    } from '../../../modules/nf-core/bismark/coverage2cytosine/main'
+include { BISMARK_REPORT               } from '../../../modules/nf-core/bismark/report/main'
+include { BISMARK_SUMMARY              } from '../../../modules/nf-core/bismark/summary/main'
 
 workflow FASTQ_ALIGN_DEDUP_BISMARK {
 
@@ -17,18 +17,20 @@ workflow FASTQ_ALIGN_DEDUP_BISMARK {
     cytosine_report      // boolean: whether the run coverage2cytosine
 
     main:
-    ch_versions                   = Channel.empty()
-    ch_coverage2cytosine_coverage = Channel.empty()
-    ch_coverage2cytosine_report   = Channel.empty()
-    ch_coverage2cytosine_summary  = Channel.empty()
+    ch_alignments                 = Channel.empty()
+    ch_alignment_reports          = Channel.empty()
     ch_methylation_bedgraph       = Channel.empty()
     ch_methylation_calls          = Channel.empty()
     ch_methylation_coverage       = Channel.empty()
     ch_methylation_report         = Channel.empty()
     ch_methylation_mbias          = Channel.empty()
+    ch_coverage2cytosine_coverage = Channel.empty()
+    ch_coverage2cytosine_report   = Channel.empty()
+    ch_coverage2cytosine_summary  = Channel.empty()
     ch_bismark_report             = Channel.empty()
     ch_bismark_summary            = Channel.empty()
     ch_multiqc_files              = Channel.empty()
+    ch_versions                   = Channel.empty()
 
     /*
      * Align with bismark
@@ -38,28 +40,44 @@ workflow FASTQ_ALIGN_DEDUP_BISMARK {
         ch_fasta,
         ch_bismark_index
     )
+    ch_alignments        = BISMARK_ALIGN.out.bam
+    ch_alignment_reports = BISMARK_ALIGN.out.report.map{ meta, report -> [ meta, report, [] ] }
     ch_versions = ch_versions.mix(BISMARK_ALIGN.out.versions)
 
-    if (skip_deduplication) {
-        alignments        = BISMARK_ALIGN.out.bam
-        alignment_reports = BISMARK_ALIGN.out.report.map{ meta, report -> [ meta, report, [] ] }
-    } else {
+    if (!skip_deduplication) {
         /*
         * Run deduplicate_bismark
         */
         BISMARK_DEDUPLICATE (
             BISMARK_ALIGN.out.bam
         )
-        alignments        = BISMARK_DEDUPLICATE.out.bam
-        alignment_reports = BISMARK_ALIGN.out.report.join(BISMARK_DEDUPLICATE.out.report)
-        ch_versions       = ch_versions.mix(BISMARK_DEDUPLICATE.out.versions)
+        ch_alignments        = BISMARK_DEDUPLICATE.out.bam
+        ch_alignment_reports = BISMARK_ALIGN.out.report.join(BISMARK_DEDUPLICATE.out.report)
+        ch_versions          = ch_versions.mix(BISMARK_DEDUPLICATE.out.versions)
     }
+
+    /*
+     * MODULE: Run samtools sort on aligned or deduplicated bam
+     */
+    SAMTOOLS_SORT (
+        ch_alignments,
+        [[:],[]] // [ [meta], [fasta]]
+    )
+    ch_versions = ch_versions.mix(SAMTOOLS_SORT.out.versions)
+
+    /*
+     * MODULE: Run samtools index on aligned or deduplicated bam
+     */
+    SAMTOOLS_INDEX (
+        SAMTOOLS_SORT.out.bam
+    )
+    ch_versions = ch_versions.mix(SAMTOOLS_INDEX.out.versions)
 
     /*
      * Run bismark_methylation_extractor
      */
     BISMARK_METHYLATIONEXTRACTOR (
-        alignments,
+        ch_alignments,
         ch_bismark_index
     )
     ch_methylation_bedgraph = BISMARK_METHYLATIONEXTRACTOR.out.bedgraph
@@ -74,7 +92,7 @@ workflow FASTQ_ALIGN_DEDUP_BISMARK {
      */
     if (cytosine_report) {
         BISMARK_COVERAGE2CYTOSINE (
-            BISMARK_METHYLATIONEXTRACTOR.out.coverage,
+            ch_methylation_coverage,
             ch_fasta,
             ch_bismark_index
         )
@@ -88,7 +106,7 @@ workflow FASTQ_ALIGN_DEDUP_BISMARK {
      * Generate bismark sample reports
      */
     BISMARK_REPORT (
-        alignment_reports
+        ch_alignment_reports
             .join(ch_methylation_report)
             .join(ch_methylation_mbias)
     )
@@ -100,54 +118,37 @@ workflow FASTQ_ALIGN_DEDUP_BISMARK {
      */
     BISMARK_SUMMARY (
         BISMARK_ALIGN.out.bam.collect{ meta, bam -> bam.name },
-        alignment_reports.collect{ meta, align_report, dedup_report -> align_report },
-        alignment_reports.collect{ meta, align_report, dedup_report -> dedup_report }.ifEmpty([]),
-        BISMARK_METHYLATIONEXTRACTOR.out.report.collect{ meta, report -> report },
-        BISMARK_METHYLATIONEXTRACTOR.out.mbias.collect{ meta, mbias -> mbias }
+        ch_alignment_reports.collect{ meta, align_report, dedup_report -> align_report },
+        ch_alignment_reports.collect{ meta, align_report, dedup_report -> dedup_report }.ifEmpty([]),
+        ch_methylation_report.collect{ meta, report -> report },
+        ch_methylation_mbias.collect{ meta, mbias -> mbias }
     )
     ch_bismark_summary = BISMARK_SUMMARY.out.summary
     ch_versions        = ch_versions.mix(BISMARK_SUMMARY.out.versions)
 
     /*
-     * MODULE: Run samtools sort on dedup bam
-     */
-    SAMTOOLS_SORT_DEDUPLICATED (
-        alignments,
-        [[:],[]] // [ [meta], [fasta]]
-    )
-    ch_versions = ch_versions.mix(SAMTOOLS_SORT_DEDUPLICATED.out.versions)
-
-    /*
-     * MODULE: Run samtools index on dedup bam
-     */
-    SAMTOOLS_INDEX_DEDUPLICATED (
-        SAMTOOLS_SORT_DEDUPLICATED.out.bam
-    )
-    ch_versions = ch_versions.mix(SAMTOOLS_INDEX_DEDUPLICATED.out.versions)
-
-    /*
      * Collect MultiQC inputs
      */
     ch_multiqc_files = BISMARK_SUMMARY.out.summary
-                        .mix(alignment_reports.collect{ meta, align_report, dedup_report -> align_report })
-                        .mix(alignment_reports.collect{ meta, align_report, dedup_report -> dedup_report })
-                        .mix(BISMARK_METHYLATIONEXTRACTOR.out.report.collect{ meta, report -> report })
-                        .mix(BISMARK_METHYLATIONEXTRACTOR.out.mbias.collect{ meta, mbias -> mbias })
-                        .mix(BISMARK_REPORT.out.report.collect{ meta, report -> report })
+                        .mix(ch_alignment_reports.collect{ meta, align_report, dedup_report -> align_report })
+                        .mix(ch_alignment_reports.collect{ meta, align_report, dedup_report -> dedup_report })
+                        .mix(ch_methylation_report.collect{ meta, report -> report })
+                        .mix(ch_methylation_mbias.collect{ meta, mbias -> mbias })
+                        .mix(ch_bismark_report.collect{ meta, report -> report })
 
     emit:
-    dedup_bam                  = SAMTOOLS_SORT_DEDUPLICATED.out.bam  // channel: [ val(meta), [ bam ] ]
-    dedup_bam_index            = SAMTOOLS_INDEX_DEDUPLICATED.out.bai // channel: [ val(meta), [ bai ] ]
-    coverage2cytosine_coverage = ch_coverage2cytosine_coverage       // channel: [ val(meta), [ coverage ] ]
-    coverage2cytosine_report   = ch_coverage2cytosine_report         // channel: [ val(meta), [ report ] ]
-    coverage2cytosine_summary  = ch_coverage2cytosine_summary        // channel: [ val(meta), [ summary ] ]
-    methylation_bedgraph       = ch_methylation_bedgraph             // channel: [ val(meta), [ bedgraph ] ]
-    methylation_calls          = ch_methylation_calls                // channel: [ val(meta), [ methylation_calls ] ]
-    methylation_coverage       = ch_methylation_coverage             // channel: [ val(meta), [ coverage ] ]
-    methylation_report         = ch_methylation_report               // channel: [ val(meta), [ report ] ]
-    methylation_mbias          = ch_methylation_mbias                // channel: [ val(meta), [ mbias ] ]
-    bismark_report             = ch_bismark_report                   // channel: [ val(meta), [ report ] ]
-    bismark_summary            = ch_bismark_summary                  // channel: [ val(meta), [ summary ] ]
-    multiqc                    = ch_multiqc_files                    // path: *{html,txt}
-    versions                   = ch_versions                         // path: *.version.txt
+    bam                        = SAMTOOLS_SORT.out.bam         // channel: [ val(meta), [ bam ] ]
+    bai                        = SAMTOOLS_INDEX.out.bai        // channel: [ val(meta), [ bai ] ]
+    coverage2cytosine_coverage = ch_coverage2cytosine_coverage // channel: [ val(meta), [ coverage ] ]
+    coverage2cytosine_report   = ch_coverage2cytosine_report   // channel: [ val(meta), [ report ] ]
+    coverage2cytosine_summary  = ch_coverage2cytosine_summary  // channel: [ val(meta), [ summary ] ]
+    methylation_bedgraph       = ch_methylation_bedgraph       // channel: [ val(meta), [ bedgraph ] ]
+    methylation_calls          = ch_methylation_calls          // channel: [ val(meta), [ methylation_calls ] ]
+    methylation_coverage       = ch_methylation_coverage       // channel: [ val(meta), [ coverage ] ]
+    methylation_report         = ch_methylation_report         // channel: [ val(meta), [ report ] ]
+    methylation_mbias          = ch_methylation_mbias          // channel: [ val(meta), [ mbias ] ]
+    bismark_report             = ch_bismark_report             // channel: [ val(meta), [ report ] ]
+    bismark_summary            = ch_bismark_summary            // channel: [ val(meta), [ summary ] ]
+    multiqc                    = ch_multiqc_files              // path: *{html,txt}
+    versions                   = ch_versions                   // path: *.version.txt
 }

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/meta.yml
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/meta.yml
@@ -32,7 +32,7 @@ input:
       description: |
         Structure: [ val(meta), path(fasta) ]
       pattern: "*.{fa,fa.gz}"
-  - ch_index:
+  - ch_bismark_index:
       description: |
         Bismark genome index files
         Structure: [ val(meta), path(index) ]

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/meta.yml
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/meta.yml
@@ -46,16 +46,16 @@ input:
       description: |
         Produce coverage2cytosine reports that relates methylation calls back to genomic cytosine contexts
 output:
-  - dedup_bam:
+  - bam:
       type: file
       description: |
-        Channel containing deduplicated BAM files.
+        Channel containing aligned or deduplicated BAM files.
         Structure: [ val(meta), path(bam) ]
       pattern: "*.bam"
-  - dedup_bam_index:
+  - bai:
       type: file
       description: |
-        Channel containing deduplicated BAM index files.
+        Channel containing aligned or deduplicated BAM index files.
         Structure: [ val(meta), path(bam.bai) ]
       pattern: "*.bai"
   - coverage2cytosine_coverage:

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test
@@ -44,7 +44,7 @@ nextflow_workflow {
         }
     }
 
-    test("Params: bismark | default") {
+    test("Params: bismark single-end | default") {
 
         when {
             params {
@@ -93,19 +93,21 @@ nextflow_workflow {
         }
     }
 
-    test("Params: bismark | skip_deduplication") {
+    test("Params: bismark paired-end | default") {
 
         when {
             params {
                 aligner            = "bismark"
-                skip_deduplication = true
+                cytosine_report    = false
+                skip_deduplication = false
             }
 
             workflow {
                 """
                 input[0] = Channel.of([
                             [ id:'test', single_end:true ],
-                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub1.fastq.gz', checkIfExists: true)
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R1.fastq.gz', checkIfExists: true),
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R2.fastq.gz', checkIfExists: true)
                 ])
                 input[1] = Channel.of([
                             [:],
@@ -141,7 +143,56 @@ nextflow_workflow {
         }
     }
 
-    test("Params: bismark | cytosine_report") {
+    test("Params: bismark paired-end | skip_deduplication") {
+
+        when {
+            params {
+                aligner            = "bismark"
+                skip_deduplication = true
+            }
+
+            workflow {
+                """
+                input[0] = Channel.of([
+                            [ id:'test', single_end:true ],
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R1.fastq.gz', checkIfExists: true),
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R2.fastq.gz', checkIfExists: true)
+                ])
+                input[1] = Channel.of([
+                            [:],
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa', checkIfExists: true)
+                ])
+                input[2] = BOWTIE2.out.untar
+                input[3] = params.skip_deduplication
+                input[4] = params.cytosine_report
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bai.collect { meta, bai -> file(bai).name },
+                    workflow.out.coverage2cytosine_coverage,
+                    workflow.out.coverage2cytosine_report,
+                    workflow.out.coverage2cytosine_summary,
+                    workflow.out.methylation_bedgraph,
+                    workflow.out.methylation_calls,
+                    workflow.out.methylation_coverage,
+                    workflow.out.methylation_report,
+                    workflow.out.methylation_mbias,
+                    workflow.out.bismark_report.collect { meta, report -> file(report).name },
+                    workflow.out.bismark_summary[0][1],
+                    workflow.out.multiqc.flatten().collect { path -> file(path).name },
+                    workflow.out.versions
+                    ).match() }
+            )
+        }
+    }
+
+    test("Params: bismark paired-end | cytosine_report") {
 
         when {
             params {
@@ -153,7 +204,8 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                             [ id:'test', single_end:true ],
-                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub1.fastq.gz', checkIfExists: true)
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R1.fastq.gz', checkIfExists: true),
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R2.fastq.gz', checkIfExists: true)
                 ])
                 input[1] = Channel.of([
                             [:],
@@ -189,7 +241,7 @@ nextflow_workflow {
         }
     }
 
-    test("Params: bismark_hisat | default") {
+    test("Params: bismark_hisat single-end | default") {
 
         when {
             params {
@@ -238,19 +290,21 @@ nextflow_workflow {
         }
     }
 
-    test("Params: bismark_hisat | skip_deduplication") {
+    test("Params: bismark_hisat paired-end | default") {
 
         when {
             params {
                 aligner            = "bismark_hisat"
-                skip_deduplication = true
+                cytosine_report    = false
+                skip_deduplication = false
             }
 
             workflow {
                 """
                 input[0] = Channel.of([
                             [ id:'test', single_end:true ],
-                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub1.fastq.gz', checkIfExists: true)
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R1.fastq.gz', checkIfExists: true),
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R2.fastq.gz', checkIfExists: true)
                 ])
                 input[1] = Channel.of([
                             [:],
@@ -286,7 +340,56 @@ nextflow_workflow {
         }
     }
 
-    test("Params: bismark_hisat | cytosine_report") {
+    test("Params: bismark_hisat paired-end | skip_deduplication") {
+
+        when {
+            params {
+                aligner            = "bismark_hisat"
+                skip_deduplication = true
+            }
+
+            workflow {
+                """
+                input[0] = Channel.of([
+                            [ id:'test', single_end:true ],
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R1.fastq.gz', checkIfExists: true),
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R2.fastq.gz', checkIfExists: true)
+                ])
+                input[1] = Channel.of([
+                            [:],
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa', checkIfExists: true)
+                ])
+                input[2] = HISAT2.out.untar
+                input[3] = params.skip_deduplication
+                input[4] = params.cytosine_report
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bai.collect { meta, bai -> file(bai).name },
+                    workflow.out.coverage2cytosine_coverage,
+                    workflow.out.coverage2cytosine_report,
+                    workflow.out.coverage2cytosine_summary,
+                    workflow.out.methylation_bedgraph,
+                    workflow.out.methylation_calls,
+                    workflow.out.methylation_coverage,
+                    workflow.out.methylation_report,
+                    workflow.out.methylation_mbias,
+                    workflow.out.bismark_report.collect { meta, report -> file(report).name },
+                    workflow.out.bismark_summary[0][1],
+                    workflow.out.multiqc.flatten().collect { path -> file(path).name },
+                    workflow.out.versions
+                    ).match() }
+            )
+        }
+    }
+
+    test("Params: bismark_hisat paired-end | cytosine_report") {
 
         when {
             params {
@@ -298,7 +401,8 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                             [ id:'test', single_end:true ],
-                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/SRR389222_sub1.fastq.gz', checkIfExists: true)
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R1.fastq.gz', checkIfExists: true),
+                            file('https://github.com/nf-core/test-datasets/raw/methylseq/testdata/Ecoli_10K_methylated_R2.fastq.gz', checkIfExists: true)
                 ])
                 input[1] = Channel.of([
                             [:],

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test
@@ -74,8 +74,8 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.dedup.collect { bam(it[1]).getReadsMD5() },
-                    workflow.out.dedup_bam_index.collect { meta, bai -> file(bai).name },
+                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
                     workflow.out.coverage2cytosine_summary,
@@ -122,8 +122,8 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.dedup.collect { bam(it[1]).getReadsMD5() },
-                    workflow.out.dedup_bam_index.collect { meta, bai -> file(bai).name },
+                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
                     workflow.out.coverage2cytosine_summary,
@@ -170,8 +170,8 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.dedup.collect { bam(it[1]).getReadsMD5() },
-                    workflow.out.dedup_bam_index.collect { meta, bai -> file(bai).name },
+                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
                     workflow.out.coverage2cytosine_summary,
@@ -219,8 +219,8 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.dedup.collect { bam(it[1]).getReadsMD5() },
-                    workflow.out.dedup_bam_index.collect { meta, bai -> file(bai).name },
+                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
                     workflow.out.coverage2cytosine_summary,
@@ -267,8 +267,8 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.dedup.collect { bam(it[1]).getReadsMD5() },
-                    workflow.out.dedup_bam_index.collect { meta, bai -> file(bai).name },
+                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
                     workflow.out.coverage2cytosine_summary,
@@ -315,8 +315,8 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.dedup.collect { bam(it[1]).getReadsMD5() },
-                    workflow.out.dedup_bam_index.collect { meta, bai -> file(bai).name },
+                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
                     workflow.out.coverage2cytosine_summary,

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test
@@ -74,7 +74,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bam.collect { meta, bamfile -> bam(bamfile).getReadsMD5() },
                     workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
@@ -124,7 +124,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bam.collect { meta, bamfile -> bam(bamfile).getReadsMD5() },
                     workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
@@ -173,7 +173,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bam.collect { meta, bamfile -> bam(bamfile).getReadsMD5() },
                     workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
@@ -222,7 +222,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bam.collect { meta, bamfile -> bam(bamfile).getReadsMD5() },
                     workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
@@ -271,7 +271,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bam.collect { meta, bamfile -> bam(bamfile).getReadsMD5() },
                     workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
@@ -321,7 +321,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bam.collect { meta, bamfile -> bam(bamfile).getReadsMD5() },
                     workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
@@ -370,7 +370,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bam.collect { meta, bamfile -> bam(bamfile).getReadsMD5() },
                     workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,
@@ -419,7 +419,7 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success },
                 { assert snapshot(
-                    workflow.out.bam.collect { bam(it[1]).getReadsMD5() },
+                    workflow.out.bam.collect { meta, bamfile -> bam(bamfile).getReadsMD5() },
                     workflow.out.bai.collect { meta, bai -> file(bai).name },
                     workflow.out.coverage2cytosine_coverage,
                     workflow.out.coverage2cytosine_report,

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "Params: bismark | skip_deduplication": {
         "content": [
             [
-                
+                "d6951f6d3381e22becf62553a37c0f3f"
             ],
             [
                 "test.sorted.bam.bai"
@@ -82,23 +82,23 @@
             ],
             [
                 "versions.yml:md5,46e043d0037e7446544ae1e25b65536c",
-                "versions.yml:md5,6c516cc03aa69228e503c540ee3794aa",
+                "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
                 "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
                 "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
                 "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
-                "versions.yml:md5,df1a6bcb24960ee4a22a2cc914c65272"
+                "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-15T15:19:32.095795684"
+        "timestamp": "2024-11-16T13:42:57.229340723"
     },
     "Params: bismark | default": {
         "content": [
             [
-                
+                "35d55bee1ca653931716e40dac4aba30"
             ],
             [
                 "test.sorted.bam.bai"
@@ -179,24 +179,24 @@
             ],
             [
                 "versions.yml:md5,46e043d0037e7446544ae1e25b65536c",
-                "versions.yml:md5,6c516cc03aa69228e503c540ee3794aa",
+                "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
                 "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
                 "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
                 "versions.yml:md5,a675051417ba65700b5db32d98aa65b6",
                 "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
-                "versions.yml:md5,df1a6bcb24960ee4a22a2cc914c65272"
+                "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-15T15:18:51.250132036"
+        "timestamp": "2024-11-16T13:42:14.896971435"
     },
     "Params: bismark | cytosine_report": {
         "content": [
             [
-                
+                "35d55bee1ca653931716e40dac4aba30"
             ],
             [
                 "test.sorted.bam.bai"
@@ -289,12 +289,12 @@
             ],
             [
                 "versions.yml:md5,46e043d0037e7446544ae1e25b65536c",
-                "versions.yml:md5,6c516cc03aa69228e503c540ee3794aa",
+                "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
                 "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
                 "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
                 "versions.yml:md5,a675051417ba65700b5db32d98aa65b6",
                 "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
-                "versions.yml:md5,df1a6bcb24960ee4a22a2cc914c65272",
+                "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c",
                 "versions.yml:md5,eb23ca81cb3427b8c5a8a9a93def4882"
             ]
         ],
@@ -302,12 +302,12 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-15T15:20:14.052464546"
+        "timestamp": "2024-11-16T13:43:38.700889773"
     },
     "Params: bismark_hisat | cytosine_report": {
         "content": [
             [
-                
+                "dae445da532c973dc9149f3ceba2d2c5"
             ],
             [
                 "test.sorted.bam.bai"
@@ -400,12 +400,12 @@
             ],
             [
                 "versions.yml:md5,46e043d0037e7446544ae1e25b65536c",
-                "versions.yml:md5,6c516cc03aa69228e503c540ee3794aa",
+                "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
                 "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
                 "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
                 "versions.yml:md5,a675051417ba65700b5db32d98aa65b6",
                 "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
-                "versions.yml:md5,df1a6bcb24960ee4a22a2cc914c65272",
+                "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c",
                 "versions.yml:md5,eb23ca81cb3427b8c5a8a9a93def4882"
             ]
         ],
@@ -413,12 +413,12 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-15T15:22:14.454171707"
+        "timestamp": "2024-11-16T13:45:42.848702637"
     },
     "Params: bismark_hisat | default": {
         "content": [
             [
-                
+                "dae445da532c973dc9149f3ceba2d2c5"
             ],
             [
                 "test.sorted.bam.bai"
@@ -499,24 +499,24 @@
             ],
             [
                 "versions.yml:md5,46e043d0037e7446544ae1e25b65536c",
-                "versions.yml:md5,6c516cc03aa69228e503c540ee3794aa",
+                "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
                 "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
                 "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
                 "versions.yml:md5,a675051417ba65700b5db32d98aa65b6",
                 "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
-                "versions.yml:md5,df1a6bcb24960ee4a22a2cc914c65272"
+                "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-15T15:20:53.556708293"
+        "timestamp": "2024-11-16T13:44:17.956032291"
     },
     "Params: bismark_hisat | skip_deduplication": {
         "content": [
             [
-                
+                "3a6485d719fcaf868c7f95c8f10a3f3c"
             ],
             [
                 "test.sorted.bam.bai"
@@ -596,17 +596,17 @@
             ],
             [
                 "versions.yml:md5,46e043d0037e7446544ae1e25b65536c",
-                "versions.yml:md5,6c516cc03aa69228e503c540ee3794aa",
+                "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
                 "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
                 "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
                 "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
-                "versions.yml:md5,df1a6bcb24960ee4a22a2cc914c65272"
+                "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-15T15:21:33.809590706"
+        "timestamp": "2024-11-16T13:45:00.81283353"
     }
 }

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/tests/main.nf.test.snap
@@ -1,8 +1,8 @@
 {
-    "Params: bismark | skip_deduplication": {
+    "Params: bismark_hisat paired-end | default": {
         "content": [
             [
-                "d6951f6d3381e22becf62553a37c0f3f"
+                "4bf31467bec7b5d5669aa4ac16f6f93f"
             ],
             [
                 "test.sorted.bam.bai"
@@ -22,7 +22,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_bt2.bedGraph.gz:md5,6896f135c70e2f4944cb43260a687c6c"
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.bedGraph.gz:md5,036f675959865a43f49899108d53b546"
                 ]
             ],
             [
@@ -32,12 +32,12 @@
                         "single_end": true
                     },
                     [
-                        "CHG_OB_SRR389222_sub1_bismark_bt2.txt.gz:md5,11ae58ebe6513375468ebe63a521d6e3",
-                        "CHG_OT_SRR389222_sub1_bismark_bt2.txt.gz:md5,d0754aef3f7066881bdee1adf72b4bd1",
-                        "CHH_OB_SRR389222_sub1_bismark_bt2.txt.gz:md5,12e9e4ebf59e6b23fb52f4872f534251",
-                        "CHH_OT_SRR389222_sub1_bismark_bt2.txt.gz:md5,b800b59b0987650ac6eb4d2eb25451ad",
-                        "CpG_OB_SRR389222_sub1_bismark_bt2.txt.gz:md5,21d614f45ecf703117550cb2eebfa3d5",
-                        "CpG_OT_SRR389222_sub1_bismark_bt2.txt.gz:md5,8bbe9103623f502908e81cc573754524"
+                        "CHG_OB_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,2c1285905b97b35a9088f811e2bda70e",
+                        "CHG_OT_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,473499e02bab8a14f8c804746bc98486",
+                        "CHH_OB_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,dda9a584b2a9bc7b84d39fe6210f8bfc",
+                        "CHH_OT_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,265670d72805a8689afe35ace9a7148a",
+                        "CpG_OB_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,d2912083fda7c2b4ad5916fe9cd8acf7",
+                        "CpG_OT_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,3f1d464af4efb77956f06546eabf8f1a"
                     ]
                 ]
             ],
@@ -47,7 +47,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_bt2.bismark.cov.gz:md5,4e31b9a432731c75a604c89cb9d471ad"
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.bismark.cov.gz:md5,63511c46275713088957950285acd653"
                 ]
             ],
             [
@@ -56,7 +56,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_bt2_splitting_report.txt:md5,d1bc9da2811d0f20981d01c3b1f4c925"
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated_splitting_report.txt:md5,5c5711d5cff9b9fb2cbb30617bf7400d"
                 ]
             ],
             [
@@ -65,18 +65,19 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_bt2.M-bias.txt:md5,d1083f305a444487fe977362a0174159"
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.M-bias.txt:md5,857b28589351f2c63f587a2c040db748"
                 ]
             ],
             [
-                "SRR389222_sub1_bismark_bt2_SE_report.html"
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.html"
             ],
-            "bismark_summary_report.txt:md5,13f7305cf7003f54e0eba22f3590889a",
+            "bismark_summary_report.txt:md5,9f62c10d005c39d3e5ee7961b6b0bf6b",
             [
-                "SRR389222_sub1_bismark_bt2.M-bias.txt",
-                "SRR389222_sub1_bismark_bt2_SE_report.html",
-                "SRR389222_sub1_bismark_bt2_SE_report.txt",
-                "SRR389222_sub1_bismark_bt2_splitting_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.M-bias.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated_splitting_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2.deduplication_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.html",
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.txt",
                 "bismark_summary_report.html",
                 "bismark_summary_report.txt"
             ],
@@ -85,6 +86,7 @@
                 "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
                 "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
                 "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
+                "versions.yml:md5,a675051417ba65700b5db32d98aa65b6",
                 "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
                 "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c"
             ]
@@ -93,9 +95,9 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-16T13:42:57.229340723"
+        "timestamp": "2024-11-17T05:13:17.213711049"
     },
-    "Params: bismark | default": {
+    "Params: bismark single-end | default": {
         "content": [
             [
                 "35d55bee1ca653931716e40dac4aba30"
@@ -191,12 +193,12 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-16T13:42:14.896971435"
+        "timestamp": "2024-11-17T05:10:13.435134357"
     },
-    "Params: bismark | cytosine_report": {
+    "Params: bismark paired-end | cytosine_report": {
         "content": [
             [
-                "35d55bee1ca653931716e40dac4aba30"
+                "4bf31467bec7b5d5669aa4ac16f6f93f"
             ],
             [
                 "test.sorted.bam.bai"
@@ -210,7 +212,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.CpG_report.txt.gz:md5,33af7ef6af01da4f1e12457ff1d782c6"
+                    "test.CpG_report.txt.gz:md5,48cfcbd77d450c55fc64c8e6d939fa03"
                 ]
             ],
             [
@@ -219,7 +221,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.cytosine_context_summary.txt:md5,0e8c65559470bc64c42dbd0278a531de"
+                    "test.cytosine_context_summary.txt:md5,d9df9696701e5799a06a18af4e49d648"
                 ]
             ],
             [
@@ -228,7 +230,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_bt2.deduplicated.bedGraph.gz:md5,5d7312489e51ca88e1ce1f689db93a64"
+                    "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.bedGraph.gz:md5,036f675959865a43f49899108d53b546"
                 ]
             ],
             [
@@ -238,12 +240,12 @@
                         "single_end": true
                     },
                     [
-                        "CHG_OB_SRR389222_sub1_bismark_bt2.deduplicated.txt.gz:md5,5c177e6f00dfc6e2335a55c6b70efa0c",
-                        "CHG_OT_SRR389222_sub1_bismark_bt2.deduplicated.txt.gz:md5,5362d479358f644fe2c17cfe02f310f8",
-                        "CHH_OB_SRR389222_sub1_bismark_bt2.deduplicated.txt.gz:md5,9469ac28e4369032b855ce1a794a56a4",
-                        "CHH_OT_SRR389222_sub1_bismark_bt2.deduplicated.txt.gz:md5,d7628ac941d3fea97297a8dfcfb7aed1",
-                        "CpG_OB_SRR389222_sub1_bismark_bt2.deduplicated.txt.gz:md5,f0404fc1fc18c7ff58e8766b405239ed",
-                        "CpG_OT_SRR389222_sub1_bismark_bt2.deduplicated.txt.gz:md5,67d04d843e9e1abc8643bc25b27a9ff5"
+                        "CHG_OB_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,2c1285905b97b35a9088f811e2bda70e",
+                        "CHG_OT_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,473499e02bab8a14f8c804746bc98486",
+                        "CHH_OB_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,dda9a584b2a9bc7b84d39fe6210f8bfc",
+                        "CHH_OT_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,265670d72805a8689afe35ace9a7148a",
+                        "CpG_OB_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,d2912083fda7c2b4ad5916fe9cd8acf7",
+                        "CpG_OT_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,3f1d464af4efb77956f06546eabf8f1a"
                     ]
                 ]
             ],
@@ -253,7 +255,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_bt2.deduplicated.bismark.cov.gz:md5,eb0d3f96ed97c5d12afeeb49c234849d"
+                    "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.bismark.cov.gz:md5,63511c46275713088957950285acd653"
                 ]
             ],
             [
@@ -262,7 +264,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_bt2.deduplicated_splitting_report.txt:md5,ec268cc572b8bcfea0959b47c7510f05"
+                    "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated_splitting_report.txt:md5,d994b435696e984419ef01ea7dc51b2c"
                 ]
             ],
             [
@@ -271,19 +273,19 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_bt2.deduplicated.M-bias.txt:md5,290ebfeca4da7809cf9adfe60bab1b29"
+                    "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.M-bias.txt:md5,857b28589351f2c63f587a2c040db748"
                 ]
             ],
             [
-                "SRR389222_sub1_bismark_bt2_SE_report.html"
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.html"
             ],
-            "bismark_summary_report.txt:md5,46f54eec58516c027e20bc9bdcaaae14",
+            "bismark_summary_report.txt:md5,855dfc95b1dbb0876aff2831380bba99",
             [
-                "SRR389222_sub1_bismark_bt2.deduplicated.M-bias.txt",
-                "SRR389222_sub1_bismark_bt2.deduplicated_splitting_report.txt",
-                "SRR389222_sub1_bismark_bt2.deduplication_report.txt",
-                "SRR389222_sub1_bismark_bt2_SE_report.html",
-                "SRR389222_sub1_bismark_bt2_SE_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.M-bias.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated_splitting_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2.deduplication_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.html",
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.txt",
                 "bismark_summary_report.html",
                 "bismark_summary_report.txt"
             ],
@@ -302,12 +304,12 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-16T13:43:38.700889773"
+        "timestamp": "2024-11-17T05:11:57.080233925"
     },
-    "Params: bismark_hisat | cytosine_report": {
+    "Params: bismark_hisat paired-end | cytosine_report": {
         "content": [
             [
-                "dae445da532c973dc9149f3ceba2d2c5"
+                "4bf31467bec7b5d5669aa4ac16f6f93f"
             ],
             [
                 "test.sorted.bam.bai"
@@ -321,7 +323,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.CpG_report.txt.gz:md5,d05837f07e4866f007d1f25166376b10"
+                    "test.CpG_report.txt.gz:md5,48cfcbd77d450c55fc64c8e6d939fa03"
                 ]
             ],
             [
@@ -330,7 +332,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.cytosine_context_summary.txt:md5,c2e99c47feb351c6666990bec7d1a9bd"
+                    "test.cytosine_context_summary.txt:md5,d9df9696701e5799a06a18af4e49d648"
                 ]
             ],
             [
@@ -339,7 +341,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_hisat2.deduplicated.bedGraph.gz:md5,1f1b14f7be535e6098ece13ea1406bfc"
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.bedGraph.gz:md5,036f675959865a43f49899108d53b546"
                 ]
             ],
             [
@@ -349,12 +351,12 @@
                         "single_end": true
                     },
                     [
-                        "CHG_OB_SRR389222_sub1_bismark_hisat2.deduplicated.txt.gz:md5,5c177e6f00dfc6e2335a55c6b70efa0c",
-                        "CHG_OT_SRR389222_sub1_bismark_hisat2.deduplicated.txt.gz:md5,138bccceb9ae71ecdae6828fd8fc327f",
-                        "CHH_OB_SRR389222_sub1_bismark_hisat2.deduplicated.txt.gz:md5,9469ac28e4369032b855ce1a794a56a4",
-                        "CHH_OT_SRR389222_sub1_bismark_hisat2.deduplicated.txt.gz:md5,f1acfc10c9f9ffb80f2a7a947a210ad7",
-                        "CpG_OB_SRR389222_sub1_bismark_hisat2.deduplicated.txt.gz:md5,f0404fc1fc18c7ff58e8766b405239ed",
-                        "CpG_OT_SRR389222_sub1_bismark_hisat2.deduplicated.txt.gz:md5,75b9acaf689411154f906bcfa7264abf"
+                        "CHG_OB_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,2c1285905b97b35a9088f811e2bda70e",
+                        "CHG_OT_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,473499e02bab8a14f8c804746bc98486",
+                        "CHH_OB_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,dda9a584b2a9bc7b84d39fe6210f8bfc",
+                        "CHH_OT_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,265670d72805a8689afe35ace9a7148a",
+                        "CpG_OB_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,d2912083fda7c2b4ad5916fe9cd8acf7",
+                        "CpG_OT_Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.txt.gz:md5,3f1d464af4efb77956f06546eabf8f1a"
                     ]
                 ]
             ],
@@ -364,7 +366,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_hisat2.deduplicated.bismark.cov.gz:md5,ec4a2575b47822ef478b3bda35c70590"
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.bismark.cov.gz:md5,63511c46275713088957950285acd653"
                 ]
             ],
             [
@@ -373,7 +375,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_hisat2.deduplicated_splitting_report.txt:md5,eaee004ea3fffb9b8aaf968f41f9f903"
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated_splitting_report.txt:md5,5c5711d5cff9b9fb2cbb30617bf7400d"
                 ]
             ],
             [
@@ -382,19 +384,19 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_hisat2.deduplicated.M-bias.txt:md5,82b760a6824f55f6732297374d77a6ec"
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.M-bias.txt:md5,857b28589351f2c63f587a2c040db748"
                 ]
             ],
             [
-                "SRR389222_sub1_bismark_hisat2_SE_report.html"
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.html"
             ],
-            "bismark_summary_report.txt:md5,762c303acee29bfffef35b3d9e04d153",
+            "bismark_summary_report.txt:md5,9f62c10d005c39d3e5ee7961b6b0bf6b",
             [
-                "SRR389222_sub1_bismark_hisat2.deduplicated.M-bias.txt",
-                "SRR389222_sub1_bismark_hisat2.deduplicated_splitting_report.txt",
-                "SRR389222_sub1_bismark_hisat2.deduplication_report.txt",
-                "SRR389222_sub1_bismark_hisat2_SE_report.html",
-                "SRR389222_sub1_bismark_hisat2_SE_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated.M-bias.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2.deduplicated_splitting_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2.deduplication_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.html",
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.txt",
                 "bismark_summary_report.html",
                 "bismark_summary_report.txt"
             ],
@@ -413,9 +415,9 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-16T13:45:42.848702637"
+        "timestamp": "2024-11-17T05:14:44.263768701"
     },
-    "Params: bismark_hisat | default": {
+    "Params: bismark_hisat single-end | default": {
         "content": [
             [
                 "dae445da532c973dc9149f3ceba2d2c5"
@@ -511,12 +513,12 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-16T13:44:17.956032291"
+        "timestamp": "2024-11-17T05:12:39.424047426"
     },
-    "Params: bismark_hisat | skip_deduplication": {
+    "Params: bismark paired-end | default": {
         "content": [
             [
-                "3a6485d719fcaf868c7f95c8f10a3f3c"
+                "4bf31467bec7b5d5669aa4ac16f6f93f"
             ],
             [
                 "test.sorted.bam.bai"
@@ -536,7 +538,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_hisat2.bedGraph.gz:md5,75be0d8be0134a48fd55e15a49568d3f"
+                    "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.bedGraph.gz:md5,036f675959865a43f49899108d53b546"
                 ]
             ],
             [
@@ -546,12 +548,12 @@
                         "single_end": true
                     },
                     [
-                        "CHG_OB_SRR389222_sub1_bismark_hisat2.txt.gz:md5,11ae58ebe6513375468ebe63a521d6e3",
-                        "CHG_OT_SRR389222_sub1_bismark_hisat2.txt.gz:md5,2963a2702be660068818073a2989c790",
-                        "CHH_OB_SRR389222_sub1_bismark_hisat2.txt.gz:md5,12e9e4ebf59e6b23fb52f4872f534251",
-                        "CHH_OT_SRR389222_sub1_bismark_hisat2.txt.gz:md5,e6815f62702d06dc01d12ea18dbd9a03",
-                        "CpG_OB_SRR389222_sub1_bismark_hisat2.txt.gz:md5,21d614f45ecf703117550cb2eebfa3d5",
-                        "CpG_OT_SRR389222_sub1_bismark_hisat2.txt.gz:md5,1a07c82f278b4ed637d33833df1e9749"
+                        "CHG_OB_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,2c1285905b97b35a9088f811e2bda70e",
+                        "CHG_OT_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,473499e02bab8a14f8c804746bc98486",
+                        "CHH_OB_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,dda9a584b2a9bc7b84d39fe6210f8bfc",
+                        "CHH_OT_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,265670d72805a8689afe35ace9a7148a",
+                        "CpG_OB_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,d2912083fda7c2b4ad5916fe9cd8acf7",
+                        "CpG_OT_Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.txt.gz:md5,3f1d464af4efb77956f06546eabf8f1a"
                     ]
                 ]
             ],
@@ -561,7 +563,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_hisat2.bismark.cov.gz:md5,ab610e006112a52e5ecb230a1704f236"
+                    "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.bismark.cov.gz:md5,63511c46275713088957950285acd653"
                 ]
             ],
             [
@@ -570,7 +572,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_hisat2_splitting_report.txt:md5,e6b01d28d7248361750dbd23eef667df"
+                    "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated_splitting_report.txt:md5,d994b435696e984419ef01ea7dc51b2c"
                 ]
             ],
             [
@@ -579,18 +581,116 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "SRR389222_sub1_bismark_hisat2.M-bias.txt:md5,bbfe49763c571a55a50d1e46c0fb4e46"
+                    "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.M-bias.txt:md5,857b28589351f2c63f587a2c040db748"
                 ]
             ],
             [
-                "SRR389222_sub1_bismark_hisat2_SE_report.html"
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.html"
             ],
-            "bismark_summary_report.txt:md5,7a466655c11944b6035901910378e559",
+            "bismark_summary_report.txt:md5,855dfc95b1dbb0876aff2831380bba99",
             [
-                "SRR389222_sub1_bismark_hisat2.M-bias.txt",
-                "SRR389222_sub1_bismark_hisat2_SE_report.html",
-                "SRR389222_sub1_bismark_hisat2_SE_report.txt",
-                "SRR389222_sub1_bismark_hisat2_splitting_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated.M-bias.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2.deduplicated_splitting_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2.deduplication_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.html",
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.txt",
+                "bismark_summary_report.html",
+                "bismark_summary_report.txt"
+            ],
+            [
+                "versions.yml:md5,46e043d0037e7446544ae1e25b65536c",
+                "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
+                "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
+                "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
+                "versions.yml:md5,a675051417ba65700b5db32d98aa65b6",
+                "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
+                "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.0"
+        },
+        "timestamp": "2024-11-17T05:10:47.730967756"
+    },
+    "Params: bismark_hisat paired-end | skip_deduplication": {
+        "content": [
+            [
+                "4bf31467bec7b5d5669aa4ac16f6f93f"
+            ],
+            [
+                "test.sorted.bam.bai"
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.bedGraph.gz:md5,036f675959865a43f49899108d53b546"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    [
+                        "CHG_OB_Ecoli_10K_methylated_R1_bismark_hisat2.txt.gz:md5,2c1285905b97b35a9088f811e2bda70e",
+                        "CHG_OT_Ecoli_10K_methylated_R1_bismark_hisat2.txt.gz:md5,473499e02bab8a14f8c804746bc98486",
+                        "CHH_OB_Ecoli_10K_methylated_R1_bismark_hisat2.txt.gz:md5,dda9a584b2a9bc7b84d39fe6210f8bfc",
+                        "CHH_OT_Ecoli_10K_methylated_R1_bismark_hisat2.txt.gz:md5,265670d72805a8689afe35ace9a7148a",
+                        "CpG_OB_Ecoli_10K_methylated_R1_bismark_hisat2.txt.gz:md5,d2912083fda7c2b4ad5916fe9cd8acf7",
+                        "CpG_OT_Ecoli_10K_methylated_R1_bismark_hisat2.txt.gz:md5,3f1d464af4efb77956f06546eabf8f1a"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.bismark.cov.gz:md5,63511c46275713088957950285acd653"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "Ecoli_10K_methylated_R1_bismark_hisat2_splitting_report.txt:md5,7767e575a343a9b077dcd03e594550f1"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "Ecoli_10K_methylated_R1_bismark_hisat2.M-bias.txt:md5,857b28589351f2c63f587a2c040db748"
+                ]
+            ],
+            [
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.html"
+            ],
+            "bismark_summary_report.txt:md5,dd73bb37e3116c25480990bd37f3f99f",
+            [
+                "Ecoli_10K_methylated_R1_bismark_hisat2.M-bias.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.html",
+                "Ecoli_10K_methylated_R1_bismark_hisat2_SE_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_hisat2_splitting_report.txt",
                 "bismark_summary_report.html",
                 "bismark_summary_report.txt"
             ],
@@ -607,6 +707,102 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.0"
         },
-        "timestamp": "2024-11-16T13:45:00.81283353"
+        "timestamp": "2024-11-17T05:13:57.892659443"
+    },
+    "Params: bismark paired-end | skip_deduplication": {
+        "content": [
+            [
+                "4bf31467bec7b5d5669aa4ac16f6f93f"
+            ],
+            [
+                "test.sorted.bam.bai"
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "Ecoli_10K_methylated_R1_bismark_bt2.bedGraph.gz:md5,036f675959865a43f49899108d53b546"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    [
+                        "CHG_OB_Ecoli_10K_methylated_R1_bismark_bt2.txt.gz:md5,2c1285905b97b35a9088f811e2bda70e",
+                        "CHG_OT_Ecoli_10K_methylated_R1_bismark_bt2.txt.gz:md5,473499e02bab8a14f8c804746bc98486",
+                        "CHH_OB_Ecoli_10K_methylated_R1_bismark_bt2.txt.gz:md5,dda9a584b2a9bc7b84d39fe6210f8bfc",
+                        "CHH_OT_Ecoli_10K_methylated_R1_bismark_bt2.txt.gz:md5,265670d72805a8689afe35ace9a7148a",
+                        "CpG_OB_Ecoli_10K_methylated_R1_bismark_bt2.txt.gz:md5,d2912083fda7c2b4ad5916fe9cd8acf7",
+                        "CpG_OT_Ecoli_10K_methylated_R1_bismark_bt2.txt.gz:md5,3f1d464af4efb77956f06546eabf8f1a"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "Ecoli_10K_methylated_R1_bismark_bt2.bismark.cov.gz:md5,63511c46275713088957950285acd653"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "Ecoli_10K_methylated_R1_bismark_bt2_splitting_report.txt:md5,39c7721863c121645d68a4827e57ec77"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "Ecoli_10K_methylated_R1_bismark_bt2.M-bias.txt:md5,857b28589351f2c63f587a2c040db748"
+                ]
+            ],
+            [
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.html"
+            ],
+            "bismark_summary_report.txt:md5,9f639cca6fe43c0461d2da88d931a036",
+            [
+                "Ecoli_10K_methylated_R1_bismark_bt2.M-bias.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.html",
+                "Ecoli_10K_methylated_R1_bismark_bt2_SE_report.txt",
+                "Ecoli_10K_methylated_R1_bismark_bt2_splitting_report.txt",
+                "bismark_summary_report.html",
+                "bismark_summary_report.txt"
+            ],
+            [
+                "versions.yml:md5,46e043d0037e7446544ae1e25b65536c",
+                "versions.yml:md5,6b5bf82c070f4410ead76cc9a363529c",
+                "versions.yml:md5,6f2f867f534bb0ae0ffbdc52d036afce",
+                "versions.yml:md5,9b480db277eebeb6265cbd003553c22c",
+                "versions.yml:md5,aa64d431e6cfc5ffcbd5012a76b0c1a3",
+                "versions.yml:md5,c2438ca96ec6728b06c8706639eb233c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.0"
+        },
+        "timestamp": "2024-11-17T05:11:19.884389766"
     }
 }

--- a/subworkflows/nf-core/fastq_align_dedup_bismark/tests/nextflow.config
+++ b/subworkflows/nf-core/fastq_align_dedup_bismark/tests/nextflow.config
@@ -9,7 +9,7 @@ process {
             ext.args = { params.aligner == 'bismark_hisat' ? ' --hisat2' : ' --bowtie2' }
     }
 
-    withName: 'SAMTOOLS_SORT_DEDUPLICATED' {
+    withName: 'SAMTOOLS_SORT' {
         ext.prefix = { "${meta.id}.sorted" }
     }
 }


### PR DESCRIPTION
renaming emit channels as depending on whether `skip_deduplication` is used, the output is either aligned or dedup bam