### PR TITLE
fix versions of mafft/guidetree

### DIFF
--- a/modules/nf-core/mafft/guidetree/main.nf
+++ b/modules/nf-core/mafft/guidetree/main.nf
@@ -32,7 +32,6 @@ process MAFFT_GUIDETREE {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mafft: \$(mafft --version 2>&1 | sed 's/^v//' | sed 's/ (.*)//')
-        pigz: \$(echo \$(pigz --version 2>&1) | sed 's/^.*pigz\\w*//' ))
     END_VERSIONS
     """
 
@@ -45,7 +44,6 @@ process MAFFT_GUIDETREE {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mafft: \$(mafft --version 2>&1 | sed 's/^v//' | sed 's/ (.*)//')
-        pigz: \$(echo \$(pigz --version 2>&1) | sed 's/^.*pigz\\w*//' ))
     END_VERSIONS
     """
 }

--- a/modules/nf-core/mafft/guidetree/main.nf
+++ b/modules/nf-core/mafft/guidetree/main.nf
@@ -27,7 +27,7 @@ process MAFFT_GUIDETREE {
         ${args} \\
         --treeout ${fasta} > log.txt
 
-    mv *.tree ${prefix}.dnd
+    mv *.tree ${prefix}.dnd.tmp
 
     # remove all prefices added by mafft which make the output incompatible with other tools
     awk '{gsub(/[0-9]+_/, ""); print}' ${prefix}.dnd.tmp > ${prefix}.dnd

--- a/modules/nf-core/mafft/guidetree/main.nf
+++ b/modules/nf-core/mafft/guidetree/main.nf
@@ -29,6 +29,9 @@ process MAFFT_GUIDETREE {
 
     mv *.tree ${prefix}.dnd
 
+    # remove all prefices added by mafft which make the output incompatible with other tools
+    awk '{gsub(/[0-9]+_/, ""); print}' ${prefix}.dnd.tmp > ${prefix}.dnd
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mafft: \$(mafft --version 2>&1 | sed 's/^v//' | sed 's/ (.*)//')

--- a/modules/nf-core/mafft/guidetree/tests/main.nf.test.snap
+++ b/modules/nf-core/mafft/guidetree/tests/main.nf.test.snap
@@ -40,7 +40,7 @@
                         {
                             "id": "test"
                         },
-                        "test.dnd:md5,c9602de546c97a4eda428c8173292e08"
+                        "test.dnd:md5,6618e2a8bb4ca1d9472de1c7347738e0"
                     ]
                 ],
                 "1": [
@@ -51,7 +51,7 @@
                         {
                             "id": "test"
                         },
-                        "test.dnd:md5,c9602de546c97a4eda428c8173292e08"
+                        "test.dnd:md5,6618e2a8bb4ca1d9472de1c7347738e0"
                     ]
                 ],
                 "versions": [
@@ -63,6 +63,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.1"
         },
-        "timestamp": "2024-11-27T15:45:17.531952893"
+        "timestamp": "2024-11-27T16:09:48.4198903"
     }
 }

--- a/modules/nf-core/mafft/guidetree/tests/main.nf.test.snap
+++ b/modules/nf-core/mafft/guidetree/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8dc0d31209c0d9fbaa1759d209c88613"
+                    "versions.yml:md5,bb10cf733d57dcd5d4c982db94bb1f2f"
                 ],
                 "tree": [
                     [
@@ -22,7 +22,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8dc0d31209c0d9fbaa1759d209c88613"
+                    "versions.yml:md5,bb10cf733d57dcd5d4c982db94bb1f2f"
                 ]
             }
         ],
@@ -30,7 +30,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.1"
         },
-        "timestamp": "2024-11-26T16:56:27.696465193"
+        "timestamp": "2024-11-27T15:45:27.111428175"
     },
     "sarscov2 - fasta": {
         "content": [
@@ -44,7 +44,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8dc0d31209c0d9fbaa1759d209c88613"
+                    "versions.yml:md5,bb10cf733d57dcd5d4c982db94bb1f2f"
                 ],
                 "tree": [
                     [
@@ -55,7 +55,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8dc0d31209c0d9fbaa1759d209c88613"
+                    "versions.yml:md5,bb10cf733d57dcd5d4c982db94bb1f2f"
                 ]
             }
         ],
@@ -63,6 +63,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.1"
         },
-        "timestamp": "2024-11-26T17:17:17.690589086"
+        "timestamp": "2024-11-27T15:45:17.531952893"
     }
 }


### PR DESCRIPTION
There was a mistake in the version reporting - i only spotted it now!

## PR checklist

- [x ] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
