### PR TITLE
fixing tag in calder2 module

### DIFF
--- a/modules/nf-core/calder2/main.nf
+++ b/modules/nf-core/calder2/main.nf
@@ -1,5 +1,5 @@
 process CALDER2 {
-    tag '$meta.id'
+    tag "$meta.id"
     label 'process_high'
 
     // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.


### PR DESCRIPTION
single quotes cause $meta.id to be evaluated as a string literal rather than a variable. 

Relates to https://github.com/nf-core/modules/pull/7734

checklist skipped as this is a minimal syntax edit