### PR TITLE
Use pre-commit in fix-linting action

### DIFF
--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -79,4 +79,4 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             @${{ github.actor }} I tried to fix the linting errors, but it didn't work. Please fix them manually.
-            See [CI log](https://github.com/nf-core/tools/actions/runs/${{ github.run_id }}) for more details.
+            See [CI log](https://github.com/nf-core/modules/actions/runs/${{ github.run_id }}) for more details.


### PR DESCRIPTION
taken from https://github.com/nf-core/tools/blob/main/.github/workflows/fix-linting.yml

Saw this while working on https://github.com/nf-core/website/pull/3305