### PR TITLE
ADDORREPLACEREADGROUPS input/output file specificity fix.

### DIFF
--- a/modules/nf-core/gatk4/addorreplacereadgroups/main.nf
+++ b/modules/nf-core/gatk4/addorreplacereadgroups/main.nf
@@ -13,7 +13,7 @@ process GATK4_ADDORREPLACEREADGROUPS {
     tuple val(meta3), path(fasta_index)
 
     output:
-    tuple val(meta), path("*.bam") , emit: bam,  optional: true
+    tuple val(meta), path("${prefix}.bam") , emit: bam,  optional: true
     tuple val(meta), path("*.bai") , emit: bai,  optional: true
     tuple val(meta), path("*.cram"), emit: cram, optional: true
     path "versions.yml"            , emit: versions


### PR DESCRIPTION
When using ADDORREPLACEREADGROUPS on an HPC with scratch enabled, the globbed *.bam  copys both the input and output bam from scratch to the work directory. The output needed to be more specific. It is now ${prefix}.bam for the output so it now targets the output bam/cram instead of all files with the right file extension. For more details see the issue.

This should fix the issue for ADDORREPLACEREADGROUPS but be on the lookout for other modules where this occurs.

PR checklist
Addresses #https://github.com/nf-core/modules/issues/7792, but more modules could have issues.

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
