### PR TITLE
Fix KRAKEN2_ADD custom seqid2taxid support

### DIFF
--- a/modules/nf-core/kraken2/add/main.nf
+++ b/modules/nf-core/kraken2/add/main.nf
@@ -24,7 +24,7 @@ process KRAKEN2_ADD {
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
-    inject_custom_seqid2taxid_map = seqid2taxid ? "mv ${seqid2taxid} ${prefix}/" : ""
+    inject_custom_seqid2taxid_map = seqid2taxid ? "cp ${seqid2taxid} ${prefix}/" : ""
     """
     mkdir -p ${prefix}
     mv "taxonomy" ${prefix}


### PR DESCRIPTION
This replaces the `mv` command to a `cp`, as Kraken2 apparently ignores symlinks and will not detect the staged premade custom seqid2taxid.

By copying it it'll then make an actual file it'll then pick up

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
