### PR TITLE
Gawk: decompress files individually, and allow disabling of shell redirect

### DIFF
--- a/modules/nf-core/galah/tests/main.nf.test
+++ b/modules/nf-core/galah/tests/main.nf.test
@@ -70,6 +70,7 @@ nextflow_process {
                     """
                     input[0] = CHECKM2_PREDICT.out.checkm2_tsv
                     input[1] = []
+                    input[2] = false
                     """
                 }
             }

--- a/modules/nf-core/gawk/main.nf
+++ b/modules/nf-core/gawk/main.nf
@@ -27,7 +27,7 @@ process GAWK {
 
     program    = program_file ? "-f ${program_file}" : "${args2}"
     lst_gz     = input.findResults{ it.getExtension().endsWith("gz") ? it.toString() : null }
-    unzip      = lst_gz ? "gunzip ${lst_gz.join(" ")}" : ""
+    unzip      = lst_gz ? "gunzip -q -f ${lst_gz.join(" ")}" : ""
     input_cmd  = input.collect { it.toString() - ~/\.gz$/ }.join(" ")
     output_cmd = suffix.endsWith("gz") ? "| gzip > ${prefix}.${suffix}" : "> ${prefix}.${suffix}"
     output     = disable_redirect_output ? "" : output_cmd

--- a/modules/nf-core/gawk/main.nf
+++ b/modules/nf-core/gawk/main.nf
@@ -10,6 +10,7 @@ process GAWK {
     input:
     tuple val(meta), path(input, arity: '0..*')
     path(program_file)
+    val(disable_redirect_output)
 
     output:
     tuple val(meta), path("${prefix}.${suffix}"), emit: output
@@ -21,14 +22,16 @@ process GAWK {
     script:
     def args  = task.ext.args  ?: '' // args is used for the main arguments of the tool
     def args2 = task.ext.args2 ?: '' // args2 is used to specify a program when no program file has been given
-    prefix = task.ext.prefix ?: "${meta.id}"
-    suffix = task.ext.suffix ?: "${input.collect{ it.getExtension()}.get(0)}" // use the first extension of the input files
+    prefix    = task.ext.prefix ?: "${meta.id}"
+    suffix    = task.ext.suffix ?: "${input.collect{ it.getExtension()}.get(0)}" // use the first extension of the input files
 
-    program   = program_file ? "-f ${program_file}" : "${args2}"
-    lst_gz    = input.collect{ it.getExtension().endsWith("gz") }
-    unzip     = lst_gz.contains(false) ? "" : "find ${input} -exec zcat {} \\; | \\"
-    input_cmd = unzip ? "" : "${input}"
-    output_cmd = suffix.endsWith("gz") ? "| gzip" : ""
+    program    = program_file ? "-f ${program_file}" : "${args2}"
+    lst_gz     = input.findResults{ it.getExtension().endsWith("gz") ? it.toString() : null }
+    unzip      = lst_gz ? "gunzip ${lst_gz.join(" ")}" : ""
+    input_cmd  = input.collect { it.toString() - ~/\.gz$/ }.join(" ")
+    output_cmd = suffix.endsWith("gz") ? "| gzip > ${prefix}.${suffix}" : "> ${prefix}.${suffix}"
+    output     = disable_redirect_output ? "" : output_cmd
+    cleanup    = lst_gz ? "rm ${lst_gz.collect{ it - ~/\.gz$/ }.join(" ")}" : ""
 
     input.collect{
         assert it.name != "${prefix}.${suffix}" : "Input and output names are the same, set prefix in module configuration to disambiguate!"
@@ -36,12 +39,14 @@ process GAWK {
 
     """
     ${unzip}
+
     awk \\
         ${args} \\
         ${program} \\
         ${input_cmd} \\
-        ${output_cmd} \\
-        > ${prefix}.${suffix}
+        ${output}
+
+    ${cleanup}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/gawk/meta.yml
+++ b/modules/nf-core/gawk/meta.yml
@@ -34,6 +34,11 @@ input:
         description: Optional file containing logic for awk to execute. If you don't
           wish to use a file, you can use `ext.args2` to specify the logic.
         pattern: "*"
+  - - disable_redirect_output:
+        type: boolean
+        description: Disable the redirection of awk output to a given file. This is
+          useful if you want to use awk's built-in redirect to write files instead
+          of the shell's redirect.
 output:
   - output:
       - meta:

--- a/modules/nf-core/gawk/tests/main.nf.test
+++ b/modules/nf-core/gawk/tests/main.nf.test
@@ -14,7 +14,7 @@ nextflow_process {
         when {
             params {
                 gawk_suffix = "bed"
-                gawk_args2  = '\'BEGIN {FS="\t"}; {print \$1 FS "0" FS \$2}\''
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }\''
             }
             process {
                 """
@@ -23,6 +23,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[1] = []
+                input[2] = false
                 """
             }
         }
@@ -47,7 +48,34 @@ nextflow_process {
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
                 ]
-                input[1] = Channel.of('BEGIN {FS="\t"}; {print \$1 FS "0" FS \$2}').collectFile(name:"program.txt")
+                input[1] = Channel.of('BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }').collectFile(name:"program.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Convert fasta to bed using awk redirect instead of shell redirect") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 > "test.bed" }\''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = true
                 """
             }
         }
@@ -73,7 +101,8 @@ nextflow_process {
                     [file(params.modules_testdata_base_path + 'generic/txt/hello.txt', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'generic/txt/species_names.txt', checkIfExists: true)]
                 ]
-                input[1] = Channel.of('BEGIN {FS=" "}; {print \$1}').collectFile(name:"program.txt")
+                input[1] = Channel.of('BEGIN {FS=" "}; {print \$1}').collectFile(name:"program.awk")
+                input[2] = false
                 """
             }
         }
@@ -99,7 +128,8 @@ nextflow_process {
                     [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/vcf/NA12878_chrM.vcf.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/vcf/NA24385_sv.vcf.gz', checkIfExists: true)]
                 ]
-                input[1] = Channel.of('/^#CHROM/ { print \$1, \$10 }').collectFile(name:"column_header.txt")
+                input[1] = Channel.of('/^#CHROM/ { print \$1, \$10 }').collectFile(name:"column_header.awk")
+                input[2] = false
                 """
             }
         }
@@ -116,7 +146,7 @@ nextflow_process {
         when {
             params {
                 gawk_suffix = "txt.gz"
-                gawk_args2  = '\'BEGIN {FS="\t"}; {print \$1 FS "0" FS \$2}\''
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }\''
             }
             process {
                 """
@@ -125,6 +155,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[1] = []
+                input[2] = false
                 """
             }
         }
@@ -141,6 +172,7 @@ nextflow_process {
         when {
             params {
                 gawk_suffix = "txt"
+                gawk_args   = ""
                 gawk_args2  = ""
             }
             process {
@@ -150,7 +182,8 @@ nextflow_process {
                     [file(params.modules_testdata_base_path + 'generic/txt/hello.txt', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'generic/txt/species_names.txt', checkIfExists: true)]
                 ]
-                input[1] = Channel.of('BEGIN {FS=" "}; {print \$1}').collectFile(name:"program.txt")
+                input[1] = Channel.of('BEGIN {FS=" "}; {print \$1}').collectFile(name:"program.awk")
+                input[2] = false
                 """
             }
         }

--- a/modules/nf-core/gawk/tests/main.nf.test.snap
+++ b/modules/nf-core/gawk/tests/main.nf.test.snap
@@ -163,5 +163,38 @@
             "nextflow": "24.04.4"
         },
         "timestamp": "2024-10-19T22:08:19.533527657"
+    },
+    "Convert fasta to bed using awk redirect instead of shell redirect": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,842acc9870dc8ac280954047cb2aa23a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-03-05T08:31:09.88842854"
     }
 }

--- a/modules/nf-core/ngscheckmate/fastq/tests/main.nf.test
+++ b/modules/nf-core/ngscheckmate/fastq/tests/main.nf.test
@@ -25,6 +25,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
                     ]
                 input[1] = []
+                input[2] = false
                 """
             }
         }
@@ -44,6 +45,7 @@ nextflow_process {
                 """
                 input[0] = BEDTOOLS_MAKEWINDOWS.out.bed
                 input[1] = []
+                input[2] = false
                 """
             }
         }

--- a/modules/nf-core/ngscheckmate/vafncm/tests/main.nf.test
+++ b/modules/nf-core/ngscheckmate/vafncm/tests/main.nf.test
@@ -26,6 +26,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
                     ]
                 input[1] = []
