### PR TITLE
Fix unpaired outputs from trimgalore

### DIFF
--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -13,7 +13,7 @@ process TRIMGALORE {
     output:
     tuple val(meta), path("*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"), emit: reads
     tuple val(meta), path("*report.txt")                               , emit: log, optional: true
-    tuple val(meta), path("*unpaired?{,_1,_2}.fq.gz")                  , emit: unpaired, optional: true
+    tuple val(meta), path("*unpaired{,_1,_2}.fq.gz")                  , emit: unpaired, optional: true
     tuple val(meta), path("*.html")                                    , emit: html, optional: true
     tuple val(meta), path("*.zip")                                     , emit: zip, optional: true
     path "versions.yml"					                               , emit: versions

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -11,12 +11,12 @@ process TRIMGALORE {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*{3prime,5prime,trimmed,val}_?[12]?.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt")                              , emit: log, optional: true
-    tuple val(meta), path("*_unpaired_?[12]?.fq.gz")                  , emit: unpaired, optional: true
-    tuple val(meta), path("*.html")                                   , emit: html, optional: true
-    tuple val(meta), path("*.zip")                                    , emit: zip, optional: true
-    path "versions.yml"					                              , emit: versions
+    tuple val(meta), path("*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"), emit: reads
+    tuple val(meta), path("*report.txt")                               , emit: log, optional: true
+    tuple val(meta), path("*unpaired?{,_1,_2}.fq.gz")                  , emit: unpaired, optional: true
+    tuple val(meta), path("*.html")                                    , emit: html, optional: true
+    tuple val(meta), path("*.zip")                                     , emit: zip, optional: true
+    path "versions.yml"					                               , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -11,12 +11,12 @@ process TRIMGALORE {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*{3prime,5prime,trimmed,val}*.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt")     , emit: log     , optional: true
-    tuple val(meta), path("*unpaired*.fq.gz"), emit: unpaired, optional: true
-    tuple val(meta), path("*.html")          , emit: html    , optional: true
-    tuple val(meta), path("*.zip")           , emit: zip     , optional: true
-    path "versions.yml"					     , emit: versions
+    tuple val(meta), path("*{3prime,5prime,trimmed,val}_?[12]?.fq.gz"), emit: reads
+    tuple val(meta), path("*report.txt")                              , emit: log, optional: true
+    tuple val(meta), path("*_unpaired_?[12]?.fq.gz")                  , emit: unpaired, optional: true
+    tuple val(meta), path("*.html")                                   , emit: html, optional: true
+    tuple val(meta), path("*.zip")                                    , emit: zip, optional: true
+    path "versions.yml"					                              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/trimgalore/meta.yml
+++ b/modules/nf-core/trimgalore/meta.yml
@@ -33,21 +33,24 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*{3prime,5prime,trimmed,val}*.fq.gz":
-          type: file
+      - "*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz":
+          type: map
           description: |
-            List of input adapter trimmed FastQ files of size 1 and 2 for
-            single-end and paired-end data, respectively.
-          pattern: "*{3prime,5prime,trimmed,val}*.fq.gz"
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+          pattern: "*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"
   - log:
       - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
+          pattern: "*_{report.txt}"
       - "*report.txt":
-          type: file
-          description: Trim Galore! trimming report
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
           pattern: "*_{report.txt}"
   - unpaired:
       - meta:
@@ -55,10 +58,11 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*unpaired*.fq.gz":
-          type: file
+      - "*unpaired{,_1,_2}.fq.gz":
+          type: map
           description: |
-            FastQ files containing unpaired reads from read 1 or read 2
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
           pattern: "*unpaired*.fq.gz"
   - html:
       - meta:
@@ -66,9 +70,12 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
+          pattern: "*_{fastqc.html}"
       - "*.html":
-          type: file
-          description: FastQC report (optional)
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
           pattern: "*_{fastqc.html}"
   - zip:
       - meta:
@@ -76,9 +83,12 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
+          pattern: "*_{fastqc.zip}"
       - "*.zip":
-          type: file
-          description: FastQC report archive (optional)
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
           pattern: "*_{fastqc.zip}"
   - versions:
       - versions.yml:

--- a/modules/nf-core/trimgalore/tests/main.nf.test
+++ b/modules/nf-core/trimgalore/tests/main.nf.test
@@ -126,6 +126,40 @@ nextflow_process {
         }
     }
 
+    test("test_trimgalore_paired_end_keep_unpaired") {
+
+        config "./nextflow.config"
+
+        when {
+
+            params {
+                module_args = '--retain_unpaired --length 150'
+            }
+
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_1.fastq.gz", checkIfExists: true),
+                        file(params.modules_testdata_base_path + "genomics/sarscov2/illumina/fastq/test_2.fastq.gz", checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    path(process.out.versions.get(0)).yaml,
+                    process.out.reads,
+                    process.out.unpaired
+                ).match() },
+            )
+        }
+    }
+
     test("test_trimgalore_paired_end - stub") {
 
     options "-stub"

--- a/modules/nf-core/trimgalore/tests/main.nf.test.snap
+++ b/modules/nf-core/trimgalore/tests/main.nf.test.snap
@@ -11,9 +11,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2024-12-05T22:56:18.454197"
+        "timestamp": "2025-01-06T12:25:01.330769598"
     },
     "test_trimgalore_single_end - stub": {
         "content": [
@@ -89,9 +89,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2024-12-05T22:56:22.085472"
+        "timestamp": "2025-01-06T12:25:15.582246999"
     },
     "test_trimgalore_paired_end - stub": {
         "content": [
@@ -172,9 +172,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2024-12-05T22:44:33.751013"
+        "timestamp": "2025-01-06T12:26:05.201562315"
     },
     "versions": {
         "content": [
@@ -188,9 +188,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2024-12-05T22:57:28.77107"
+        "timestamp": "2025-01-06T12:26:05.229598492"
     },
     "test_trimgalore_paired_end": {
         "content": [
@@ -204,8 +204,48 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2024-12-05T22:56:27.019872"
+        "timestamp": "2025-01-06T12:25:33.510924538"
+    },
+    "test_trimgalore_paired_end_keep_unpaired": {
+        "content": [
+            {
+                "TRIMGALORE": {
+                    "trimgalore": "0.6.10",
+                    "cutadapt": 4.9,
+                    "pigz": 2.8
+                }
+            },
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1_val_1.fq.gz:md5,75413e85910bbc2e1556e12f6479f935",
+                        "test_2_val_2.fq.gz:md5,d3c588c12646ebd36a0812fe02d0bda6"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1_unpaired_1.fq.gz:md5,17e0e878f6d0e93b9008a05f128660b6",
+                        "test_2_unpaired_2.fq.gz:md5,b09a064368a867e099e66df5ef69b044"
+                    ]
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-06T12:25:46.461002981"
     }
 }

--- a/modules/nf-core/trimgalore/tests/nextflow.config
+++ b/modules/nf-core/trimgalore/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: TRIMGALORE {
+        ext.args = params.module_args
+    }
+}


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

In order to fix the linked issue, we need to constrain the output to the `reads` channel so that it can't also catch the 'unpaired'.

Note: thinking about it, I'm unsure if the catching of unpaired reads in the reads channel was intentional. I'll consult @FelixKrueger .

## PR checklist

Closes #7268

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
