### PR TITLE
Replace switch with else-if in utils_nfcore_pipeline

### DIFF
--- a/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
@@ -206,22 +206,20 @@ def logColours(monochrome_logs=true) {
 // Return a single report from an object that may be a Path or List
 //
 def getSingleReport(multiqc_reports) {
-    switch (multiqc_reports) {
-        case Path:
-            return multiqc_reports
-        case List:
-            switch (multiqc_reports.size()) {
-                case 0:
-                    log.warn("[${workflow.manifest.name}] No reports found from process 'MULTIQC'")
-                    return null
-                case 1:
-                    return multiqc_reports.first()
-                default:
-                    log.warn("[${workflow.manifest.name}] Found multiple reports from process 'MULTIQC', will use only one")
-                    return multiqc_reports.first()
-            }
-        default:
+    if (multiqc_reports instanceof Path) {
+        return multiqc_reports
+    } else if (multiqc_reports instanceof List) {
+        if (multiqc_reports.size() == 0) {
+            log.warn("[${workflow.manifest.name}] No reports found from process 'MULTIQC'")
             return null
+        } else if (multiqc_reports.size() == 1) {
+            return multiqc_reports.first()
+        } else {
+            log.warn("[${workflow.manifest.name}] Found multiple reports from process 'MULTIQC', will use only one")
+            return multiqc_reports.first()
+        }
+    } else {
+        return null
     }
 }
 

--- a/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.function.nf.test
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.function.nf.test
@@ -79,4 +79,48 @@ nextflow_function {
             )
         }
     }
+
+    test("Test Function getSingleReport with a single file") {
+        function "getSingleReport"
+
+        when {
+            function {
+                """
+                input[0] = file(params.modules_testdata_base_path + '/generic/tsv/test.tsv', checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result.contains("test.tsv") }
+            )
+        }
+    }
+
+    test("Test Function getSingleReport with multiple files") {
+        function "getSingleReport"
+
+        when {
+            function {
+                """
+                input[0] = [
+                    file(params.modules_testdata_base_path + '/generic/tsv/test.tsv', checkIfExists: true),
+                    file(params.modules_testdata_base_path + '/generic/tsv/network.tsv', checkIfExists: true),
+                    file(params.modules_testdata_base_path + '/generic/tsv/expression.tsv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert function.success },
+                { assert function.result.contains("test.tsv") },
+                { assert !function.result.contains("network.tsv") },
+                { assert !function.result.contains("expression.tsv") }
+            )
+        }
+    }
 }


### PR DESCRIPTION
The use of the switch syntax is not yet supported by the LSP, so replacing it with if-else for the time being. Less elegant, but functionally identical.

I also added some tests to check that the function works as expected.


## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
