### PR TITLE
shellcheck: Run on .nf scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ test_output/
 tests/data/
 work/
 .github/CODEOWNERS-tmp
+shellcheck_output.json
+shellcheck_output.md

--- a/tests/test_shellcheck.py
+++ b/tests/test_shellcheck.py
@@ -1,0 +1,126 @@
+import json
+import os
+import re
+import subprocess
+import textwrap
+
+
+def extract_shell_scripts(nf_content):
+    # Match script or shell blocks with triple quotes, excluding groovy in between
+    # (e.g. // comments or def variable definitions)
+    pattern = re.compile(r'\n\s*(script|shell):\s*(?:.*?\n)*?\s*"""(.*?)"""', re.DOTALL)
+    matches = pattern.findall(nf_content)
+
+    scripts = []
+    positions = []
+
+    for match in matches:
+        script = match[1]
+        start_pos = nf_content.find(script)
+        scripts.append(script)
+        positions.append(start_pos)
+
+    return scripts, positions
+
+def save_scripts(scripts, base_filename):
+    script_files = []
+    for i, script in enumerate(scripts):
+        filename = f"{base_filename}_script_{i+1}.sh"
+        with open(filename, mode='w', newline="\n") as f:
+            # backslashes are escaped, so we unescape them:
+            script = script.replace("\\\\", "\\")
+            # the script is indented, we unindent it:
+            script = textwrap.dedent(script)
+            # Now it looks like the bash script, write it:
+            f.write(script)
+        script_files.append(filename)
+    return script_files
+
+def run_shellcheck(script_files, nf_content, positions, nf_file):
+    markdown_output = []
+    json_output = []
+    code_block = False  # Keep track of code blocks in markdown file
+    for i, script_file in enumerate(script_files):
+        with open(script_file) as f:
+            first_line = f.readline().strip()
+            if first_line.startswith('#!') and 'bash' not in first_line:
+                markdown_output.append(f"Skipping {script_file} due to non-Bash shebang: {first_line}\n")
+                json_output.append({"file": script_file, "message": f"Skipping due to non-Bash shebang: {first_line}"})
+                print(f"Skipping {script_file} due to non-Bash shebang: {first_line}")
+                continue
+
+        # Let shellcheck ignore SC2154 (ignore using undefined variables). There is a lot of
+        # false positives due to variables defined by groovy before the script.
+        result = subprocess.run(['shellcheck', '--shell=bash', '--exclude=SC2154', script_file], capture_output=True, text=True)
+        start_pos = positions[i]
+
+        if result.stdout or result.stderr:
+            if code_block:
+                markdown_output.append("\n```\n")
+                code_block = False
+            markdown_output.append(f"\n## ShellCheck results for `{nf_file}`:\n")
+            json_output.append({"file": nf_file, "results": [{"line": -1, "message": []}]})
+            print(f"\nShellCheck results for {nf_file}:\n")
+            for line in result.stdout.splitlines():
+                match = re.match('In (.*\\.sh) line (\\d+):', line)
+                if match:
+                    script_line_num = int(match.group(2))
+                    nf_line_num = nf_content.count('\n', 0, start_pos) + script_line_num
+                    if code_block:
+                        markdown_output.append("\n```\n")
+                        code_block = False
+                    markdown_output.append(f"### In `{nf_file}` line {nf_line_num}:\n")
+                    markdown_output.append("\n```\n")
+                    code_block = True
+                    json_output[-1]["results"].append({"line": nf_line_num, "message": [line]})
+                    print(f"In {nf_file} line {nf_line_num}:")
+                else:
+                    markdown_output.append(line + "\n")
+                    json_output[-1]["results"][-1]["message"].append(line)
+                    print(line)
+
+            if result.stderr:
+                markdown_output.append(result.stderr + "\n")
+                json_output[-1]["results"].append({"error": result.stderr})
+                print(result.stderr)
+        os.remove(script_file)
+
+    if code_block:
+        markdown_output.append("\n```\n")
+        code_block = False
+    return (markdown_output, json_output)
+
+
+
+def process_nf_file(nf_file):
+    with open(nf_file) as f:
+        nf_content = f.read().replace("\r\n", "\n")
+
+    scripts, positions = extract_shell_scripts(nf_content)
+    base_filename = os.path.splitext(nf_file.replace('/', '_'))[0]
+    script_files = save_scripts(scripts, base_filename)
+    return run_shellcheck(script_files, nf_content, positions, nf_file)
+
+def main():
+    nf_files = []
+    for root, dirs, files in os.walk('.'):
+        for file in files:
+            if file.endswith('.nf'):
+                nf_file = os.path.join(root, file)
+                nf_files.append(nf_file)
+    markdown_output = []
+    json_output = []
+    for i, nf_file in enumerate(nf_files):
+        print(f"Processing {nf_file} ({i+1}/{len(nf_files)})")
+        (md_i, js_i) = process_nf_file(nf_file)
+        markdown_output.extend(md_i)
+        json_output.extend(js_i)
+
+    with open("shellcheck_output.md", "w") as md_file:
+        md_file.writelines(markdown_output)
+
+    with open("shellcheck_output.json", "w") as json_file:
+        json.dump(json_output, json_file, indent=4)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I found a bug on a shell script embedded in a `script:` section of a nextflow file from one of the nf-core modules. I provided a fix on this PR:

- https://github.com/nf-core/modules/pull/8177

@mashehu suggested me to provide a unit test. I decided it would be better to use shellcheck on the script, to automatically report all warnings and linting errors.

Why not do it on all shell scripts in the nf-core/modules? I guess it could run on the CI if you wanted.

The included `tests/test_shellcheck.py` is a python script that extracts all the bash scripts from .nf files and runs shellcheck on them. Even if the scripts extracts each script block into a .sh file and runs shellcheck on it, the script parses shellcheck output and maps it to the original file and line. Besides, it reports the linting information on both markdown and json formats.

Since the `script:` sections use variables defined earlier in the nf script, and shellcheck is not aware of those variables, I have disabled the "undefined variable" warning (SC2154), because it gave lots of false positives.

I ran `python tests/test_shellcheck.py` and this was the generated output:

[shellcheck_output.json](https://github.com/user-attachments/files/20140994/shellcheck_output.json)
[shellcheck_output.md](https://github.com/user-attachments/files/20140995/shellcheck_output.md)

For your convenience, I uploaded the markdown file to a gist, so you can easily preview it:

https://gist.github.com/zeehio/305177fcbec25659211feb2276d5fe35

The report is long, and probably many of the warnings are harmless. Still, PR #8177 is proof that a linter would be beneficial to some of the shell scripts, and I believe shellcheck is quite widely used.

Disclaimer: I got support from an LLM (copilot) to speed up the development of this script.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
