### PR TITLE
ci: Only run GPU tags and rely on "changed-since"

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -47,10 +47,10 @@ jobs:
         shard: [1, 2]
         profile: [docker_self_hosted, singularity] # conda?
         # TODO Pass these in from GitHub PR trigger events
-        tags:
-          - parabricks/applybqsr
-          - parabricks/fq2bam
-          - parabricks/fq2bammeth
+        # tags:
+        #   - parabricks/applybqsr
+        #   - parabricks/fq2bam
+        #   - parabricks/fq2bammeth
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: 2
@@ -70,4 +70,4 @@ jobs:
           profile: ${{ matrix.profile }},gpu
           shard: ${{ matrix.shard }}
           total_shards: ${{ env.TOTAL_SHARDS }}
-          tags: ${{matrix.tags}},gpu
+          tags: gpu


### PR DESCRIPTION
This should allow up to actually specify expected tests GitHub actions.