### PR TITLE
Add busco downloads as output

### DIFF
--- a/modules/nf-core/busco/busco/main.nf
+++ b/modules/nf-core/busco/busco/main.nf
@@ -24,7 +24,8 @@ process BUSCO_BUSCO {
     tuple val(meta), path("*-busco/*/run_*/busco_sequences")          , emit: seq_dir               , optional: true
     tuple val(meta), path("*-busco/*/translated_proteins")            , emit: translated_dir        , optional: true
     tuple val(meta), path("*-busco")                                  , emit: busco_dir
-    tuple val(meta), path("busco_downloads")                          , emit: busco_downloads_dir   , optional: true
+    tuple val(meta), path("busco_downloads/lineages/*")               , emit: downloaded_lineages   , optional: true
+
     path "versions.yml"                                               , emit: versions
 
     when:

--- a/modules/nf-core/busco/busco/main.nf
+++ b/modules/nf-core/busco/busco/main.nf
@@ -24,6 +24,7 @@ process BUSCO_BUSCO {
     tuple val(meta), path("*-busco/*/run_*/busco_sequences")          , emit: seq_dir               , optional: true
     tuple val(meta), path("*-busco/*/translated_proteins")            , emit: translated_dir        , optional: true
     tuple val(meta), path("*-busco")                                  , emit: busco_dir
+    tuple val(meta), path("busco_downloads")                          , emit: busco_downloads_dir   , optional: true
     path "versions.yml"                                               , emit: versions
 
     when:

--- a/modules/nf-core/busco/busco/meta.yml
+++ b/modules/nf-core/busco/busco/meta.yml
@@ -138,7 +138,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*busco_downloads":
+      - "busco_downloads":
           type: directory
           description: BUSCO downloads directory
           pattern: "busco_downloads"

--- a/modules/nf-core/busco/busco/meta.yml
+++ b/modules/nf-core/busco/busco/meta.yml
@@ -132,6 +132,16 @@ output:
           type: directory
           description: BUSCO lineage specific output
           pattern: "*-busco"
+  - busco_downloads_dir:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*busco_downloads":
+          type: directory
+          description: BUSCO downloads directory
+          pattern: "busco_downloads"
   - versions:
       - versions.yml:
           type: file

--- a/modules/nf-core/busco/busco/meta.yml
+++ b/modules/nf-core/busco/busco/meta.yml
@@ -132,16 +132,16 @@ output:
           type: directory
           description: BUSCO lineage specific output
           pattern: "*-busco"
-  - busco_downloads_dir:
+  - busco_downloaded_lineages:
       - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "busco_downloads":
+      - "busco_downloads/lineages/*":
           type: directory
-          description: BUSCO downloads directory
-          pattern: "busco_downloads"
+          description: BUSCO lineages downloaded
+          pattern: "busco_downloads/lineages/*"
   - versions:
       - versions.yml:
           type: file

--- a/modules/nf-core/busco/busco/meta.yml
+++ b/modules/nf-core/busco/busco/meta.yml
@@ -132,7 +132,7 @@ output:
           type: directory
           description: BUSCO lineage specific output
           pattern: "*-busco"
-  - busco_downloaded_lineages:
+  - downloaded_lineages:
       - meta:
           type: map
           description: |

--- a/modules/nf-core/busco/busco/meta.yml
+++ b/modules/nf-core/busco/busco/meta.yml
@@ -46,7 +46,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - "*-busco.batch_summary.txt":
           type: file
           description: Summary of all sequence files analyzed
@@ -56,7 +56,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - short_summary.*.txt:
           type: file
           description: Short Busco summary in plain text format
@@ -66,7 +66,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - short_summary.*.json:
           type: file
           description: Short Busco summary in JSON format
@@ -76,7 +76,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - "*-busco/*/run_*/full_table.tsv":
           type: file
           description: Full BUSCO results table
@@ -86,7 +86,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - "*-busco/*/run_*/missing_busco_list.tsv":
           type: file
           description: List of missing BUSCOs
@@ -96,7 +96,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - "*-busco/*/run_*/single_copy_proteins.faa":
           type: file
           description: Fasta file of single copy proteins (transcriptome mode)
@@ -106,7 +106,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - "*-busco/*/run_*/busco_sequences":
           type: directory
           description: BUSCO sequence directory
@@ -116,7 +116,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - "*-busco/*/translated_proteins":
           type: directory
           description: Six frame translations of each transcript made by the transcriptome
@@ -127,7 +127,7 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - "*-busco":
           type: directory
           description: BUSCO lineage specific output
@@ -137,10 +137,10 @@ output:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
+            e.g. [ id:'test' ]
       - "busco_downloads/lineages/*":
           type: directory
-          description: BUSCO lineages downloaded
+          description: Lineages downloaded by BUSCO when running the analysis, for example bacteria_odb12
           pattern: "busco_downloads/lineages/*"
   - versions:
       - versions.yml:

--- a/modules/nf-core/busco/busco/tests/main.nf.test
+++ b/modules/nf-core/busco/busco/tests/main.nf.test
@@ -406,7 +406,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out.batch_summary,
+                    process.out.versions
+                ).match() }
             )
         }
     }

