### PR TITLE
style: Sort environment.yml dependencies

### DIFF
--- a/.github/scripts/conda_env_sorter.py
+++ b/.github/scripts/conda_env_sorter.py
@@ -15,6 +15,7 @@ from typing import Optional, Sequence
 import ruamel.yaml
 
 yaml = ruamel.yaml.YAML()
+yaml.indent(mapping=2, sequence=2, offset=2)  # Set indentation to 2 spaces
 
 
 def main(argv: Optional[Sequence[str]] = None) -> None:

--- a/.github/scripts/conda_env_sorter.py
+++ b/.github/scripts/conda_env_sorter.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "ruamel.yaml",
+# ]
+# ///
+
+"""Sort dependencies in conda environment files."""
+
+import argparse
+from pathlib import Path
+from typing import Optional, Sequence
+
+import ruamel.yaml
+
+yaml = ruamel.yaml.YAML()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Sort dependencies in conda environment files."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="*", type=Path)
+    args = parser.parse_args(argv)
+    for path in args.paths:
+        doc = yaml.load(path)
+        dicts = []
+        others = []
+
+        for term in doc["dependencies"]:
+            if isinstance(term, dict):
+                dicts.append(term)
+            else:
+                others.append(term)
+        others.sort(key=str)
+        for dict_term in dicts:
+            for value in dict_term.values():
+                if isinstance(value, list):
+                    value.sort(key=str)
+        dicts.sort(key=str)
+        doc["dependencies"].clear()
+        doc["dependencies"].extend(others)
+        doc["dependencies"].extend(dicts)
+
+        yaml.dump(doc, path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/conda_env_sorter.py
+++ b/.github/scripts/conda_env_sorter.py
@@ -24,6 +24,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
     parser.add_argument("paths", nargs="*", type=Path)
     args = parser.parse_args(argv)
     for path in args.paths:
+        # Read the entire file content
         with path.open() as f:
             lines = f.readlines()
 
@@ -35,14 +36,12 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
         # Check if the first two lines match the expected schema lines
         if lines[:2] == schema_lines:
-            header = lines[:2]
-            content = lines[2:]
+            content = "".join(lines[2:])  # Skip schema lines when reading content
         else:
-            # Add schema lines if they are missing
-            header = schema_lines
-            content = lines
+            content = "".join(lines)  # Use all content if no schema lines present
 
-        doc = yaml.load("".join(content))
+        # Parse the YAML content
+        doc = yaml.load(content)
         dicts = []
         others = []
 
@@ -61,8 +60,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         doc["dependencies"].extend(others)
         doc["dependencies"].extend(dicts)
 
+        # Write back to file with headers
         with path.open("w") as f:
-            f.writelines(header)
+            # Always write schema lines first
+            f.writelines(schema_lines)
+            # Then dump the sorted YAML
             yaml.dump(doc, f)
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,8 @@ repos:
     rev: pre-commit
     hooks:
       - id: lint-subworkflows
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: sort-simple-yaml
+        files: ^.*/environment\.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,13 @@
 repos:
+  - repo: local
+    hooks:
+      - id: conda-env-sorter
+        name: Sort dependencies in conda environment files.
+        entry: ./.github/scripts/conda_env_sorter.py
+        language: python
+        files: environment
+        types: [yaml]
+        additional_dependencies: ["ruamel.yaml"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.1.0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
         args: ["--schemafile", "subworkflows/yaml-schema.json"]
       - id: check-github-workflows
       - id: check-github-actions
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: sort-simple-yaml
+        files: ^modules/nf-core/.*/environment\.yml$
   # use ruff for python files
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.3
@@ -42,8 +47,3 @@ repos:
     rev: pre-commit
     hooks:
       - id: lint-subworkflows
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-      - id: sort-simple-yaml
-        files: ^.*/environment\.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,11 +25,15 @@ repos:
         args: ["--schemafile", "subworkflows/yaml-schema.json"]
       - id: check-github-workflows
       - id: check-github-actions
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+  - repo: local
     hooks:
-      - id: sort-simple-yaml
-        files: ^modules/nf-core/.*/environment\.yml$
+      - id: conda-env-sorter
+        name: Sort dependencies in conda environment files.
+        entry: ./.github/scripts/conda_env_sorter.py
+        language: python
+        files: environment
+        types: [yaml]
+        additional_dependencies: ["ruamel.yaml"]
   # use ruff for python files
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.3

--- a/modules/nf-core/basicpy/environment.yml
+++ b/modules/nf-core/basicpy/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/bowtie/align/environment.yml
+++ b/modules/nf-core/bowtie/align/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  # renovate: datasource=conda depName=bioconda/bowtie
-  - bioconda::bowtie=1.3.1
   # renovate: datasource=conda depName=bioconda/samtools
   - bioconda::samtools=1.20
+  # renovate: datasource=conda depName=bioconda/bowtie
+  - bioconda::bowtie=1.3.1

--- a/modules/nf-core/cellrangeratac/count/environment.yml
+++ b/modules/nf-core/cellrangeratac/count/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/cellrangeratac/mkfastq/environment.yml
+++ b/modules/nf-core/cellrangeratac/mkfastq/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/cellrangeratac/mkref/environment.yml
+++ b/modules/nf-core/cellrangeratac/mkref/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/ensemblvep/environment.yml
+++ b/modules/nf-core/ensemblvep/environment.yml
@@ -1,5 +1,3 @@
-# You can use this file to create a conda environment for this module:
-#   conda env create -f environment.yml
 channels:
   - conda-forge
   - bioconda

--- a/modules/nf-core/fastk/histex/environment.yml
+++ b/modules/nf-core/fastk/histex/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/fastk/merge/environment.yml
+++ b/modules/nf-core/fastk/merge/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/fcs/fcsgx/environment.yml
+++ b/modules/nf-core/fcs/fcsgx/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/gatk4/variantstotable/environment.yml
+++ b/modules/nf-core/gatk4/variantstotable/environment.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda

--- a/modules/nf-core/genescopefk/environment.yml
+++ b/modules/nf-core/genescopefk/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/hlala/preparegraph/environment.yml
+++ b/modules/nf-core/hlala/preparegraph/environment.yml
@@ -1,3 +1,5 @@
 channels:
   - conda-forge
   - bioconda
+dependencies:
+  - bioconda::hla-la=1.0.4

--- a/modules/nf-core/ilastik/multicut/environment.yml
+++ b/modules/nf-core/ilastik/multicut/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/ilastik/pixelclassification/environment.yml
+++ b/modules/nf-core/ilastik/pixelclassification/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/merquryfk/katcomp/environment.yml
+++ b/modules/nf-core/merquryfk/katcomp/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/merquryfk/katgc/environment.yml
+++ b/modules/nf-core/merquryfk/katgc/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda

--- a/modules/nf-core/regtools/junctionsextract/environment.yml
+++ b/modules/nf-core/regtools/junctionsextract/environment.yml
@@ -1,4 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+
+---
 channels:
   - conda-forge
   - bioconda

--- a/modules/nf-core/regtools/junctionsextract/environment.yml
+++ b/modules/nf-core/regtools/junctionsextract/environment.yml
@@ -1,8 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
-
----
 channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::regtools=1.0.0"
+  - bioconda::regtools=1.0.0

--- a/modules/nf-core/snpeff/environment.yml
+++ b/modules/nf-core/snpeff/environment.yml
@@ -1,5 +1,6 @@
-# You can use this file to create a conda environment for this module:
-#   conda env create -f environment.yml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+
+---
 channels:
   - conda-forge
   - bioconda

--- a/modules/nf-core/trgt/merge/environment.yml
+++ b/modules/nf-core/trgt/merge/environment.yml
@@ -1,4 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+
+---
 channels:
   - conda-forge
   - bioconda

--- a/modules/nf-core/trgt/plot/environment.yml
+++ b/modules/nf-core/trgt/plot/environment.yml
@@ -1,4 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+
+---
 channels:
   - conda-forge
   - bioconda

--- a/modules/nf-core/universc/environment.yml
+++ b/modules/nf-core/universc/environment.yml
@@ -1,3 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda


### PR DESCRIPTION
This fixes an issue with the Seqera containers naming.

The Seqera containers site doesn't care about the context of what module the
image is for. It just sorts the dependencies.

This avoids having multiple containers with a bunch of different names.

Should probably handle that on the wave-cli side.
