### PR TITLE
update to doubled runner resources

### DIFF
--- a/tests/config/nextflow.config
+++ b/tests/config/nextflow.config
@@ -7,8 +7,8 @@ params {
 
 process {
     resourceLimits = [
-        cpus: 2,
-        memory: '4.GB',
+        cpus: 4,
+        memory: '16.GB',
         time: '1.h'
     ]
 }


### PR DESCRIPTION
A while ago github doubled the memory and cpu count in their runners (and we copied that with the self-hosted runners): https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories