### PR TITLE
Allow for gziped reference files in gatk4/variantfiltration

### DIFF
--- a/modules/nf-core/gatk4/variantfiltration/meta.yml
+++ b/modules/nf-core/gatk4/variantfiltration/meta.yml
@@ -64,7 +64,7 @@ input:
           e.g. [ id:'genome' ]
     - gzi:
         type: file
-        description: Genome index file needed when the genome file
+        description: Genome index file only needed when the genome file
           was compressed with the BGZF algorithm.
         pattern: "*.gzi"
 output:

--- a/modules/nf-core/gatk4/variantfiltration/meta.yml
+++ b/modules/nf-core/gatk4/variantfiltration/meta.yml
@@ -57,6 +57,16 @@ input:
         type: file
         description: Sequence dictionary of fastea file
         pattern: "*.dict"
+  - - meta5:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome' ]
+    - gzi:
+        type: file
+        description: Genome index file needed when the genome file
+          was compressed with the BGZF algorithm.
+        pattern: "*.gzi"
 output:
   - vcf:
       - meta:

--- a/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test
+++ b/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test
@@ -31,6 +31,10 @@ nextflow_process {
                     [ id:'genome' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
                 ]
+                input[4] = [
+                    [ id:'genome' ], // meta map
+                    []
+                ]
                 """
             }
         }
@@ -68,6 +72,10 @@ nextflow_process {
                     [ id:'genome' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
                 ]
+                input[4] = [
+                    [ id:'genome' ], // meta map
+                    []
+                ]
                 """
             }
         }
@@ -84,4 +92,3 @@ nextflow_process {
     }
 
 }
-

--- a/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test
+++ b/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test
@@ -9,7 +9,7 @@ nextflow_process {
     tag "gatk4"
     tag "gatk4/variantfiltration"
 
-    test("test_gatk4_variantfiltration_vcf_input") {
+    test("gatk4_variantfiltration - human - vcf - fasta") {
 
         when {
             process {
@@ -50,7 +50,7 @@ nextflow_process {
 
     }
 
-    test("test_gatk4_variantfiltration_vcf_input_gz_ref") {
+    test("gatk4_variantfiltration - human - vcf - fasta.gz") {
 
         when {
             process {
@@ -84,14 +84,14 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out.versions,
-                                  file(process.out.vcf.get(0).get(1)).name,
+                                  path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
                                   file(process.out.tbi.get(0).get(1)).name).match() },
             )
         }
 
     }
 
-    test("test_gatk4_variantfiltration_gz_input") {
+    test("gatk4_variantfiltration - human - vcf.gz - fasta") {
 
         when {
             process {
@@ -125,7 +125,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out.versions,
-                                  file(process.out.vcf.get(0).get(1)).name,
+                                  path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
                                   file(process.out.tbi.get(0).get(1)).name).match() },
             )
         }

--- a/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test
+++ b/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test
@@ -43,7 +43,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out.versions,
-                                  file(process.out.vcf.get(0).get(1)).name,
+                                  path(process.out.vcf.get(0).get(1)).vcf.variantsMD5,
                                   file(process.out.tbi.get(0).get(1)).name).match() },
             )
         }

--- a/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test
+++ b/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test
@@ -50,6 +50,47 @@ nextflow_process {
 
     }
 
