### PR TITLE
new module: `hmmer/hmmpress`

### DIFF
--- a/modules/nf-core/hmmer/hmmpress/environment.yml
+++ b/modules/nf-core/hmmer/hmmpress/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::hmmer=3.4

--- a/modules/nf-core/hmmer/hmmpress/main.nf
+++ b/modules/nf-core/hmmer/hmmpress/main.nf
@@ -5,7 +5,7 @@ process HMMER_HMMPRESS {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/hmmer:3.4--hdbdd923_1' :
-        'community.wave.seqera.io/library/hmmer:3.4--cb5d2dd2e85974ca' }"
+        'biocontainers/hmmer:3.4--hdbdd923_1' }"
 
     input:
     tuple val(meta), path(hmmfile)
@@ -13,6 +13,9 @@ process HMMER_HMMPRESS {
     output:
     tuple val(meta), path("*.h3?"), emit: compressed_db
     path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''

--- a/modules/nf-core/hmmer/hmmpress/main.nf
+++ b/modules/nf-core/hmmer/hmmpress/main.nf
@@ -1,6 +1,6 @@
 process HMMER_HMMPRESS {
     tag "$meta.id"
-    label 'process_low'
+    label 'process_single'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/hmmer/hmmpress/main.nf
+++ b/modules/nf-core/hmmer/hmmpress/main.nf
@@ -1,0 +1,45 @@
+process HMMER_HMMPRESS {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/hmmer:3.4--hdbdd923_1' :
+        'community.wave.seqera.io/library/hmmer:3.4--cb5d2dd2e85974ca' }"
+
+    input:
+    tuple val(meta), path(hmmfile)
+
+    output:
+    tuple val(meta), path("*.h3?"), emit: compressed_db
+    path "versions.yml"           , emit: versions
+
+    script:
+    def args = task.ext.args ?: ''
+
+    """
+    hmmpress \\
+        $args \\
+        ${hmmfile}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmmer: \$(echo \$(hmmpress -h | grep HMMER | sed 's/# HMMER //' | sed 's/ .*//' 2>&1))
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "stub"
+
+    """
+    touch ${prefix}.h3m
+    touch ${prefix}.h3i
+    touch ${prefix}.h3f
+    touch ${prefix}.h3p
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmmer: \$(echo \$(hmmpress -h | grep HMMER | sed 's/# HMMER //' | sed 's/ .*//' 2>&1))
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/hmmer/hmmpress/meta.yml
+++ b/modules/nf-core/hmmer/hmmpress/meta.yml
@@ -32,7 +32,7 @@ output:
           description: |
           Groovy Map containing sample information
           e.g. [ id:'test', single_end:false ]
-      - "*.h3?"
+      - "*.h3?":
           type: dir
           description: Binary files with compressed profiles and their index
           pattern: "*.h3?"

--- a/modules/nf-core/hmmer/hmmpress/meta.yml
+++ b/modules/nf-core/hmmer/hmmpress/meta.yml
@@ -33,7 +33,7 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.h3?":
-          type: dir
+          type: list
           description: Binary files with compressed profiles and their index
           pattern: "*.h3?"
   - versions:

--- a/modules/nf-core/hmmer/hmmpress/meta.yml
+++ b/modules/nf-core/hmmer/hmmpress/meta.yml
@@ -1,0 +1,47 @@
+name: "hmmer_hmmpress"
+description: compress and index profile database for hmmscan
+keywords:
+  - hidden Markov model
+  - HMM
+  - hmmer
+  - hmmpress
+  - hmmscan
+tools:
+  - "hmmer":
+      description: "Biosequence analysis using profile hidden Markov models"
+      homepage: "http://hmmer.org"
+      documentation: "http://hmmer.org/documentation.html"
+      tool_dev_url: "https://github.com/EddyRivasLab/hmmer"
+      doi: "10.1371/journal.pcbi.1002195"
+      licence: ["BSD"]
+      identifier: biotools:hmmer
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - hmmfile:
+        type: file
+        description: HMMER flatfile database of HMM profiles
+        pattern: "*"
+output:
+  - compressed_db:
+      - meta:
+          type: map
+          description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+      - "*.h3?"
+          type: dir
+          description: Binary files with compressed profiles and their index
+          pattern: "*.h3?"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@ochkalova"
+maintainers:
+  - "@ochkalova"

--- a/modules/nf-core/hmmer/hmmpress/meta.yml
+++ b/modules/nf-core/hmmer/hmmpress/meta.yml
@@ -30,8 +30,8 @@ output:
       - meta:
           type: map
           description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
       - "*.h3?":
           type: dir
           description: Binary files with compressed profiles and their index

--- a/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
@@ -26,7 +26,7 @@ nextflow_process {
             }
         }
 
-    test("sarscov2 - proteome_hmm_gz") {
+    test("sarscov2 - proteome - hmm - gz") {
 
         when {
             process {

--- a/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
@@ -9,6 +9,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "hmmer"
     tag "hmmer/hmmpress"
+    tag "gunzip"
 
     setup {
             run("GUNZIP") {

--- a/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
@@ -10,10 +10,7 @@ nextflow_process {
     tag "hmmer"
     tag "hmmer/hmmpress"
 
-    test("sarscov2 - proteome_hmm_gz") {
-
-        setup {
-
+    setup {
             run("GUNZIP") {
                 script "../../../gunzip"
 
@@ -27,6 +24,8 @@ nextflow_process {
                 }
             }
         }
+
+    test("sarscov2 - proteome_hmm_gz") {
 
         when {
             process {
@@ -46,22 +45,6 @@ nextflow_process {
 
     test("test-hmmer-hmmpress-stub") {
         options '-stub'
-
-        setup {
-
-            run("GUNZIP") {
-                script "../../../gunzip"
-
-                process {
-                    """
-                    input[0] = [
-                        [ id:'test' ],
-                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.hmm.gz', checkIfExists: true)
-                    ]
-                    """
-                }
-            }
-        }
 
         when {
             process {

--- a/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
@@ -44,7 +44,7 @@ nextflow_process {
         }
     }
 
-    test("test-hmmer-hmmpress-stub") {
+    test("sarscov2 - proteome - hmm - gz - stub") {
         options '-stub'
 
         when {

--- a/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmpress/tests/main.nf.test
@@ -1,0 +1,82 @@
+
+nextflow_process {
+
+    name "Test Process HMMER_HMMPRESS"
+    script "../main.nf"
+    process "HMMER_HMMPRESS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "hmmer"
+    tag "hmmer/hmmpress"
+
+    test("sarscov2 - proteome_hmm_gz") {
+
+        setup {
+
+            run("GUNZIP") {
+                script "../../../gunzip"
+
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.hmm.gz', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = GUNZIP.out.gunzip
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test-hmmer-hmmpress-stub") {
+        options '-stub'
+
+        setup {
+
+            run("GUNZIP") {
+                script "../../../gunzip"
+
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.hmm.gz', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = GUNZIP.out.gunzip
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/hmmer/hmmpress/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmer/hmmpress/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "test-hmmer-hmmpress": {
+    "sarscov2 - proteome - hmm - gz": {
         "content": [
             {
                 "0": [
@@ -40,9 +40,9 @@
             "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-02-25T11:03:43.174815"
+        "timestamp": "2025-02-25T14:43:13.712539"
     },
-    "test-hmmer-hmmpress-stub": {
+    "sarscov2 - proteome - hmm - gz - stub": {
         "content": [
             {
                 "0": [
@@ -83,49 +83,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-02-25T11:03:49.564115"
-    },
-    "sarscov2 - proteome_hmm_gz": {
-        "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "proteome.hmm.h3f:md5,d0640e710a5eec56aa95a64e6dcb9971",
-                            "proteome.hmm.h3i:md5,1e68ee61bfe47697e3df24b5551dbb82",
-                            "proteome.hmm.h3m:md5,9fa27bd2fda0e8c037852301245dcbfb",
-                            "proteome.hmm.h3p:md5,e73ab76f194340b797e8485464caa369"
-                        ]
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,f5473ee4ad53142d92c79b5a0fe94bf6"
-                ],
-                "compressed_db": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "proteome.hmm.h3f:md5,d0640e710a5eec56aa95a64e6dcb9971",
-                            "proteome.hmm.h3i:md5,1e68ee61bfe47697e3df24b5551dbb82",
-                            "proteome.hmm.h3m:md5,9fa27bd2fda0e8c037852301245dcbfb",
-                            "proteome.hmm.h3p:md5,e73ab76f194340b797e8485464caa369"
-                        ]
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,f5473ee4ad53142d92c79b5a0fe94bf6"
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-02-25T11:11:46.372817"
+        "timestamp": "2025-02-25T14:43:19.740161"
     }
 }

--- a/modules/nf-core/hmmer/hmmpress/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmer/hmmpress/tests/main.nf.test.snap
@@ -1,0 +1,131 @@
+{
+    "test-hmmer-hmmpress": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "proteome.hmm.h3f:md5,d0640e710a5eec56aa95a64e6dcb9971",
+                            "proteome.hmm.h3i:md5,1e68ee61bfe47697e3df24b5551dbb82",
+                            "proteome.hmm.h3m:md5,9fa27bd2fda0e8c037852301245dcbfb",
+                            "proteome.hmm.h3p:md5,e73ab76f194340b797e8485464caa369"
+                        ]
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f5473ee4ad53142d92c79b5a0fe94bf6"
+                ],
+                "compressed_db": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "proteome.hmm.h3f:md5,d0640e710a5eec56aa95a64e6dcb9971",
+                            "proteome.hmm.h3i:md5,1e68ee61bfe47697e3df24b5551dbb82",
+                            "proteome.hmm.h3m:md5,9fa27bd2fda0e8c037852301245dcbfb",
+                            "proteome.hmm.h3p:md5,e73ab76f194340b797e8485464caa369"
+                        ]
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,f5473ee4ad53142d92c79b5a0fe94bf6"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-02-25T11:03:43.174815"
+    },
+    "test-hmmer-hmmpress-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "stub.h3f:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "stub.h3i:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "stub.h3m:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "stub.h3p:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f5473ee4ad53142d92c79b5a0fe94bf6"
+                ],
+                "compressed_db": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "stub.h3f:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "stub.h3i:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "stub.h3m:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "stub.h3p:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,f5473ee4ad53142d92c79b5a0fe94bf6"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-02-25T11:03:49.564115"
+    },
+    "sarscov2 - proteome_hmm_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "proteome.hmm.h3f:md5,d0640e710a5eec56aa95a64e6dcb9971",
+                            "proteome.hmm.h3i:md5,1e68ee61bfe47697e3df24b5551dbb82",
+                            "proteome.hmm.h3m:md5,9fa27bd2fda0e8c037852301245dcbfb",
+                            "proteome.hmm.h3p:md5,e73ab76f194340b797e8485464caa369"
+                        ]
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f5473ee4ad53142d92c79b5a0fe94bf6"
+                ],
+                "compressed_db": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "proteome.hmm.h3f:md5,d0640e710a5eec56aa95a64e6dcb9971",
+                            "proteome.hmm.h3i:md5,1e68ee61bfe47697e3df24b5551dbb82",
+                            "proteome.hmm.h3m:md5,9fa27bd2fda0e8c037852301245dcbfb",
+                            "proteome.hmm.h3p:md5,e73ab76f194340b797e8485464caa369"
+                        ]
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,f5473ee4ad53142d92c79b5a0fe94bf6"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-02-25T11:11:46.372817"
+    }
+}


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist


- [x] This comment contains a description of changes (with reason).
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
   

PR adds new tool hmmpress from HMMER package. It indexes and compressed hmm flatfiles to prepare input database for hmmscan. 

Anticipating possible quesstions about pattern of the input file in meta.yml
The input file is supposed to be `*.hmm`, but file can have no extension for better looking output names
Even in the manual author suggests using input filename without extension:

> **Step 2: compress and index the flatfile with hmmpress**
> hmmscan has to read a lot of profiles in a hurry, and HMMER’s text
> flatfiles are bulky. To accelerate this, hmmscan depends on binary compression and indexing of the flatfiles. First you compress and index
> your profile database with the hmmpress program:
> ```
>% hmmpress minifam
>```
> This will produce:
> ```
> Working... done.
> Pressed and indexed 3 HMMs (3 names and 2 accessions).
> Models pressed into binary file: minifam.h3m
> SSI index for binary model file: minifam.h3i
> Profiles (MSV part) pressed into: minifam.h3f
> Profiles (remainder) pressed into: minifam.h3p
> ```
> and you’ll see these four new binary files in the directory.

Otherwise, output files will be `minifam.hmm.h3m` and etc

