### PR TITLE
`samtools/bgzip`: default to `fasta.gz` as file suffix.

### DIFF
--- a/modules/nf-core/samtools/bgzip/main.nf
+++ b/modules/nf-core/samtools/bgzip/main.nf
@@ -20,7 +20,7 @@ process SAMTOOLS_BGZIP {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    output = "${prefix}.gz"
+    output = "${prefix}.fasta.gz"
     """
     FILE_TYPE=\$(htsfile $fasta)
     case "\$FILE_TYPE" in

--- a/modules/nf-core/samtools/bgzip/tests/main.nf.test
+++ b/modules/nf-core/samtools/bgzip/tests/main.nf.test
@@ -53,7 +53,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'genome.fasta', single_end:false ], // meta map
+                input[0] = [ [ id:'genome', single_end:false ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true) ]
                 """
             }

--- a/modules/nf-core/samtools/bgzip/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/bgzip/tests/main.nf.test.snap
@@ -5,7 +5,7 @@
                 "0": [
                     [
                         {
-                            "id": "genome.fasta",
+                            "id": "genome",
                             "single_end": false
                         },
                         "genome.fasta.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
@@ -17,7 +17,7 @@
                 "fasta": [
                     [
                         {
-                            "id": "genome.fasta",
+                            "id": "genome",
                             "single_end": false
                         },
                         "genome.fasta.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
@@ -30,9 +30,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.6"
+            "nextflow": "25.04.0"
         },
-        "timestamp": "2025-05-08T17:25:33.790115"
+        "timestamp": "2025-05-13T12:59:22.890899759"
     },
     "test_samtools_bgzip - fasta": {
         "content": [
@@ -43,7 +43,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
+                        "test.fasta.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
                     ]
                 ],
                 "1": [
@@ -55,7 +55,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
+                        "test.fasta.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
                     ]
                 ],
                 "versions": [
@@ -65,9 +65,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.6"
+            "nextflow": "25.04.0"
         },
-        "timestamp": "2025-05-08T17:24:59.282133"
+        "timestamp": "2025-05-13T11:47:14.455609182"
     },
     "test_samtools_bgzip - fasta bgzipped": {
         "content": [
@@ -78,7 +78,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
+                        "test.fasta.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
                     ]
                 ],
                 "1": [
@@ -90,7 +90,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
+                        "test.fasta.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
                     ]
                 ],
                 "versions": [
@@ -100,9 +100,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.6"
+            "nextflow": "25.04.0"
         },
-        "timestamp": "2025-05-08T17:25:16.484846"
+        "timestamp": "2025-05-13T11:48:14.51040889"
     },
     "test_samtools_bgzip - fasta stub": {
         "content": [
@@ -148,7 +148,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.gz:md5,db0ecd5dbce6bf9730685b94ec87854d"
+                        "test.fasta.gz:md5,db0ecd5dbce6bf9730685b94ec87854d"
                     ]
                 ],
                 "1": [
@@ -160,7 +160,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.gz:md5,db0ecd5dbce6bf9730685b94ec87854d"
+                        "test.fasta.gz:md5,db0ecd5dbce6bf9730685b94ec87854d"
                     ]
                 ],
                 "versions": [
@@ -170,8 +170,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.6"
+            "nextflow": "25.04.0"
         },
-        "timestamp": "2025-05-08T17:25:52.739942"
+        "timestamp": "2025-05-13T11:50:14.675590675"
     }
 }


### PR DESCRIPTION
We know that the input is always a FASTA file.  This fix makes sure that the output name ends in `fasta.gz` without the user having to change the prefix or the meta.id.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
