### PR TITLE
Fix splitubam stub

### DIFF
--- a/modules/nf-core/splitubam/main.nf
+++ b/modules/nf-core/splitubam/main.nf
@@ -37,10 +37,10 @@ process SPLITUBAM {
     def create_cmd = ""
     if (match) {
         def n_splits = match[0][1].toInteger()
-        (1..n_splits).each { i ->
+        create_cmd = (1..n_splits).collect { i ->
             def formattedIteration = String.format('%03d', i)
-            create_cmd += "touch ${formattedIteration}.${bam}.bam\n"
-        }
+            "touch ${formattedIteration}.${bam}.bam"
+        }.join(" ")
     } else { error("No `--split N` detected in args") }
     """
     $create_cmd

--- a/modules/nf-core/splitubam/tests/main.nf.test.snap
+++ b/modules/nf-core/splitubam/tests/main.nf.test.snap
@@ -15,7 +15,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,78006e47ec8ddb5d6f098dcef4a3e099"
+                    "versions.yml:md5,e5c9bb35328e8dcde2e934d9e6729fa6"
                 ],
                 "bam": [
                     [
@@ -30,15 +30,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,78006e47ec8ddb5d6f098dcef4a3e099"
+                    "versions.yml:md5,e5c9bb35328e8dcde2e934d9e6729fa6"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
         },
-        "timestamp": "2024-07-23T13:07:19.115592832"
+        "timestamp": "2025-03-11T10:28:23.9775998"
     },
     "sarscov2 - bam": {
         "content": [


### PR DESCRIPTION
The newline caused `END_VERSIONS` to end up in versions.yml failing stub runs within pipelines. 

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
