### PR TITLE
Make arg parsing regex in seaqtk sample more specific avoiding spurious matches

### DIFF
--- a/modules/nf-core/seqtk/sample/main.nf
+++ b/modules/nf-core/seqtk/sample/main.nf
@@ -20,7 +20,7 @@ process SEQTK_SAMPLE {
     script:
     def args   = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if (!(args ==~ /.*-s[0-9]+.*/)) {
+    if (!(args ==~ /.*\ -s\ ?[0-9]+.*/)) {
         args += " -s100"
     }
     if ( !sample_size ) {


### PR DESCRIPTION
While reviewing a PR pulling down the seqtk sample module, we noticed a regex in some of the argument parsing logic that could cause troubles by being too inspecific.

It is on [this line](https://github.com/nf-core/modules/blob/7f88aae/modules/nf-core/seqtk/sample/main.nf#L23)

I have tested the current pattern against a number of imaginary contents of the arg variable in the `nextflow console`, and one can see that the pattern:

1. Misses cases where there is a space between `-s` and the number.
2. Erroneously matches against filenames containing `-s[0-9]` as part of the filename.

![image](https://github.com/user-attachments/assets/e36d2163-dc74-46f3-b2f7-ec6a418156e0)

With the fixed regex, that adds a space before the `-s` flag, and an optional space after it, both of these are fixed:

![image](https://github.com/user-attachments/assets/95f37471-7860-4b46-89c6-964fc473713b)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`