### PR TITLE
Add pigz to trimgalore

### DIFF
--- a/modules/nf-core/trimgalore/environment.yml
+++ b/modules/nf-core/trimgalore/environment.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
   - bioconda
-
 dependencies:
   - bioconda::cutadapt=4.9
   - bioconda::trim-galore=0.6.10
+  - conda-forge::pigz=2.8

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -51,6 +51,7 @@ process TRIMGALORE {
         "${task.process}":
             trimgalore: \$(echo \$(trim_galore --version 2>&1) | sed 's/^.*version //; s/Last.*\$//')
             cutadapt: \$(cutadapt --version)
+            pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
         END_VERSIONS
         """
     } else {
@@ -69,6 +70,7 @@ process TRIMGALORE {
         "${task.process}":
             trimgalore: \$(echo \$(trim_galore --version 2>&1) | sed 's/^.*version //; s/Last.*\$//')
             cutadapt: \$(cutadapt --version)
+            pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
         END_VERSIONS
         """
     }
@@ -91,6 +93,7 @@ process TRIMGALORE {
     "${task.process}":
         trimgalore: \$(echo \$(trim_galore --version 2>&1) | sed 's/^.*version //; s/Last.*\$//')
         cutadapt: \$(cutadapt --version)
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
     END_VERSIONS
     """
 }

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -12,11 +12,11 @@ process TRIMGALORE {
 
     output:
     tuple val(meta), path("*{3prime,5prime,trimmed,val}*.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt"), emit: log, optional: true
+    tuple val(meta), path("*report.txt")     , emit: log     , optional: true
     tuple val(meta), path("*unpaired*.fq.gz"), emit: unpaired, optional: true
-    tuple val(meta), path("*.html"), emit: html, optional: true
-    tuple val(meta), path("*.zip"), emit: zip, optional: true
-    path "versions.yml", emit: versions
+    tuple val(meta), path("*.html")          , emit: html    , optional: true
+    tuple val(meta), path("*.zip")           , emit: zip     , optional: true
+    path "versions.yml"					     , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -1,22 +1,22 @@
 process TRIMGALORE {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9b/9becad054093ad4083a961d12733f2a742e11728fe9aa815d678b882b3ede520/data' :
-        'community.wave.seqera.io/library/cutadapt_trim-galore_pigz:a98edd405b34582d' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9b/9becad054093ad4083a961d12733f2a742e11728fe9aa815d678b882b3ede520/data'
+        : 'community.wave.seqera.io/library/cutadapt_trim-galore_pigz:a98edd405b34582d'}"
 
     input:
     tuple val(meta), path(reads)
 
     output:
     tuple val(meta), path("*{3prime,5prime,trimmed,val}*.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt")                        , emit: log     , optional: true
-    tuple val(meta), path("*unpaired*.fq.gz")                   , emit: unpaired, optional: true
-    tuple val(meta), path("*.html")                             , emit: html    , optional: true
-    tuple val(meta), path("*.zip")                              , emit: zip     , optional: true
-    path "versions.yml"                                         , emit: versions
+    tuple val(meta), path("*report.txt"), emit: log, optional: true
+    tuple val(meta), path("*unpaired*.fq.gz"), emit: unpaired, optional: true
+    tuple val(meta), path("*.html"), emit: html, optional: true
+    tuple val(meta), path("*.zip"), emit: zip, optional: true
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,9 +29,15 @@ process TRIMGALORE {
     def cores = 1
     if (task.cpus) {
         cores = (task.cpus as int) - 4
-        if (meta.single_end) cores = (task.cpus as int) - 3
-        if (cores < 1) cores = 1
-        if (cores > 8) cores = 8
+        if (meta.single_end) {
+            cores = (task.cpus as int) - 3
+        }
+        if (cores < 1) {
+            cores = 1
+        }
+        if (cores > 8) {
+            cores = 8
+        }
     }
 
     // Added soft-links to original fastqs for consistent naming in MultiQC
@@ -40,10 +46,10 @@ process TRIMGALORE {
         def args_list = args.split("\\s(?=--)").toList()
         args_list.removeAll { it.toLowerCase().contains('_r2 ') }
         """
-        [ ! -f  ${prefix}.fastq.gz ] && ln -s $reads ${prefix}.fastq.gz
+        [ ! -f  ${prefix}.fastq.gz ] && ln -s ${reads} ${prefix}.fastq.gz
         trim_galore \\
             ${args_list.join(' ')} \\
-            --cores $cores \\
+            --cores ${cores} \\
             --gzip \\
             ${prefix}.fastq.gz
 
@@ -54,13 +60,14 @@ process TRIMGALORE {
             pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
         END_VERSIONS
         """
-    } else {
+    }
+    else {
         """
         [ ! -f  ${prefix}_1.fastq.gz ] && ln -s ${reads[0]} ${prefix}_1.fastq.gz
         [ ! -f  ${prefix}_2.fastq.gz ] && ln -s ${reads[1]} ${prefix}_2.fastq.gz
         trim_galore \\
-            $args \\
-            --cores $cores \\
+            ${args} \\
+            --cores ${cores} \\
             --paired \\
             --gzip \\
             ${prefix}_1.fastq.gz \\
@@ -80,7 +87,8 @@ process TRIMGALORE {
     if (meta.single_end) {
         output_command = "echo '' | gzip > ${prefix}_trimmed.fq.gz ;"
         output_command += "touch ${prefix}.fastq.gz_trimming_report.txt"
-    } else {
+    }
+    else {
         output_command = "echo '' | gzip > ${prefix}_1_trimmed.fq.gz ;"
         output_command += "touch ${prefix}_1.fastq.gz_trimming_report.txt ;"
         output_command += "echo '' | gzip > ${prefix}_2_trimmed.fq.gz ;"

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -4,8 +4,8 @@ process TRIMGALORE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/trim-galore%3A0.6.10--hdfd78af_1' :
-        'biocontainers/trim-galore:0.6.10--hdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9b/9becad054093ad4083a961d12733f2a742e11728fe9aa815d678b882b3ede520/data' :
+        'community.wave.seqera.io/library/cutadapt_trim-galore_pigz:a98edd405b34582d' }"
 
     input:
     tuple val(meta), path(reads)
@@ -24,7 +24,7 @@ process TRIMGALORE {
     script:
     def args = task.ext.args ?: ''
     // Calculate number of --cores for TrimGalore based on value of task.cpus
-    // See: https://github.com/FelixKrueger/TrimGalore/blob/master/Changelog.md#version-060-release-on-1-mar-2019
+    // See: https://github.com/FelixKrueger/TrimGalore/blob/master/CHANGELOG.md#version-060-release-on-1-mar-2019
     // See: https://github.com/nf-core/atacseq/pull/65
     def cores = 1
     if (task.cpus) {

--- a/modules/nf-core/trimgalore/tests/main.nf.test
+++ b/modules/nf-core/trimgalore/tests/main.nf.test
@@ -39,7 +39,7 @@ nextflow_process {
                     { assert path(process.out.log.get(0).get(1)).getText().contains(report1_line) }
                     }
                 },
-                { assert snapshot(process.out.versions).match() }
+                { assert snapshot(path(process.out.versions.get(0)).yaml).match() },
             )
         }
     }
@@ -61,7 +61,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions.get(0)).yaml
+                ).match() },
             )
         }
     }
