### PR TITLE
[new module] Add tRNAScan-SE module

### DIFF
--- a/modules/nf-core/trnascanse/environment.yml
+++ b/modules/nf-core/trnascanse/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::trnascan-se=2.0.12"

--- a/modules/nf-core/trnascanse/main.nf
+++ b/modules/nf-core/trnascanse/main.nf
@@ -1,0 +1,89 @@
+process TRNASCANSE {
+    tag "${meta.id}"
+    label "process_medium"
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/trnascan-se:2.0.12--pl5321h7b50bb2_2':
+        'biocontainers/trnascan-se:2.0.12--pl5321h7b50bb2_2' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    val(write_fasta)
+    val(write_gff)
+    val(write_bed)
+
+    output:
+    tuple val(meta), path("*.tsv")   , emit: tsv
+    tuple val(meta), path("*.log")   , emit: log
+    tuple val(meta), path("*.stats") , emit: stats
+    tuple val(meta), path("*.fasta") , emit: fasta , optional: true
+    tuple val(meta), path("*.gff")   , emit: gff   , optional: true
+    tuple val(meta), path("*.bed")   , emit: bed   , optional: true
+    path("versions.yml")             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args      = task.ext.args   ?: ''
+    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def fasta_out = write_fasta     ? "-a ${prefix}.fasta" : ""
+    def gff       = write_gff       ? "-j ${prefix}.gff" : ""
+    def bed       = write_bed       ? "-a ${prefix}.bed" : ""
+    def input     = fasta.toString() - ~/\.gz$/
+    def unzip     = fasta.getExtension() == "gz" ? "gunzip -c ${fasta} > ${input}" : ""
+    def cleanup   = fasta.getExtension() == "gz" ? "rm ${input}" : ""
+    """
+    ${unzip}
+
+    ## larger genomes can fill up the limited temp space in the singularity container
+    ## expected location of the default config file is with the exectuable
+    ## copy this and modify to use the working dir as the temp directory
+    conf=\$(which tRNAscan-SE).conf
+    cp \${conf} trnascan.conf
+    sed -i s#/tmp#.#g trnascan.conf
+
+    tRNAscan-SE \\
+        --thread ${task.cpus} \\
+        -c trnascan.conf \\
+        ${args} \\
+        -o ${prefix}.tsv \\
+        -l ${prefix}.log \\
+        -m ${prefix}.stats \\
+        ${fasta_out} \\
+        ${gff} \\
+        ${bed} \\
+        ${input}
+
+    if [ -f ${prefix}.fasta ]; then
+        ${prefix}.fasta
+    fi
+
+    ${cleanup}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        tRNAscan-SE: \$(tRNAscan-SE 2>&1 >/dev/null | awk 'NR==2 {print \$2}')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix      = task.ext.prefix ?: "${meta.id}"
+    def touch_fasta = write_fasta ? "echo '' | gzip > ${prefix}.fasta.gz" : ""
+    def touch_gff   = write_gff ? "touch ${prefix}.gff" : ""
+    def touch_bed   = write_bed ? "touch ${prefix}.bed" : ""
+    """
+    touch ${prefix}.tsv
+    touch ${prefix}.log
+    touch ${prefix}.stats
+    ${touch_fasta}
+    ${touch_gff}
+    ${touch_bed}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        tRNAscan-SE: \$(tRNAscan-SE 2>&1 >/dev/null | awk 'NR==2 {print \$2}')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/trnascanse/meta.yml
+++ b/modules/nf-core/trnascanse/meta.yml
@@ -1,0 +1,119 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "trnascanse"
+description: Detection of tRNA sequences using covariance models
+keywords:
+  - covariance models
+  - trna
+  - genome annotation
+tools:
+  - "trnascanse":
+      description: "tRNA detection in large-scale genomic sequences"
+      homepage: "http://lowelab.ucsc.edu/tRNAscan-SE/help.html"
+      documentation: "http://lowelab.ucsc.edu/tRNAscan-SE/help.html"
+      tool_dev_url: "https://github.com/UCSC-LoweLab/tRNAscan-SE"
+      doi: "10.1093/nar/gkab688"
+      licence: ["GPL v3", "GPL v3-or-later"]
+      identifier: biotools:trnascan-se
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - fasta:
+        type: file
+        description: |
+          Fasta file for tRNA annotation. Can be gzipped.
+        ontologies: []
+  - - write_fasta:
+        type: boolean
+        description: |
+          Flag to enable FASTA output of identified tRNA sequences
+  - - write_gff:
+        type: boolean
+        description: Flag to enable GFF output of tRNA annotations of input sequences
+  - - write_bed:
+        type: boolean
+        description: Flag to enable BED output of tRNA annotations of input sequences
+
+output:
+  - tsv:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+          pattern: "*.tsv"
+      - "*.tsv":
+          type: file
+          description: TSV summary output of tRNA annotations
+          pattern: "*.tsv"
+  - log:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+          pattern: "*.log"
+      - "*.log":
+          type: file
+          description: tRNAScan-SE log file
+          pattern: "*.log"
+  - stats:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+          pattern: "*.stats"
+      - "*.stats":
+          type: file
+          description: Unstructured results file describing tRNA annotations
+          pattern: "*.stats"
+  - fasta:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+          pattern: "*.fasta.gz"
+      - "*.fasta":
+          type: file
+          description: |
+            (optional) FASTA output of annotated tRNA sequences
+          pattern: "*.fasta.gz"
+  - gff:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+          pattern: "*.gff"
+      - "*.gff":
+          type: file
+          description: |
+            (optional) GFF annotation of tRNA sequences in input fasta
+          pattern: "*.gff"
+  - bed:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+          pattern: "*.bed"
+      - "*.bed":
+          type: file
+          description: |
+            (optional) BED annotation of tRNA sequences in input fasta
+          pattern: "*.bed"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+          ontologies: []
+authors:
+  - "@prototaxites"
+maintainers:
+  - "@prototaxites"

--- a/modules/nf-core/trnascanse/tests/main.nf.test
+++ b/modules/nf-core/trnascanse/tests/main.nf.test
@@ -1,0 +1,71 @@
+nextflow_process {
+
+    name "Test Process TRNASCANSE"
+    script "../main.nf"
+    process "TRNASCANSE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "trnascanse"
+
+    test("bacteroides fragilis - write all") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                ]
+                input[1] = true
+                input[2] = true
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.log[0][1]).readLines().first().contains("Application: tRNAscan-SE") }, // timestamped log
+                { assert snapshot(
+                    process.out.tsv,
+                    process.out.stats,
+                    process.out.fasta,
+                    process.out.gff,
+                    process.out.bed,
+                    process.out.versions
+                    ).match() }
+            )
+        }
+
+    }
+
+    test("bacteroides fragilis - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                ]
+                input[1] = true
+                input[2] = true
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/trnascanse/tests/main.nf.test.snap
+++ b/modules/nf-core/trnascanse/tests/main.nf.test.snap
@@ -1,0 +1,166 @@
+{
+    "bacteroides fragilis - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "6": [
+                    "versions.yml:md5,a16c909b344a78a4197ae3a50d9dee7c"
+                ],
+                "bed": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fasta": [
+                    
+                ],
+                "gff": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,a16c909b344a78a4197ae3a50d9dee7c"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-25T11:43:23.206937928"
+    },
+    "bacteroides fragilis - write all": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.tsv:md5,23c19ff33ce36f041803b5b3e7b7681b"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.stats:md5,2183f64c6ccf1c779e06abed4573f961"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.gff:md5,7e91ca1cbf554e63fa2d31e78e4fe7dd"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.bed:md5,51c1dcb70d5a9400f05f18127c03d2a1"
+                ]
+            ],
+            [
+                "versions.yml:md5,a16c909b344a78a4197ae3a50d9dee7c"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-25T12:06:44.404218636"
+    }
+}


### PR DESCRIPTION
Adds module for tRNAScan-SE. 

In local testing, I was having a problem where when running in a Singularity container, the default internal /tmp space would fill up very quickly and the program would fail due to lack of disk space. I implemented a solution that moves the working directory from /tmp to the nextflow work dir, but this requires modifying an internal configuration file. Open to better solutions, but this one was working for me.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
