### PR TITLE
use prefix for pilon ouput

### DIFF
--- a/modules/nf-core/pilon/main.nf
+++ b/modules/nf-core/pilon/main.nf
@@ -40,7 +40,7 @@ process PILON {
     PILON_JAR=\$(dirname \$(which pilon))/../share/pilon*/pilon.jar
     java -Xmx${mem_mb}M -jar \$PILON_JAR \\
         --genome $fasta \\
-        --output ${meta.id} \\
+        --output ${prefix} \\
         $args \\
         --$pilon_mode $bam
 


### PR DESCRIPTION
pilon did not use prefix in the script; instead used ${meta.id} as fixed output.

## PR checklist

- [x] This comment contains a description of changes (with reason).
