### PR TITLE
Update BAM_MARKDUPLICATES_PICARD take docs

### DIFF
--- a/subworkflows/nf-core/bam_markduplicates_picard/main.nf
+++ b/subworkflows/nf-core/bam_markduplicates_picard/main.nf
@@ -10,8 +10,8 @@ workflow BAM_MARKDUPLICATES_PICARD {
 
     take:
     ch_reads   // channel: [ val(meta), path(reads) ]
-    ch_fasta // channel: [ path(fasta) ]
-    ch_fai   // channel: [ path(fai) ]
+    ch_fasta // channel: [ val(meta), path(fasta) ]
+    ch_fai   // channel: [ val(meta), path(fai) ]
 
     main:
 


### PR DESCRIPTION
This pull request updates the input channel definitions in the `BAM_MARKDUPLICATES_PICARD` workflow to include metadata for the `ch_fasta` and `ch_fai` channels. 

### Workflow input updates:

* [`subworkflows/nf-core/bam_markduplicates_picard/main.nf`](diffhunk://#diff-f860eca129d5e81ddd4fe2c0d56a7c3a8eae51d9beb2d78e944f636041f651b3L13-R14): Modified the `ch_fasta` and `ch_fai` channels to include `val(meta)` in addition to `path(fasta)` and `path(fai)` respectively. This ensures metadata is passed along with the file paths.


# PR Checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [[contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
