### PR TITLE
Update PIRATE

### DIFF
--- a/modules/nf-core/pirate/environment.yml
+++ b/modules/nf-core/pirate/environment.yml
@@ -5,5 +5,5 @@ channels:
   - bioconda
 
 dependencies:
-  - bioconda::perl-bioperl=1.7.2
-  - bioconda::pirate=1.0.4
+  - bioconda::perl-bioperl=1.7.8
+  - bioconda::pirate=1.0.5

--- a/modules/nf-core/pirate/main.nf
+++ b/modules/nf-core/pirate/main.nf
@@ -4,29 +4,33 @@ process PIRATE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pirate:1.0.4--hdfd78af_2' :
-        'biocontainers/pirate:1.0.4--hdfd78af_2' }"
+        'https://depot.galaxyproject.org/singularity/pirate:1.0.5--hdfd78af_0' :
+        'biocontainers/pirate:1.0.5--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(gff)
 
     output:
-    tuple val(meta), path("results/*")                                   , emit: results
-    tuple val(meta), path("results/core_alignment.fasta"), optional: true, emit: aln
-    path "versions.yml"                                                  , emit: versions
+    tuple val(meta), path("${prefix}_results/*")                                   , emit: results
+    tuple val(meta), path("${prefix}_results/core_alignment.fasta"), optional: true, emit: aln
+    path "versions.yml"                                                            , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
+    # Rename .gff3 to .gff if needed
+    find -regex .*\\.gff3\$ | sed 's/3\$//' | xargs -I {} mv {}3 {}
+
+    # Run pirate on all .gff in input directory
     PIRATE \\
         $args \\
         --threads $task.cpus \\
         --input ./ \\
-        --output results/
+        --output ${prefix}_results/
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -35,10 +39,10 @@ process PIRATE {
     """
 
     stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
-    mkdir results
-
-    touch results/PIRATE.gene_families.ordered.tsv
+    mkdir ${prefix}_results
+    touch ${prefix}_results/PIRATE.gene_families.ordered.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/pirate/meta.yml
+++ b/modules/nf-core/pirate/meta.yml
@@ -30,7 +30,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - results/*:
+      - ${prefix}_results/*:
           type: directory
           description: Directory containing PIRATE result files
           pattern: "*/*"
@@ -40,7 +40,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - results/core_alignment.fasta:
+      - ${prefix}_results/core_alignment.fasta:
           type: file
           description: Core-genome alignment produced by PIRATE (Optional)
           pattern: "*.{fasta}"
@@ -51,5 +51,6 @@ output:
           pattern: "versions.yml"
 authors:
   - "@rpetit3"
+  - "@zachary-foster"
 maintainers:
   - "@rpetit3"

--- a/modules/nf-core/pirate/tests/main.nf.test
+++ b/modules/nf-core/pirate/tests/main.nf.test
@@ -14,13 +14,13 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-				    [ id:'test', single_end:false ], // meta map
-				    [
-				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test1.gff', checkIfExists: true),
-				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test2.gff', checkIfExists: true),
-				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test3.gff', checkIfExists: true)
-				    ]
-				]
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test1.gff', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test2.gff', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test3.gff', checkIfExists: true)
+                    ]
+                ]
 
                 """
             }
@@ -47,13 +47,13 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-				    [ id:'test', single_end:false ], // meta map
-				    [
-				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test1.gff', checkIfExists: true),
-				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test2.gff', checkIfExists: true),
-				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test3.gff', checkIfExists: true)
-				    ]
-				]
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test1.gff', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test2.gff', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/genome/gff/test3.gff', checkIfExists: true)
+                    ]
+                ]
 
                 """
             }

--- a/modules/nf-core/pirate/tests/main.nf.test.snap
+++ b/modules/nf-core/pirate/tests/main.nf.test.snap
@@ -37,14 +37,14 @@
                 
             ],
             [
-                "versions.yml:md5,2f5a68c53da1146ee3000263ea61d769"
+                "versions.yml:md5,ce4d40e2b87e2e5cac6e755fcb0c023b"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-09-05T16:38:56.92857"
+        "timestamp": "2025-03-13T18:11:29.1710884"
     },
     "test-pirate-stub": {
         "content": [
@@ -62,7 +62,7 @@
                     
                 ],
                 "2": [
-                    "versions.yml:md5,2f5a68c53da1146ee3000263ea61d769"
+                    "versions.yml:md5,ce4d40e2b87e2e5cac6e755fcb0c023b"
                 ],
                 "aln": [
                     
@@ -77,14 +77,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,2f5a68c53da1146ee3000263ea61d769"
+                    "versions.yml:md5,ce4d40e2b87e2e5cac6e755fcb0c023b"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-09-05T16:18:13.292321"
+        "timestamp": "2025-03-13T18:12:53.377886301"
     }
 }


### PR DESCRIPTION
This does a few things:

* Renames .gff3 files (like those produced by `bakta` to .gff so `PIRATE` uses them
* Updates conda/docker/singularity versions
* Names output directories by the prefix, so multiple runs dont mix their results in the same published directory 