### PR TITLE
Pin bcftools in ngscheckmate conda YAML to same version as biocontainer

### DIFF
--- a/modules/nf-core/ngscheckmate/fastq/environment.yml
+++ b/modules/nf-core/ngscheckmate/fastq/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::ngscheckmate=1.0.1
+  - bioconda::bcftools=1.12

--- a/modules/nf-core/ngscheckmate/fastq/environment.yml
+++ b/modules/nf-core/ngscheckmate/fastq/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::ngscheckmate=1.0.1
-  - bioconda::bcftools=1.12
+  - bioconda::bcftools=1.21

--- a/modules/nf-core/ngscheckmate/fastq/main.nf
+++ b/modules/nf-core/ngscheckmate/fastq/main.nf
@@ -4,8 +4,8 @@ process NGSCHECKMATE_FASTQ {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1':
-        'biocontainers/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py312pl5321h577a1d6_4':
+        'biocontainers/ngscheckmate:1.0.1--py312pl5321h577a1d6_4' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/ngscheckmate/ncm/environment.yml
+++ b/modules/nf-core/ngscheckmate/ncm/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::ngscheckmate=1.0.1
+  - bioconda::bcftools=1.12

--- a/modules/nf-core/ngscheckmate/ncm/environment.yml
+++ b/modules/nf-core/ngscheckmate/ncm/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::ngscheckmate=1.0.1
-  - bioconda::bcftools=1.12
+  - bioconda::bcftools=1.21

--- a/modules/nf-core/ngscheckmate/ncm/main.nf
+++ b/modules/nf-core/ngscheckmate/ncm/main.nf
@@ -3,8 +3,8 @@ process NGSCHECKMATE_NCM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1':
-        'biocontainers/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py312pl5321h577a1d6_4':
+        'biocontainers/ngscheckmate:1.0.1--py312pl5321h577a1d6_4' }"
 
     input:
     tuple val(meta) , path(files)

--- a/modules/nf-core/ngscheckmate/ncm/tests/main.nf.test.snap
+++ b/modules/nf-core/ngscheckmate/ncm/tests/main.nf.test.snap
@@ -93,7 +93,7 @@
                     {
                         "id": "test1"
                     },
-                    "test1_output_corr_matrix.txt:md5,0c86bdad2721c470fe6be119f291c8e5"
+                    "test1_output_corr_matrix.txt:md5,a3158f79596b04996a5e9c8d33fe17f7"
                 ]
             ],
             [
@@ -118,10 +118,10 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-05-22T19:53:29.123160766"
+        "timestamp": "2025-03-05T14:50:34.781729419"
     },
     "sarscov2 - bam": {
         "content": [

--- a/modules/nf-core/ngscheckmate/patterngenerator/environment.yml
+++ b/modules/nf-core/ngscheckmate/patterngenerator/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::ngscheckmate=1.0.1
+  - bioconda::bcftools=1.12

--- a/modules/nf-core/ngscheckmate/patterngenerator/environment.yml
+++ b/modules/nf-core/ngscheckmate/patterngenerator/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::ngscheckmate=1.0.1
-  - bioconda::bcftools=1.12
+  - bioconda::bcftools=1.21

--- a/modules/nf-core/ngscheckmate/patterngenerator/main.nf
+++ b/modules/nf-core/ngscheckmate/patterngenerator/main.nf
@@ -4,8 +4,8 @@ process NGSCHECKMATE_PATTERNGENERATOR {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1' :
-        'biocontainers/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py312pl5321h577a1d6_4':
+        'biocontainers/ngscheckmate:1.0.1--py312pl5321h577a1d6_4' }"
 
     input:
     tuple val(meta), path(bed)

--- a/modules/nf-core/ngscheckmate/vafncm/environment.yml
+++ b/modules/nf-core/ngscheckmate/vafncm/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::ngscheckmate=1.0.1
+  - bioconda::bcftools=1.12

--- a/modules/nf-core/ngscheckmate/vafncm/environment.yml
+++ b/modules/nf-core/ngscheckmate/vafncm/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::ngscheckmate=1.0.1
-  - bioconda::bcftools=1.12
+  - bioconda::bcftools=1.21

--- a/modules/nf-core/ngscheckmate/vafncm/main.nf
+++ b/modules/nf-core/ngscheckmate/vafncm/main.nf
@@ -3,8 +3,8 @@ process NGSCHECKMATE_VAFNCM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1' :
-        'biocontainers/ngscheckmate:1.0.1--py27pl5321r40hdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/ngscheckmate:1.0.1--py312pl5321h577a1d6_4':
+        'biocontainers/ngscheckmate:1.0.1--py312pl5321h577a1d6_4' }"
 
     input:
     tuple val(meta), path(vafs)

--- a/modules/nf-core/ngscheckmate/vafncm/tests/main.nf.test.snap
+++ b/modules/nf-core/ngscheckmate/vafncm/tests/main.nf.test.snap
@@ -87,7 +87,7 @@
                     {
                         "id": "combined"
                     },
-                    "output_corr_matrix.txt:md5,fe8139cc3dffb7df41d17aa24c599dba"
+                    "output_corr_matrix.txt:md5,31c79c250bd22ef458b9a614c5fff66d"
                 ]
             ],
             [
@@ -103,7 +103,7 @@
                     {
                         "id": "combined"
                     },
-                    "combined_all.txt:md5,6e7c7446bb308af84ee9b1689e1e60ee"
+                    "combined_all.txt:md5,9c4de0f90192f410df70076b48659d51"
                 ]
             ],
             [
@@ -111,9 +111,9 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-06-18T09:12:04.852698041"
+        "timestamp": "2025-03-05T14:52:07.698272255"
     }
 }


### PR DESCRIPTION
ngscheckmate test depends on GAWK, which I am updating here: https://github.com/nf-core/modules/pull/7738

This pins the version of bcftools in conda to the same version in the biocontainer - the test for ngscheckmate/vafncm fails with newer versions of bcftools which are pulled in by conda.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
