### PR TITLE
Update `graphtyper/vcfconcatenate`: Add batching to avoid long command line error

### DIFF
--- a/modules/nf-core/graphtyper/vcfconcatenate/environment.yml
+++ b/modules/nf-core/graphtyper/vcfconcatenate/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::graphtyper=2.7.2
+  - bioconda::graphtyper=2.7.7

--- a/modules/nf-core/graphtyper/vcfconcatenate/main.nf
+++ b/modules/nf-core/graphtyper/vcfconcatenate/main.nf
@@ -4,32 +4,43 @@ process GRAPHTYPER_VCFCONCATENATE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/graphtyper:2.7.2--h7d7f7ad_0':
-        'biocontainers/graphtyper:2.7.2--h7d7f7ad_0' }"
+        'https://depot.galaxyproject.org/singularity/graphtyper:2.7.7--h7594796_1':
+        'biocontainers/graphtyper:2.7.7--h7594796_1' }"
 
     input:
     tuple val(meta), path(vcf)
 
     output:
-    tuple val(meta), path("*.vcf.gz"), emit: vcf
-    tuple val(meta), path("*.tbi")                , emit: tbi
-    path "versions.yml"                           , emit: versions
+    tuple val(meta), path("${prefix}.vcf.gz")    , emit: vcf
+    tuple val(meta), path("${prefix}.vcf.gz.tbi"), emit: tbi
+    path "versions.yml"                          , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     if ("$vcf" == "${prefix}.vcf.gz") {
         error "Input and output names are the same, set prefix in module configuration to disambiguate!"
     }
+    input_vcfs = vcf.collate(1000).collect{it.join(' ')} // Batching needed because if there are too many VCFs the shell cannot run the command
+    commands = input_vcfs.withIndex().collect{ batch_vcfs, index ->
+        "graphtyper vcf_concatenate ${batch_vcfs} ${args} --output=${prefix}_subset_${index}.vcf.gz"
+    }.join('\n    ')
     """
+    # Run each batch of VCFs
+    ${commands}
+
+    # Combine the VCF for each batch into a single output VCF
     graphtyper vcf_concatenate \\
-        $vcf \\
+        ${prefix}_subset_*.vcf.gz \\
         $args \\
         --write_tbi \\
         --output=${prefix}.vcf.gz
+
+    # Delete batch VCFs
+    rm ${prefix}_subset_*.vcf.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -38,13 +49,13 @@ process GRAPHTYPER_VCFCONCATENATE {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     if ("$vcf" == "${prefix}.vcf.gz") {
         error "Input and output names are the same, set prefix in module configuration to disambiguate!"
     }
     """
     echo | gzip > ${prefix}.vcf.gz
-    touch ${prefix}.tbi
+    touch ${prefix}.vcf.gz.tbi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/graphtyper/vcfconcatenate/meta.yml
+++ b/modules/nf-core/graphtyper/vcfconcatenate/meta.yml
@@ -32,7 +32,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
-      - "*.vcf.gz":
+      - ${prefix}.vcf.gz:
           type: file
           description: Concatenated VCF file
           pattern: "*.{vcf.gz}"
@@ -42,7 +42,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
-      - "*.tbi":
+      - ${prefix}.vcf.gz.tbi:
           type: file
           description: Concatenated VCF file index
           pattern: "*.{tbi}"

--- a/modules/nf-core/graphtyper/vcfconcatenate/tests/main.nf.test
+++ b/modules/nf-core/graphtyper/vcfconcatenate/tests/main.nf.test
@@ -17,12 +17,12 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-				    [ id:'test', single_end:false ], // meta map
-				    [
-				        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
-				        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true)
-				    ]
-				]
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true)
+                    ]
+                ]
 
                 """
             }
@@ -32,11 +32,11 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-					path(process.out.vcf[0][1]).vcf.variantsMD5,
-					file(process.out.tbi[0][1]).name,
-					process.out.versions
-					).match()
-				}
+                    path(process.out.vcf[0][1]).vcf.variantsMD5,
+                    file(process.out.tbi[0][1]).name,
+                    process.out.versions
+                    ).match()
+                }
             )
         }
     }
@@ -48,12 +48,12 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-				    [ id:'test', single_end:false ], // meta map
-				    [
-				        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
-				        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true)
-				    ]
-				]
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.vcf.gz', checkIfExists: true)
+                    ]
+                ]
 
                 """
             }

--- a/modules/nf-core/graphtyper/vcfconcatenate/tests/main.nf.test.snap
+++ b/modules/nf-core/graphtyper/vcfconcatenate/tests/main.nf.test.snap
@@ -17,11 +17,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "prefix.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "prefix.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,da65963fb13e605b770c500fcddca43f"
+                    "versions.yml:md5,98cf72d3f556b54f0cb2c11c6d3b46b9"
                 ],
                 "tbi": [
                     [
@@ -29,7 +29,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "prefix.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "prefix.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "vcf": [
@@ -42,28 +42,28 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,da65963fb13e605b770c500fcddca43f"
+                    "versions.yml:md5,98cf72d3f556b54f0cb2c11c6d3b46b9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-09-06T08:42:58.201156"
+        "timestamp": "2025-03-14T14:07:03.164929021"
     },
     "test-graphtyper-vcfconcatenate": {
         "content": [
-            "ff00185efbeeac85dbe22d3b63466f71",
+            "93f741cc7a648675dfc13f0a42a39788",
             "prefix.vcf.gz.tbi",
             [
-                "versions.yml:md5,da65963fb13e605b770c500fcddca43f"
+                "versions.yml:md5,98cf72d3f556b54f0cb2c11c6d3b46b9"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2024-09-06T08:42:53.20738"
+        "timestamp": "2025-03-14T13:58:20.53915175"
     }
 }


### PR DESCRIPTION
For very large datasets (>300 samples) the number of VCFs produced by `graphtyper/genotype` can be so many that the shell cannot execute the command. This adds batching to avoid this error but does not change the input or output. This also updates the conda/docker dependencies.   