### PR TITLE
Move output format information to the first queue channel of `last/mafconvert`

### DIFF
--- a/modules/nf-core/last/mafconvert/main.nf
+++ b/modules/nf-core/last/mafconvert/main.nf
@@ -8,8 +8,7 @@ process LAST_MAFCONVERT {
         : 'community.wave.seqera.io/library/last_samtools:e2b51d2d9a1ce9fa'}"
 
     input:
-    tuple val(meta), path(maf)
-    val(format)
+    tuple val(meta), path(maf), val(format)
     tuple val(meta2), path(fasta)
     tuple val(meta3), path(fai)
     tuple val(meta4), path(gzi)
@@ -61,7 +60,17 @@ process LAST_MAFCONVERT {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo stub | gzip --no-name > ${prefix}.${format}.gz
+    case $format in
+        bam)
+            touch ${prefix}.${format}
+            ;;
+        cram)
+            touch ${prefix}.${format}
+            ;;
+        *)
+            echo stub | gzip --no-name > ${prefix}.${format}.gz
+            ;;
+    esac
 
     # maf-convert has no --version option but lastdb (part of the same package) has.
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/last/mafconvert/meta.yml
+++ b/modules/nf-core/last/mafconvert/meta.yml
@@ -25,10 +25,10 @@ input:
         description: Multiple Alignment Format (MAF) file, optionally compressed with
           gzip
         pattern: "*.{maf.gz,maf}"
-  - - format:
+    - format:
         type: string
-        description: Output format (one of axt, blast, blasttab, chain, gff, html, psl,
-          sam, or tab)
+        description: Output format (one of axt, bam, blast, blasttab, cram, chain, gff,
+          html, psl, sam, or tab)
   - - meta2:
         type: map
         description: |

--- a/modules/nf-core/last/mafconvert/tests/main.nf.test
+++ b/modules/nf-core/last/mafconvert/tests/main.nf.test
@@ -16,12 +16,12 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'contigs.genome' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true),
+                    'psl'
                 ]
-                input[1] = 'psl'
+                input[1] = [[],[]]
                 input[2] = [[],[]]
                 input[3] = [[],[]]
-                input[4] = [[],[]]
                 """
             }
         }
@@ -42,12 +42,12 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'contigs.genome' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true),
+                    'bam'
                 ]
-                input[1] = 'bam'
+                input[1] = [[],[]]
                 input[2] = [[],[]]
                 input[3] = [[],[]]
-                input[4] = [[],[]]
                 """
             }
         }
@@ -71,18 +71,18 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'contigs.genome' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true),
+                    'cram'
                 ]
-                input[1] = 'cram'
-                input[2] = [
+                input[1] = [
                     [ id:'contigs.genome' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta',     checkIfExists: true)
                 ]
-                input[3] = [
+                input[2] = [
                     [ id:'contigs.genome' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
                 ]
-                input[4] = [[],[]]
+                input[3] = [[],[]]
                 """
             }
         }
@@ -107,12 +107,12 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'contigs.genome' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true),
+                    'psl'
                 ]
-                input[1] = 'psl'
+                input[1] = [[],[]]
                 input[2] = [[],[]]
                 input[3] = [[],[]]
-                input[4] = [[],[]]
                 """
             }
         }


### PR DESCRIPTION
This allows pipelines to use the `last/mafconvert` module to convert the same alignment file to different formats in parallel through a channel `combine` operation.

In addition I made a minor fix to the stubs that ensured that output files are the same as in the real computation.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
