### PR TITLE
Utils Nextflow: Avoid unused variables

### DIFF
--- a/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
@@ -92,10 +92,12 @@ def checkCondaChannels() {
         channels = config.channels
     }
     catch (NullPointerException e) {
+        log.debug(e)
         log.warn("Could not verify conda channel configuration.")
         return null
     }
     catch (IOException e) {
+        log.debug(e)
         log.warn("Could not verify conda channel configuration.")
         return null
     }


### PR DESCRIPTION
New Nextflow language server throws a warning about these unused variables. Figured the easiest solution is to print them to the debug log.