--- a/modules/nf-core/busco/busco/tests/main.nf.test.snap
+++ b/modules/nf-core/busco/busco/tests/main.nf.test.snap
@@ -1,130 +1,23 @@
 {
     "minimal-stub": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test-bacteria_odb12-busco.batch_summary.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "10": [
-                    "versions.yml:md5,c6e638f981761c13cd9ff7663cf707e6"
-                ],
-                "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    
-                ],
-                "6": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            
-                        ]
-                    ]
-                ],
-                "7": [
-                    
-                ],
-                "8": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            [
-                                [
-                                    [
-                                        
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ],
-                "9": [
-                    
-                ],
-                "batch_summary": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test-bacteria_odb12-busco.batch_summary.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "busco_dir": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            [
-                                [
-                                    [
-                                        
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ],
-                "downloaded_lineages": [
-                    
-                ],
-                "full_table": [
-                    
-                ],
-                "missing_busco_list": [
-                    
-                ],
-                "seq_dir": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            
-                        ]
-                    ]
-                ],
-                "short_summaries_json": [
-                    
-                ],
-                "short_summaries_txt": [
-                    
-                ],
-                "single_copy_proteins": [
-                    
-                ],
-                "translated_dir": [
-                    
-                ],
-                "versions": [
-                    "versions.yml:md5,c6e638f981761c13cd9ff7663cf707e6"
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test-bacteria_odb12-busco.batch_summary.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
-            }
+            ],
+            [
+                "versions.yml:md5,c6e638f981761c13cd9ff7663cf707e6"
+            ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
+            "nextflow": "24.10.2"
         },
-        "timestamp": "2024-12-12T17:53:12.04195472"
+        "timestamp": "2024-12-13T15:30:45.505241761"
     },
     "test_busco_eukaryote_augustus": {
         "content": [

--- a/modules/nf-core/busco/busco/tests/main.nf.test.snap
+++ b/modules/nf-core/busco/busco/tests/main.nf.test.snap
@@ -13,6 +13,9 @@
                 "1": [
                     
                 ],
+                "10": [
+                    "versions.yml:md5,c6e638f981761c13cd9ff7663cf707e6"
+                ],
                 "2": [
                     
                 ],
@@ -55,7 +58,7 @@
                     ]
                 ],
                 "9": [
-                    "versions.yml:md5,c6e638f981761c13cd9ff7663cf707e6"
+                    
                 ],
                 "batch_summary": [
                     [
@@ -80,6 +83,9 @@
                             ]
                         ]
                     ]
+                ],
+                "busco_downloads_dir": [
+                    
                 ],
                 "full_table": [
                     
@@ -118,7 +124,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.1"
         },
