### PR TITLE
change links test-data to sarscov

### DIFF
--- a/modules/nf-core/links/tests/main.nf.test
+++ b/modules/nf-core/links/tests/main.nf.test
@@ -7,7 +7,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "links"
 
-    test("LINKS - LINKS test data") {
+    test("LINKS - sarscov2 test data - contigs") {
         config './nextflow.config'
 
         when {
@@ -18,11 +18,11 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.modules_testdata_base_path + 'genomics/scaffolding/LINKS/contigs.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true),
                 ]
                 input[1] = [
                     [ id:'test'], 
-                    file(params.modules_testdata_base_path + 'genomics/scaffolding/LINKS/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
                 ]
                 """
             }
@@ -48,7 +48,7 @@ nextflow_process {
 
     }
 
-    test("LINKS - longstitch test data 1") {
+    test("LINKS - sarscov2 test data - scaffolds") {
         config './nextflow.config'
 
         when {
@@ -59,11 +59,11 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.modules_testdata_base_path + 'genomics/scaffolding/longstitch/test_scaffolds1.fa', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/scaffolds.fasta', checkIfExists: true),
                 ]
                 input[1] = [
                     [ id:'test'], 
-                    file(params.modules_testdata_base_path + 'genomics/scaffolding/longstitch/test_reads1.fa.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true),
                 ]
                 """
             }
@@ -74,53 +74,13 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     file(process.out.log[0][1]).name,
-                    file(process.out.pairing_issues[0][1]).name,
+                    process.out.pairing_issues,
                     process.out.scaffolds_csv,
                     process.out.scaffolds_fasta,
                     process.out.bloom,
                     file(process.out.scaffolds_graph[0][1]).name,
-                    file(process.out.assembly_correspondence[0][1]).name,
-                    file(process.out.tigpair_checkpoint[0][1]).name,
-                    process.out.versions
-                    ).match()
-                }
-            )
-        }
-
-    }
-    test("LINKS - longstitch test data 2") {
-        config './nextflow.config'
-
-        when {
-            params {
-                module_args = "-d 1000,2000,3000,4000,5000,6000,7000,8000,9000,10000,12000,14000,16000,18000,20000"
-            }
-            process {
-                """
-                input[0] = [
-                    [ id:'test' ],
-                    file(params.modules_testdata_base_path + 'genomics/scaffolding/longstitch/test_scaffolds2.fa', checkIfExists: true),
-                ]
-                input[1] = [
-                    [ id:'test'], 
-                    file(params.modules_testdata_base_path + 'genomics/scaffolding/longstitch/test_reads2.fa.gz', checkIfExists: true),
-                ]
-                """
-            }
-        }
-
-        then {
-            assertAll(
-                { assert process.success },
-                { assert snapshot(
-                    file(process.out.log[0][1]).name,
-                    file(process.out.pairing_issues[0][1]).name,
-                    process.out.scaffolds_csv,
-                    process.out.scaffolds_fasta,
-                    process.out.bloom,
-                    file(process.out.scaffolds_graph[0][1]).name,
-                    file(process.out.assembly_correspondence[0][1]).name,
-                    file(process.out.tigpair_checkpoint[0][1]).name,
+                    process.out.assembly_correspondence,
+                    process.out.tigpair_checkpoint,
                     process.out.versions
                     ).match()
                 }
@@ -140,12 +100,12 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test' ], 
-                    file(params.modules_testdata_base_path + 'genomics/scaffolding/LINKS/contigs.fasta', checkIfExists: true),
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
                 ]
                 input[1] = [
-                    [ id:'test' ], 
-                    file(params.modules_testdata_base_path + 'genomics/scaffolding/LINKS/genome.fasta', checkIfExists: true),
+                    [ id:'test'], 
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true),
                 ]
                 """
             }

--- a/modules/nf-core/links/tests/main.nf.test.snap
+++ b/modules/nf-core/links/tests/main.nf.test.snap
@@ -1,4 +1,66 @@
 {
+    "LINKS - sarscov2 test data - scaffolds": {
+        "content": [
+            "test.log",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.pairing_issues:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.scaffolds:md5,095cc323b3af3a7873c8b80cf3736a1f"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.scaffolds.fa:md5,b8c7938abbc3d2f9b5c3d709d43b4a60"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.bloom:md5,23737e49d9a2f070b312da844201b494"
+                ]
+            ],
+            "test.gv",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.assembly_correspondence.tsv:md5,a65d30663dce705d382df52ab87ca8a4"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.tigpair_checkpoint.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                "versions.yml:md5,f58863e433b849b1ef0dfc19cb57656b"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-04-25T14:13:53.050775593"
+    },
     "LINKS - stub": {
         "content": [
             {
@@ -176,89 +238,7 @@
         },
         "timestamp": "2025-04-11T11:49:53.947870525"
     },
-    "LINKS - longstitch test data 1": {
-        "content": [
-            "test.log",
-            "test.pairing_issues",
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.scaffolds:md5,e12db5e5e6a1b5e26d2b50b6256c960d"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.scaffolds.fa:md5,afe56607a3d2c3b1e2d605bdf7ca545f"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.bloom:md5,b912b31cfadaf81e722f5441ac639f60"
-                ]
-            ],
-            "test.gv",
-            "test.assembly_correspondence.tsv",
-            "test.tigpair_checkpoint.tsv",
-            [
-                "versions.yml:md5,f58863e433b849b1ef0dfc19cb57656b"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-04-11T13:39:00.252899964"
-    },
-    "LINKS - longstitch test data 2": {
-        "content": [
-            "test.log",
-            "test.pairing_issues",
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.scaffolds:md5,00a943691b987adebe0ab40efced9c7e"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.scaffolds.fa:md5,ed43c629e8d440e3cf6fb8b21742557c"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.bloom:md5,695262bb4beda52665d2f7ec476a4e7b"
-                ]
-            ],
-            "test.gv",
-            "test.assembly_correspondence.tsv",
-            "test.tigpair_checkpoint.tsv",
-            [
-                "versions.yml:md5,f58863e433b849b1ef0dfc19cb57656b"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.3"
-        },
-        "timestamp": "2025-04-11T13:39:36.483298325"
-    },
-    "LINKS - LINKS test data": {
+    "LINKS - sarscov2 test data - contigs": {
         "content": [
             "test.log",
             [
@@ -266,7 +246,7 @@
                     {
                         "id": "test"
                     },
-                    "test.pairing_issues:md5,eb8b04b4ec170a319b40d2ee16a5cf96"
+                    "test.pairing_issues:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
             [
@@ -274,7 +254,7 @@
                     {
                         "id": "test"
                     },
-                    "test.scaffolds:md5,afe5339405b830e97095058080550064"
+                    "test.scaffolds:md5,41c129edd1e66140fcfb7efce81197ad"
                 ]
             ],
             [
@@ -282,7 +262,7 @@
                     {
                         "id": "test"
                     },
-                    "test.scaffolds.fa:md5,4aa442ee4b05e1608daf7b5b033a4203"
+                    "test.scaffolds.fa:md5,8abc4f609d0ad415f900b0046b38a72b"
                 ]
             ],
             [
@@ -290,7 +270,7 @@
                     {
                         "id": "test"
                     },
-                    "test.bloom:md5,96f54f577d1c589251ea0cfe624b898d"
+                    "test.bloom:md5,23737e49d9a2f070b312da844201b494"
                 ]
             ],
             "test.gv",
@@ -299,7 +279,7 @@
                     {
                         "id": "test"
                     },
-                    "test.assembly_correspondence.tsv:md5,0efc40db474ba8d5b334ad48add4bd9d"
+                    "test.assembly_correspondence.tsv:md5,b36e951b0a1bb4b1c1ccd50925392e3d"
                 ]
             ],
             [
@@ -307,7 +287,7 @@
                     {
                         "id": "test"
                     },
-                    "test.tigpair_checkpoint.tsv:md5,9208c8fe686b5989eaec1485a74cf44e"
+                    "test.tigpair_checkpoint.tsv:md5,168f2075f524a86216118c7230ad65e9"
                 ]
             ],
             [
@@ -318,6 +298,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-04-11T11:30:01.790074303"
+        "timestamp": "2025-04-25T14:07:49.212617595"
     }
 }


### PR DESCRIPTION
Following [some discussion on slack](https://nfcore.slack.com/archives/C02L5UB4Y9G/p1745578136387789), `scaffolding/` should be removed from `test-datasets/data/genomics/`. This module now uses sarscov2 data for testing.