### PR TITLE
fixed bug in bandage/image module, wrong versions.yml outputted

### DIFF
--- a/modules/nf-core/bandage/image/main.nf
+++ b/modules/nf-core/bandage/image/main.nf
@@ -7,6 +7,8 @@ process BANDAGE_IMAGE {
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3eabbd074e3bc45e2643783450330cae3afc6697fefc635755ab964dc43665a1/data' :
         'community.wave.seqera.io/library/bandage:0.9.0--4f0567049a14ea6d' }"
 
+    containerOptions "--env QT_QPA_PLATFORM=offscreen --env XDG_RUNTIME_DIR=/tmp/runtime-${task.uid}"
+
     input:
     tuple val(meta), path(gfa)
 

--- a/modules/nf-core/bandage/image/main.nf
+++ b/modules/nf-core/bandage/image/main.nf
@@ -7,8 +7,6 @@ process BANDAGE_IMAGE {
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3e/3eabbd074e3bc45e2643783450330cae3afc6697fefc635755ab964dc43665a1/data' :
         'community.wave.seqera.io/library/bandage:0.9.0--4f0567049a14ea6d' }"
 
-    containerOptions "--env QT_QPA_PLATFORM=offscreen --env XDG_RUNTIME_DIR=/tmp/runtime-${task.uid}"
-
     input:
     tuple val(meta), path(gfa)
 
@@ -29,7 +27,7 @@ process BANDAGE_IMAGE {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        bandage: \$(echo \$(Bandage --version 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
+        bandage: \$(echo \$(export QT_QPA_PLATFORM=offscreen; Bandage --version 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
     END_VERSIONS
     """
 }

--- a/modules/nf-core/bandage/image/tests/main.nf.test.snap
+++ b/modules/nf-core/bandage/image/tests/main.nf.test.snap
@@ -10,13 +10,13 @@
                 "</defs>"
             ],
             [
-                "versions.yml:md5,5eabdcb1b40eff04990c1a33375386a6"
+                "versions.yml:md5,fbde52dd28ce0b0245e301c7a3fd4629"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-04-01T16:11:16.054583631"
+        "timestamp": "2025-04-02T14:07:25.265702735"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

### PR Description

While testing the updated module on `nf-core/viralrecon`, I encountered a Nextflow syntax error related to the `versions.yml` generation. Upon inspection, I noticed that the version command being executed was:

```bash
docker run -i --cpu-shares 2048 --memory 12288m \
  -e "NXF_TASK_WORKDIR" \
  -e "NXF_DEBUG=${NXF_DEBUG:=0}" \
  -v /home/smonzon/Documents/desarrollo/viralrecon:/home/smonzon/Documents/desarrollo/viralrecon \
  -w $PWD -u $(id -u):$(id -g) \
  quay.io/biocontainers/bandage:0.9.0--h9948957_0 \
  Bandage --version
```

This led to the following error output:

```
qt.qpa.xcb: could not connect to display
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized.
```

The issue arises because Bandage uses the Qt library and attempts to launch a GUI (X11) by default, which isn't accessible in container environments.

Since we are only using Bandage's command-line interface (no GUI features), this PR sets the environment variable `QT_QPA_PLATFORM=offscreen` to bypass the X11 requirement and allow the tool to run successfully in containers.

Additionally, `XDG_RUNTIME_DIR=/tmp/runtime-$(id -u)` is set to suppress a Qt warning and keep the version output cleaner, though it is not strictly required for functionality.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
