### PR TITLE
Fix: Quote shell parameters

### DIFF
--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -38,13 +38,13 @@ process SHINYNGS_APP {
 
     """
     make_app_from_files.R \\
-        --sample_metadata $sample \\
-        --feature_metadata $feature_meta \\
-        --assay_files ${assay_files.join(',')} \\
-        --contrast_file $contrasts \\
-        --contrast_stats_assay $contrast_stats_assay \\
-        --differential_results ${differential_results.join(',')} \\
-        --output_dir $prefix \\
+        --sample_metadata "$sample" \\
+        --feature_metadata "$feature_meta" \\
+        --assay_files "${assay_files.join(',')}" \\
+        --contrast_file "$contrasts" \\
+        --contrast_stats_assay "$contrast_stats_assay" \\
+        --differential_results "${differential_results.join(',')}" \\
+        --output_dir "$prefix" \\
         $args \\
 
     cat <<-END_VERSIONS > versions.yml
@@ -58,9 +58,9 @@ process SHINYNGS_APP {
     def prefix = task.ext.prefix ?: meta.id
 
     """
-    mkdir -p $prefix
-    touch ${prefix}/data.rds
-    touch ${prefix}/app.R
+    mkdir -p "$prefix"
+    touch "${prefix}/data.rds"
+    touch "${prefix}/app.R"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
https://github.com/nf-core/differentialabundance/pull/444


I ran a differential abundance pipeline with a study name that had spaces in it, and the pipeline crashed because the `make_app_from_files.R` caller script was not escaping parameters as expected. I believe the patch included in this PR is pretty easy to follow: The parameters were expanded by the `$` and the second word of the study name was interpreted as another argument.

Making this change made the pipeline succeed.

If you believe this contribution is of your interest but you require of me to add tests I can try to find time to learn how to write tests and comply with the rest of the checklist. It may take me a while though to find the time, and the patch is really minor so I would appreciate your consideration.

You may want to consider security ramifications of being able to pass a study_name like `; arbitrary_command` and inject code that would be executed by the pipeline. I am not familiar enough with nextflow to understand whether that should be considered a vulnerability risk or not, but if you think this is an issue, then this PR would fix it.

In any case, thanks for your time and for all the work you do. 



## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
