### PR TITLE
Update: SEQKIT/REPLACE to optionally emit uncompressed output

### DIFF
--- a/modules/nf-core/seqkit/replace/main.nf
+++ b/modules/nf-core/seqkit/replace/main.nf
@@ -1,18 +1,18 @@
 process SEQKIT_REPLACE {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/seqkit:2.9.0--h9ee0642_0':
-        'biocontainers/seqkit:2.9.0--h9ee0642_0' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/seqkit:2.9.0--h9ee0642_0'
+        : 'biocontainers/seqkit:2.9.0--h9ee0642_0'}"
 
     input:
     tuple val(meta), path(fastx)
 
     output:
     tuple val(meta), path("*.fast*"), emit: fastx
-    path "versions.yml"             , emit: versions
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -21,10 +21,14 @@ process SEQKIT_REPLACE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def extension = "fastq"
-    if ("$fastx" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz/) {
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.faa|.+\.faa.gz/) {
         extension = "fasta"
     }
-    def endswith = task.ext.suffix ?: "${extension}.gz"
+    def isgz = ""
+    if ("${fastx}" ==~ /.+\.gz/) {
+        isgz = ".gz"
+    }
+    def endswith = task.ext.suffix ?: "${extension}${isgz}"
     """
     seqkit \\
         replace \\
@@ -42,7 +46,7 @@ process SEQKIT_REPLACE {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     def extension = "fastq"
-    if ("$fastx" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz/) {
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz/) {
         extension = "fasta"
     }
     def endswith = task.ext.suffix ?: "${extension}.gz"
@@ -55,5 +59,4 @@ process SEQKIT_REPLACE {
         seqkit: \$( seqkit version | sed 's/seqkit v//' )
     END_VERSIONS
     """
-
 }

--- a/modules/nf-core/seqkit/replace/tests/main.nf.test
+++ b/modules/nf-core/seqkit/replace/tests/main.nf.test
@@ -17,8 +17,8 @@ nextflow_process {
             process {
                 """
                     input[0] = [ [ id:'test' ],   // meta map
-                                 [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
-                     ]
+                                 [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta.gz', checkIfExists: true) ]
+                    ]
                 """
             }
         }
@@ -32,7 +32,31 @@ nextflow_process {
 
     }
 
-    test("sarscov2 - fasta - uncomp") {
+
+    test("sarscov2 - fasta - replace - uncompressed") {
+
+        config "./replace.config"
+
+        when {
+            process {
+                """
+                    input[0] = [ [ id:'test' ],   // meta map
+                                 [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fasta - uncomp - custom") {
 
         config "./uncomp.config"
 
@@ -41,7 +65,7 @@ nextflow_process {
                 """
                     input[0] = [ [ id:'test' ],   // meta map
                                  [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
-                     ]
+                    ]
                 """
             }
         }
@@ -64,7 +88,7 @@ nextflow_process {
                 """
                     input[0] = [ [ id:'test' ],   // meta map
                                  [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
-                     ]
+                    ]
                 """
             }
         }

--- a/modules/nf-core/seqkit/replace/tests/main.nf.test.snap
+++ b/modules/nf-core/seqkit/replace/tests/main.nf.test.snap
@@ -32,6 +32,72 @@
         },
         "timestamp": "2025-01-15T15:10:45.336609"
     },
+    "sarscov2 - fasta - replace - uncompressed": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,b1518908253a4997fcad98270751112e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,b1518908253a4997fcad98270751112e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-01-23T11:36:29.526831467"
+    },
+    "sarscov2 - fasta - uncomp - custom": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test..fasta:md5,05d3294a62c72f5489f067c1da3c2f6c"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test..fasta:md5,05d3294a62c72f5489f067c1da3c2f6c"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-01-23T11:36:34.791793064"
+    },
     "sarscov2 - fasta - replace": {
         "content": [
             {
@@ -40,7 +106,7 @@
                         {
                             "id": "test"
                         },
-                        "test.fasta.gz:md5,b1518908253a4997fcad98270751112e"
+                        "test.fasta.gz:md5,c40eaff961f6f2a48bb7e8fd156ed5d7"
                     ]
                 ],
                 "1": [
@@ -51,7 +117,7 @@
                         {
                             "id": "test"
                         },
-                        "test.fasta.gz:md5,b1518908253a4997fcad98270751112e"
+                        "test.fasta.gz:md5,c40eaff961f6f2a48bb7e8fd156ed5d7"
                     ]
                 ],
                 "versions": [
@@ -61,41 +127,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-15T15:10:36.722731"
-    },
-    "sarscov2 - fasta - uncomp": {
-        "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test..fasta:md5,05d3294a62c72f5489f067c1da3c2f6c"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
-                ],
-                "fastx": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test..fasta:md5,05d3294a62c72f5489f067c1da3c2f6c"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-01-15T15:10:41.090521"
+        "timestamp": "2025-01-23T11:36:24.47433864"
     }
 }


### PR DESCRIPTION
I have a tool that doesn't accept gzipped inputs. Rather than having a whole other redundant unzippign step after running `seqkit/replace`, I've tweaked the module that the output compression will match whatever the input is.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
