### PR TITLE
Fixed ivar version for all ivar modules

### DIFF
--- a/modules/nf-core/ivar/consensus/main.nf
+++ b/modules/nf-core/ivar/consensus/main.nf
@@ -40,7 +40,7 @@ process IVAR_CONSENSUS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        ivar: \$(echo \$(ivar version 2>&1) | sed 's/^.*iVar version //; s/ .*\$//')
+        ivar: \$(ivar version | sed -n 's|iVar version \\(.*\\)|\\1|p')
     END_VERSIONS
     """
 
@@ -54,7 +54,7 @@ process IVAR_CONSENSUS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        ivar: \$(echo \$(ivar version 2>&1) | sed 's/^.*iVar version //; s/ .*\$//')
+        ivar: \$(ivar version | sed -n 's|iVar version \\(.*\\)|\\1|p')
     END_VERSIONS
     """
 }

--- a/modules/nf-core/ivar/variants/main.nf
+++ b/modules/nf-core/ivar/variants/main.nf
@@ -44,7 +44,7 @@ process IVAR_VARIANTS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        ivar: \$(ivar version | sed 's/^.*iVar version //; s/ .*\$//')
+        ivar: \$(ivar version | sed -n 's|iVar version \\(.*\\)|\\1|p')
     END_VERSIONS
     """
 
@@ -57,7 +57,7 @@ process IVAR_VARIANTS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        ivar: \$(ivar version | sed 's/^.*iVar version //; s/ .*\$//')
+        ivar: \$(ivar version | sed -n 's|iVar version \\(.*\\)|\\1|p')
     END_VERSIONS
     """
 }


### PR DESCRIPTION
`ivar version` returns:

```
iVar version 1.4.3

Please raise issues and bug reports at https://github.com/andersen-lab/ivar/
```
Second line has to be removed to get `[process IVAR_VARIANTS:[ivar:1.4.3]]` properly. This was already fixed in [ivar trim module](https://github.com/nf-core/modules/blob/ce475295fb2edd3264ca8481fa9324a9c90753a5/modules/nf-core/ivar/trim/main.nf#L48). Using that fix for other ivar modules.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
