### PR TITLE
Reduce bbnorm memory

### DIFF
--- a/modules/nf-core/bbmap/bbnorm/environment.yml
+++ b/modules/nf-core/bbmap/bbnorm/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::bbmap=39.17
+  - bioconda::bbmap=39.18
   - pigz=2.8

--- a/modules/nf-core/bbmap/bbnorm/main.nf
+++ b/modules/nf-core/bbmap/bbnorm/main.nf
@@ -30,7 +30,7 @@ process BBMAP_BBNORM {
         $output \\
         $args \\
         threads=$task.cpus \\
-        -Xmx${task.memory.toGiga()}g \\
+        -Xmx${Math.round(Math.max(1, Math.floor(task.memory.toGiga() * 0.95)))}g \\
         &> ${prefix}.bbnorm.log
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/bbmap/bbnorm/main.nf
+++ b/modules/nf-core/bbmap/bbnorm/main.nf
@@ -4,8 +4,8 @@ process BBMAP_BBNORM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://community.wave.seqera.io/library/bbmap_samtools_pigz:2a066f0214cc5eb0' :
-        'community.wave.seqera.io/library/bbmap_samtools_pigz:79703e935236b43b' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/5a/5aae5977ff9de3e01ff962dc495bfa23f4304c676446b5fdf2de5c7edfa2dc4e/data' :
+        'wave.seqera.io/wt/5ce851926d93/wave/build:bbmap-39.18_pigz-2.8--4a8254d490b5baa0' }"
     input:
     tuple val(meta), path(fastq)
 

--- a/modules/nf-core/bbmap/bbnorm/tests/main.nf.test.snap
+++ b/modules/nf-core/bbmap/bbnorm/tests/main.nf.test.snap
@@ -10,14 +10,14 @@
             ],
             "test.bbnorm.log",
             [
-                "versions.yml:md5,1aee8175e324cb47f12450f2fae2b7c2"
+                "versions.yml:md5,ac3758cd9e5b0a3e270844785bc3e40c"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-08-26T14:56:27.169474"
+        "timestamp": "2025-03-10T12:00:11.671843"
     },
     "test-bbmap-bbnorm-multiple-input": {
         "content": [
@@ -30,14 +30,14 @@
             ],
             "test.bbnorm.log",
             [
-                "versions.yml:md5,1aee8175e324cb47f12450f2fae2b7c2"
+                "versions.yml:md5,ac3758cd9e5b0a3e270844785bc3e40c"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-08-26T14:56:35.01159"
+        "timestamp": "2025-03-10T12:00:21.944921"
     },
     "test-bbmap-bbnorm-pe": {
         "content": [
@@ -53,29 +53,29 @@
             ],
             "test.bbnorm.log",
             [
-                "versions.yml:md5,1aee8175e324cb47f12450f2fae2b7c2"
+                "versions.yml:md5,ac3758cd9e5b0a3e270844785bc3e40c"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-08-26T14:59:24.68372"
+        "timestamp": "2025-03-10T12:00:02.30382"
     },
     "test-bbmap-bbnorm-se": {
         "content": [
             [
-
+                
             ],
             "test.bbnorm.log",
             [
-                "versions.yml:md5,1aee8175e324cb47f12450f2fae2b7c2"
+                "versions.yml:md5,ac3758cd9e5b0a3e270844785bc3e40c"
             ]
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-08-26T14:59:16.676091"
+        "timestamp": "2025-03-10T11:59:54.002084"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

The module is often killed for using more memory than allocated. This happens at a relatively late stage of execution, and my hypothesis is that it happens when results are written out. To help with this, I updated the module so the program receives only 0.95 times the memory allocated to the module (or at least 1 GiB). This worked in metatdenovo where the module is used.

I also updated the version of the tool itself to avoid one linting warning.