### PR TITLE
SENTIEON_BWAMEM license path 

### DIFF
--- a/modules/nf-core/sentieon/bwamem/main.nf
+++ b/modules/nf-core/sentieon/bwamem/main.nf
@@ -25,7 +25,7 @@ process SENTIEON_BWAMEM {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}.bam"
     def sentieonLicense = secrets.SENTIEON_LICENSE_BASE64 ?
-        "export SENTIEON_LICENSE=\$(mktemp);echo -e \"${secrets.SENTIEON_LICENSE_BASE64}\" | base64 -d > \$SENTIEON_LICENSE; " :
+        "export SENTIEON_LICENSE=\"\${PWD}/sentieon_license.lic\"; echo -e \"${secrets.SENTIEON_LICENSE_BASE64}\" | base64 -d > \${SENTIEON_LICENSE}; " :
         ""
 
     """


### PR DESCRIPTION
Sets it to a static file in the process instead of a temporary one. I don't love it, but it is what it is.