### PR TITLE
Fixing cellrangeratac/mkfastq stub gz

### DIFF
--- a/modules/nf-core/cellrangeratac/mkfastq/main.nf
+++ b/modules/nf-core/cellrangeratac/mkfastq/main.nf
@@ -37,7 +37,7 @@ process CELLRANGERATAC_MKFASTQ {
     stub:
     """
     mkdir -p "${bcl.getSimpleName()}/outs/fastq_path/"
-    touch ${bcl.getSimpleName()}/outs/fastq_path/fake_file.fastq.gz
+    echo "" | gzip > ${bcl.getSimpleName()}/outs/fastq_path/fake_file.fastq.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## Description of changes
- Changed from using `touch` to `echo "" | gzip > .gz` to create `.gz` file in stub

## PR checklist

Closes #7899 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