+                input[2] = false
                 """
             }
         }
@@ -45,6 +46,7 @@ nextflow_process {
                 """
                 input[0] = BEDTOOLS_MAKEWINDOWS.out.bed
                 input[1] = []
+                input[2] = false
                 """
             }
         }

--- a/modules/nf-core/plink/exclude/tests/main.nf.test
+++ b/modules/nf-core/plink/exclude/tests/main.nf.test
@@ -36,6 +36,7 @@ nextflow_process {
                     input[0] = PLINK_VCF.out.bim
                     input[1] = Channel.value('BEGIN {OFS="\t"}  (\$5\$6 == "GC" || \$5\$6 == "CG" || \$5\$6 == "AT" || \$5\$6 == "TA")  {print \$2}')
                         .collectFile(name:"program.txt")
+                    input[2] = false
                     """
                 }
             }

--- a/modules/nf-core/quilt/quilt/tests/main.nf.test
+++ b/modules/nf-core/quilt/quilt/tests/main.nf.test
@@ -38,6 +38,7 @@ nextflow_process {
                     program  = Channel.of('BEGIN{print "NA12878"} {print}').collectFile(name: 'program.txt', newLine: true)
                     input[0] = BCFTOOLS_QUERY.out.output
                     input[1] = program
+                    input[2] = false
                     """
                 }
             }
@@ -52,6 +53,7 @@ nextflow_process {
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/1000GP.chr22.legend.gz', checkIfExists: true)
                     ]
                     input[1] = program
+                    input[2] = false
                     """
                 }
             }

