### PR TITLE
Bump multiqc to 1.28

### DIFF
--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::multiqc=1.27
+  - bioconda::multiqc=1.28

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,8 +3,8 @@ process MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.27--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.27--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.28--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.28--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "multiqc_versions_single": {
         "content": [
             [
-                "versions.yml:md5,8f3b8c1cec5388cf2708be948c9fa42f"
+                "versions.yml:md5,92381009065e97a8a1af0dc482cf020a"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
+            "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T09:29:57.631982377"
+        "timestamp": "2025-03-26T15:52:52.251757"
     },
     "multiqc_stub": {
         "content": [
@@ -17,25 +17,25 @@
                 "multiqc_report.html",
                 "multiqc_data",
                 "multiqc_plots",
-                "versions.yml:md5,8f3b8c1cec5388cf2708be948c9fa42f"
+                "versions.yml:md5,92381009065e97a8a1af0dc482cf020a"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
+            "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T09:30:34.743726958"
+        "timestamp": "2025-03-26T15:53:22.147722"
     },
     "multiqc_versions_config": {
         "content": [
             [
-                "versions.yml:md5,8f3b8c1cec5388cf2708be948c9fa42f"
+                "versions.yml:md5,92381009065e97a8a1af0dc482cf020a"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
+            "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T09:30:21.44383553"
+        "timestamp": "2025-03-26T15:53:14.798692"
     }
 }

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -2,14 +2,14 @@
     "multiqc_versions_single": {
         "content": [
             [
-                "versions.yml:md5,92381009065e97a8a1af0dc482cf020a"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-03-26T15:52:52.251757"
+        "timestamp": "2025-03-26T16:05:18.927925"
     },
     "multiqc_stub": {
         "content": [
@@ -17,25 +17,25 @@
                 "multiqc_report.html",
                 "multiqc_data",
                 "multiqc_plots",
-                "versions.yml:md5,92381009065e97a8a1af0dc482cf020a"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-03-26T15:53:22.147722"
+        "timestamp": "2025-03-26T16:05:55.639955"
     },
     "multiqc_versions_config": {
         "content": [
             [
-                "versions.yml:md5,92381009065e97a8a1af0dc482cf020a"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-03-26T15:53:14.798692"
+        "timestamp": "2025-03-26T16:05:44.067369"
     }
 }


### PR DESCRIPTION
Update MultiQC to latest version

## PR checklist

Fixes nf-core/seqinspector#102

- [X] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
