### PR TITLE
catpack/contigs fix a typo in the option for the diamond table

### DIFF
--- a/modules/nf-core/catpack/contigs/main.nf
+++ b/modules/nf-core/catpack/contigs/main.nf
@@ -30,7 +30,7 @@ process CATPACK_CONTIGS {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def premade_proteins = proteins ? "-p ${proteins}" : ''
-    def premade_table = diamond_table ? "-d ${diamond_table}" : ''
+    def premade_table = diamond_table ? "-a ${diamond_table}" : ''
     """
     CAT_pack contigs \\
         -n ${task.cpus} \\

--- a/modules/nf-core/catpack/contigs/main.nf
+++ b/modules/nf-core/catpack/contigs/main.nf
@@ -29,15 +29,15 @@ process CATPACK_CONTIGS {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def premade_proteins = proteins ? "-p ${proteins}" : ''
-    def premade_table = diamond_table ? "-a ${diamond_table}" : ''
+    def premade_proteins = proteins ? "--proteins_fasta ${proteins}" : ''
+    def premade_table = diamond_table ? "--diamond_alignment ${diamond_table}" : ''
     """
     CAT_pack contigs \\
-        -n ${task.cpus} \\
-        -c ${contigs} \\
-        -d ${database} \\
-        -t ${taxonomy} \\
-        -o ${prefix} \\
+        --nproc ${task.cpus} \\
+        --contigs_fasta ${contigs} \\
+        --database_folder ${database} \\
+        --taxonomy_folder ${taxonomy} \\
+        --out_prefix ${prefix} \\
         ${premade_proteins} \\
         ${premade_table} \\
         ${args}


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).

Hello, 

Thank you for the [recent update for this module](https://github.com/nf-core/modules/commit/3486e0ae4ae7ff09d64e807e51d9581f782e605e) that added missing input options. It was really helpful for me. 

However I've noticed that there is a typo in a flag for diamond alignment file. 
The correct flag is 
```
  -a , --diamond_alignment
                        Path to alignment table. If supplied, the alignment
                        step is skipped and classification is carried out
                        directly. A predicted proteins fasta file should also
                        be supplied with argument [-p / --proteins].
```
The flag used is a flag for providing the database:
` def premade_table = diamond_table ? "-d ${diamond_table}" : ''`
Documentation for CAT_pack: https://github.com/MGXlab/CAT_pack?tab=readme-ov-file#taxonomic-annotation-of-contigs-or-mags-with-cat-and-bat

Thank you for your time. 
