### PR TITLE
Allow `last/maf-convert` to output multiple files in different formats.

### DIFF
--- a/modules/nf-core/last/mafconvert/meta.yml
+++ b/modules/nf-core/last/mafconvert/meta.yml
@@ -25,10 +25,10 @@ input:
         description: Multiple Alignment Format (MAF) file, optionally compressed with
           gzip
         pattern: "*.{maf.gz,maf}"
-  - - format:
-        type: string
-        description: Output format (one of axt, blast, blasttab, chain, gff, html, psl,
-          sam, or tab)
+  - - format_list:
+        type: list
+        description: List of output formats (among axt, bam, blast, blasttab, chain,
+          cram, gff, html, psl, sam, or tab).
   - - meta2:
         type: map
         description: |

--- a/modules/nf-core/last/mafconvert/tests/main.nf.test
+++ b/modules/nf-core/last/mafconvert/tests/main.nf.test
@@ -9,7 +9,7 @@ nextflow_process {
     tag "last"
     tag "last/mafconvert"
 
-    test("sarscov2 - psl") {
+    test("sarscov2 - psl,gff") {
 
         when {
             process {
@@ -18,7 +18,7 @@ nextflow_process {
                     [ id:'contigs.genome' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
                 ]
-                input[1] = 'psl'
+                input[1] = ['psl','gff']
                 input[2] = [[],[]]
                 input[3] = [[],[]]
                 input[4] = [[],[]]
@@ -99,7 +99,7 @@ nextflow_process {
 
     }
 
-    test("sarscov2 - psl - stub") {
+    test("sarscov2 - psl,bam - stub") {
 
         options "-stub"
         when {
@@ -109,7 +109,7 @@ nextflow_process {
                     [ id:'contigs.genome' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
                 ]
-                input[1] = 'psl'
+                input[1] = ['psl','bam']
                 input[2] = [[],[]]
                 input[3] = [[],[]]
                 input[4] = [[],[]]

--- a/modules/nf-core/last/mafconvert/tests/main.nf.test.snap
+++ b/modules/nf-core/last/mafconvert/tests/main.nf.test.snap
@@ -1,97 +1,4 @@
 {
-    "sarscov2 - psl": {
-        "content": [
-            {
-                "0": [
-                    
-                ],
-                "1": [
-                    
-                ],
-                "10": [
-                    
-                ],
-                "11": [
-                    "versions.yml:md5,7c66667735aa9f79367b8b8fc8df4497"
-                ],
-                "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    
-                ],
-                "6": [
-                    
-                ],
-                "7": [
-                    
-                ],
-                "8": [
-                    [
-                        {
-                            "id": "contigs.genome"
-                        },
-                        "contigs.genome.psl.gz:md5,515d3cff55d159309bedd38f47dd034b"
-                    ]
-                ],
-                "9": [
-                    
-                ],
-                "axt_gz": [
-                    
-                ],
-                "bam": [
-                    
-                ],
-                "blast_gz": [
-                    
-                ],
-                "blasttab_gz": [
-                    
-                ],
-                "chain_gz": [
-                    
-                ],
-                "cram": [
-                    
-                ],
-                "gff_gz": [
-                    
-                ],
-                "html_gz": [
-                    
-                ],
-                "psl_gz": [
-                    [
-                        {
-                            "id": "contigs.genome"
-                        },
-                        "contigs.genome.psl.gz:md5,515d3cff55d159309bedd38f47dd034b"
-                    ]
-                ],
-                "sam_gz": [
-                    
-                ],
-                "tab_gz": [
-                    
-                ],
-                "versions": [
-                    "versions.yml:md5,7c66667735aa9f79367b8b8fc8df4497"
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-01-30T10:31:47.133387"
-    },
     "sarscov2 - cram": {
         "content": [
             [
@@ -112,16 +19,21 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-30T10:32:17.048046"
+        "timestamp": "2025-02-04T11:02:18.936016"
     },
-    "sarscov2 - psl - stub": {
+    "sarscov2 - psl,bam - stub": {
         "content": [
             {
                 "0": [
                     
                 ],
                 "1": [
-                    
+                    [
+                        {
+                            "id": "contigs.genome"
+                        },
+                        "contigs.genome.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "10": [
                     
@@ -162,7 +74,12 @@
                     
                 ],
                 "bam": [
-                    
+                    [
+                        {
+                            "id": "contigs.genome"
+                        },
+                        "contigs.genome.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "blast_gz": [
                     
@@ -205,7 +122,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-30T10:32:31.669726"
+        "timestamp": "2025-02-04T11:02:33.89028"
     },
     "sarscov2 - bam": {
         "content": [
@@ -227,6 +144,109 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-31T21:57:36.433274"
+        "timestamp": "2025-02-04T11:02:03.989741"
+    },
+    "sarscov2 - psl,gff": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "10": [
+                    
+                ],
+                "11": [
+                    "versions.yml:md5,7c66667735aa9f79367b8b8fc8df4497"
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "contigs.genome"
+                        },
+                        "contigs.genome.gff.gz:md5,d518db13e7f286614cd5fb014c5f2482"
+                    ]
+                ],
+                "7": [
+                    
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "contigs.genome"
+                        },
+                        "contigs.genome.psl.gz:md5,515d3cff55d159309bedd38f47dd034b"
+                    ]
+                ],
+                "9": [
+                    
+                ],
+                "axt_gz": [
+                    
+                ],
+                "bam": [
+                    
+                ],
+                "blast_gz": [
+                    
+                ],
+                "blasttab_gz": [
+                    
+                ],
+                "chain_gz": [
+                    
+                ],
+                "cram": [
+                    
+                ],
+                "gff_gz": [
+                    [
+                        {
+                            "id": "contigs.genome"
+                        },
+                        "contigs.genome.gff.gz:md5,d518db13e7f286614cd5fb014c5f2482"
+                    ]
+                ],
+                "html_gz": [
+                    
+                ],
+                "psl_gz": [
+                    [
+                        {
+                            "id": "contigs.genome"
+                        },
+                        "contigs.genome.psl.gz:md5,515d3cff55d159309bedd38f47dd034b"
+                    ]
+                ],
+                "sam_gz": [
+                    
+                ],
+                "tab_gz": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,7c66667735aa9f79367b8b8fc8df4497"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-02-04T11:01:48.26252"
     }
 }


### PR DESCRIPTION
The input channel conveying output format information becomes a list of strings instead of just a string.  The module loops on the formats and runs `maf-convert` on each of them.  This will simplify the structure of pipelines that need conversions to more than one format.

Silently, the module still accepts the input of single format as a simple string, for backwards compatibility.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
