### PR TITLE
Update the documentation links in meta.yml files for rtg tools

### DIFF
--- a/modules/nf-core/rtgtools/format/meta.yml
+++ b/modules/nf-core/rtgtools/format/meta.yml
@@ -12,7 +12,7 @@ tools:
       description: "RealTimeGenomics Tools -- Utilities for accurate VCF comparison
         and manipulation"
       homepage: "https://www.realtimegenomics.com/products/rtg-tools"
-      documentation: "https://github.com/RealTimeGenomics/rtg-tools"
+      documentation: "https://realtimegenomics.github.io/rtg-tools/rtg_command_reference.html#format"
       tool_dev_url: "https://github.com/RealTimeGenomics/rtg-tools"
       licence: ["BSD"]
       identifier: ""

--- a/modules/nf-core/rtgtools/pedfilter/meta.yml
+++ b/modules/nf-core/rtgtools/pedfilter/meta.yml
@@ -10,7 +10,7 @@ tools:
       description: "RealTimeGenomics Tools -- Utilities for accurate VCF comparison
         and manipulation"
       homepage: "https://www.realtimegenomics.com/products/rtg-tools"
-      documentation: "https://github.com/RealTimeGenomics/rtg-tools"
+      documentation: "https://realtimegenomics.github.io/rtg-tools/rtg_command_reference.html#pedfilter"
       tool_dev_url: "https://github.com/RealTimeGenomics/rtg-tools"
       licence: ["BSD"]
       identifier: ""

--- a/modules/nf-core/rtgtools/rocplot/meta.yml
+++ b/modules/nf-core/rtgtools/rocplot/meta.yml
@@ -11,7 +11,7 @@ tools:
       description: "RealTimeGenomics Tools -- Utilities for accurate VCF comparison
         and manipulation"
       homepage: "https://www.realtimegenomics.com/products/rtg-tools"
-      documentation: "https://github.com/RealTimeGenomics/rtg-tools"
+      documentation: "https://realtimegenomics.github.io/rtg-tools/rtg_command_reference.html#rocplot"
       tool_dev_url: "https://github.com/RealTimeGenomics/rtg-tools"
       licence: ["BSD"]
       identifier: ""

--- a/modules/nf-core/rtgtools/vcfeval/meta.yml
+++ b/modules/nf-core/rtgtools/vcfeval/meta.yml
@@ -10,7 +10,7 @@ tools:
       description: "RealTimeGenomics Tools -- Utilities for accurate VCF comparison
         and manipulation"
       homepage: "https://www.realtimegenomics.com/products/rtg-tools"
-      documentation: "https://github.com/RealTimeGenomics/rtg-tools"
+      documentation: "https://realtimegenomics.github.io/rtg-tools/rtg_command_reference.html#vcfeval"
       tool_dev_url: "https://github.com/RealTimeGenomics/rtg-tools"
       licence: ["BSD"]
       identifier: ""


### PR DESCRIPTION
## Overview

Changed `documentation` links in `meta.yml` files to point to more informative pages in the [rtg tools documentation site](https://realtimegenomics.github.io/rtg-tools/index.html) rather than the [github page](https://github.com/RealTimeGenomics/rtg-tools)
- rocplot
- pedfilter
- format
- vcfeval

part of:
- #7995
- #7996
- #7997
- #7998

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
