### PR TITLE
READY FOR REVIEW: Adapt output declarations

### DIFF
--- a/modules/nf-core/abacas/main.nf
+++ b/modules/nf-core/abacas/main.nf
@@ -12,7 +12,7 @@ process ABACAS {
     path  fasta
 
     output:
-    tuple val(meta), path('*.abacas*'), emit: results
+    tuple val(meta), path("*.abacas*"), emit: results
     path "versions.yml"               , emit: versions
 
     when:

--- a/modules/nf-core/adapterremoval/main.nf
+++ b/modules/nf-core/adapterremoval/main.nf
@@ -18,7 +18,7 @@ process ADAPTERREMOVAL {
     tuple val(meta), path("${prefix}.collapsed.fastq.gz")            , optional: true, emit: collapsed
     tuple val(meta), path("${prefix}.collapsed.truncated.fastq.gz")  , optional: true, emit: collapsed_truncated
     tuple val(meta), path("${prefix}.paired.fastq.gz")               , optional: true, emit: paired_interleaved
-    tuple val(meta), path('*.settings')                              , emit: settings
+    tuple val(meta), path("*.settings")                              , emit: settings
     path "versions.yml"                                              , emit: versions
 
     when:

--- a/modules/nf-core/amplify/predict/main.nf
+++ b/modules/nf-core/amplify/predict/main.nf
@@ -13,7 +13,7 @@ process AMPLIFY_PREDICT {
     path(model_dir)
 
     output:
-    tuple val(meta), path('*.tsv'), emit: tsv
+    tuple val(meta), path("*.tsv"), emit: tsv
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/bandage/image/main.nf
+++ b/modules/nf-core/bandage/image/main.nf
@@ -11,8 +11,8 @@ process BANDAGE_IMAGE {
     tuple val(meta), path(gfa)
 
     output:
-    tuple val(meta), path('*.png'), emit: png
-    tuple val(meta), path('*.svg'), emit: svg
+    tuple val(meta), path("*.png"), emit: png
+    tuple val(meta), path("*.svg"), emit: svg
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/bases2fastq/main.nf
+++ b/modules/nf-core/bases2fastq/main.nf
@@ -8,13 +8,13 @@ process BASES2FASTQ {
     tuple val(meta), path(run_manifest), path(run_dir)
 
     output:
-    tuple val(meta), path('output/Samples/**/*_R*.fastq.gz'), emit: sample_fastq
-    tuple val(meta), path('output/Samples/**/*_stats.json') , emit: sample_json
-    tuple val(meta), path('output/*.html')                  , emit: qc_report
-    tuple val(meta), path('output/RunStats.json')           , emit: run_stats
-    tuple val(meta), path('output/RunManifest.json')        , emit: generated_run_manifest
-    tuple val(meta), path('output/Metrics.csv')             , emit: metrics
-    tuple val(meta), path('output/UnassignedSequences.csv') , emit: unassigned
+    tuple val(meta), path("output/Samples/**/*_R*.fastq.gz"), emit: sample_fastq
+    tuple val(meta), path("output/Samples/**/*_stats.json") , emit: sample_json
+    tuple val(meta), path("output/*.html")                  , emit: qc_report
+    tuple val(meta), path("output/RunStats.json")           , emit: run_stats
+    tuple val(meta), path("output/RunManifest.json")        , emit: generated_run_manifest
+    tuple val(meta), path("output/Metrics.csv")             , emit: metrics
+    tuple val(meta), path("output/UnassignedSequences.csv") , emit: unassigned
     path "versions.yml"                                     , emit: versions
 
     when:

--- a/modules/nf-core/bbmap/bbduk/main.nf
+++ b/modules/nf-core/bbmap/bbduk/main.nf
@@ -12,8 +12,8 @@ process BBMAP_BBDUK {
     path contaminants
 
     output:
-    tuple val(meta), path('*.fastq.gz'), emit: reads
-    tuple val(meta), path('*.log')     , emit: log
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    tuple val(meta), path("*.log")     , emit: log
     path "versions.yml"                , emit: versions
 
     when:

--- a/modules/nf-core/bbmap/bbsplit/main.nf
+++ b/modules/nf-core/bbmap/bbsplit/main.nf
@@ -17,10 +17,10 @@ process BBMAP_BBSPLIT {
 
     output:
     path "bbsplit"                            , optional:true, emit: index
-    tuple val(meta), path('*primary*fastq.gz'), optional:true, emit: primary_fastq
-    tuple val(meta), path('*fastq.gz')        , optional:true, emit: all_fastq
-    tuple val(meta), path('*txt')             , optional:true, emit: stats
-    tuple val(meta), path('*.log')            , optional:true, emit: log
+    tuple val(meta), path("*primary*fastq.gz"), optional:true, emit: primary_fastq
+    tuple val(meta), path("*fastq.gz")        , optional:true, emit: all_fastq
+    tuple val(meta), path("*txt")             , optional:true, emit: stats
+    tuple val(meta), path("*.log")            , optional:true, emit: log
     path "versions.yml"                       , emit: versions
 
     when:

--- a/modules/nf-core/bbmap/clumpify/main.nf
+++ b/modules/nf-core/bbmap/clumpify/main.nf
@@ -12,8 +12,8 @@ process BBMAP_CLUMPIFY {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path('*.fastq.gz'), emit: reads
-    tuple val(meta), path('*.log')     , emit: log
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    tuple val(meta), path("*.log")     , emit: log
     path "versions.yml"                , emit: versions
 
     when:

--- a/modules/nf-core/bbmap/filterbyname/main.nf
+++ b/modules/nf-core/bbmap/filterbyname/main.nf
@@ -15,7 +15,7 @@ process BBMAP_FILTERBYNAME {
 
     output:
     tuple val(meta), path("*.${output_format}"), emit: reads
-    tuple val(meta), path('*.log')             , emit: log
+    tuple val(meta), path("*.log")             , emit: log
     path "versions.yml"                        , emit: versions
 
     when:

--- a/modules/nf-core/bcftools/consensus/main.nf
+++ b/modules/nf-core/bcftools/consensus/main.nf
@@ -11,7 +11,7 @@ process BCFTOOLS_CONSENSUS {
     tuple val(meta), path(vcf), path(tbi), path(fasta), path(mask)
 
     output:
-    tuple val(meta), path('*.fa'), emit: fasta
+    tuple val(meta), path("*.fa"), emit: fasta
     path  "versions.yml"         , emit: versions
 
     when:

--- a/modules/nf-core/bedops/gtf2bed/main.nf
+++ b/modules/nf-core/bedops/gtf2bed/main.nf
@@ -11,7 +11,7 @@ process BEDOPS_GTF2BED {
     tuple val(meta), path(gtf)
 
     output:
-    tuple val(meta), path('*.bed'), emit: bed
+    tuple val(meta), path("*.bed"), emit: bed
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/bedtools/complement/main.nf
+++ b/modules/nf-core/bedtools/complement/main.nf
@@ -12,7 +12,7 @@ process BEDTOOLS_COMPLEMENT {
     path  sizes
 
     output:
-    tuple val(meta), path('*.bed'), emit: bed
+    tuple val(meta), path("*.bed"), emit: bed
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/bedtools/groupby/main.nf
+++ b/modules/nf-core/bedtools/groupby/main.nf
@@ -12,7 +12,7 @@ process BEDTOOLS_GROUPBY {
     val(summary_col)
 
     output:
-    tuple val(meta), path('*.bed'), emit: bed
+    tuple val(meta), path("*.bed"), emit: bed
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/bedtools/merge/main.nf
+++ b/modules/nf-core/bedtools/merge/main.nf
@@ -11,7 +11,7 @@ process BEDTOOLS_MERGE {
     tuple val(meta), path(bed)
 
     output:
-    tuple val(meta), path('*.bed'), emit: bed
+    tuple val(meta), path("*.bed"), emit: bed
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/blast/blastn/main.nf
+++ b/modules/nf-core/blast/blastn/main.nf
@@ -12,7 +12,7 @@ process BLAST_BLASTN {
     tuple val(meta2), path(db)
 
     output:
-    tuple val(meta), path('*.txt'), emit: txt
+    tuple val(meta), path("*.txt"), emit: txt
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/blast/tblastn/main.nf
+++ b/modules/nf-core/blast/tblastn/main.nf
@@ -12,7 +12,7 @@ process BLAST_TBLASTN {
     tuple val(meta2), path(db)
 
     output:
-    tuple val(meta), path('*.txt'), emit: txt
+    tuple val(meta), path("*.txt"), emit: txt
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/bowtie/align/main.nf
+++ b/modules/nf-core/bowtie/align/main.nf
@@ -13,9 +13,9 @@ process BOWTIE_ALIGN {
     val (save_unaligned)
 
     output:
-    tuple val(meta), path('*.bam')     , emit: bam
-    tuple val(meta), path('*.out')     , emit: log
-    tuple val(meta), path('*fastq.gz') , emit: fastq, optional : true
+    tuple val(meta), path("*.bam")     , emit: bam
+    tuple val(meta), path("*.out")     , emit: log
+    tuple val(meta), path("*fastq.gz") , emit: fastq, optional : true
     path  "versions.yml"               , emit: versions
 
     when:

--- a/modules/nf-core/bowtie/build/main.nf
+++ b/modules/nf-core/bowtie/build/main.nf
@@ -11,7 +11,7 @@ process BOWTIE_BUILD {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path('bowtie') , emit: index
+    tuple val(meta), path("bowtie") , emit: index
     path "versions.yml"             , emit: versions
 
     when:

--- a/modules/nf-core/bowtie2/build/main.nf
+++ b/modules/nf-core/bowtie2/build/main.nf
@@ -11,7 +11,7 @@ process BOWTIE2_BUILD {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path('bowtie2')    , emit: index
+    tuple val(meta), path("bowtie2")    , emit: index
     path "versions.yml"                 , emit: versions
 
     when:

--- a/modules/nf-core/cellsnp/modea/main.nf
+++ b/modules/nf-core/cellsnp/modea/main.nf
@@ -11,12 +11,12 @@ process CELLSNP_MODEA {
     tuple val(meta), path(bam), path(bai), path(region_vcf), path(barcode)
 
     output:
-    tuple val(meta), path('*.base.vcf.gz') , emit: base
-    tuple val(meta), path('*.cells.vcf.gz'), emit: cell          , optional: true
-    tuple val(meta), path('*.samples.tsv') , emit: sample
-    tuple val(meta), path('*.tag.AD.mtx')  , emit: allele_depth
-    tuple val(meta), path('*.tag.DP.mtx')  , emit: depth_coverage
-    tuple val(meta), path('*.tag.OTH.mtx') , emit: depth_other
+    tuple val(meta), path("*.base.vcf.gz") , emit: base
+    tuple val(meta), path("*.cells.vcf.gz"), emit: cell          , optional: true
+    tuple val(meta), path("*.samples.tsv") , emit: sample
+    tuple val(meta), path("*.tag.AD.mtx")  , emit: allele_depth
+    tuple val(meta), path("*.tag.DP.mtx")  , emit: depth_coverage
+    tuple val(meta), path("*.tag.OTH.mtx") , emit: depth_other
     path 'versions.yml'                    , emit: versions
 
     when:

--- a/modules/nf-core/centrifuge/centrifuge/main.nf
+++ b/modules/nf-core/centrifuge/centrifuge/main.nf
@@ -14,11 +14,11 @@ process CENTRIFUGE_CENTRIFUGE {
     val save_aligned
 
     output:
-    tuple val(meta), path('*report.txt')                 , emit: report
-    tuple val(meta), path('*results.txt')                , emit: results
-    tuple val(meta), path('*.{sam,tab}')                 , optional: true, emit: sam
-    tuple val(meta), path('*.mapped.fastq{,.1,.2}.gz')   , optional: true, emit: fastq_mapped
-    tuple val(meta), path('*.unmapped.fastq{,.1,.2}.gz') , optional: true, emit: fastq_unmapped
+    tuple val(meta), path("*report.txt")                 , emit: report
+    tuple val(meta), path("*results.txt")                , emit: results
+    tuple val(meta), path("*.{sam,tab}")                 , optional: true, emit: sam
+    tuple val(meta), path("*.mapped.fastq{,.1,.2}.gz")   , optional: true, emit: fastq_mapped
+    tuple val(meta), path("*.unmapped.fastq{,.1,.2}.gz") , optional: true, emit: fastq_unmapped
     path "versions.yml"                                  , emit: versions
 
     when:

--- a/modules/nf-core/centrifuge/kreport/main.nf
+++ b/modules/nf-core/centrifuge/kreport/main.nf
@@ -12,7 +12,7 @@ process CENTRIFUGE_KREPORT {
     path db
 
     output:
-    tuple val(meta), path('*.txt'), emit: kreport
+    tuple val(meta), path("*.txt"), emit: kreport
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/custom/sratoolsncbisettings/main.nf
+++ b/modules/nf-core/custom/sratoolsncbisettings/main.nf
@@ -11,7 +11,7 @@ process CUSTOM_SRATOOLSNCBISETTINGS {
     val ids
 
     output:
-    path('*.mkfg')     , emit: ncbi_settings
+    path("*.mkfg")     , emit: ncbi_settings
     path 'versions.yml', emit: versions
 
     when:

--- a/modules/nf-core/cutadapt/main.nf
+++ b/modules/nf-core/cutadapt/main.nf
@@ -11,8 +11,8 @@ process CUTADAPT {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path('*.trim.fastq.gz'), emit: reads
-    tuple val(meta), path('*.log')          , emit: log
+    tuple val(meta), path("*.trim.fastq.gz"), emit: reads
+    tuple val(meta), path("*.log")          , emit: log
     path "versions.yml"                     , emit: versions
 
     when:

--- a/modules/nf-core/diamond/blastp/main.nf
+++ b/modules/nf-core/diamond/blastp/main.nf
@@ -14,13 +14,13 @@ process DIAMOND_BLASTP {
     val blast_columns
 
     output:
-    tuple val(meta), path('*.blast'), optional: true, emit: blast
-    tuple val(meta), path('*.xml')  , optional: true, emit: xml
-    tuple val(meta), path('*.txt')  , optional: true, emit: txt
-    tuple val(meta), path('*.daa')  , optional: true, emit: daa
-    tuple val(meta), path('*.sam')  , optional: true, emit: sam
-    tuple val(meta), path('*.tsv')  , optional: true, emit: tsv
-    tuple val(meta), path('*.paf')  , optional: true, emit: paf
+    tuple val(meta), path("*.blast"), optional: true, emit: blast
+    tuple val(meta), path("*.xml")  , optional: true, emit: xml
+    tuple val(meta), path("*.txt")  , optional: true, emit: txt
+    tuple val(meta), path("*.daa")  , optional: true, emit: daa
+    tuple val(meta), path("*.sam")  , optional: true, emit: sam
+    tuple val(meta), path("*.tsv")  , optional: true, emit: tsv
+    tuple val(meta), path("*.paf")  , optional: true, emit: paf
     path "versions.yml"             , emit: versions
 
     when:

--- a/modules/nf-core/diamond/blastx/main.nf
+++ b/modules/nf-core/diamond/blastx/main.nf
@@ -14,13 +14,13 @@ process DIAMOND_BLASTX {
     val blast_columns
 
     output:
-    tuple val(meta), path('*.blast'), optional: true, emit: blast
-    tuple val(meta), path('*.xml')  , optional: true, emit: xml
-    tuple val(meta), path('*.txt')  , optional: true, emit: txt
-    tuple val(meta), path('*.daa')  , optional: true, emit: daa
-    tuple val(meta), path('*.sam')  , optional: true, emit: sam
-    tuple val(meta), path('*.tsv')  , optional: true, emit: tsv
-    tuple val(meta), path('*.paf')  , optional: true, emit: paf
+    tuple val(meta), path("*.blast"), optional: true, emit: blast
+    tuple val(meta), path("*.xml")  , optional: true, emit: xml
+    tuple val(meta), path("*.txt")  , optional: true, emit: txt
+    tuple val(meta), path("*.daa")  , optional: true, emit: daa
+    tuple val(meta), path("*.sam")  , optional: true, emit: sam
+    tuple val(meta), path("*.tsv")  , optional: true, emit: tsv
+    tuple val(meta), path("*.paf")  , optional: true, emit: paf
     tuple val(meta), path("*.log")  , emit: log
     path "versions.yml"             , emit: versions
 

--- a/modules/nf-core/dragmap/align/main.nf
+++ b/modules/nf-core/dragmap/align/main.nf
@@ -19,7 +19,7 @@ process DRAGMAP_ALIGN {
     tuple val(meta), path("*.cram") , emit: cram  , optional: true
     tuple val(meta), path("*.crai") , emit: crai  , optional: true
     tuple val(meta), path("*.csi")  , emit: csi   , optional: true
-    tuple val(meta), path('*.log')  , emit: log
+    tuple val(meta), path("*.log")  , emit: log
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/dysgu/main.nf
+++ b/modules/nf-core/dysgu/main.nf
@@ -12,8 +12,8 @@ process DYSGU {
     tuple val(meta2), path(fasta), path(fai)
 
     output:
-    tuple val(meta), path('*.vcf.gz')       , emit: vcf
-    tuple val(meta), path('*.vcf.gz.tbi')   , emit: tbi
+    tuple val(meta), path("*.vcf.gz")       , emit: vcf
+    tuple val(meta), path("*.vcf.gz.tbi")   , emit: tbi
     path 'versions.yml'                     , emit: versions
 
     when:

--- a/modules/nf-core/faqcs/main.nf
+++ b/modules/nf-core/faqcs/main.nf
@@ -11,13 +11,13 @@ process FAQCS {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path('*.trimmed.fastq.gz')           , emit: reads         , optional: true
-    tuple val(meta), path('*.stats.txt')                  , emit: stats         , optional: true
-    tuple val(meta), path('./debug')                      , emit: debug         , optional: true
-    tuple val(meta), path('*_qc_report.pdf')              , emit: statspdf      , optional: true
-    tuple val(meta), path('*.discard.fastq.gz')           , emit: reads_fail    , optional: true
-    tuple val(meta), path('*.trimmed.unpaired.fastq.gz')  , emit: reads_unpaired, optional: true
-    tuple val(meta), path('*.log')                        , emit: log
+    tuple val(meta), path("*.trimmed.fastq.gz")           , emit: reads         , optional: true
+    tuple val(meta), path("*.stats.txt")                  , emit: stats         , optional: true
+    tuple val(meta), path("./debug")                      , emit: debug         , optional: true
+    tuple val(meta), path("*_qc_report.pdf")              , emit: statspdf      , optional: true
+    tuple val(meta), path("*.discard.fastq.gz")           , emit: reads_fail    , optional: true
+    tuple val(meta), path("*.trimmed.unpaired.fastq.gz")  , emit: reads_unpaired, optional: true
+    tuple val(meta), path("*.log")                        , emit: log
     path "versions.yml"                                   , emit: versions
 
     when:

--- a/modules/nf-core/fastavalidator/main.nf
+++ b/modules/nf-core/fastavalidator/main.nf
@@ -11,8 +11,8 @@ process FASTAVALIDATOR {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path('*.success.log')  , emit: success_log , optional: true
-    tuple val(meta), path('*.error.log')    , emit: error_log   , optional: true
+    tuple val(meta), path("*.success.log")  , emit: success_log , optional: true
+    tuple val(meta), path("*.error.log")    , emit: error_log   , optional: true
     path "versions.yml"                     , emit: versions
 
     when:

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -15,12 +15,12 @@ process FASTP {
     val   save_merged
 
     output:
-    tuple val(meta), path('*.fastp.fastq.gz') , optional:true, emit: reads
-    tuple val(meta), path('*.json')           , emit: json
-    tuple val(meta), path('*.html')           , emit: html
-    tuple val(meta), path('*.log')            , emit: log
-    tuple val(meta), path('*.fail.fastq.gz')  , optional:true, emit: reads_fail
-    tuple val(meta), path('*.merged.fastq.gz'), optional:true, emit: reads_merged
+    tuple val(meta), path("*.fastp.fastq.gz") , optional:true, emit: reads
+    tuple val(meta), path("*.json")           , emit: json
+    tuple val(meta), path("*.html")           , emit: html
+    tuple val(meta), path("*.log")            , emit: log
+    tuple val(meta), path("*.fail.fastq.gz")  , optional:true, emit: reads_fail
+    tuple val(meta), path("*.merged.fastq.gz"), optional:true, emit: reads_merged
     path "versions.yml"                       , emit: versions
 
     when:

--- a/modules/nf-core/fqtk/main.nf
+++ b/modules/nf-core/fqtk/main.nf
@@ -14,9 +14,9 @@ process FQTK {
 
     output:
     // Demultiplexed file name changes depending on the arg '--output-types'
-    tuple val(meta), path('output/*.fq.gz')                         , emit: sample_fastq
-    tuple val(meta), path('output/demux-metrics.txt')               , emit: metrics
-    tuple val(meta), path('output/unmatched*.fq.gz')                , emit: most_frequent_unmatched
+    tuple val(meta), path("output/*.fq.gz")                         , emit: sample_fastq
+    tuple val(meta), path("output/demux-metrics.txt")               , emit: metrics
+    tuple val(meta), path("output/unmatched*.fq.gz")                , emit: most_frequent_unmatched
     path "versions.yml"                                             , emit: versions
 
 

--- a/modules/nf-core/gatk4/bedtointervallist/main.nf
+++ b/modules/nf-core/gatk4/bedtointervallist/main.nf
@@ -12,7 +12,7 @@ process GATK4_BEDTOINTERVALLIST {
     tuple val(meta2), path(dict)
 
     output:
-    tuple val(meta), path('*.interval_list'), emit: interval_list
+    tuple val(meta), path("*.interval_list"), emit: interval_list
     path  "versions.yml"                    , emit: versions
 
     when:

--- a/modules/nf-core/gatk4/calculatecontamination/main.nf
+++ b/modules/nf-core/gatk4/calculatecontamination/main.nf
@@ -11,8 +11,8 @@ process GATK4_CALCULATECONTAMINATION {
     tuple val(meta), path(pileup), path(matched)
 
     output:
-    tuple val(meta), path('*.contamination.table'), emit: contamination
-    tuple val(meta), path('*.segmentation.table') , emit: segmentation, optional:true
+    tuple val(meta), path("*.contamination.table"), emit: contamination
+    tuple val(meta), path("*.segmentation.table") , emit: segmentation, optional:true
     path "versions.yml"                           , emit: versions
 
     when:

--- a/modules/nf-core/gatk4/createsequencedictionary/main.nf
+++ b/modules/nf-core/gatk4/createsequencedictionary/main.nf
@@ -11,7 +11,7 @@ process GATK4_CREATESEQUENCEDICTIONARY {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path('*.dict')  , emit: dict
+    tuple val(meta), path("*.dict")  , emit: dict
     path "versions.yml"              , emit: versions
 
     when:

--- a/modules/nf-core/gatk4/estimatelibrarycomplexity/main.nf
+++ b/modules/nf-core/gatk4/estimatelibrarycomplexity/main.nf
@@ -14,7 +14,7 @@ process GATK4_ESTIMATELIBRARYCOMPLEXITY {
     path  dict
 
     output:
-    tuple val(meta), path('*.metrics'), emit: metrics
+    tuple val(meta), path("*.metrics"), emit: metrics
     path "versions.yml"               , emit: versions
 
     when:

--- a/modules/nf-core/gatk4/getpileupsummaries/main.nf
+++ b/modules/nf-core/gatk4/getpileupsummaries/main.nf
@@ -16,7 +16,7 @@ process GATK4_GETPILEUPSUMMARIES {
     path  variants_tbi
 
     output:
-    tuple val(meta), path('*.pileups.table'), emit: table
+    tuple val(meta), path("*.pileups.table"), emit: table
     path "versions.yml"                     , emit: versions
 
     when:

--- a/modules/nf-core/gatk4/mergebamalignment/main.nf
+++ b/modules/nf-core/gatk4/mergebamalignment/main.nf
@@ -13,7 +13,7 @@ process GATK4_MERGEBAMALIGNMENT {
     tuple val(meta3), path(dict)
 
     output:
-    tuple val(meta), path('*.bam'), emit: bam
+    tuple val(meta), path("*.bam"), emit: bam
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/gatk4/mergevcfs/main.nf
+++ b/modules/nf-core/gatk4/mergevcfs/main.nf
@@ -12,7 +12,7 @@ process GATK4_MERGEVCFS {
     tuple val(meta2), path(dict)
 
     output:
-    tuple val(meta), path('*.vcf.gz'), emit: vcf
+    tuple val(meta), path("*.vcf.gz"), emit: vcf
     tuple val(meta), path("*.tbi")   , emit: tbi
     path  "versions.yml"             , emit: versions
 

--- a/modules/nf-core/gatk4/revertsam/main.nf
+++ b/modules/nf-core/gatk4/revertsam/main.nf
@@ -11,7 +11,7 @@ process GATK4_REVERTSAM {
     tuple val(meta), path(bam)
 
     output:
-    tuple val(meta), path('*.bam'), emit: bam
+    tuple val(meta), path("*.bam"), emit: bam
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/gatk4/samtofastq/main.nf
+++ b/modules/nf-core/gatk4/samtofastq/main.nf
@@ -11,7 +11,7 @@ process GATK4_SAMTOFASTQ {
     tuple val(meta), path(bam)
 
     output:
-    tuple val(meta), path('*.fastq.gz'), emit: fastq
+    tuple val(meta), path("*.fastq.gz"), emit: fastq
     path  "versions.yml"               , emit: versions
 
     when:

--- a/modules/nf-core/gatk4/splitncigarreads/main.nf
+++ b/modules/nf-core/gatk4/splitncigarreads/main.nf
@@ -14,7 +14,7 @@ process GATK4_SPLITNCIGARREADS {
     tuple val(meta4), path(dict)
 
     output:
-    tuple val(meta), path('*.bam'), emit: bam
+    tuple val(meta), path("*.bam"), emit: bam
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/gt/gff3validator/main.nf
+++ b/modules/nf-core/gt/gff3validator/main.nf
@@ -11,8 +11,8 @@ process GT_GFF3VALIDATOR {
     tuple val(meta), path(gff3)
 
     output:
-    tuple val(meta), path('*.success.log')  , emit: success_log , optional: true
-    tuple val(meta), path('*.error.log')    , emit: error_log   , optional: true
+    tuple val(meta), path("*.success.log")  , emit: success_log , optional: true
+    tuple val(meta), path("*.error.log")    , emit: error_log   , optional: true
     path "versions.yml"                     , emit: versions
 
     when:

--- a/modules/nf-core/happy/happy/main.nf
+++ b/modules/nf-core/happy/happy/main.nf
@@ -17,17 +17,17 @@ process HAPPY_HAPPY {
     tuple val(meta6), path(stratification_beds)
 
     output:
-    tuple val(meta), path('*.summary.csv')                      , emit: summary_csv
-    tuple val(meta), path('*.roc.all.csv.gz')                   , emit: roc_all_csv
-    tuple val(meta), path('*.roc.Locations.INDEL.csv.gz')       , emit: roc_indel_locations_csv
-    tuple val(meta), path('*.roc.Locations.INDEL.PASS.csv.gz')  , emit: roc_indel_locations_pass_csv
-    tuple val(meta), path('*.roc.Locations.SNP.csv.gz')         , emit: roc_snp_locations_csv
-    tuple val(meta), path('*.roc.Locations.SNP.PASS.csv.gz')    , emit: roc_snp_locations_pass_csv
-    tuple val(meta), path('*.extended.csv')                     , emit: extended_csv
-    tuple val(meta), path('*.runinfo.json')                     , emit: runinfo
-    tuple val(meta), path('*.metrics.json.gz')                  , emit: metrics_json
-    tuple val(meta), path('*.vcf.gz')                           , emit: vcf, optional:true
-    tuple val(meta), path('*.tbi')                              , emit: tbi, optional:true
+    tuple val(meta), path("*.summary.csv")                      , emit: summary_csv
+    tuple val(meta), path("*.roc.all.csv.gz")                   , emit: roc_all_csv
+    tuple val(meta), path("*.roc.Locations.INDEL.csv.gz")       , emit: roc_indel_locations_csv
+    tuple val(meta), path("*.roc.Locations.INDEL.PASS.csv.gz")  , emit: roc_indel_locations_pass_csv
+    tuple val(meta), path("*.roc.Locations.SNP.csv.gz")         , emit: roc_snp_locations_csv
+    tuple val(meta), path("*.roc.Locations.SNP.PASS.csv.gz")    , emit: roc_snp_locations_pass_csv
+    tuple val(meta), path("*.extended.csv")                     , emit: extended_csv
+    tuple val(meta), path("*.runinfo.json")                     , emit: runinfo
+    tuple val(meta), path("*.metrics.json.gz")                  , emit: metrics_json
+    tuple val(meta), path("*.vcf.gz")                           , emit: vcf, optional:true
+    tuple val(meta), path("*.tbi")                              , emit: tbi, optional:true
     path "versions.yml"                                         , emit: versions
 
     when:

--- a/modules/nf-core/happy/prepy/main.nf
+++ b/modules/nf-core/happy/prepy/main.nf
@@ -14,7 +14,7 @@ process HAPPY_PREPY {
     tuple val(meta3), path(fasta_fai)
 
     output:
-    tuple val(meta), path('*.vcf.gz')  , emit: preprocessed_vcf
+    tuple val(meta), path("*.vcf.gz")  , emit: preprocessed_vcf
     path "versions.yml"                , emit: versions
 
     when:

--- a/modules/nf-core/happy/sompy/main.nf
+++ b/modules/nf-core/happy/sompy/main.nf
@@ -17,9 +17,9 @@ process HAPPY_SOMPY {
     tuple val(meta6), path(bams)
 
     output:
-    tuple val(meta), path('*.features.csv')           , emit: features, optional: true
-    tuple val(meta), path('*.metrics.json')           , emit: metrics
-    tuple val(meta), path('*.stats.csv')              , emit: stats
+    tuple val(meta), path("*.features.csv")           , emit: features, optional: true
+    tuple val(meta), path("*.metrics.json")           , emit: metrics
+    tuple val(meta), path("*.stats.csv")              , emit: stats
     path "versions.yml"                               , emit: versions
 
     when:

--- a/modules/nf-core/hmmer/hmmsearch/main.nf
+++ b/modules/nf-core/hmmer/hmmsearch/main.nf
@@ -11,10 +11,10 @@ process HMMER_HMMSEARCH {
     tuple val(meta), path(hmmfile), path(seqdb), val(write_align), val(write_target), val(write_domain)
 
     output:
-    tuple val(meta), path('*.txt.gz')   , emit: output
-    tuple val(meta), path('*.sto.gz')   , emit: alignments    , optional: true
-    tuple val(meta), path('*.tbl.gz')   , emit: target_summary, optional: true
-    tuple val(meta), path('*.domtbl.gz'), emit: domain_summary, optional: true
+    tuple val(meta), path("*.txt.gz")   , emit: output
+    tuple val(meta), path("*.sto.gz")   , emit: alignments    , optional: true
+    tuple val(meta), path("*.tbl.gz")   , emit: target_summary, optional: true
+    tuple val(meta), path("*.domtbl.gz"), emit: domain_summary, optional: true
     path "versions.yml"                 , emit: versions
 
     when:

--- a/modules/nf-core/interproscan/main.nf
+++ b/modules/nf-core/interproscan/main.nf
@@ -13,10 +13,10 @@ process INTERPROSCAN {
     path(interproscan_database, stageAs: 'data')
 
     output:
-    tuple val(meta), path('*.tsv') , optional: true, emit: tsv
-    tuple val(meta), path('*.xml') , optional: true, emit: xml
-    tuple val(meta), path('*.gff3'), optional: true, emit: gff3
-    tuple val(meta), path('*.json'), optional: true, emit: json
+    tuple val(meta), path("*.tsv") , optional: true, emit: tsv
+    tuple val(meta), path("*.xml") , optional: true, emit: xml
+    tuple val(meta), path("*.gff3"), optional: true, emit: gff3
+    tuple val(meta), path("*.json"), optional: true, emit: json
     path "versions.yml"            , emit: versions
 
     when:

--- a/modules/nf-core/ivar/trim/main.nf
+++ b/modules/nf-core/ivar/trim/main.nf
@@ -13,7 +13,7 @@ process IVAR_TRIM {
 
     output:
     tuple val(meta), path("*.bam"), emit: bam
-    tuple val(meta), path('*.log'), emit: log
+    tuple val(meta), path("*.log"), emit: log
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/kaiju/kaiju/main.nf
+++ b/modules/nf-core/kaiju/kaiju/main.nf
@@ -12,7 +12,7 @@ process KAIJU_KAIJU {
     path(db)
 
     output:
-    tuple val(meta), path('*.tsv'), emit: results
+    tuple val(meta), path("*.tsv"), emit: results
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/kaiju/kaiju2table/main.nf
+++ b/modules/nf-core/kaiju/kaiju2table/main.nf
@@ -13,7 +13,7 @@ process KAIJU_KAIJU2TABLE {
     val taxon_rank
 
     output:
-    tuple val(meta), path('*.txt'), emit: summary
+    tuple val(meta), path("*.txt"), emit: summary
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/kofamscan/main.nf
+++ b/modules/nf-core/kofamscan/main.nf
@@ -13,8 +13,8 @@ process KOFAMSCAN {
     path ko_list
 
     output:
-    tuple val(meta), path('*.txt'), optional: true, emit: txt
-    tuple val(meta), path('*.tsv'), optional: true, emit: tsv
+    tuple val(meta), path("*.txt"), optional: true, emit: txt
+    tuple val(meta), path("*.tsv"), optional: true, emit: tsv
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/kraken2/kraken2/main.nf
+++ b/modules/nf-core/kraken2/kraken2/main.nf
@@ -14,10 +14,10 @@ process KRAKEN2_KRAKEN2 {
     val save_reads_assignment
 
     output:
-    tuple val(meta), path('*.classified{.,_}*')     , optional:true, emit: classified_reads_fastq
-    tuple val(meta), path('*.unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
-    tuple val(meta), path('*classifiedreads.txt')   , optional:true, emit: classified_reads_assignment
-    tuple val(meta), path('*report.txt')                           , emit: report
+    tuple val(meta), path("*.classified{.,_}*")     , optional:true, emit: classified_reads_fastq
+    tuple val(meta), path("*.unclassified{.,_}*")   , optional:true, emit: unclassified_reads_fastq
+    tuple val(meta), path("*classifiedreads.txt")   , optional:true, emit: classified_reads_assignment
+    tuple val(meta), path("*report.txt")                           , emit: report
     path "versions.yml"                                            , emit: versions
 
     when:

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -20,8 +20,8 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
     output:
     tuple val(meta), path("*.classified.${sequence_type}.gz")  , optional:true, emit: classified_reads
     tuple val(meta), path("*.unclassified.${sequence_type}.gz"), optional:true, emit: unclassified_reads
-    tuple val(meta), path('*.krakenuniq.classified.txt')       , optional:true, emit: classified_assignment
-    tuple val(meta), path('*.krakenuniq.report.txt')           , emit: report
+    tuple val(meta), path("*.krakenuniq.classified.txt")       , optional:true, emit: classified_assignment
+    tuple val(meta), path("*.krakenuniq.report.txt")           , emit: report
     path "versions.yml"                                        , emit: versions
 
     when:

--- a/modules/nf-core/megahit/main.nf
+++ b/modules/nf-core/megahit/main.nf
@@ -15,7 +15,7 @@ process MEGAHIT {
     tuple val(meta), path("intermediate_contigs/k*.addi.fa.gz")         , emit: addi_contigs
     tuple val(meta), path("intermediate_contigs/k*.local.fa.gz")        , emit: local_contigs
     tuple val(meta), path("intermediate_contigs/k*.final.contigs.fa.gz"), emit: kfinal_contigs
-    tuple val(meta), path('*.log')                                      , emit: log
+    tuple val(meta), path("*.log")                                      , emit: log
     path "versions.yml"                                                 , emit: versions
 
     when:

--- a/modules/nf-core/merqury/hapmers/main.nf
+++ b/modules/nf-core/merqury/hapmers/main.nf
@@ -13,11 +13,11 @@ process MERQURY_HAPMERS {
     path(paternal_meryl, stageAs: 'pat.meryl')
 
     output:
-    tuple val(meta), path('*_mat.hapmer.meryl')         , emit: mat_hapmer_meryl
-    tuple val(meta), path('*_pat.hapmer.meryl')         , emit: pat_hapmer_meryl
-    tuple val(meta), path('*_inherited_hapmers.fl.png') , emit: inherited_hapmers_fl_png
-    tuple val(meta), path('*_inherited_hapmers.ln.png') , emit: inherited_hapmers_ln_png
-    tuple val(meta), path('*_inherited_hapmers.st.png') , emit: inherited_hapmers_st_png
+    tuple val(meta), path("*_mat.hapmer.meryl")         , emit: mat_hapmer_meryl
+    tuple val(meta), path("*_pat.hapmer.meryl")         , emit: pat_hapmer_meryl
+    tuple val(meta), path("*_inherited_hapmers.fl.png") , emit: inherited_hapmers_fl_png
+    tuple val(meta), path("*_inherited_hapmers.ln.png") , emit: inherited_hapmers_ln_png
+    tuple val(meta), path("*_inherited_hapmers.st.png") , emit: inherited_hapmers_st_png
     path "versions.yml"                                 , emit: versions
 
     when:

--- a/modules/nf-core/metaphlan/metaphlan/main.nf
+++ b/modules/nf-core/metaphlan/metaphlan/main.nf
@@ -14,7 +14,7 @@ process METAPHLAN_METAPHLAN {
     output:
     tuple val(meta), path("*_profile.txt")   ,                emit: profile
     tuple val(meta), path("*.biom")          ,                emit: biom
-    tuple val(meta), path('*.bowtie2out.txt'), optional:true, emit: bt2out
+    tuple val(meta), path("*.bowtie2out.txt"), optional:true, emit: bt2out
     path "versions.yml"                      ,                emit: versions
 
     when:

--- a/modules/nf-core/metaphlan3/metaphlan3/main.nf
+++ b/modules/nf-core/metaphlan3/metaphlan3/main.nf
@@ -14,7 +14,7 @@ process METAPHLAN3_METAPHLAN3 {
     output:
     tuple val(meta), path("*_profile.txt")   ,                emit: profile
     tuple val(meta), path("*.biom")          ,                emit: biom
-    tuple val(meta), path('*.bowtie2out.txt'), optional:true, emit: bt2out
+    tuple val(meta), path("*.bowtie2out.txt"), optional:true, emit: bt2out
     path "versions.yml"                      ,                emit: versions
 
     when:

--- a/modules/nf-core/minia/main.nf
+++ b/modules/nf-core/minia/main.nf
@@ -11,9 +11,9 @@ process MINIA {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path('*.contigs.fa'), emit: contigs
-    tuple val(meta), path('*.unitigs.fa'), emit: unitigs
-    tuple val(meta), path('*.h5')        , emit: h5
+    tuple val(meta), path("*.contigs.fa"), emit: contigs
+    tuple val(meta), path("*.unitigs.fa"), emit: unitigs
+    tuple val(meta), path("*.h5")        , emit: h5
     path  "versions.yml"                 , emit: versions
 
     when:

--- a/modules/nf-core/mirdeep2/mapper/main.nf
+++ b/modules/nf-core/mirdeep2/mapper/main.nf
@@ -12,7 +12,7 @@ process MIRDEEP2_MAPPER {
     tuple val(meta2), path(index, stageAs: '*')
 
     output:
-    tuple val(meta), path('*.fa'), path('*.arf'), emit: outputs
+    tuple val(meta), path("*.fa"), path("*.arf"), emit: outputs
     path "versions.yml"                         , emit: versions
 
     when:

--- a/modules/nf-core/mosdepth/main.nf
+++ b/modules/nf-core/mosdepth/main.nf
@@ -12,18 +12,18 @@ process MOSDEPTH {
     tuple val(meta2), path(fasta)
 
     output:
-    tuple val(meta), path('*.global.dist.txt')      , emit: global_txt
-    tuple val(meta), path('*.summary.txt')          , emit: summary_txt
-    tuple val(meta), path('*.region.dist.txt')      , optional:true, emit: regions_txt
-    tuple val(meta), path('*.per-base.d4')          , optional:true, emit: per_base_d4
-    tuple val(meta), path('*.per-base.bed.gz')      , optional:true, emit: per_base_bed
-    tuple val(meta), path('*.per-base.bed.gz.csi')  , optional:true, emit: per_base_csi
-    tuple val(meta), path('*.regions.bed.gz')       , optional:true, emit: regions_bed
-    tuple val(meta), path('*.regions.bed.gz.csi')   , optional:true, emit: regions_csi
-    tuple val(meta), path('*.quantized.bed.gz')     , optional:true, emit: quantized_bed
-    tuple val(meta), path('*.quantized.bed.gz.csi') , optional:true, emit: quantized_csi
-    tuple val(meta), path('*.thresholds.bed.gz')    , optional:true, emit: thresholds_bed
-    tuple val(meta), path('*.thresholds.bed.gz.csi'), optional:true, emit: thresholds_csi
+    tuple val(meta), path("*.global.dist.txt")      , emit: global_txt
+    tuple val(meta), path("*.summary.txt")          , emit: summary_txt
+    tuple val(meta), path("*.region.dist.txt")      , optional:true, emit: regions_txt
+    tuple val(meta), path("*.per-base.d4")          , optional:true, emit: per_base_d4
+    tuple val(meta), path("*.per-base.bed.gz")      , optional:true, emit: per_base_bed
+    tuple val(meta), path("*.per-base.bed.gz.csi")  , optional:true, emit: per_base_csi
+    tuple val(meta), path("*.regions.bed.gz")       , optional:true, emit: regions_bed
+    tuple val(meta), path("*.regions.bed.gz.csi")   , optional:true, emit: regions_csi
+    tuple val(meta), path("*.quantized.bed.gz")     , optional:true, emit: quantized_bed
+    tuple val(meta), path("*.quantized.bed.gz.csi") , optional:true, emit: quantized_csi
+    tuple val(meta), path("*.thresholds.bed.gz")    , optional:true, emit: thresholds_bed
+    tuple val(meta), path("*.thresholds.bed.gz.csi"), optional:true, emit: thresholds_csi
     path  "versions.yml"                            , emit: versions
 
     when:

--- a/modules/nf-core/multivcfanalyzer/main.nf
+++ b/modules/nf-core/multivcfanalyzer/main.nf
@@ -21,17 +21,17 @@ process MULTIVCFANALYZER {
 
 
     output:
-    tuple val(meta), path('fullAlignment.fasta.gz')                       , emit: full_alignment
-    tuple val(meta), path('info.txt')                                     , emit: info_txt
-    tuple val(meta), path('snpAlignment.fasta.gz')                        , emit: snp_alignment
-    tuple val(meta), path('snpAlignmentIncludingRefGenome.fasta.gz')      , emit: snp_genome_alignment
-    tuple val(meta), path('snpStatistics.tsv')                            , emit: snpstatistics
-    tuple val(meta), path('snpTable.tsv')                                 , emit: snptable
-    tuple val(meta), path('snpTableForSnpEff.tsv')                        , emit: snptable_snpeff
-    tuple val(meta), path('snpTableWithUncertaintyCalls.tsv')             , emit: snptable_uncertainty
-    tuple val(meta), path('structureGenotypes.tsv')                       , emit: structure_genotypes
-    tuple val(meta), path('structureGenotypes_noMissingData-Columns.tsv') , emit: structure_genotypes_nomissing
-    tuple val(meta), path('MultiVCFAnalyzer.json')                        , emit: json
+    tuple val(meta), path("fullAlignment.fasta.gz")                       , emit: full_alignment
+    tuple val(meta), path("info.txt")                                     , emit: info_txt
+    tuple val(meta), path("snpAlignment.fasta.gz")                        , emit: snp_alignment
+    tuple val(meta), path("snpAlignmentIncludingRefGenome.fasta.gz")      , emit: snp_genome_alignment
+    tuple val(meta), path("snpStatistics.tsv")                            , emit: snpstatistics
+    tuple val(meta), path("snpTable.tsv")                                 , emit: snptable
+    tuple val(meta), path("snpTableForSnpEff.tsv")                        , emit: snptable_snpeff
+    tuple val(meta), path("snpTableWithUncertaintyCalls.tsv")             , emit: snptable_uncertainty
+    tuple val(meta), path("structureGenotypes.tsv")                       , emit: structure_genotypes
+    tuple val(meta), path("structureGenotypes_noMissingData-Columns.tsv") , emit: structure_genotypes_nomissing
+    tuple val(meta), path("MultiVCFAnalyzer.json")                        , emit: json
     path "versions.yml"                                  , emit: versions
 
     when:

--- a/modules/nf-core/narfmap/align/main.nf
+++ b/modules/nf-core/narfmap/align/main.nf
@@ -15,7 +15,7 @@ process NARFMAP_ALIGN {
 
     output:
     tuple val(meta), path("*.bam"), emit: bam
-    tuple val(meta), path('*.log'), emit: log
+    tuple val(meta), path("*.log"), emit: log
     path "versions.yml"           , emit: versions
 
     when:

--- a/modules/nf-core/pangolin/run/main.nf
+++ b/modules/nf-core/pangolin/run/main.nf
@@ -12,7 +12,7 @@ process PANGOLIN_RUN {
     path(db)
 
     output:
-    tuple val(meta), path('*.csv'), emit: report
+    tuple val(meta), path("*.csv"), emit: report
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/picard/bedtointervallist/main.nf
+++ b/modules/nf-core/picard/bedtointervallist/main.nf
@@ -13,7 +13,7 @@ process PICARD_BEDTOINTERVALLIST {
     file  arguments_file
 
     output:
-    tuple val(meta), path('*.interval_list'), emit: interval_list
+    tuple val(meta), path("*.interval_list"), emit: interval_list
     path  "versions.yml"                    , emit: versions
 
     when:

--- a/modules/nf-core/platypus/main.nf
+++ b/modules/nf-core/platypus/main.nf
@@ -20,9 +20,9 @@ process PLATYPUS {
     path skipregions_file
 
     output:
-    tuple val(meta), path('*.vcf.gz')            , emit: vcf
-    tuple val(meta), path('*.vcf.gz.tbi')        , emit: tbi
-    tuple val(meta), path('*.log')               , emit: log
+    tuple val(meta), path("*.vcf.gz")            , emit: vcf
+    tuple val(meta), path("*.vcf.gz.tbi")        , emit: tbi
+    tuple val(meta), path("*.log")               , emit: log
     path  "versions.yml"                         , emit: version
 
     when:

--- a/modules/nf-core/popscle/demuxlet/main.nf
+++ b/modules/nf-core/popscle/demuxlet/main.nf
@@ -11,7 +11,7 @@ process POPSCLE_DEMUXLET {
     tuple val(meta), val(plp_prefix), path(bam), path(donor_genotype)
 
     output:
-    tuple val(meta), path('*.best'), emit: demuxlet_result
+    tuple val(meta), path("*.best"), emit: demuxlet_result
     path 'versions.yml'            , emit: versions
 
     when:

--- a/modules/nf-core/popscle/dscpileup/main.nf
+++ b/modules/nf-core/popscle/dscpileup/main.nf
@@ -11,10 +11,10 @@ process POPSCLE_DSCPILEUP {
     tuple val(meta), path(bam), path(vcf)
 
     output:
-    tuple val(meta), path('*.cel.gz'), emit: cel
-    tuple val(meta), path('*.plp.gz'), emit: plp
-    tuple val(meta), path('*.var.gz'), emit: var
-    tuple val(meta), path('*.umi.gz'), emit: umi
+    tuple val(meta), path("*.cel.gz"), emit: cel
+    tuple val(meta), path("*.plp.gz"), emit: plp
+    tuple val(meta), path("*.var.gz"), emit: var
+    tuple val(meta), path("*.umi.gz"), emit: umi
     path 'versions.yml'              , emit: versions
 
     when:

--- a/modules/nf-core/popscle/freemuxlet/main.nf
+++ b/modules/nf-core/popscle/freemuxlet/main.nf
@@ -11,11 +11,11 @@ process POPSCLE_FREEMUXLET {
     tuple val(meta), path(plp), val(n_sample)
 
     output:
-    tuple val(meta), path('*.clust1.samples.gz')  , emit: result
-    tuple val(meta), path('*.clust1.vcf.gz')      , emit: vcf
-    tuple val(meta), path('*.lmix')               , emit: lmix
-    tuple val(meta), path('*.clust0.samples.gz')  , emit: singlet_result   , optional: true
-    tuple val(meta), path('*.clust0.vcf.gz')      , emit: singlet_vcf      , optional: true
+    tuple val(meta), path("*.clust1.samples.gz")  , emit: result
+    tuple val(meta), path("*.clust1.vcf.gz")      , emit: vcf
+    tuple val(meta), path("*.lmix")               , emit: lmix
+    tuple val(meta), path("*.clust0.samples.gz")  , emit: singlet_result   , optional: true
+    tuple val(meta), path("*.clust0.vcf.gz")      , emit: singlet_vcf      , optional: true
     path 'versions.yml'                           , emit: versions
 
     when:

--- a/modules/nf-core/pretextsnapshot/main.nf
+++ b/modules/nf-core/pretextsnapshot/main.nf
@@ -11,7 +11,7 @@ process PRETEXTSNAPSHOT {
     tuple val(meta), path(pretext_map)
 
     output:
-    tuple val(meta), path('*.{jpeg,png,bmp}'), emit: image
+    tuple val(meta), path("*.{jpeg,png,bmp}"), emit: image
     path "versions.yml" , emit: versions
 
     when:

--- a/modules/nf-core/pypgx/computecontrolstatistics/main.nf
+++ b/modules/nf-core/pypgx/computecontrolstatistics/main.nf
@@ -13,7 +13,7 @@ process PYPGX_COMPUTECONTROLSTATISTICS {
     val(assembly_version)
 
     output:
-    tuple val(meta), path('*.zip'), emit: control_stats
+    tuple val(meta), path("*.zip"), emit: control_stats
     path("versions.yml"), emit: versions
 
     when:

--- a/modules/nf-core/pypgx/preparedepthofcoverage/main.nf
+++ b/modules/nf-core/pypgx/preparedepthofcoverage/main.nf
@@ -13,7 +13,7 @@ process PYPGX_PREPAREDEPTHOFCOVERAGE {
     val(assembly_version)
 
     output:
-    tuple val(meta), path('*.zip'), emit: coverage
+    tuple val(meta), path("*.zip"), emit: coverage
     path("versions.yml"), emit: versions
 
     when:

--- a/modules/nf-core/racon/main.nf
+++ b/modules/nf-core/racon/main.nf
@@ -11,7 +11,7 @@ process RACON {
     tuple val(meta), path(reads), path(assembly), path(paf)
 
     output:
-    tuple val(meta), path('*_assembly_consensus.fasta.gz') , emit: improved_assembly
+    tuple val(meta), path("*_assembly_consensus.fasta.gz") , emit: improved_assembly
     path "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/rasusa/main.nf
+++ b/modules/nf-core/rasusa/main.nf
@@ -12,7 +12,7 @@ process RASUSA {
     val   depth_cutoff
 
     output:
-    tuple val(meta), path('*.fastq.gz'), emit: reads
+    tuple val(meta), path("*.fastq.gz"), emit: reads
     path "versions.yml"                , emit: versions
 
     when:

--- a/modules/nf-core/ribotricer/detectorfs/main.nf
+++ b/modules/nf-core/ribotricer/detectorfs/main.nf
@@ -12,16 +12,16 @@ process RIBOTRICER_DETECTORFS {
     tuple val(meta2), path(candidate_orfs)
 
     output:
-    tuple val(meta), path('*_protocol.txt')             , emit: protocol, optional: true
-    tuple val(meta), path('*_bam_summary.txt')          , emit: bam_summary
-    tuple val(meta), path('*_read_length_dist.pdf')     , emit: read_length_dist
-    tuple val(meta), path('*_metagene_profiles_5p.tsv') , emit: metagene_profile_5p
-    tuple val(meta), path('*_metagene_profiles_3p.tsv') , emit: metagene_profile_3p
-    tuple val(meta), path('*_metagene_plots.pdf')       , emit: metagene_plots
-    tuple val(meta), path('*_psite_offsets.txt')        , emit: psite_offsets, optional: true
-    tuple val(meta), path('*_pos.wig')                  , emit: pos_wig
-    tuple val(meta), path('*_neg.wig')                  , emit: neg_wig
-    tuple val(meta), path('*_translating_ORFs.tsv')     , emit: orfs
+    tuple val(meta), path("*_protocol.txt")             , emit: protocol, optional: true
+    tuple val(meta), path("*_bam_summary.txt")          , emit: bam_summary
+    tuple val(meta), path("*_read_length_dist.pdf")     , emit: read_length_dist
+    tuple val(meta), path("*_metagene_profiles_5p.tsv") , emit: metagene_profile_5p
+    tuple val(meta), path("*_metagene_profiles_3p.tsv") , emit: metagene_profile_3p
+    tuple val(meta), path("*_metagene_plots.pdf")       , emit: metagene_plots
+    tuple val(meta), path("*_psite_offsets.txt")        , emit: psite_offsets, optional: true
+    tuple val(meta), path("*_pos.wig")                  , emit: pos_wig
+    tuple val(meta), path("*_neg.wig")                  , emit: neg_wig
+    tuple val(meta), path("*_translating_ORFs.tsv")     , emit: orfs
     path "versions.yml"                                 , emit: versions
 
     when:

--- a/modules/nf-core/sentieon/datametrics/main.nf
+++ b/modules/nf-core/sentieon/datametrics/main.nf
@@ -15,16 +15,16 @@ process SENTIEON_DATAMETRICS {
     val plot_results
 
     output:
-    tuple val(meta), path('*mq_metrics.txt') , emit: mq_metrics
-    tuple val(meta), path('*qd_metrics.txt') , emit: qd_metrics
-    tuple val(meta), path('*gc_summary.txt') , emit: gc_summary
-    tuple val(meta), path('*gc_metrics.txt') , emit: gc_metrics
-    tuple val(meta), path('*aln_metrics.txt'), emit: aln_metrics
-    tuple val(meta), path('*is_metrics.txt') , emit: is_metrics
-    tuple val(meta), path('*mq_metrics.pdf') , emit: mq_plot, optional: true
-    tuple val(meta), path('*qd_metrics.pdf') , emit: qd_plot, optional: true
-    tuple val(meta), path('*is_metrics.pdf') , emit: is_plot, optional: true
-    tuple val(meta), path('*gc_metrics.pdf') , emit: gc_plot, optional: true
+    tuple val(meta), path("*mq_metrics.txt") , emit: mq_metrics
+    tuple val(meta), path("*qd_metrics.txt") , emit: qd_metrics
+    tuple val(meta), path("*gc_summary.txt") , emit: gc_summary
+    tuple val(meta), path("*gc_metrics.txt") , emit: gc_metrics
+    tuple val(meta), path("*aln_metrics.txt"), emit: aln_metrics
+    tuple val(meta), path("*is_metrics.txt") , emit: is_metrics
+    tuple val(meta), path("*mq_metrics.pdf") , emit: mq_plot, optional: true
+    tuple val(meta), path("*qd_metrics.pdf") , emit: qd_plot, optional: true
+    tuple val(meta), path("*is_metrics.pdf") , emit: is_plot, optional: true
+    tuple val(meta), path("*gc_metrics.pdf") , emit: gc_plot, optional: true
     path  "versions.yml"                     , emit: versions
 
     when:

--- a/modules/nf-core/sentieon/wgsmetrics/main.nf
+++ b/modules/nf-core/sentieon/wgsmetrics/main.nf
@@ -15,7 +15,7 @@ process SENTIEON_WGSMETRICS {
     tuple val(meta4), path(intervals_list)
 
     output:
-    tuple val(meta), path('*.txt'), emit: wgs_metrics
+    tuple val(meta), path("*.txt"), emit: wgs_metrics
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/sgdemux/main.nf
+++ b/modules/nf-core/sgdemux/main.nf
@@ -12,12 +12,12 @@ process SGDEMUX {
     tuple val(meta), path(sample_sheet), path(fastqs_dir)
 
     output:
-    tuple val(meta), path('output/*_R*.fastq.gz')                   , emit: sample_fastq
-    tuple val(meta), path('output/metrics.tsv')                     , emit: metrics
-    tuple val(meta), path('output/most_frequent_unmatched.tsv')     , emit: most_frequent_unmatched
-    tuple val(meta), path('output/per_project_metrics.tsv')         , emit: per_project_metrics
-    tuple val(meta), path('output/per_sample_metrics.tsv')          , emit: per_sample_metrics
-    tuple val(meta), path('output/sample_barcode_hop_metrics.tsv')  , emit: sample_barcode_hop_metrics
+    tuple val(meta), path("output/*_R*.fastq.gz")                   , emit: sample_fastq
+    tuple val(meta), path("output/metrics.tsv")                     , emit: metrics
+    tuple val(meta), path("output/most_frequent_unmatched.tsv")     , emit: most_frequent_unmatched
+    tuple val(meta), path("output/per_project_metrics.tsv")         , emit: per_project_metrics
+    tuple val(meta), path("output/per_sample_metrics.tsv")          , emit: per_sample_metrics
+    tuple val(meta), path("output/sample_barcode_hop_metrics.tsv")  , emit: sample_barcode_hop_metrics
     path "versions.yml"                                             , emit: versions
 
     when:

--- a/modules/nf-core/snpeff/download/main.nf
+++ b/modules/nf-core/snpeff/download/main.nf
@@ -11,7 +11,7 @@ process SNPEFF_DOWNLOAD {
     tuple val(meta), val(snpeff_db)
 
     output:
-    tuple val(meta), path('snpeff_cache'), emit: cache
+    tuple val(meta), path("snpeff_cache"), emit: cache
     path "versions.yml"                  , emit: versions
 
     when:

--- a/modules/nf-core/sourmash/gather/main.nf
+++ b/modules/nf-core/sourmash/gather/main.nf
@@ -16,11 +16,11 @@ process SOURMASH_GATHER {
     val save_prefetch_csv
 
     output:
-    tuple val(meta), path('*.csv.gz')             , optional:true, emit: result
-    tuple val(meta), path('*_unassigned.sig.zip') , optional:true, emit: unassigned
-    tuple val(meta), path('*_matches.sig.zip')    , optional:true, emit: matches
-    tuple val(meta), path('*_prefetch.sig.zip')   , optional:true, emit: prefetch
-    tuple val(meta), path('*_prefetch.csv.gz')    , optional:true, emit: prefetchcsv
+    tuple val(meta), path("*.csv.gz")             , optional:true, emit: result
+    tuple val(meta), path("*_unassigned.sig.zip") , optional:true, emit: unassigned
+    tuple val(meta), path("*_matches.sig.zip")    , optional:true, emit: matches
+    tuple val(meta), path("*_prefetch.sig.zip")   , optional:true, emit: prefetch
+    tuple val(meta), path("*_prefetch.csv.gz")    , optional:true, emit: prefetchcsv
     path "versions.yml"                           , emit: versions
 
     when:

--- a/modules/nf-core/spades/main.nf
+++ b/modules/nf-core/spades/main.nf
@@ -13,13 +13,13 @@ process SPADES {
     path hmm
 
     output:
-    tuple val(meta), path('*.scaffolds.fa.gz')    , optional:true, emit: scaffolds
-    tuple val(meta), path('*.contigs.fa.gz')      , optional:true, emit: contigs
-    tuple val(meta), path('*.transcripts.fa.gz')  , optional:true, emit: transcripts
-    tuple val(meta), path('*.gene_clusters.fa.gz'), optional:true, emit: gene_clusters
-    tuple val(meta), path('*.assembly.gfa.gz')    , optional:true, emit: gfa
-    tuple val(meta), path('*.warnings.log')         , optional:true, emit: warnings
-    tuple val(meta), path('*.spades.log')         , emit: log
+    tuple val(meta), path("*.scaffolds.fa.gz")    , optional:true, emit: scaffolds
+    tuple val(meta), path("*.contigs.fa.gz")      , optional:true, emit: contigs
+    tuple val(meta), path("*.transcripts.fa.gz")  , optional:true, emit: transcripts
+    tuple val(meta), path("*.gene_clusters.fa.gz"), optional:true, emit: gene_clusters
+    tuple val(meta), path("*.assembly.gfa.gz")    , optional:true, emit: gfa
+    tuple val(meta), path("*.warnings.log")         , optional:true, emit: warnings
+    tuple val(meta), path("*.spades.log")         , emit: log
     path  "versions.yml"                          , emit: versions
 
     when:

--- a/modules/nf-core/sratools/fasterqdump/main.nf
+++ b/modules/nf-core/sratools/fasterqdump/main.nf
@@ -13,7 +13,7 @@ process SRATOOLS_FASTERQDUMP {
     path certificate
 
     output:
-    tuple val(meta), path('*.fastq.gz'), emit: reads
+    tuple val(meta), path("*.fastq.gz"), emit: reads
     path "versions.yml"                , emit: versions
 
     when:

--- a/modules/nf-core/star/align/main.nf
+++ b/modules/nf-core/star/align/main.nf
@@ -16,24 +16,24 @@ process STAR_ALIGN {
     val seq_center
 
     output:
-    tuple val(meta), path('*Log.final.out')   , emit: log_final
-    tuple val(meta), path('*Log.out')         , emit: log_out
-    tuple val(meta), path('*Log.progress.out'), emit: log_progress
+    tuple val(meta), path("*Log.final.out")   , emit: log_final
+    tuple val(meta), path("*Log.out")         , emit: log_out
+    tuple val(meta), path("*Log.progress.out"), emit: log_progress
     path  "versions.yml"                      , emit: versions
 
-    tuple val(meta), path('*d.out.bam')                              , optional:true, emit: bam
+    tuple val(meta), path("*d.out.bam")                              , optional:true, emit: bam
     tuple val(meta), path("${prefix}.sortedByCoord.out.bam")         , optional:true, emit: bam_sorted
     tuple val(meta), path("${prefix}.Aligned.sortedByCoord.out.bam") , optional:true, emit: bam_sorted_aligned
-    tuple val(meta), path('*toTranscriptome.out.bam')                , optional:true, emit: bam_transcript
-    tuple val(meta), path('*Aligned.unsort.out.bam')                 , optional:true, emit: bam_unsorted
-    tuple val(meta), path('*fastq.gz')                               , optional:true, emit: fastq
-    tuple val(meta), path('*.tab')                                   , optional:true, emit: tab
-    tuple val(meta), path('*.SJ.out.tab')                            , optional:true, emit: spl_junc_tab
-    tuple val(meta), path('*.ReadsPerGene.out.tab')                  , optional:true, emit: read_per_gene_tab
-    tuple val(meta), path('*.out.junction')                          , optional:true, emit: junction
-    tuple val(meta), path('*.out.sam')                               , optional:true, emit: sam
-    tuple val(meta), path('*.wig')                                   , optional:true, emit: wig
-    tuple val(meta), path('*.bg')                                    , optional:true, emit: bedgraph
+    tuple val(meta), path("*toTranscriptome.out.bam")                , optional:true, emit: bam_transcript
+    tuple val(meta), path("*Aligned.unsort.out.bam")                 , optional:true, emit: bam_unsorted
+    tuple val(meta), path("*fastq.gz")                               , optional:true, emit: fastq
+    tuple val(meta), path("*.tab")                                   , optional:true, emit: tab
+    tuple val(meta), path("*.SJ.out.tab")                            , optional:true, emit: spl_junc_tab
+    tuple val(meta), path("*.ReadsPerGene.out.tab")                  , optional:true, emit: read_per_gene_tab
+    tuple val(meta), path("*.out.junction")                          , optional:true, emit: junction
+    tuple val(meta), path("*.out.sam")                               , optional:true, emit: sam
+    tuple val(meta), path("*.wig")                                   , optional:true, emit: wig
+    tuple val(meta), path("*.bg")                                    , optional:true, emit: bedgraph
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/star/starsolo/main.nf
+++ b/modules/nf-core/star/starsolo/main.nf
@@ -13,11 +13,11 @@ process STARSOLO {
     tuple val(meta2), path(index)
 
     output:
-    tuple val(meta),  path('*.Solo.out')         , emit: counts
-    tuple val(meta),  path('*Log.final.out')     , emit: log_final
-    tuple val(meta),  path('*Log.out')           , emit: log_out
-    tuple val(meta),  path('*Log.progress.out')  , emit: log_progress
-    tuple val(meta),  path('*/Gene/Summary.csv') , emit: summary
+    tuple val(meta),  path("*.Solo.out")         , emit: counts
+    tuple val(meta),  path("*Log.final.out")     , emit: log_final
+    tuple val(meta),  path("*Log.out")           , emit: log_out
+    tuple val(meta),  path("*Log.progress.out")  , emit: log_progress
+    tuple val(meta),  path("*/Gene/Summary.csv") , emit: summary
     path "versions.yml"                          , emit: versions
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/sylph/sketch/main.nf
+++ b/modules/nf-core/sylph/sketch/main.nf
@@ -12,7 +12,7 @@ process SYLPH_SKETCH {
     path(reference)
 
     output:
-    tuple val(meta), path('my_sketches/*.sylsp'), path('database.syldb'), emit: sketch_fastq_genome
+    tuple val(meta), path("my_sketches/*.sylsp"), path("database.syldb"), emit: sketch_fastq_genome
     path "versions.yml"                                                 , emit: versions
 
     when:

--- a/modules/nf-core/umitools/prepareforrsem/main.nf
+++ b/modules/nf-core/umitools/prepareforrsem/main.nf
@@ -11,8 +11,8 @@ process UMITOOLS_PREPAREFORRSEM {
     tuple val(meta), path(bam), path(bai)
 
     output:
-    tuple val(meta), path('*.bam'), emit: bam
-    tuple val(meta), path('*.log'), emit: log
+    tuple val(meta), path("*.bam"), emit: bam
+    tuple val(meta), path("*.log"), emit: log
     path  "versions.yml"          , emit: versions
 
     when:

--- a/modules/nf-core/unicycler/main.nf
+++ b/modules/nf-core/unicycler/main.nf
@@ -11,9 +11,9 @@ process UNICYCLER {
     tuple val(meta), path(shortreads), path(longreads)
 
     output:
-    tuple val(meta), path('*.scaffolds.fa.gz'), emit: scaffolds
-    tuple val(meta), path('*.assembly.gfa.gz'), emit: gfa
-    tuple val(meta), path('*.log')            , emit: log
+    tuple val(meta), path("*.scaffolds.fa.gz"), emit: scaffolds
+    tuple val(meta), path("*.assembly.gfa.gz"), emit: gfa
+    tuple val(meta), path("*.log")            , emit: log
     path  "versions.yml"                      , emit: versions
 
     when:

--- a/modules/nf-core/vireo/main.nf
+++ b/modules/nf-core/vireo/main.nf
@@ -10,10 +10,10 @@ process VIREO {
     input:
     tuple val(meta), path(cell_data), val(n_donor), path(donor_file), path(vartrix_data)
     output:
-    tuple val(meta), path('*_summary.tsv')        , emit: summary
-    tuple val(meta), path('*_donor_ids.tsv')      , emit: donor_ids
-    tuple val(meta), path('*_prob_singlet.tsv.gz'), emit: prob_singlets
-    tuple val(meta), path('*_prob_doublet.tsv.gz'), emit: prob_doublets
+    tuple val(meta), path("*_summary.tsv")        , emit: summary
+    tuple val(meta), path("*_donor_ids.tsv")      , emit: donor_ids
+    tuple val(meta), path("*_prob_singlet.tsv.gz"), emit: prob_singlets
+    tuple val(meta), path("*_prob_doublet.tsv.gz"), emit: prob_doublets
     path 'versions.yml'                           , emit: versions
 
     when:

--- a/modules/nf-core/vsearch/cluster/main.nf
+++ b/modules/nf-core/vsearch/cluster/main.nf
@@ -11,18 +11,18 @@ process VSEARCH_CLUSTER {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path('*.aln.gz')                , optional: true, emit: aln
-    tuple val(meta), path('*.biom.gz')               , optional: true, emit: biom
-    tuple val(meta), path('*.mothur.tsv.gz')         , optional: true, emit: mothur
-    tuple val(meta), path('*.otu.tsv.gz')            , optional: true, emit: otu
-    tuple val(meta), path('*.bam')                   , optional: true, emit: bam
-    tuple val(meta), path('*.out.tsv.gz')            , optional: true, emit: out
-    tuple val(meta), path('*.blast.tsv.gz')          , optional: true, emit: blast
-    tuple val(meta), path('*.uc.tsv.gz')             , optional: true, emit: uc
-    tuple val(meta), path('*.centroids.fasta.gz')    , optional: true, emit: centroids
-    tuple val(meta), path('*.clusters.fasta*.gz')    , optional: true, emit: clusters
-    tuple val(meta), path('*.profile.txt.gz')        , optional: true, emit: profile
-    tuple val(meta), path('*.msa.fasta.gz')          , optional: true, emit: msa
+    tuple val(meta), path("*.aln.gz")                , optional: true, emit: aln
+    tuple val(meta), path("*.biom.gz")               , optional: true, emit: biom
+    tuple val(meta), path("*.mothur.tsv.gz")         , optional: true, emit: mothur
+    tuple val(meta), path("*.otu.tsv.gz")            , optional: true, emit: otu
+    tuple val(meta), path("*.bam")                   , optional: true, emit: bam
+    tuple val(meta), path("*.out.tsv.gz")            , optional: true, emit: out
+    tuple val(meta), path("*.blast.tsv.gz")          , optional: true, emit: blast
+    tuple val(meta), path("*.uc.tsv.gz")             , optional: true, emit: uc
+    tuple val(meta), path("*.centroids.fasta.gz")    , optional: true, emit: centroids
+    tuple val(meta), path("*.clusters.fasta*.gz")    , optional: true, emit: clusters
+    tuple val(meta), path("*.profile.txt.gz")        , optional: true, emit: profile
+    tuple val(meta), path("*.msa.fasta.gz")          , optional: true, emit: msa
     path "versions.yml"                              , emit: versions
 
     when:

--- a/modules/nf-core/vsearch/dereplicate/main.nf
+++ b/modules/nf-core/vsearch/dereplicate/main.nf
@@ -11,8 +11,8 @@ process VSEARCH_DEREPLICATE {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path('*.derep.fasta')   , emit: fasta
-    tuple val(meta), path('*.derep.uc')      , emit: clustering
+    tuple val(meta), path("*.derep.fasta")   , emit: fasta
+    tuple val(meta), path("*.derep.uc")      , emit: clustering
     path "*.derep.log"                       , emit: log
     path "versions.yml"                      , emit: versions
 

--- a/modules/nf-core/vsearch/fastqfilter/main.nf
+++ b/modules/nf-core/vsearch/fastqfilter/main.nf
@@ -12,7 +12,7 @@ process VSEARCH_FASTQFILTER {
     tuple val(meta), path(fastq)
 
     output:
-    tuple val(meta), path('*.fasta')   , emit: fasta
+    tuple val(meta), path("*.fasta")   , emit: fasta
     path "*.log"                       , emit: log
     path "versions.yml"                , emit: versions
 

--- a/modules/nf-core/vsearch/sintax/main.nf
+++ b/modules/nf-core/vsearch/sintax/main.nf
@@ -12,7 +12,7 @@ process VSEARCH_SINTAX {
     path db
 
     output:
-    tuple val(meta), path('*.tsv')   , optional: true, emit: tsv
+    tuple val(meta), path("*.tsv")   , optional: true, emit: tsv
     path "versions.yml"              , emit: versions
 
     when:

--- a/modules/nf-core/vsearch/usearchglobal/main.nf
+++ b/modules/nf-core/vsearch/usearchglobal/main.nf
@@ -15,15 +15,15 @@ process VSEARCH_USEARCHGLOBAL {
     val user_columns
 
     output:
-    tuple val(meta), path('*.aln')    , optional: true, emit: aln
-    tuple val(meta), path('*.biom')   , optional: true, emit: biom
-    tuple val(meta), path('*.lca')    , optional: true, emit: lca
-    tuple val(meta), path('*.mothur') , optional: true, emit: mothur
-    tuple val(meta), path('*.otu')    , optional: true, emit: otu
-    tuple val(meta), path('*.sam')    , optional: true, emit: sam
-    tuple val(meta), path('*.tsv')    , optional: true, emit: tsv
-    tuple val(meta), path('*.txt')    , optional: true, emit: txt
-    tuple val(meta), path('*.uc')     , optional: true, emit: uc
+    tuple val(meta), path("*.aln")    , optional: true, emit: aln
+    tuple val(meta), path("*.biom")   , optional: true, emit: biom
+    tuple val(meta), path("*.lca")    , optional: true, emit: lca
+    tuple val(meta), path("*.mothur") , optional: true, emit: mothur
+    tuple val(meta), path("*.otu")    , optional: true, emit: otu
+    tuple val(meta), path("*.sam")    , optional: true, emit: sam
+    tuple val(meta), path("*.tsv")    , optional: true, emit: tsv
+    tuple val(meta), path("*.txt")    , optional: true, emit: txt
+    tuple val(meta), path("*.uc")     , optional: true, emit: uc
     path "versions.yml"                               , emit: versions
 
     when:

--- a/tests/modules/nf-core/artic/guppyplex/main.nf
+++ b/tests/modules/nf-core/artic/guppyplex/main.nf
@@ -9,7 +9,7 @@ process STAGE_FASTQ_DIR {
     tuple val(meta), path(fastq_file)
 
     output:
-    tuple val(meta), path('fastq'), emit: fastq_dir
+    tuple val(meta), path("fastq"), emit: fastq_dir
 
     script:
     """


### PR DESCRIPTION
When adapting nf-core code, I realized that some modules declare their output paths using single-quoted strings (e.g. `path('*.txt')`), while others use double-quoted strings (like `path("*.txt")`). When adapting the code, this leads to inconsistencies: 

Within single quoted outputs, process variables (such as `meta.id`) cannot be referenced using the usual mechanism `${meta.id}`. This makes the code significantly harder to adapt, since using this reference mechanism in single-quoted strings leads to a (not very helpful) "Output file not found" error. I also have not found any helpful information on how to debug this problem, so it took quite some time to fix. Changing output declarations to double-quoted strings everywhere would not bring any disadvantages I'm aware of, but just enable better adaptability because the usual reference mechanism for nextflow process variables with `$' could be used in all output declarations.
 
Especially the inconsistent use of both single- and double-quoted strings in the different modules makes no sense. I would therefore propose to change all output path declarations to double-quoted strings.
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ x] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ x] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
