### PR TITLE
Update conda channels priority in csvtk and mafft

### DIFF
--- a/modules/nf-core/csvtk/concat/environment.yml
+++ b/modules/nf-core/csvtk/concat/environment.yml
@@ -1,8 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
-  - conda-forge
   - bioconda
-
+  - conda-forge
 dependencies:
   - bioconda::csvtk=0.31.0

--- a/modules/nf-core/csvtk/join/environment.yml
+++ b/modules/nf-core/csvtk/join/environment.yml
@@ -1,8 +1,8 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
 
 dependencies:
   - bioconda::csvtk=0.31.0

--- a/modules/nf-core/csvtk/split/environment.yml
+++ b/modules/nf-core/csvtk/split/environment.yml
@@ -1,8 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
-  - conda-forge
   - bioconda
-
+  - conda-forge
 dependencies:
   - bioconda::csvtk=0.31.0

--- a/modules/nf-core/mafft/align/environment.yml
+++ b/modules/nf-core/mafft/align/environment.yml
@@ -1,8 +1,8 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
 dependencies:
   - bioconda::mafft=7.520
   - conda-forge::pigz=2.8

--- a/modules/nf-core/mafft/guidetree/environment.yml
+++ b/modules/nf-core/mafft/guidetree/environment.yml
@@ -1,7 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
 dependencies:
   - bioconda::mafft=7.525


### PR DESCRIPTION
Because now there is ane entry of csvkt and mafft in conda-forge, it will throw an error becuse the channels order in environment.yml is inverted compared to what we state in the dependencies:

I want the bioconda entry of mafft so bioconda needs to be first in the channels. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
