### PR TITLE
Update bwa/index: Name bwa/index output path relative to input

### DIFF
--- a/modules/nf-core/bwa/index/main.nf
+++ b/modules/nf-core/bwa/index/main.nf
@@ -13,21 +13,21 @@ process BWA_INDEX {
     tuple val(meta), path(fasta)
 
     output:
-    tuple val(meta), path("bwa")  , emit: index
-    path "versions.yml"             , emit: versions
+    tuple val(meta), path("${prefix}_bwa"), emit: index
+    path "versions.yml"                   , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def prefix = task.ext.prefix ?: "${fasta.baseName}"
-    def args   = task.ext.args ?: ''
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
-    mkdir bwa
+    mkdir ${prefix}_bwa
     bwa \\
         index \\
         $args \\
-        -p bwa/${prefix} \\
+        -p ${prefix}_bwa/${fasta.baseName} \\
         $fasta
 
     cat <<-END_VERSIONS > versions.yml
@@ -39,13 +39,13 @@ process BWA_INDEX {
     stub:
     def prefix = task.ext.prefix ?: "${fasta.baseName}"
     """
-    mkdir bwa
+    mkdir ${prefix}_bwa
 
-    touch bwa/${prefix}.amb
-    touch bwa/${prefix}.ann
-    touch bwa/${prefix}.bwt
-    touch bwa/${prefix}.pac
-    touch bwa/${prefix}.sa
+    touch ${prefix}_bwa/${fasta.baseName}.amb
+    touch ${prefix}_bwa/${fasta.baseName}.ann
+    touch ${prefix}_bwa/${fasta.baseName}.bwt
+    touch ${prefix}_bwa/${fasta.baseName}.pac
+    touch ${prefix}_bwa/${fasta.baseName}.sa
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bwa/index/meta.yml
+++ b/modules/nf-core/bwa/index/meta.yml
@@ -34,12 +34,11 @@ output:
           description: |
             Groovy Map containing reference information.
             e.g. [ id:'test', single_end:false ]
-      - bwa:
+      - ${prefix}_bwa:
           type: map
           description: |
             Groovy Map containing reference information.
             e.g. [ id:'test', single_end:false ]
-          pattern: "*.{amb,ann,bwt,pac,sa}"
           ontologies:
             - edam: "http://edamontology.org/data_3210" # Genome index
   - versions:


### PR DESCRIPTION
This will make is so the published output directory has a better structure. Each reference will have its own folder instead of them all being mixed into a redundant `bwa` directory underneath a `bwa_index` directory.