### PR TITLE
Update tabix/bgzip to make index file parameter detection more robust

### DIFF
--- a/modules/nf-core/tabix/bgzip/main.nf
+++ b/modules/nf-core/tabix/bgzip/main.nf
@@ -11,9 +11,9 @@ process TABIX_BGZIP {
     tuple val(meta), path(input)
 
     output:
-    tuple val(meta), path("${output}")    , emit: output
-    tuple val(meta), path("${output}.gzi"), emit: gzi, optional: true
-    path  "versions.yml"                  , emit: versions
+    tuple val(meta), path("${output}"), emit: output
+    tuple val(meta), path("*.gzi")    , emit: gzi, optional: true
+    path  "versions.yml"              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,7 +26,8 @@ process TABIX_BGZIP {
     output   = in_bgzip ? "${prefix}.${extension}" : "${prefix}.${extension}.gz"
     command = in_bgzip ? '-d' : ''
     // Name the index according to $prefix, unless a name has been requested
-    if ((args.matches("(^| )-i\\b") || args.matches("(^| )--index(\$| )")) && !args.matches("(^| )-I\\b") && !args.matches("(^| )--index-name\\b")) {
+    split_args = args.split(' +|=')
+    if ((split_args.contains('-i') || split_args.contains('--index')) && !split_args.contains('-I') && !split_args.contains('--index-name')) {
         args = args + " -I ${output}.gzi"
     }
     """

--- a/modules/nf-core/tabix/bgzip/meta.yml
+++ b/modules/nf-core/tabix/bgzip/meta.yml
@@ -40,7 +40,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - *.gzi:
+      - '*.gzi':
           type: file
           description: Optional gzip index file for compressed inputs
           pattern: "*.gzi"

--- a/modules/nf-core/tabix/bgzip/meta.yml
+++ b/modules/nf-core/tabix/bgzip/meta.yml
@@ -40,7 +40,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - ${output}.gzi:
+      - *.gzi:
           type: file
           description: Optional gzip index file for compressed inputs
           pattern: "*.gzi"


### PR DESCRIPTION
The regular expressions to detect arguments in line 29 were not working when multiple arguments were passed  (e.g. `-r -i`). This is because `.matches()` checks for matches to the entire string, not just a match to a part. Instead of updating the regex, I found it easier to split by spaces and check for arguments that way. 

Also, the name of the `gzi` output is not always `${output}.gzi` (e.g. if the `-I` parameter is used), so I changed that to look for any `.gzi` file.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