@@ -118,7 +121,7 @@ nextflow_process {
                     { assert path(process.out.log.get(0).get(1).get(1)).getText().contains(report2_line) }
                     }
                 },
-                { assert snapshot(process.out.versions).match() }
+                { assert snapshot(path(process.out.versions.get(0)).yaml).match() },
             )
         }
     }
@@ -143,7 +146,8 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out).match() },
+                { assert snapshot(path(process.out.versions.get(0)).yaml).match("versions") },
             )
         }
     }

--- a/modules/nf-core/trimgalore/tests/main.nf.test.snap
+++ b/modules/nf-core/trimgalore/tests/main.nf.test.snap
@@ -1,15 +1,19 @@
 {
     "test_trimgalore_single_end": {
         "content": [
-            [
-                "versions.yml:md5,81a0b49f3a9e1315fe564f9946eb8c50"
-            ]
+            {
+                "TRIMGALORE": {
+                    "trimgalore": "0.6.10",
+                    "cutadapt": 4.9,
+                    "pigz": 2.8
+                }
+            }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:23:17.969056957"
+        "timestamp": "2024-12-05T22:56:18.454197"
     },
     "test_trimgalore_single_end - stub": {
         "content": [
@@ -42,7 +46,7 @@
                     
                 ],
                 "5": [
-                    "versions.yml:md5,81a0b49f3a9e1315fe564f9946eb8c50"
+                    "versions.yml:md5,5928323d579768de37e83c56c821757f"
                 ],
                 "html": [
                     
@@ -69,18 +73,25 @@
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,81a0b49f3a9e1315fe564f9946eb8c50"
+                    "versions.yml:md5,5928323d579768de37e83c56c821757f"
                 ],
                 "zip": [
                     
                 ]
+            },
+            {
+                "TRIMGALORE": {
+                    "trimgalore": "0.6.10",
+                    "cutadapt": 4.9,
+                    "pigz": 2.8
+                }
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:23:28.617831159"
+        "timestamp": "2024-12-05T22:56:22.085472"
     },
     "test_trimgalore_paired_end - stub": {
         "content": [
@@ -119,7 +130,7 @@
                     
                 ],
                 "5": [
-                    "versions.yml:md5,81a0b49f3a9e1315fe564f9946eb8c50"
+                    "versions.yml:md5,5928323d579768de37e83c56c821757f"
                 ],
                 "html": [
                     
@@ -152,7 +163,7 @@
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,81a0b49f3a9e1315fe564f9946eb8c50"
+                    "versions.yml:md5,5928323d579768de37e83c56c821757f"
                 ],
                 "zip": [
                     
@@ -160,21 +171,41 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:23:51.539787731"
+        "timestamp": "2024-12-05T22:44:33.751013"
+    },
+    "versions": {
+        "content": [
+            {
+                "TRIMGALORE": {
+                    "trimgalore": "0.6.10",
+                    "cutadapt": 4.9,
+                    "pigz": 2.8
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
+        },
+        "timestamp": "2024-12-05T22:57:28.77107"
     },
     "test_trimgalore_paired_end": {
         "content": [
-            [
-                "versions.yml:md5,81a0b49f3a9e1315fe564f9946eb8c50"
-            ]
+            {
+                "TRIMGALORE": {
+                    "trimgalore": "0.6.10",
+                    "cutadapt": 4.9,
+                    "pigz": 2.8
+                }
+            }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:23:41.16485915"
+        "timestamp": "2024-12-05T22:56:27.019872"
     }
 }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test.snap
@@ -61,8 +61,8 @@
                 ],
                 "9": [
                     "versions.yml:md5,3e4b7f058c0aa96ba41c3e4d6df6e839",
-                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                    "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                    "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
                 ],
                 "fastqc_html": [
                     [
@@ -123,16 +123,16 @@
                 ],
                 "versions": [
                     "versions.yml:md5,3e4b7f058c0aa96ba41c3e4d6df6e839",
-                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                    "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                    "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:25:19.153139356"
+        "timestamp": "2024-12-05T22:45:22.365353"
     },
     "test paired end read without UMI - stub": {
         "content": [
@@ -192,8 +192,8 @@
                     ]
                 ],
                 "9": [
-                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                    "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                    "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
                 ],
                 "fastqc_html": [
                     [
@@ -250,16 +250,16 @@
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                    "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                    "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:25:30.433084765"
+        "timestamp": "2024-12-05T22:45:26.514305"
     },
     "test paired end read without UMI": {
         "content": [
@@ -288,15 +288,15 @@
                 
             ],
             [
-                "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:24:40.341840093"
+        "timestamp": "2024-12-05T22:45:06.899923"
     },
     "test single end read with UMI": {
         "content": [
@@ -323,15 +323,15 @@
             ],
             [
                 "versions.yml:md5,3e4b7f058c0aa96ba41c3e4d6df6e839",
-                "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:24:09.307037853"
+        "timestamp": "2024-12-05T22:44:50.05749"
     },
     "test paired end read with UMI": {
         "content": [
@@ -358,15 +358,15 @@
             ],
             [
                 "versions.yml:md5,3e4b7f058c0aa96ba41c3e4d6df6e839",
-                "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:24:26.93011239"
+        "timestamp": "2024-12-05T22:45:00.015694"
     },
     "test skip all steps": {
         "content": [
@@ -448,8 +448,8 @@
                 ],
                 "9": [
                     "versions.yml:md5,3e4b7f058c0aa96ba41c3e4d6df6e839",
-                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                    "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                    "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
                 ],
                 "fastqc_html": [
                     [
@@ -510,15 +510,15 @@
                 ],
                 "versions": [
                     "versions.yml:md5,3e4b7f058c0aa96ba41c3e4d6df6e839",
-                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2",
-                    "versions.yml:md5,c1bbaea7bd77a49018d36e859e297118"
+                    "versions.yml:md5,6bcfe4e08308ca239c09bbd6cbcef429",
+                    "versions.yml:md5,7e740129a23c5ac21c27476e30f8a6d2"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-10-22T19:25:05.585472049"
+        "timestamp": "2024-12-05T22:45:15.763472"
     }
 }


### PR DESCRIPTION
- **feat: Add pigz to trimgalore**
- **style: Run lsp format**

This one shouldn't be controversial. It's documented that using pigz speeds up trimgalore. In the DSL2 transition the requirement got dropped because it was in mega environment.yml in methylseq, and atac-seq.

Closes https://github.com/nf-core/atacseq/issues/394 

> Added multi-threading support with the new option -j/--cores INT; many thanks to Frankie James for initiating this. Multi-threading support works effectively if Cutadapt is run with Python 3, and if parallel gzip (pigz) is installed: 

https://github.com/FelixKrueger/TrimGalore/blob/master/CHANGELOG.md#version-060-release-on-1-mar-2019