### PR TITLE
reduce memory for meryl count to avoid crash

### DIFF
--- a/modules/nf-core/meryl/count/main.nf
+++ b/modules/nf-core/meryl/count/main.nf
@@ -21,12 +21,13 @@ process MERYL_COUNT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def reduced_mem = task.memory.multiply(0.9).toGiga()
     """
     for READ in $reads; do
         meryl count \\
             k=$kvalue \\
             threads=$task.cpus \\
-            memory=${task.memory.toGiga()} \\
+            memory=$reduced_mem \\
             $args \\
             $reads \\
             output read.\${READ%.f*}.meryl


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

Avoid that meryl count crashes due to memory issues. It seems that meryl uses the complete buffer provided via `memory=SIZE` for the kmer counts, but meryl itself uses some memory too. When using meryl count within singularity containers and slurm,  then usually slurm is killing meryl due to that overhead. 

Solution, reduce the meryl memory kmer buffer `task.memory` by 10%. This is potentially a bit to much as usually the memory overhead was around 2-4Gb, but it solved all my issues on 3 three different compute clusters (Uppmax rackham, PDC dardel, and nac).

