### PR TITLE
deeptools_bamcoverage - Minor fix to stub script

### DIFF
--- a/modules/nf-core/deeptools/bamcoverage/main.nf
+++ b/modules/nf-core/deeptools/bamcoverage/main.nf
@@ -66,9 +66,9 @@ process DEEPTOOLS_BAMCOVERAGE {
 
     stub:
     def prefix    = task.ext.prefix ?: "${meta.id}"
-    def extension = args.contains("--outFileFormat bedgraph") || args.contains("-of bedgraph") ? ".bedgraph" : ".bigWig"
+    def extension = args.contains("--outFileFormat bedgraph") || args.contains("-of bedgraph") ? "bedgraph" : "bigWig"
     """
-    touch ${prefix}
+    touch ${prefix}.${extension}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/deeptools/bamcoverage/tests/main.nf.test.snap
+++ b/modules/nf-core/deeptools/bamcoverage/tests/main.nf.test.snap
@@ -45,7 +45,13 @@
         "content": [
             {
                 "0": [
-                    
+                         [
+                             {
+                                 "id": "test",
+                                 "single_end": false
+                             },
+                            "test.bigWig:md5,d41d8cd98f00b204e9800998ecf8427e"
+                         ]
                 ],
                 "1": [
                     
@@ -57,7 +63,13 @@
                     
                 ],
                 "bigwig": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bigWig:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "versions": [
                     "versions.yml:md5,241ec68695b08434d2db71ad878ed162"


### PR DESCRIPTION
Make it return `prefix.extension` to be consistent with what is expected from the actual run

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [X] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
