### PR TITLE
fix linting on meta.yml files

### DIFF
--- a/modules/nf-core/nacho/normalize/meta.yml
+++ b/modules/nf-core/nacho/normalize/meta.yml
@@ -21,7 +21,7 @@ tools:
       homepage: https://github.com/mcanouil/NACHO
       documentation: https://cran.r-project.org/web/packages/NACHO/vignettes/NACHO.html
       doi: "10.1093/bioinformatics/btz647"
-      licence: [ "GPL-3.0" ]
+      licence: ["GPL-3.0"]
       identifier: ""
       args_id: "$args"
 
@@ -49,34 +49,34 @@ input:
 
 output:
   - normalized_counts:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test' ]
-    - "normalized_counts.tsv":
-        type: file
-        description: |
-          Tab-separated file with gene normalized counts for the samples
-        pattern: "normalized_counts.tsv"
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "normalized_counts.tsv":
+          type: file
+          description: |
+            Tab-separated file with gene normalized counts for the samples
+          pattern: "normalized_counts.tsv"
 
   - normalized_counts_wo_HK:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test' ]
-    - "normalized_counts_wo_HKnorm.tsv":
-        type: file
-        description: |
-          Tab-separated file with gene normalized counts for the samples, without housekeeping genes.
-        pattern: "normalized_counts_wo_HKnorm.tsv"
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "normalized_counts_wo_HKnorm.tsv":
+          type: file
+          description: |
+            Tab-separated file with gene normalized counts for the samples, without housekeeping genes.
+          pattern: "normalized_counts_wo_HKnorm.tsv"
   - versions:
-    - "versions.yml":
-        type: file
-        description: |
-          File containing software versions
-        pattern: "versions.yml"
+      - "versions.yml":
+          type: file
+          description: |
+            File containing software versions
+          pattern: "versions.yml"
 
 authors:
   - "@alanmmobbs93"

--- a/modules/nf-core/nacho/qc/meta.yml
+++ b/modules/nf-core/nacho/qc/meta.yml
@@ -20,7 +20,7 @@ tools:
       homepage: https://github.com/mcanouil/NACHO
       documentation: https://cran.r-project.org/web/packages/NACHO/vignettes/NACHO.html
       doi: "10.1093/bioinformatics/btz647"
-      licence: [ "GPL-3.0" ]
+      licence: ["GPL-3.0"]
       identifier: ""
 input:
   - - meta:
@@ -45,44 +45,44 @@ input:
           Comma-separated file with 3 columns: RCC_FILE, RCC_FILE_NAME, and SAMPLE_ID
 output:
   - nacho_qc_reports:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test' ]
-    - "*.html":
-        type: file
-        description: |
-          HTML report
-        pattern: "*.html"
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.html":
+          type: file
+          description: |
+            HTML report
+          pattern: "*.html"
   - nacho_qc_png:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test' ]
-    - "*_mqc.png":
-        type: file
-        description: |
-          Output PNG files
-        pattern: "*_mqc.png"
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*_mqc.png":
+          type: file
+          description: |
+            Output PNG files
+          pattern: "*_mqc.png"
   - nacho_qc_txt:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test' ]
-    - "*_mqc.txt":
-        type: file
-        description: |
-          Plain text reports
-        pattern: "*_mqc.txt"
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*_mqc.txt":
+          type: file
+          description: |
+            Plain text reports
+          pattern: "*_mqc.txt"
   - versions:
-    - "versions.yml":
-        type: file
-        description: |
-          File containing software versions
-        pattern: "versions.yml"
+      - "versions.yml":
+          type: file
+          description: |
+            File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@alanmmobbs93"
 maintainers:


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Continues [NACHO_QC](https://github.com/nf-core/modules/pull/7100) and [NACHO_NORMALIZE](https://github.com/nf-core/modules/pull/7108)

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

Fix linting problems on meta.yml files.

**NOTE**: linting on this modules with `nf-core modules lint` did not thow errors. However, after applying them to Nanostring pipeline and running `nf-core pipelines lint`, it changed these two files. So, this changed the files there causing a mismatch with nf-core repository.

nf-core version used on pipeline: 3.0.2 (Gitpod session)
nf-core version used on modules: 3.0.3dev0 (Gitpod session)