### PR TITLE
Update vsearch/usearchglobal to strict syntax

### DIFF
--- a/modules/nf-core/vsearch/usearchglobal/main.nf
+++ b/modules/nf-core/vsearch/usearchglobal/main.nf
@@ -33,21 +33,36 @@ process VSEARCH_USEARCHGLOBAL {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def columns = user_columns ? "--userfields ${user_columns}" : ''
-    switch ( outoption ) {
-        case "alnout": outfmt = "--alnout"; out_ext = 'aln'; break
-        case "biomout": outfmt = "--biomout"; out_ext = 'biom'; break
-        case "blast6out": outfmt = "--blast6out"; out_ext = 'txt'; break
-        case "mothur_shared_out": outfmt = "--mothur_shared_out"; out_ext = 'mothur'; break
-        case "otutabout": outfmt = "--otutabout"; out_ext = 'otu'; break
-        case "samout": outfmt = "--samout"; out_ext = 'sam'; break
-        case "uc": outfmt = "--uc"; out_ext = 'uc'; break
-        case "userout": outfmt = "--userout"; out_ext = 'tsv'; break
-        case "lcaout": outfmt = "--lcaout"; out_ext = 'lca'; break
-        default:
-            outfmt = "--alnout";
-            out_ext = 'aln';
-            log.warn("Unknown output file format provided (${outoption}): selecting pairwise alignments (alnout)");
-            break
+    if (outoption == "alnout") {
+        outfmt = "--alnout"
+        out_ext = 'aln'
+    } else if (outoption == "biomout") {
+        outfmt = "--biomout"
+        out_ext = 'biom'
+    } else if (outoption == "blast6out") {
+        outfmt = "--blast6out"
+        out_ext = 'txt'
+    } else if (outoption == "mothur_shared_out") {
+        outfmt = "--mothur_shared_out"
+        out_ext = 'mothur'
+    } else if (outoption == "otutabout") {
+        outfmt = "--otutabout"
+        out_ext = 'otu'
+    } else if (outoption == "samout") {
+        outfmt = "--samout"
+        out_ext = 'sam'
+    } else if (outoption == "uc") {
+        outfmt = "--uc"
+        out_ext = 'uc'
+    } else if (outoption == "userout") {
+        outfmt = "--userout"; out_ext = 'tsv'
+    } else if (outoption == "lcaout") {
+        outfmt = "--lcaout"
+        out_ext = 'lca'
+    } else {
+        outfmt = "--alnout"
+        out_ext = 'aln'
+        log.warn("Unknown output file format provided (${outoption}): selecting pairwise alignments (alnout)")
     }
     """
     vsearch \\


### PR DESCRIPTION
The `switch` block in this module doesnt follow nextflow's _strict syntax_, the block is replaced here with if/else to make the module future proof.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
