### PR TITLE
updated for 9.5, remove gfastats from meta, fixed version output

### DIFF
--- a/modules/nf-core/gnu/sort/environment.yml
+++ b/modules/nf-core/gnu/sort/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::coreutils=9.3
+  - conda-forge::coreutils=9.5

--- a/modules/nf-core/gnu/sort/main.nf
+++ b/modules/nf-core/gnu/sort/main.nf
@@ -4,8 +4,8 @@ process GNU_SORT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/coreutils:9.3':
-        'biocontainers/coreutils:9.3' }"
+        'https://depot.galaxyproject.org/singularity/coreutils:9.5':
+        'biocontainers/coreutils:9.5' }"
 
     input:
     tuple val(meta), path(input)
@@ -22,14 +22,13 @@ process GNU_SORT {
     def prefix      = task.ext.prefix   ?: "${meta.id}"
     suffix          = task.ext.suffix   ?: "${input.extension}"
     output_file     = "${prefix}.${suffix}"
-    def VERSION     = "9.3"             // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     if ("$input" == "$output_file") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     sort ${args} ${input} > ${output_file}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        coreutils: $VERSION
+        coreutils: \$(sort --version |& sed '1!d ; s/sort (GNU coreutils) //')
     END_VERSIONS
     """
 
@@ -37,15 +36,13 @@ process GNU_SORT {
     def prefix      = task.ext.prefix   ?: "${meta.id}"
     suffix          = task.ext.suffix   ?: "${input.extension}"
     output_file     = "${prefix}.${suffix}"
-    def VERSION     = "9.3"
-
     if ("$input" == "$output_file") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """
     touch ${output_file}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        coreutils: $VERSION
+        coreutils: \$(sort --version |& sed '1!d ; s/sort (GNU coreutils) //')
     END_VERSIONS
     """
 }

--- a/modules/nf-core/gnu/sort/meta.yml
+++ b/modules/nf-core/gnu/sort/meta.yml
@@ -3,13 +3,18 @@ description: |
   Writes a sorted concatenation of file/s
 keywords:
   - GNU
+  - coreutils
   - sort
   - merge compare
 tools:
-  - sort:
-      description: "Writes a sorted concatenation of file/s"
-      homepage: "https://github.com/vgl-hub/gfastats"
-      documentation: "https://www.gnu.org/software/coreutils/manual/html_node/sort-invocation.html"
+  - "gnu":
+      description: "The GNU Core Utilities are the basic file, shell and text manipulation
+        utilities of the GNU operating system. These are the core utilities which are
+        expected to exist on every operating system."
+      homepage: "https://www.gnu.org/software/coreutils/"
+      documentation: "https://www.gnu.org/software/coreutils/manual/html_node/index.html"
+      tool_dev_url: "https://git.savannah.gnu.org/cgit/coreutils.git"
+      doi: "10.5281/zenodo.581670"
       licence: ["GPL"]
       identifier: ""
 input:

--- a/modules/nf-core/gnu/sort/tests/main.nf.test.snap
+++ b/modules/nf-core/gnu/sort/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
+                    "versions.yml:md5,0d7afd9c97fa2ed3cc6273a6158fb1c8"
                 ],
                 "sorted": [
                     [
@@ -22,15 +22,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
+                    "versions.yml:md5,0d7afd9c97fa2ed3cc6273a6158fb1c8"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-06-14T11:13:44.714632791"
+        "timestamp": "2025-04-22T17:00:56.041784"
     },
     "interval_sort": {
         "content": [
@@ -54,7 +54,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
+                    "versions.yml:md5,0d7afd9c97fa2ed3cc6273a6158fb1c8"
                 ],
                 "sorted": [
                     [
@@ -65,15 +65,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
+                    "versions.yml:md5,0d7afd9c97fa2ed3cc6273a6158fb1c8"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-06-14T11:13:51.456258705"
+        "timestamp": "2025-04-22T17:01:12.352886"
     },
     "csv_sort": {
         "content": [
@@ -97,7 +97,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
+                    "versions.yml:md5,0d7afd9c97fa2ed3cc6273a6158fb1c8"
                 ],
                 "sorted": [
                     [
@@ -108,15 +108,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
+                    "versions.yml:md5,0d7afd9c97fa2ed3cc6273a6158fb1c8"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-06-14T11:13:31.041778719"
+        "timestamp": "2025-04-22T17:00:23.567294"
     },
     "genome_sort": {
         "content": [
@@ -140,7 +140,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
+                    "versions.yml:md5,0d7afd9c97fa2ed3cc6273a6158fb1c8"
                 ],
                 "sorted": [
                     [
@@ -151,14 +151,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,dd412503ec9dd665203e083ea44326cb"
+                    "versions.yml:md5,0d7afd9c97fa2ed3cc6273a6158fb1c8"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-06-14T11:13:37.951397547"
+        "timestamp": "2025-04-22T17:00:40.089614"
     }
 }

--- a/modules/nf-core/gnu/split/environment.yml
+++ b/modules/nf-core/gnu/split/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::coreutils=9.3
+  - conda-forge::coreutils=9.5

--- a/modules/nf-core/gnu/split/main.nf
+++ b/modules/nf-core/gnu/split/main.nf
@@ -4,8 +4,8 @@ process GNU_SPLIT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/coreutils:9.3':
-        'biocontainers/coreutils:9.3' }"
+        'https://depot.galaxyproject.org/singularity/coreutils:9.5':
+        'biocontainers/coreutils:9.5' }"
 
     input:
     tuple val(meta), path(input)

--- a/modules/nf-core/gnu/split/tests/main.nf.test.snap
+++ b/modules/nf-core/gnu/split/tests/main.nf.test.snap
@@ -51,13 +51,13 @@
     },
     "split_csv_version": {
         "content": [
-            "versions.yml:md5,c38fd07d59dbe00739b38d5a7582518b"
+            "versions.yml:md5,203065874e53c65e263d069bdbb38577"
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-04-03T17:03:13.594709"
+        "timestamp": "2025-04-22T17:23:45.534966"
     },
     "split_fastq_gz_0": {
         "content": [
@@ -250,22 +250,22 @@
     },
     "split_fastq_gz_version": {
         "content": [
-            "versions.yml:md5,c38fd07d59dbe00739b38d5a7582518b"
+            "versions.yml:md5,203065874e53c65e263d069bdbb38577"
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-04-03T17:03:44.587886"
+        "timestamp": "2025-04-22T17:24:38.051931"
     },
     "split_stub_version": {
         "content": [
-            "versions.yml:md5,c38fd07d59dbe00739b38d5a7582518b"
+            "versions.yml:md5,203065874e53c65e263d069bdbb38577"
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-04-03T17:03:56.077482"
+        "timestamp": "2025-04-22T17:25:24.244781"
     }
 }


### PR DESCRIPTION
- Updates coreutils to 9.5.
- Removes gfastats link from meta.yml
- Corrected version output for sort.
- Updated snapshots