### PR TITLE
handle filtered out moudles and subworkflow files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,7 +118,7 @@ jobs:
       - image=ubuntu22-full-x64
     name: nf-core lint modules
     needs: nf-core-changes
-    if: ${{ (needs.nf-core-changes.outputs.modules == 'true') }}
+    if: ${{ (needs.nf-core-changes.outputs.modules == 'true' && needs.nf-core-changes.outputs.modules != '[]') }}
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +166,7 @@ jobs:
       - image=ubuntu22-full-x64
     name: nf-core lint subworkflows
     needs: nf-core-changes
-    if: ${{ (needs.nf-core-changes.outputs.subworkflows == 'true') }}
+    if: ${{ (needs.nf-core-changes.outputs.subworkflows == 'true' && needs.nf-core-changes.outputs.subworkflows != '[]') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
FIxes cases like https://github.com/nf-core/modules/actions/runs/14330785888/job/40166110711?pr=8229
where nf-changes output
```
[modules/nf-core/survivor/filter/tests/main.nf.test,modules/nf-core/survivor/filter/tests/main.nf.test.snap]
[]
[]
[]
```
leads to failed `nf-core-lint-modules` steps.