### PR TITLE
fixing tag in verifybamid2 module

### DIFF
--- a/modules/nf-core/verifybamid/verifybamid2/main.nf
+++ b/modules/nf-core/verifybamid/verifybamid2/main.nf
@@ -1,5 +1,5 @@
 process VERIFYBAMID_VERIFYBAMID2 {
-    tag '${meta.id}'
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"


### PR DESCRIPTION
single quotes cause ${meta.id} to be evaluated as a string literal rather than a variable

PR checklist skipped as this is a minor change not requiring tests.