+    test("test_gatk4_variantfiltration_vcf_input_gz_ref") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.idx', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                input[2] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz.fai', checkIfExists: true)
+                ]
+                input[3] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
+                ]
+                input[4] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz.gzi', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions,
+                                  file(process.out.vcf.get(0).get(1)).name,
+                                  file(process.out.tbi.get(0).get(1)).name).match() },
+            )
+        }
+
+    }
+
     test("test_gatk4_variantfiltration_gz_input") {
 
         when {

--- a/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test.snap
+++ b/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test.snap
@@ -1,44 +1,44 @@
 {
-    "test_gatk4_variantfiltration_gz_input": {
+    "gatk4_variantfiltration - human - vcf - fasta.gz": {
         "content": [
             [
                 "versions.yml:md5,ad4241d2454ae3611dd8e7383b3109ff"
             ],
-            "test.vcf.gz",
-            "test.vcf.gz.tbi"
-        ],
-        "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "24.10.0"
-        },
-        "timestamp": "2024-10-31T12:10:17.964554959"
-    },
-    "test_gatk4_variantfiltration_vcf_input_gz_ref": {
-        "content": [
-            [
-                "versions.yml:md5,ad4241d2454ae3611dd8e7383b3109ff"
-            ],
-            "test.vcf.gz",
+            "cf0477cc14953b16caacbf5be507b88",
             "test.vcf.gz.tbi"
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-12T21:15:26.833824727"
+        "timestamp": "2025-03-13T11:54:44.786680849"
     },
-    "test_gatk4_variantfiltration_vcf_input": {
+    "gatk4_variantfiltration - human - vcf.gz - fasta": {
         "content": [
             [
                 "versions.yml:md5,ad4241d2454ae3611dd8e7383b3109ff"
             ],
-            "test.vcf.gz",
+            "cf0477cc14953b16caacbf5be507b88",
             "test.vcf.gz.tbi"
         ],
         "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "24.10.0"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-10-31T12:10:04.6172075"
+        "timestamp": "2025-03-13T11:54:56.133634292"
+    },
+    "gatk4_variantfiltration - human - vcf - fasta": {
+        "content": [
+            [
+                "versions.yml:md5,ad4241d2454ae3611dd8e7383b3109ff"
+            ],
+            "cf0477cc14953b16caacbf5be507b88",
+            "test.vcf.gz.tbi"
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-13T11:54:33.562779033"
     }
 }

--- a/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test.snap
+++ b/modules/nf-core/gatk4/variantfiltration/tests/main.nf.test.snap
@@ -13,6 +13,20 @@
         },
         "timestamp": "2024-10-31T12:10:17.964554959"
     },
+    "test_gatk4_variantfiltration_vcf_input_gz_ref": {
+        "content": [
+            [
+                "versions.yml:md5,ad4241d2454ae3611dd8e7383b3109ff"
+            ],
+            "test.vcf.gz",
+            "test.vcf.gz.tbi"
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-12T21:15:26.833824727"
+    },
     "test_gatk4_variantfiltration_vcf_input": {
         "content": [
             [

--- a/modules/nf-core/tabix/bgzip/main.nf
+++ b/modules/nf-core/tabix/bgzip/main.nf
@@ -11,9 +11,9 @@ process TABIX_BGZIP {
     tuple val(meta), path(input)
 
     output:
-    tuple val(meta), path("${output}")    , emit: output
-    tuple val(meta), path("${output}.gzi"), emit: gzi, optional: true
-    path  "versions.yml"                  , emit: versions
+    tuple val(meta), path("${output}"), emit: output
+    tuple val(meta), path("*.gzi")    , emit: gzi, optional: true
+    path  "versions.yml"              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,7 +26,8 @@ process TABIX_BGZIP {
     output   = in_bgzip ? "${prefix}.${extension}" : "${prefix}.${extension}.gz"
     command = in_bgzip ? '-d' : ''
     // Name the index according to $prefix, unless a name has been requested
-    if ((args.matches("(^| )-i\\b") || args.matches("(^| )--index(\$| )")) && !args.matches("(^| )-I\\b") && !args.matches("(^| )--index-name\\b")) {
+    split_args = args.split(' +|=')
+    if ((split_args.contains('-i') || split_args.contains('--index')) && !split_args.contains('-I') && !split_args.contains('--index-name')) {
         args = args + " -I ${output}.gzi"
     }
     """

--- a/modules/nf-core/tabix/bgzip/meta.yml
+++ b/modules/nf-core/tabix/bgzip/meta.yml
@@ -40,7 +40,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - ${output}.gzi:
+      - '*.gzi':
           type: file
           description: Optional gzip index file for compressed inputs
           pattern: "*.gzi"


### PR DESCRIPTION
This allows for the use of compressed reference genome files, but does introduce an extra argument, so will break existing pipelines unfortunately. However, the extra parameter is optional it is an easy fix to add `, []` to fix any affected pipelines. I can do a search for use of the module in nf-core pipeline and open a PR to fix this if that would be helpful.

Resolves #3621 and #3622

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
