### PR TITLE
fix: quartonotebook imported over multiple lines which broke detect-nf-test-changes

### DIFF
--- a/modules/nf-core/quartonotebook/main.nf
+++ b/modules/nf-core/quartonotebook/main.nf
@@ -1,7 +1,4 @@
-include {
-    dumpParamsYaml ;
-    indentCodeBlock
-} from "./parametrize"
+include { dumpParamsYaml ; indentCodeBlock } from "./parametrize"
 
 // NB: You'll likely want to override this with a container containing all
 // required dependencies for your analyses. Or use wave to build the container


### PR DESCRIPTION
See https://github.com/nf-core/modules/actions/runs/11974423411/job/33385468168 for an example of a broken test caused by this change.

This reverts the multi-line import introduced in https://github.com/nf-core/modules/pull/5561

We need to fix the detect-nf-test but for now this will keep us going.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
