### PR TITLE
Move extended arguments to end of krakenuniq command line.

### DIFF
--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -55,11 +55,11 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
 
         # Preload the KrakenUniq database into memory.
         krakenuniq \\
-            $args \\
             --db $db \\
             --preload \\
             --preload-size $ram_chunk_size \\
-            --threads $task.cpus
+            --threads $task.cpus \\
+            $args
 
         # Run the KrakenUniq classification on each sample in the batch.
         while IFS='\t' read -r SEQ PREFIX; do
@@ -93,11 +93,11 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
 
         # Preload the KrakenUniq database into memory.
         krakenuniq \\
-            $args \\
             --db $db \\
             --preload \\
             --preload-size $ram_chunk_size \\
-            --threads $task.cpus
+            --threads $task.cpus \\
+            $args
 
         # Run the KrakenUniq classification on each sample in the batch.
         while IFS='\t' read -r FIRST_SEQ SECOND_SEQ PREFIX; do
@@ -150,11 +150,11 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
 
         # Preload the KrakenUniq database into memory.
         echo krakenuniq \\
-            $args \\
             --db $db \\
             --preload \\
             --preload-size $ram_chunk_size \\
-            --threads $task.cpus
+            --threads $task.cpus \\
+            $args
 
         create_file() {
             echo '<3 nf-core' > "\$1"
@@ -201,11 +201,11 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
 
         # Preload the KrakenUniq database into memory.
         echo krakenuniq \\
-            $args \\
             --db $db \\
             --preload \\
             --preload-size $ram_chunk_size \\
-            --threads $task.cpus
+            --threads $task.cpus \\
+            $args
 
         create_file() {
             echo '<3 nf-core' > "\$1"


### PR DESCRIPTION
The `args` argument passes additional arguments to krakenuniq from `task.ext.args`.  Placing this argument last on the command line, and in particular, after `--preload-size $ram_chunk_size` allows this option to be overridden through the `task.ext.args`.

This change was suggested [here](https://github.com/nf-core/taxprofiler/issues/603).  In the context of [nf-core/taxprofiler](https://github.com/nf-core/taxprofiler), this PR enables the `ram_chunk_size` option to be passed in the input `database.csv` file.  Krakenuniq can be run: multiple times with a single database, with different `ram_chunk_size` values;  as suggested by @jfy133, using a different value of `ram_chunk_size` with each database.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
