### PR TITLE
Fix ampcombi2/parsetables output declarations

### DIFF
--- a/modules/nf-core/ampcombi2/parsetables/main.nf
+++ b/modules/nf-core/ampcombi2/parsetables/main.nf
@@ -17,10 +17,10 @@ process AMPCOMBI2_PARSETABLES {
 
     output:
     tuple val(meta), path("${meta.id}/")                                , emit: sample_dir
-    tuple val(meta), path("${meta.id}/contig_gbks/")                    , emit: contig_gbks
-    tuple val(meta), path("${meta.id}/${meta.id}_mmseqs_matches.tsv")   , emit: db_tsv
-    tuple val(meta), path("${meta.id}/${meta.id}_ampcombi.tsv")         , emit: tsv
-    tuple val(meta), path("${meta.id}/${meta.id}_amp.faa")              , emit: faa
+    tuple val(meta), path("${meta.id}/contig_gbks/")                    , emit: contig_gbks  , optional:true
+    tuple val(meta), path("${meta.id}/${meta.id}_mmseqs_matches.tsv")   , emit: db_tsv       , optional:true
+    tuple val(meta), path("${meta.id}/${meta.id}_ampcombi.tsv")         , emit: tsv          , optional:true
+    tuple val(meta), path("${meta.id}/${meta.id}_amp.faa")              , emit: faa          , optional:true
     tuple val(meta), path("${meta.id}/${meta.id}_ampcombi.log")         , emit: sample_log   , optional:true
     tuple val(meta), path("Ampcombi_parse_tables.log")                  , emit: full_log     , optional:true
     tuple val(meta), path("amp_${opt_amp_db}_database/")                , emit: db           , optional:true


### PR DESCRIPTION
This changes all output files per sample created by ampcombi2/parsetables to 'Optional' to allow for empty sample files in case of no AMPs detected. Which is creating a problem in nf-core/funcscan  https://github.com/nf-core/funcscan/issues/444

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