--- a/subworkflows/nf-core/bam_subsampledepth_samtools/main.nf
+++ b/subworkflows/nf-core/bam_subsampledepth_samtools/main.nf
@@ -16,7 +16,7 @@ workflow BAM_SUBSAMPLEDEPTH_SAMTOOLS {
     ch_versions = ch_versions.mix(SAMTOOLS_DEPTH.out.versions.first())
 
     // Use GAWK to get mean depth
-    GAWK(SAMTOOLS_DEPTH.out.tsv, [])
+    GAWK(SAMTOOLS_DEPTH.out.tsv, [], false)
     ch_versions = ch_versions.mix(GAWK.out.versions.first())
 
     // Compute downsampling factor

--- a/subworkflows/nf-core/bam_subsampledepth_samtools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_subsampledepth_samtools/tests/main.nf.test
@@ -13,7 +13,6 @@ nextflow_workflow {
     tag "samtools"
     tag "samtools/depth"
     tag "samtools/view"
-    tag "gawk"
 
     test("Downsample to 4X and 2X") {
         when {

--- a/subworkflows/nf-core/bam_subsampledepth_samtools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_subsampledepth_samtools/tests/main.nf.test
@@ -13,6 +13,7 @@ nextflow_workflow {
     tag "samtools"
     tag "samtools/depth"
     tag "samtools/view"
+    tag "gawk"
 
     test("Downsample to 4X and 2X") {
         when {


### PR DESCRIPTION
There are a couple of handy features in awk that are not currently completely usable in the GAWK module:

- Awk file redirection: You can redirect awk output to a file using ">" within an awk program, which allows you to do handy things like split a file into multiple files. This PR adds an option to disable shell redirection, allowing use of the awk redirect without creating an empty file.
- (GNU awk specific) BEGINFILE and ENDFILE rules: GNU awk provides the [BEGINFILE and ENDFILE rules](https://www.gnu.org/software/gawk/manual/html_node/BEGINFILE_002fENDFILE.html), which work like BEGIN and END but are repeated each time a new file is read. The old method for processing gzipped input concatenated all files together in a single `zcat`, eliding the ability to use this feature on gzipped input. This PR fixes this by unzipping gzipped files to disk, and then cleaning up the gzipped input at the end, allowing gzipped input to make use of this feature.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
