### PR TITLE
feat: add literal string to make contrasts in `variancepartition/dream`

### DIFF
--- a/modules/nf-core/variancepartition/dream/main.nf
+++ b/modules/nf-core/variancepartition/dream/main.nf
@@ -8,7 +8,7 @@ process VARIANCEPARTITION_DREAM {
         'community.wave.seqera.io/library/bioconductor-edger_bioconductor-variancepartition_r-optparse:ba778938d72f30c5' }"
 
     input:
-    tuple val(meta), val(contrast_variable), val(reference), val(target), val(formula)
+    tuple val(meta), val(contrast_variable), val(reference), val(target), val(formula), val(comparison)
     tuple val(meta2), path(samplesheet), path(counts)
 
     output:

--- a/modules/nf-core/variancepartition/dream/meta.yml
+++ b/modules/nf-core/variancepartition/dream/meta.yml
@@ -37,6 +37,9 @@ input:
     - formula:
         type: string
         description: (Mandatory) R formula string used for modeling, e.g. '~ treatment + (1 | sample_number)'.
+    - comparison:
+        type: string
+        description: (Optional) Literal string passed to `limma::makeContrasts`, e.g. 'treatmenthND6 - treatmentmCherry'.
   - - meta2:
         type: map
         description: |

--- a/modules/nf-core/variancepartition/dream/tests/main.nf.test
+++ b/modules/nf-core/variancepartition/dream/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of(['id': 'treatment_mCherry_hND6', 'variable': 'treatment', 'reference': 'mCherry', 'target': 'hND6', 'blocking_factors':null, 'formula':null])
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
 
                 input[1] = Channel.of([
@@ -36,6 +36,62 @@ nextflow_process {
         }
     }
 
+    test("Mus musculus - expression table - contrasts + formula + comparison contrast string") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(['id': 'treatment_mCherry_hND6', 'variable': 'treatment', 'reference': 'mCherry', 'target': 'hND6', 'blocking_factors':'sample_number', 'formula':'~ treatment', 'comparison':'treatmenthND6'])
+                    .map{
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
+                    }
+
+                input[1] = Channel.of([
+                    [ id:'test' ],
+                        file("https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv", checkIfExists: true),
+                        file("https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv", checkIfExists: true)
+                    ]
+                )
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+                )
+        }
+    }
+
+    test("Mus musculus - expression table - contrasts + formula + comparison contrast string - no intercept") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(['id': 'treatment_mCherry_hND6', 'variable': 'treatment', 'reference': 'mCherry', 'target': 'hND6', 'blocking_factors':'sample_number', 'formula':'~ 0 + treatment + sample_number', 'comparison':'treatmenthND6 - treatmentmCherry'])
+                    .map{
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
+                    }
+
+                input[1] = Channel.of([
+                    [ id:'test' ],
+                        file("https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.samplesheet.csv", checkIfExists: true),
+                        file("https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.salmon.merged.gene_counts.top1000cov.tsv", checkIfExists: true)
+                    ]
+                )
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+                )
+        }
+    }
+
     test("Mus musculus - expression table - contrasts + blocking factors") {
 
         when {
@@ -43,7 +99,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of(['id': 'treatment_mCherry_hND6', 'variable': 'treatment', 'reference': 'mCherry', 'target': 'hND6', 'blocking_factors':'sample_number', 'formula':'~ treatment + (1 | sample_number)'])
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
 
                 input[1] = Channel.of([
@@ -72,7 +128,7 @@ nextflow_process {
                 """
                 input[0] = Channel.of(['id': 'treatment_mCherry_hND6', 'variable': 'treatment', 'reference': 'mCherry', 'target': 'hND6', 'blocking_factors':'sample_number', 'formula':'~ treatment + (1 | sample_number)'])
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
 
                 input[1] = Channel.of([

--- a/modules/nf-core/variancepartition/dream/tests/main.nf.test.snap
+++ b/modules/nf-core/variancepartition/dream/tests/main.nf.test.snap
@@ -1,4 +1,77 @@
 {
+    "Mus musculus - expression table - contrasts + formula + comparison contrast string - no intercept": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "treatment_mCherry_hND6",
+                            "variable": "treatment",
+                            "reference": "mCherry",
+                            "target": "hND6",
+                            "blocking_factors": "sample_number",
+                            "formula": "~ 0 + treatment + sample_number",
+                            "comparison": "treatmenthND6 - treatmentmCherry"
+                        },
+                        "treatment_mCherry_hND6.dream.results.tsv:md5,650932ec8d26dc3957ae1cffc22af3ab"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "treatment_mCherry_hND6",
+                            "variable": "treatment",
+                            "reference": "mCherry",
+                            "target": "hND6",
+                            "blocking_factors": "sample_number",
+                            "formula": "~ 0 + treatment + sample_number",
+                            "comparison": "treatmenthND6 - treatmentmCherry"
+                        },
+                        "treatment_mCherry_hND6.dream.model.txt:md5,46fe9413749f1475edc6985647b0e4e1"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
+                ],
+                "model": [
+                    [
+                        {
+                            "id": "treatment_mCherry_hND6",
+                            "variable": "treatment",
+                            "reference": "mCherry",
+                            "target": "hND6",
+                            "blocking_factors": "sample_number",
+                            "formula": "~ 0 + treatment + sample_number",
+                            "comparison": "treatmenthND6 - treatmentmCherry"
+                        },
+                        "treatment_mCherry_hND6.dream.model.txt:md5,46fe9413749f1475edc6985647b0e4e1"
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "treatment_mCherry_hND6",
+                            "variable": "treatment",
+                            "reference": "mCherry",
+                            "target": "hND6",
+                            "blocking_factors": "sample_number",
+                            "formula": "~ 0 + treatment + sample_number",
+                            "comparison": "treatmenthND6 - treatmentmCherry"
+                        },
+                        "treatment_mCherry_hND6.dream.results.tsv:md5,650932ec8d26dc3957ae1cffc22af3ab"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-07T17:45:58.378583778"
+    },
     "Mus musculus - expression table - contrasts + blocking factors": {
         "content": [
             {
@@ -66,7 +139,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-31T15:03:03.556133605"
+        "timestamp": "2025-04-07T17:49:43.723050911"
     },
     "Mus musculus - expression table - contrasts + blocking factors stub": {
         "content": [
@@ -135,38 +208,68 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-31T15:03:25.932056996"
+        "timestamp": "2025-04-07T17:50:03.51650916"
     },
-    "Mus musculus - expression table - contrasts": {
+    "Mus musculus - expression table - contrasts + formula + comparison contrast string": {
         "content": [
             {
                 "0": [
                     [
                         {
-                            "contrast_id": "treatment_mCherry_hND6",
-                            "contrast_variable": "treatment",
-                            "contrast_reference": "mCherry",
-                            "contrast_target": "hND6",
-                            "blocking_factors": null,
-                            "formula": null
+                            "id": "treatment_mCherry_hND6",
+                            "variable": "treatment",
+                            "reference": "mCherry",
+                            "target": "hND6",
+                            "blocking_factors": "sample_number",
+                            "formula": "~ treatment",
+                            "comparison": "treatmenthND6"
                         },
-                        "treatment_mCherry_hND6.dream.results.tsv:md5,c5e1ef96753cc13dc064a14371c8e0a9"
+                        "treatment_mCherry_hND6.dream.results.tsv:md5,0b9521f3aafdbc7f2df761bdc8b1a1ea"
                     ]
                 ],
                 "1": [
+                    [
+                        {
+                            "id": "treatment_mCherry_hND6",
+                            "variable": "treatment",
+                            "reference": "mCherry",
+                            "target": "hND6",
+                            "blocking_factors": "sample_number",
+                            "formula": "~ treatment",
+                            "comparison": "treatmenthND6"
+                        },
+                        "treatment_mCherry_hND6.dream.model.txt:md5,8cb944a29e3d3d0e540048b4d8331b17"
+                    ]
+                ],
+                "2": [
                     "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
+                ],
+                "model": [
+                    [
+                        {
+                            "id": "treatment_mCherry_hND6",
+                            "variable": "treatment",
+                            "reference": "mCherry",
+                            "target": "hND6",
+                            "blocking_factors": "sample_number",
+                            "formula": "~ treatment",
+                            "comparison": "treatmenthND6"
+                        },
+                        "treatment_mCherry_hND6.dream.model.txt:md5,8cb944a29e3d3d0e540048b4d8331b17"
+                    ]
                 ],
                 "results": [
                     [
                         {
-                            "contrast_id": "treatment_mCherry_hND6",
-                            "contrast_variable": "treatment",
-                            "contrast_reference": "mCherry",
-                            "contrast_target": "hND6",
-                            "blocking_factors": null,
-                            "formula": null
+                            "id": "treatment_mCherry_hND6",
+                            "variable": "treatment",
+                            "reference": "mCherry",
+                            "target": "hND6",
+                            "blocking_factors": "sample_number",
+                            "formula": "~ treatment",
+                            "comparison": "treatmenthND6"
                         },
-                        "treatment_mCherry_hND6.dream.results.tsv:md5,c5e1ef96753cc13dc064a14371c8e0a9"
+                        "treatment_mCherry_hND6.dream.results.tsv:md5,0b9521f3aafdbc7f2df761bdc8b1a1ea"
                     ]
                 ],
                 "versions": [
@@ -178,6 +281,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-13T14:36:58.660878384"
+        "timestamp": "2025-04-07T17:45:38.612858235"
     }
 }

--- a/subworkflows/nf-core/abundance_differential_filter/main.nf
+++ b/subworkflows/nf-core/abundance_differential_filter/main.nf
@@ -26,14 +26,14 @@ workflow ABUNDANCE_DIFFERENTIAL_FILTER {
     ch_samplesheet           // [ meta_exp, samplesheet ]
     ch_transcript_lengths    // [ meta_exp, transcript_lengths]
     ch_control_features      // [meta_exp, control_features]
-    ch_contrasts             // [[ meta_contrast, contrast_variable, reference, target, formula ]]
+    ch_contrasts             // [[ meta_contrast, contrast_variable, reference, target, formula, comparison ]]
 
     main:
 
     ch_versions = Channel.empty()
 
     // Set up how the channels crossed below will be used to generate channels for processing
-    def criteria = multiMapCriteria { meta_input, abundance, analysis_method, fc_threshold, stat_threshold, meta_exp, samplesheet, meta_contrasts, variable, reference, target, formula ->
+    def criteria = multiMapCriteria { meta_input, abundance, analysis_method, fc_threshold, stat_threshold, meta_exp, samplesheet, meta_contrasts, variable, reference, target, formula, comparison ->
         def meta_for_diff = mergeMaps(meta_contrasts, meta_input) + [ 'method_differential': analysis_method ]
         def meta_input_new = meta_input + [ 'method_differential': analysis_method ]
         samples_and_matrix:
@@ -41,7 +41,7 @@ workflow ABUNDANCE_DIFFERENTIAL_FILTER {
         contrasts_for_diff:
             [ meta_for_diff, variable, reference, target ]
         contrasts_for_diff_with_formula:
-            [ meta_for_diff, variable, reference, target, formula ]
+            [ meta_for_diff, variable, reference, target, formula, comparison ]
         filter_params:
             [ meta_for_diff, [ 'fc_threshold': fc_threshold, 'stat_threshold': stat_threshold ]]
         contrasts_for_norm:
@@ -138,7 +138,7 @@ workflow ABUNDANCE_DIFFERENTIAL_FILTER {
 
     // DREAM only runs with formula
     dream_inputs = inputs.contrasts_for_diff_with_formula
-        .filter { meta, variable, reference, target, formula ->
+        .filter { meta, _variable, _reference, _target, formula, _comparison ->
             meta.method_differential == 'dream' && formula != null
         }
 

--- a/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test
+++ b/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test
@@ -37,7 +37,60 @@ nextflow_workflow {
                 ch_control_features = Channel.of([ [], [] ])
                 ch_contrasts =  Channel.of(['id': 'treatment_mCherry_hND6', 'variable': 'treatment', 'reference': 'mCherry', 'target': 'hND6', 'blocking_factors':'sample_number', 'formula':'~ treatment + (1 | sample_number)'])
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
+                    }
+                ch_input = Channel.of([
+                    [ id:'test' ],
+                    file(testData.expression_test_data_dir + testData.abundance_file),
+                    'dream',  // analysis method
+                    1.5,       // FC threshold
+                    0.05       // stat (adjusted p-value) threshold
+                ])
+
+                input[0] = ch_input
+                input[1] = ch_samplesheet
+                input[2] = ch_transcript_lengths
+                input[3] = ch_control_features
+                input[4] = ch_contrasts
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.results_genewise,
+                    workflow.out.results_genewise_filtered,
+                    workflow.out.model,
+                    workflow.out.versions
+                ).match() }
+            )
+        }
+    }
+
+    test("dream - complex contrast - literal contrast string comparison") {
+        tag "dream"
+
+        when {
+            workflow {
+                """
+
+                def testData = [
+                    expression_test_data_dir: params.modules_testdata_base_path + 'genomics/mus_musculus/rnaseq_expression/',
+                    contrasts_file: 'SRP254919.contrasts.csv',
+                    abundance_file: 'SRP254919.salmon.merged.gene_counts.top1000cov.tsv',
+                    samplesheet_file: 'SRP254919.samplesheet.csv'
+                ]
+
+                ch_samplesheet = Channel.of([
+                    [ id:'test' ],
+                    file(testData.expression_test_data_dir + testData.samplesheet_file)
+                ])
+                ch_transcript_lengths = Channel.of([ [], [] ])
+                ch_control_features = Channel.of([ [], [] ])
+                ch_contrasts =  Channel.of(['id': 'treatment_mCherry_hND6', 'variable': 'treatment', 'reference': 'mCherry', 'target': 'hND6', 'blocking_factors':'sample_number', 'formula':'~ 0 + treatment + sample_number', 'comparison':'treatmenthND6 - treatmentmCherry'])
+                    .map{
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],
@@ -93,7 +146,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],
@@ -177,7 +230,7 @@ nextflow_workflow {
                 ch_control_features = Channel.of([ [], [] ])
                 ch_contrasts = Channel.of(['id': 'diagnosis_normal_uremia', 'variable': 'diagnosis', 'reference': 'normal', 'target': 'uremia'])
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = AFFY_JUSTRMA.out.expression.map{ meta, file -> [
                     meta,
@@ -235,7 +288,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],
@@ -296,7 +349,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],
@@ -354,7 +407,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],
@@ -410,7 +463,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of(
                     [
@@ -479,7 +532,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of(
                     [
@@ -558,7 +611,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],

--- a/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test.snap
@@ -711,6 +711,66 @@
         },
         "timestamp": "2025-03-11T17:37:02.499176561"
     },
+    "dream - complex contrast - literal contrast string comparison": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "treatment_mCherry_hND6_test",
+                        "variable": "treatment",
+                        "reference": "mCherry",
+                        "target": "hND6",
+                        "blocking_factors": "sample_number",
+                        "formula": "~ 0 + treatment + sample_number",
+                        "comparison": "treatmenthND6 - treatmentmCherry",
+                        "method_differential": "dream"
+                    },
+                    "treatment_mCherry_hND6_test.dream.results.tsv:md5,650932ec8d26dc3957ae1cffc22af3ab"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "treatment_mCherry_hND6_test",
+                        "variable": "treatment",
+                        "reference": "mCherry",
+                        "target": "hND6",
+                        "blocking_factors": "sample_number",
+                        "formula": "~ 0 + treatment + sample_number",
+                        "comparison": "treatmenthND6 - treatmentmCherry",
+                        "method_differential": "dream",
+                        "fc_threshold": 1.5,
+                        "stat_threshold": 0.05
+                    },
+                    "treatment_mCherry_hND6_test_filtered.tsv:md5,2882175ce3930af457addbe732309bee"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "treatment_mCherry_hND6_test",
+                        "variable": "treatment",
+                        "reference": "mCherry",
+                        "target": "hND6",
+                        "blocking_factors": "sample_number",
+                        "formula": "~ 0 + treatment + sample_number",
+                        "comparison": "treatmenthND6 - treatmentmCherry",
+                        "method_differential": "dream"
+                    },
+                    "treatment_mCherry_hND6_test.dream.model.txt:md5,46fe9413749f1475edc6985647b0e4e1"
+                ]
+            ],
+            [
+                "versions.yml:md5,1c02d4e455e8f3809c8ce37bee947690",
+                "versions.yml:md5,736da31f06f854355d45aeb9d9c874e0"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-04-07T18:04:50.627530843"
+    },
     "deseq2 - with transcript lengths": {
         "content": [
             [

--- a/subworkflows/nf-core/differential_functional_enrichment/main.nf
+++ b/subworkflows/nf-core/differential_functional_enrichment/main.nf
@@ -26,7 +26,7 @@ workflow DIFFERENTIAL_FUNCTIONAL_ENRICHMENT {
     // other - for the moment these files are only needed for GSEA
     // as it is the only one that takes expression data as input
     // if in the future this setting is changed, this section could be removed
-    ch_contrasts             // [ meta_contrast, contrast_variable, reference, target, formula ]
+    ch_contrasts             // [ meta_contrast, contrast_variable, reference, target, formula, comparison ]
     ch_samplesheet           // [ meta_exp, samples sheet ]
     ch_featuresheet          // [ meta_exp, features sheet, features id, features symbol ]
 
@@ -53,7 +53,7 @@ workflow DIFFERENTIAL_FUNCTIONAL_ENRICHMENT {
     // In the case of GSEA, it needs additional files coming from other channels that other methods don't use
     // here we define the input channel for the GSEA section
 
-    def criteria = multiMapCriteria { meta_input, input, genesets, meta_exp, samplesheet, featuresheet, features_id, features_symbol, meta_contrasts, variable, reference, target, _formula ->
+    def criteria = multiMapCriteria { meta_input, input, genesets, meta_exp, samplesheet, featuresheet, features_id, features_symbol, meta_contrasts, variable, reference, target, _formula, _comparison ->
         def meta_contrasts_new = meta_contrasts + [ 'variable': variable, 'reference': reference, 'target': target ]  // make sure variable, reference, target are in the meta
         def meta_all = mergeMaps(meta_contrasts_new, meta_input)
         input:

--- a/subworkflows/nf-core/differential_functional_enrichment/tests/main.nf.test
+++ b/subworkflows/nf-core/differential_functional_enrichment/tests/main.nf.test
@@ -37,7 +37,7 @@ nextflow_workflow {
                 ])
 
                 input[0] = ch_input
-                input[1] = Channel.of([[], [], [], [], []])
+                input[1] = Channel.of([[], [], [], [], [], []])
                 input[2] = Channel.of([[], []])
                 input[3] = Channel.of([[], [], [], []])
                 """
@@ -85,7 +85,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],
@@ -114,7 +114,7 @@ nextflow_workflow {
                     }
 
                 input[0] = ch_input
-                input[1] = Channel.of([[], [], [], [], []])
+                input[1] = Channel.of([[], [], [], [], [], []])
                 input[2] = Channel.of([[], []])
                 input[3] = Channel.of([[], [], [], []])
                 """
@@ -162,7 +162,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],
@@ -203,7 +203,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_samplesheet = Channel.of([
                     [ id:'test' ],
@@ -263,7 +263,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of([
                     [ id:'test' ],
@@ -293,7 +293,7 @@ nextflow_workflow {
                     }
 
                 input[0] = ch_input
-                input[1] = Channel.of([[], [], [], [], []])
+                input[1] = Channel.of([[], [], [], [], [], []])
                 input[2] = Channel.of([[], []])
                 input[3] = Channel.of([[], [], [], []])
                 """
@@ -339,7 +339,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_input = Channel.of(
                     [
@@ -406,7 +406,7 @@ nextflow_workflow {
                 ch_contrasts = Channel.fromPath(file(testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
                     .map{
-                        tuple(it, it.variable, it.reference, it.target, it.formula)
+                        tuple(it, it.variable, it.reference, it.target, it.formula, it.comparison)
                     }
                 ch_samplesheet = Channel.of([
                     [ id:'test' ],
@@ -460,7 +460,7 @@ nextflow_workflow {
                 ])
 
                 input[0] = ch_input
-                input[1] = Channel.of([[], [], [], [], []])
+                input[1] = Channel.of([[], [], [], [], [], []])
                 input[2] = Channel.of([[], []])
                 input[3] = Channel.of([[], [], [], []])
                 """


### PR DESCRIPTION
POC of https://github.com/nf-core/differentialabundance/issues/386

Current implementation is:
- If `comparison` is provided, then it is passed as a literal string to `limma::makeContrasts`.
- Otherwise, the previous design remains.
- The `comparison` is only used in `inputs.contrasts_for_diff_with_formula`, which is the input to `VARIANCEPARTITION_DREAM` in `ABUNDANCE_DIFFERENTIAL_FILTER` for now. 

@grst , when you have a chance, could you take a look and let me know if this implementation makes sense? If anything needs updating, I’m happy to make the changes.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