-        "timestamp": "2024-12-11T12:45:52.045550047"
+        "timestamp": "2024-12-12T13:52:55.9049764"
     },
     "test_busco_eukaryote_augustus": {
         "content": [

--- a/modules/nf-core/busco/busco/tests/main.nf.test.snap
+++ b/modules/nf-core/busco/busco/tests/main.nf.test.snap
@@ -84,7 +84,7 @@
                         ]
                     ]
                 ],
-                "busco_downloads_dir": [
+                "downloaded_lineages": [
                     
                 ],
                 "full_table": [
@@ -124,7 +124,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.1"
         },
-        "timestamp": "2024-12-12T13:52:55.9049764"
+        "timestamp": "2024-12-12T17:53:12.04195472"
     },
     "test_busco_eukaryote_augustus": {
         "content": [

--- a/modules/nf-core/busco/generateplot/environment.yml
+++ b/modules/nf-core/busco/generateplot/environment.yml
@@ -1,7 +1,6 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda
+
 dependencies:
-  - bioconda::busco=5.7.1
+  - bioconda::busco=5.8.2

--- a/modules/nf-core/busco/generateplot/main.nf
+++ b/modules/nf-core/busco/generateplot/main.nf
@@ -3,8 +3,8 @@ process BUSCO_GENERATEPLOT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/busco:5.7.1--pyhdfd78af_0':
-        'biocontainers/busco:5.7.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/busco:5.8.2--pyhdfd78af_0':
+        'biocontainers/busco:5.8.2--pyhdfd78af_0' }"
 
     input:
     path short_summary_txt, stageAs: 'busco/*'

--- a/modules/nf-core/busco/generateplot/tests/main.nf.test.snap
+++ b/modules/nf-core/busco/generateplot/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "versions": {
         "content": [
             [
-                "versions.yml:md5,726fa3440ea3a0b2e9d032d7e4d25e74"
+                "versions.yml:md5,de6313bd06a673b9db4a982abf9019e6"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.1"
         },
-        "timestamp": "2024-05-03T15:40:01.523993"
+        "timestamp": "2024-12-12T17:44:49.021631034"
     },
     "stub": {
         "content": [
@@ -18,20 +18,20 @@
                     "busco_figure.png:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "1": [
-                    "versions.yml:md5,726fa3440ea3a0b2e9d032d7e4d25e74"
+                    "versions.yml:md5,de6313bd06a673b9db4a982abf9019e6"
                 ],
                 "png": [
                     "busco_figure.png:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "versions": [
-                    "versions.yml:md5,726fa3440ea3a0b2e9d032d7e4d25e74"
+                    "versions.yml:md5,de6313bd06a673b9db4a982abf9019e6"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.1"
         },
-        "timestamp": "2024-05-03T15:40:11.864276"
+        "timestamp": "2024-12-12T17:44:57.632273743"
     }
 }

--- a/subworkflows/nf-core/fasta_gxf_busco_plot/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_gxf_busco_plot/tests/main.nf.test.snap
@@ -239,17 +239,17 @@
                 ]
             ],
             [
-                "versions.yml:md5,05d8022e3afb0d5642ed17147b991730",
-                "versions.yml:md5,53987b35fc275297efdaf525937fdca3",
                 "versions.yml:md5,624e4661a636558db4521457fcddf6dd",
                 "versions.yml:md5,9435355f913e283f60b4fb7ef77dd52a",
-                "versions.yml:md5,98062b1a1c90be0537d21ccfbf08bc64"
+                "versions.yml:md5,98062b1a1c90be0537d21ccfbf08bc64",
+                "versions.yml:md5,ab3572b594228efec5824329cba08997",
+                "versions.yml:md5,b717797e52f95b2e9d5fb139f7c1e8ac"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.1"
         },
-        "timestamp": "2024-12-11T12:47:41.989229128"
+        "timestamp": "2024-12-12T17:45:57.908942636"
     }
 }


### PR DESCRIPTION
This PR
- Adds downloaded BUSCO lineages as an output.
- Updates BUSCO version in busco/generateplot

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
