### PR TITLE
Add db to output meta object for diamond/blastp

### DIFF
--- a/modules/nf-core/diamond/blastp/main.nf
+++ b/modules/nf-core/diamond/blastp/main.nf
@@ -1,5 +1,5 @@
 process DIAMOND_BLASTP {
-    tag "$meta.id"
+    tag "${meta.id}.${meta2.id}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
@@ -14,19 +14,21 @@ process DIAMOND_BLASTP {
     val blast_columns
 
     output:
-    tuple val(meta), path('*.{blast,blast.gz}'), optional: true, emit: blast
-    tuple val(meta), path('*.{xml,xml.gz}')    , optional: true, emit: xml
-    tuple val(meta), path('*.{txt,txt.gz}')    , optional: true, emit: txt
-    tuple val(meta), path('*.{daa,daa.gz}')    , optional: true, emit: daa
-    tuple val(meta), path('*.{sam,sam.gz}')    , optional: true, emit: sam
-    tuple val(meta), path('*.{tsv,tsv.gz}')    , optional: true, emit: tsv
-    tuple val(meta), path('*.{paf,paf.gz}')    , optional: true, emit: paf
+    tuple val(outmeta), path('*.{blast,blast.gz}'), optional: true, emit: blast
+    tuple val(outmeta), path('*.{xml,xml.gz}')    , optional: true, emit: xml
+    tuple val(outmeta), path('*.{txt,txt.gz}')    , optional: true, emit: txt
+    tuple val(outmeta), path('*.{daa,daa.gz}')    , optional: true, emit: daa
+    tuple val(outmeta), path('*.{sam,sam.gz}')    , optional: true, emit: sam
+    tuple val(outmeta), path('*.{tsv,tsv.gz}')    , optional: true, emit: tsv
+    tuple val(outmeta), path('*.{paf,paf.gz}')    , optional: true, emit: paf
     path "versions.yml"                        , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
+    outmeta = meta + [ db: meta2.id ]
+
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
@@ -72,6 +74,8 @@ process DIAMOND_BLASTP {
     """
 
     stub:
+    outmeta = meta + [ db: meta2.id ]
+
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     def out_ext = ""

--- a/modules/nf-core/diamond/blastp/tests/main.nf.test.snap
+++ b/modules/nf-core/diamond/blastp/tests/main.nf.test.snap
@@ -11,7 +11,8 @@
                 "2": [
                     [
                         {
-                            "id": "test"
+                            "id": "test",
+                            "db": "test2"
                         },
                         "test.txt:md5,8131b1afd717f3d5f2f2417c5b562e6e"
                     ]
@@ -49,7 +50,8 @@
                 "txt": [
                     [
                         {
-                            "id": "test"
+                            "id": "test",
+                            "db": "test2"
                         },
                         "test.txt:md5,8131b1afd717f3d5f2f2417c5b562e6e"
                     ]
@@ -64,9 +66,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-28T10:25:13.48912978"
+        "timestamp": "2025-01-30T20:38:52.731932"
     },
     "txt_gz": {
         "content": [
@@ -80,7 +82,8 @@
                 "2": [
                     [
                         {
-                            "id": "test"
+                            "id": "test",
+                            "db": "test2"
                         },
                         "test.txt.gz:md5,8131b1afd717f3d5f2f2417c5b562e6e"
                     ]
@@ -118,7 +121,8 @@
                 "txt": [
                     [
                         {
-                            "id": "test"
+                            "id": "test",
+                            "db": "test2"
                         },
                         "test.txt.gz:md5,8131b1afd717f3d5f2f2417c5b562e6e"
                     ]
@@ -133,9 +137,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-28T10:36:04.361504205"
+        "timestamp": "2025-01-30T20:39:13.482569"
     },
     "gz_txt": {
         "content": [
@@ -149,7 +153,8 @@
                 "2": [
                     [
                         {
-                            "id": "test"
+                            "id": "test",
+                            "db": "test2"
                         },
                         "test.txt:md5,8131b1afd717f3d5f2f2417c5b562e6e"
                     ]
@@ -187,7 +192,8 @@
                 "txt": [
                     [
                         {
-                            "id": "test"
+                            "id": "test",
+                            "db": "test2"
                         },
                         "test.txt:md5,8131b1afd717f3d5f2f2417c5b562e6e"
                     ]
@@ -202,9 +208,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-28T10:25:20.993203497"
+        "timestamp": "2025-01-30T20:39:00.385491"
     },
     "daa": {
         "content": [
@@ -230,7 +236,8 @@
                 "2": [
                     [
                         {
-                            "id": "test"
+                            "id": "test",
+                            "db": "test2"
                         },
                         "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
@@ -268,7 +275,8 @@
                 "txt": [
                     [
                         {
-                            "id": "test"
+                            "id": "test",
+                            "db": "test2"
                         },
                         "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
@@ -283,8 +291,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-28T10:25:34.911633513"
+        "timestamp": "2025-01-30T20:41:01.846481"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

Sorry for this, @vagkaratzas , but I need to keep track of the combination of fasta file and database so I need the output meta object to contain the id of the database's meta.