### PR TITLE
GAWK: Fix output specification

### DIFF
--- a/modules/nf-core/gawk/main.nf
+++ b/modules/nf-core/gawk/main.nf
@@ -13,8 +13,8 @@ process GAWK {
     val(disable_redirect_output)
 
     output:
-    tuple val(meta), path("${prefix}.${suffix}"), emit: output
-    path "versions.yml"                         , emit: versions
+    tuple val(meta), path("*.${suffix}"), emit: output
+    path "versions.yml"                 , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/gawk/meta.yml
+++ b/modules/nf-core/gawk/meta.yml
@@ -46,10 +46,11 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - ${prefix}.${suffix}:
+      - "*.${suffix}":
           type: file
-          description: The output file - specify the name of this file using `ext.prefix`
-            and the extension using `ext.suffix`
+          description: The output file - if using shell redirection, specify the name of this
+            file using `ext.prefix` and the extension using `ext.suffix`. Otherwise, ensure
+            the awk program produces files with the extension in `ext.suffix`.
           pattern: "*"
   - versions:
       - versions.yml:


### PR DESCRIPTION
Missed one little thing in the last PR: https://github.com/nf-core/modules/pull/7738

If you can write multiple output files, the process needs to be able to catch them!

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
