### PR TITLE
Optional filtering of the alignments input to `last/dotplot`.

### DIFF
--- a/modules/nf-core/last/dotplot/main.nf
+++ b/modules/nf-core/last/dotplot/main.nf
@@ -11,6 +11,7 @@ process LAST_DOTPLOT {
     tuple val(meta), path(maf), path(annot_b)
     tuple val(meta2), path(annot_a)
     val(format)
+    val(filter)
 
     output:
     tuple val(meta), path("*.gif"), optional:true, emit: gif
@@ -22,18 +23,21 @@ process LAST_DOTPLOT {
 
     script:
     def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def annot_a_arg = annot_a ? "-a ${annot_a}" : ''
     def annot_b_arg = annot_b ? "-b ${annot_b}" : ''
+    def input_command = filter ? "maf-linked ${args2}" : "zcat -f"
     """
     TTF=/home/ubuntu/conda_pkgs_dir/open-fonts-0.7.0-1/fonts/open-fonts/DejaVuSansMono-Regular.ttf
     [ -e "\$TTF" ] || TTF="/opt/conda/fonts/open-fonts/DejaVuSansMono-Regular.ttf"
+    $input_command $maf |
     last-dotplot \\
         -f \$TTF \\
         $args \\
         $annot_a_arg \\
         $annot_b_arg \\
-        $maf \\
+        - \\
         $prefix.$format
 
     # last-dotplot has no --version option so let's use lastal from the same suite

--- a/modules/nf-core/last/dotplot/meta.yml
+++ b/modules/nf-core/last/dotplot/meta.yml
@@ -43,6 +43,9 @@ input:
   - - format:
         type: string
         description: Output format (PNG or GIF).
+  - - filter:
+        type: boolean
+        description: Remove isolated alignments using the `maf-linked` software.
 output:
   - gif:
       - meta:

--- a/modules/nf-core/last/dotplot/tests/main.nf.test
+++ b/modules/nf-core/last/dotplot/tests/main.nf.test
@@ -25,6 +25,37 @@ nextflow_process {
                          . collectFile(name: 'dummy_annot_a.bed', newLine: true)
                          . map { [ [ id:'test'], it ] }
                 input[2] = channel.of("png")
+                input[3] = channel.of([])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - contigs - genome - png - filter") {
+
+        when {
+            process {
+                """
+                input[0] = channel.of('NODE_1_length_20973_cov_191.628754\t2000\t2010')
+                         . collectFile(name: 'dummy_annot_b.bed', newLine: true)
+                         . map { [
+                                   [ id:'test' ], // meta map
+                                   file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/last/contigs.genome.maf.gz', checkIfExists: true),
+                                   it
+                                 ] }
+                input[1] = channel.of('MT192765.1\t1000\t1010')
+                         . collectFile(name: 'dummy_annot_a.bed', newLine: true)
+                         . map { [ [ id:'test'], it ] }
+                input[2] = channel.of("png")
+                input[3] = channel.of("filter")
                 """
             }
         }
@@ -50,6 +81,7 @@ nextflow_process {
                 ]
                 input[1] = [ [id: 'test'], [] ]
                 input[2] = "gif"
+                input[3] = []
                 """
             }
         }
@@ -76,6 +108,7 @@ nextflow_process {
                 ]
                 input[1] = [ [id: 'test'], [] ]
                 input[2] = "png"
+                input[3] = []
                 """
             }
         }

--- a/modules/nf-core/last/dotplot/tests/main.nf.test.snap
+++ b/modules/nf-core/last/dotplot/tests/main.nf.test.snap
@@ -77,6 +77,45 @@
         },
         "timestamp": "2025-01-31T09:55:40.665796"
     },
+    "sarscov2 - contigs - genome - png - filter": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.png:md5,9e3892ca780f112fc0266543455ce9e5"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,143ef48514afd0c39da64d8f11fd18f7"
+                ],
+                "gif": [
+                    
+                ],
+                "png": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.png:md5,9e3892ca780f112fc0266543455ce9e5"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,143ef48514afd0c39da64d8f11fd18f7"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-02-04T16:58:29.410356"
+    },
     "sarscov2 - contigs - genome - png": {
         "content": [
             {


### PR DESCRIPTION
This uses the `maf-filter` tool distributed together with `last-dotplot` in the LAST suite.

The genome alignments that are plotted can be very large, even after the filtering step.  Therefore I implemented it with a pipe command rather than creating a separate module, which would consume a lot of disk space.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
