### PR TITLE
Mindagap stub and test updates

### DIFF
--- a/modules/nf-core/mindagap/duplicatefinder/environment.yml
+++ b/modules/nf-core/mindagap/duplicatefinder/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - conda-forge::numpy=1.24.2
   - bioconda::mindagap=0.0.2

--- a/modules/nf-core/mindagap/duplicatefinder/main.nf
+++ b/modules/nf-core/mindagap/duplicatefinder/main.nf
@@ -2,9 +2,9 @@ process MINDAGAP_DUPLICATEFINDER {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::mindagap=0.0.2"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mindagap:0.0.2--pyhdfd78af_1':
+        'https://depot.galaxyproject.org/singularity/mindagap:0.0.2--pyhdfd78af_1' :
         'biocontainers/mindagap:0.0.2--pyhdfd78af_1' }"
 
     input:
@@ -18,12 +18,21 @@ process MINDAGAP_DUPLICATEFINDER {
     task.ext.when == null || task.ext.when
 
     script:
-    def args   = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args = task.ext.args ?: ''
     """
     duplicate_finder.py \\
         $spot_table \\
         $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        mindagap: \$(mindagap.py test -v)
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch ${spot_table.baseName}_markedDups.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/mindagap/duplicatefinder/tests/main.nf.test
+++ b/modules/nf-core/mindagap/duplicatefinder/tests/main.nf.test
@@ -9,14 +9,46 @@ nextflow_process {
     tag "mindagap"
     tag "mindagap/duplicatefinder"
 
-    test("test_mindagap_duplicatefinder_spots") {
+    test("mindagap - duplicatefinder - spots - txt") {
 
         when {
+            params {
+                modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/molkart/'
+            }
+
             process {
                 """
                 input[0] = [
-                    [ id:'test'], // meta map
-                    file('https://raw.githubusercontent.com/nf-core/test-datasets/molkart/test_data/input_data/spots.txt')
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + 'test_data/input_data/spots.txt', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("mindagap - duplicatefinder - spots - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/molkart/'
+            }
+
+            process {
+                """
+                input[0] = [
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + 'test_data/input_data/spots.txt', checkIfExists: true)
                     ]
                 """
             }

--- a/modules/nf-core/mindagap/duplicatefinder/tests/main.nf.test.snap
+++ b/modules/nf-core/mindagap/duplicatefinder/tests/main.nf.test.snap
@@ -1,5 +1,38 @@
 {
-    "test_mindagap_duplicatefinder_spots": {
+    "mindagap - duplicatefinder - spots - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "spots_markedDups.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,ae112b853ec32ee1c5eecaf421d01003"
+                ],
+                "marked_dups_spots": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "spots_markedDups.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ae112b853ec32ee1c5eecaf421d01003"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-02T19:57:30.980911113"
+    },
+    "mindagap - duplicatefinder - spots - txt": {
         "content": [
             {
                 "0": [
@@ -26,6 +59,10 @@
                 ]
             }
         ],
-        "timestamp": "2023-11-30T22:56:20.101101751"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-02T19:57:24.039800026"
     }
 }

--- a/modules/nf-core/mindagap/mindagap/main.nf
+++ b/modules/nf-core/mindagap/mindagap/main.nf
@@ -4,8 +4,8 @@ process MINDAGAP_MINDAGAP {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-    'https://depot.galaxyproject.org/singularity/mindagap:0.0.2--pyhdfd78af_1' :
-    'biocontainers/mindagap:0.0.2--pyhdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/mindagap:0.0.2--pyhdfd78af_1' :
+        'biocontainers/mindagap:0.0.2--pyhdfd78af_1' }"
 
     input:
     tuple val(meta), path(panorama)
@@ -18,8 +18,7 @@ process MINDAGAP_MINDAGAP {
     task.ext.when == null || task.ext.when
 
     script:
-    def args   = task.ext.args   ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args = task.ext.args ?: ''
     """
     mindagap.py \\
         $panorama \\
@@ -32,7 +31,6 @@ process MINDAGAP_MINDAGAP {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${panorama.baseName}_gridfilled.tiff
 

--- a/modules/nf-core/mindagap/mindagap/tests/main.nf.test
+++ b/modules/nf-core/mindagap/mindagap/tests/main.nf.test
@@ -17,7 +17,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.test_data['imaging']['tiff']['mouse_heart_wga'], checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'imaging/tiff/mindagap.mouse_heart.wga.tiff', checkIfExists: true)
                 ]
                 """
             }
@@ -28,6 +28,30 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(process.out.tiff).match("tiff") },
                 { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+    test("mindgap - tiff - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'imaging/tiff/mindagap.mouse_heart.wga.tiff', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
             )
         }
 

--- a/modules/nf-core/mindagap/mindagap/tests/main.nf.test.snap
+++ b/modules/nf-core/mindagap/mindagap/tests/main.nf.test.snap
@@ -1,4 +1,37 @@
 {
+    "mindgap - tiff - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "mindagap.mouse_heart.wga_gridfilled.tiff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,937acaba2cb90efc2705b71839e6cefc"
+                ],
+                "tiff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "mindagap.mouse_heart.wga_gridfilled.tiff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,937acaba2cb90efc2705b71839e6cefc"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-02T19:54:00.036000058"
+    },
     "tiff": {
         "content": [
             [
@@ -10,6 +43,10 @@
                 ]
             ]
         ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
         "timestamp": "2023-12-15T11:01:20.825556802"
     },
     "versions": {
@@ -18,6 +55,10 @@
                 "versions.yml:md5,937acaba2cb90efc2705b71839e6cefc"
             ]
         ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
         "timestamp": "2023-12-15T11:01:20.840211732"
     }
 }


### PR DESCRIPTION
In this PR I've:
* added a stub section to MINDAGAP/DUPLICATEFINDER
* updated tests for both MINDAGAP/DUPLICATEFINDER and MINDAGAP/MINDAGAP modules to use `params.modules_testdata_base_path`
* fixed the numpy version for duplicatefinder in the env because a newer version was causing the conda outputs to not match 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
