### PR TITLE
Make erroring wave builds fail CI

### DIFF
--- a/.github/workflows/wave.yml
+++ b/.github/workflows/wave.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         files: "${{ fromJson(needs.generate-matrix.outputs.conda-matrix) }}"
         profile: [docker, singularity]
@@ -72,10 +72,9 @@ jobs:
           chmod +x /usr/local/bin/wave
 
       - name: Build ${{ matrix.profile }} container
-        # FIXME Hack while iron out the CI
-        continue-on-error: true
         env:
           PROFILE: ${{ (contains(matrix.profile, 'singularity') && '--singularity') || '' }}
+        continue-on-error: false
         run: |
           wave --conda-file "${{ matrix.files }}" \
               $PROFILE \
@@ -95,7 +94,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 2
       matrix:
         files: "${{ fromJson(needs.generate-matrix.outputs.dockerfile-matrix) }}"
         # NOTE singularity build requires a Singularity definition file in place of Dockerfile


### PR DESCRIPTION
So we can know when the arm builds are failing. Reporting hook to come later.
