### PR TITLE
Fix broken versions.yml file in last/train.

### DIFF
--- a/modules/nf-core/last/train/main.nf
+++ b/modules/nf-core/last/train/main.nf
@@ -32,15 +32,15 @@ process LAST_TRAIN {
         $fastx \\
         > ${prefix}.train
 
-    echo "id\tsubstitution_percent_identity\tlast -t\tlast -a\tlast -A\tlast -b\tlast -B\tlast -S"       > ${prefix}.train.tsv
-    printf "\$(basename ${prefix}.train .target.train)\t"                                               >> ${prefix}.train.tsv
-    grep 'substitution percent identity' ${prefix}.train | tail -n 1 | awk '{print \$5}' | tr '\n' '\t' >> ${prefix}.train.tsv
-    grep 'last -t' ${prefix}.train | tail -n 1 | awk '{print \$2}'   | sed -e 's/-t//'   | tr '\n' '\t' >> ${prefix}.train.tsv
-    grep 'last -a' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\n' '\t' >> ${prefix}.train.tsv
-    grep 'last -A' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\n' '\t' >> ${prefix}.train.tsv
-    grep 'last -b' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\n' '\t' >> ${prefix}.train.tsv
-    grep 'last -B' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\n' '\t' >> ${prefix}.train.tsv
-    grep 'last -S' ${prefix}.train | tail -n 1 | awk '{print \$3}'                                      >> ${prefix}.train.tsv
+    echo "id\tsubstitution_percent_identity\tlast -t\tlast -a\tlast -A\tlast -b\tlast -B\tlast -S"         > ${prefix}.train.tsv
+    printf "\$(basename ${prefix}.train .target.train)\t"                                                 >> ${prefix}.train.tsv
+    grep 'substitution percent identity' ${prefix}.train | tail -n 1 | awk '{print \$5}' | tr '\\n' '\\t' >> ${prefix}.train.tsv
+    grep 'last -t' ${prefix}.train | tail -n 1 | awk '{print \$2}'   | sed -e 's/-t//'   | tr '\\n' '\\t' >> ${prefix}.train.tsv
+    grep 'last -a' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\\n' '\\t' >> ${prefix}.train.tsv
+    grep 'last -A' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\\n' '\\t' >> ${prefix}.train.tsv
+    grep 'last -b' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\\n' '\\t' >> ${prefix}.train.tsv
+    grep 'last -B' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\\n' '\\t' >> ${prefix}.train.tsv
+    grep 'last -S' ${prefix}.train | tail -n 1 | awk '{print \$3}'                                        >> ${prefix}.train.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/last/train/tests/main.nf.test.snap
+++ b/modules/nf-core/last/train/tests/main.nf.test.snap
@@ -74,7 +74,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,c1f06f4162a8b4ee1b8094d967f6678d"
+                    "versions.yml:md5,b2d4a4fce93a910c90768053127969b3"
                 ],
                 "multiqc": [
                     [
@@ -95,14 +95,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,c1f06f4162a8b4ee1b8094d967f6678d"
+                    "versions.yml:md5,b2d4a4fce93a910c90768053127969b3"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-22T10:22:21.360808"
+        "timestamp": "2025-01-30T18:37:11.305733"
     }
 }


### PR DESCRIPTION
Here is the long story:

Escape sequences for newline and tab in a shell `tr` command were not escaped in the script section of the module, causing them to be expanded in `.command.sh`.

This did not prevent `tr` from doing its job, but this caused the lines in the script to be indented, like this:

```
    cat <<-END_VERSIONS > versions.yml
    "NFCORE_PAIRGENOMEALIGN:PAIRGENOMEALIGN:PAIRALIGN_M2M:ALIGNMENT_TRAIN":
        last: $(lastdb --version | sed 's/lastdb //')
    END_VERSIONS
```

The indentation broke the herescript, but did not cause the module to fail.

Therefore, the `versions.yml` file contained one extra line with
`    END_VERSIONS` in it.  This crashes the pipelines that collect the
version numbers, but this was not noticed because `last/train` is always
used with other `last/` submodules, and I was not using `last/train`'s
versions file until today, because I was assuming that the information
would always be redundant.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
