### PR TITLE
allow --Reference to be .fa as well as .fasta

### DIFF
--- a/modules/nf-core/verifybamid/verifybamid2/main.nf
+++ b/modules/nf-core/verifybamid/verifybamid2/main.nf
@@ -36,7 +36,7 @@ process VERIFYBAMID_VERIFYBAMID2 {
         "--SVDPrefix ${svd_ud.baseName}" : "--UDPath ${svd_ud} --MeanPath ${svd_mu} --BedPath ${svd_bed}"
     def refvcf_args = "${refvcf}".endsWith(".vcf") ? "--RefVCF ${refvcf}" : ""
 
-    def reference_args = ("$references".endsWith('.fasta')) ?
+    def reference_args = ("$references".endsWith('.fasta') || "$references".endsWith('.fa')) ?
         "--Reference ${references}" : ''
 
     """


### PR DESCRIPTION
Another small change that checks for both extensions (.fa or .fasta) in the input reference file.

No checklist/tests as this is a minor change.


