### PR TITLE
fix docker ownership issue

### DIFF
--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -29,7 +29,7 @@ profiles {
         docker.enabled          = true
         docker.userEmulation    = false
         docker.fixOwnership     = true
-        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
+        docker.runOptions       = '--platform=linux/amd64'
     }
     arm {
         docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'


### PR DESCRIPTION
reverting to the old settings hoping this will fix the error:
```
touch: cannot touch '.command.trace': Permission denied
```