### PR TITLE
Ensure concatenation is always in the same order

### DIFF
--- a/modules/nf-core/bcftools/concat/main.nf
+++ b/modules/nf-core/bcftools/concat/main.nf
@@ -29,6 +29,7 @@ process BCFTOOLS_CONCAT {
                 args.contains("--output-type z") || args.contains("-Oz") ? "vcf.gz" :
                 args.contains("--output-type v") || args.contains("-Ov") ? "vcf" :
                 "vcf"
+    def input = vcfs.sort{it.toString()}.join(" ")
     """
     ${create_input_index}
 
@@ -36,7 +37,7 @@ process BCFTOOLS_CONCAT {
         --output ${prefix}.${extension} \\
         $args \\
         --threads $task.cpus \\
-        ${vcfs}
+        ${input}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bcftools/concat/tests/main.nf.test
+++ b/modules/nf-core/bcftools/concat/tests/main.nf.test
@@ -9,7 +9,6 @@ nextflow_process {
     tag "bcftools"
     tag "bcftools/concat"
 
-
     test("homo_sapiens - [[vcf1, vcf2], [tbi1, tbi2]]") {
 
         config "./nextflow.config"

--- a/modules/nf-core/bcftools/concat/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/concat/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                     {
                         "id": "test3"
                     },
-                    "test3_vcf.vcf.gz:md5,5f6796c3ae109a1a5b87353954693f5a"
+                    "test3_vcf.vcf.gz:md5,3ca82190228ce687e21d1bd7599fe793"
                 ]
             ],
             [
@@ -26,9 +26,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:07:59.602632725"
+        "timestamp": "2025-05-13T15:54:28.967414243"
     },
     "homo_sapiens - [[vcf1, vcf2], []]": {
         "content": [
@@ -38,7 +38,7 @@
                         {
                             "id": "test3"
                         },
-                        "test3.vcf:md5,5f6796c3ae109a1a5b87353954693f5a"
+                        "test3.vcf:md5,3ca82190228ce687e21d1bd7599fe793"
                     ]
                 ],
                 "1": [
@@ -61,7 +61,7 @@
                         {
                             "id": "test3"
                         },
-                        "test3.vcf:md5,5f6796c3ae109a1a5b87353954693f5a"
+                        "test3.vcf:md5,3ca82190228ce687e21d1bd7599fe793"
                     ]
                 ],
                 "versions": [
@@ -71,9 +71,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:08:10.612937747"
+        "timestamp": "2025-05-13T15:54:57.525291616"
     },
     "homo_sapiens - [[vcf1, vcf2], [tbi1, tbi2]] - stub": {
         "content": [
@@ -116,9 +116,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:08:14.560167356"
+        "timestamp": "2025-05-13T15:55:09.668861806"
     },
     "homo_sapiens - [[vcf1, vcf2], [tbi1, tbi2]] - vcf_gz_index - stub": {
         "content": [
@@ -171,9 +171,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:08:21.582631265"
+        "timestamp": "2025-05-13T15:55:21.480201465"
     },
     "homo_sapiens - [[vcf1, vcf2], [tbi1, tbi2]] - vcf_gz_index_tbi": {
         "content": [
@@ -182,7 +182,7 @@
                     {
                         "id": "test3"
                     },
-                    "test3_vcf.vcf.gz:md5,5f6796c3ae109a1a5b87353954693f5a"
+                    "test3_vcf.vcf.gz:md5,3ca82190228ce687e21d1bd7599fe793"
                 ]
             ],
             [
@@ -202,9 +202,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:08:06.771571575"
+        "timestamp": "2025-05-13T15:54:42.767071694"
     },
     "homo_sapiens - [[vcf1, vcf2], [tbi1, tbi2]]": {
         "content": [
@@ -214,7 +214,7 @@
                         {
                             "id": "test3"
                         },
-                        "test3.vcf:md5,5f6796c3ae109a1a5b87353954693f5a"
+                        "test3.vcf:md5,3ca82190228ce687e21d1bd7599fe793"
                     ]
                 ],
                 "1": [
@@ -237,7 +237,7 @@
                         {
                             "id": "test3"
                         },
-                        "test3.vcf:md5,5f6796c3ae109a1a5b87353954693f5a"
+                        "test3.vcf:md5,3ca82190228ce687e21d1bd7599fe793"
                     ]
                 ],
                 "versions": [
@@ -247,9 +247,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:07:47.748357665"
+        "timestamp": "2025-05-13T15:53:54.158773297"
     },
     "homo_sapiens - [[vcf1, vcf2], [tbi1, tbi2]] - vcf_gz_index": {
         "content": [
@@ -258,7 +258,7 @@
                     {
                         "id": "test3"
                     },
-                    "test3_vcf.vcf.gz:md5,5f6796c3ae109a1a5b87353954693f5a"
+                    "test3_vcf.vcf.gz:md5,3ca82190228ce687e21d1bd7599fe793"
                 ]
             ],
             [
@@ -278,9 +278,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:07:55.303850698"
+        "timestamp": "2025-05-12T09:00:48.118242075"
     },
     "homo_sapiens - [[vcf1, vcf2], [tbi1, tbi2]] - vcf_gz_index_tbi - stub": {
         "content": [
@@ -333,9 +333,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:08:32.675839006"
+        "timestamp": "2025-05-13T15:55:47.059904526"
     },
     "homo_sapiens - [[vcf1, vcf2], [tbi1, tbi2]] - vcf_gz_index_csi - stub": {
         "content": [
@@ -388,8 +388,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2025-04-01T13:08:25.698924757"
+        "timestamp": "2025-05-13T15:55:32.755057506"
     }
 }

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/tests/main.nf.test.snap
@@ -129,10 +129,10 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2024-10-18T07:57:12.127577423"
+        "timestamp": "2025-05-12T09:04:28.296077"
     },
     "sarscov2 - ensemblvep - large chunks": {
         "content": [
@@ -170,10 +170,10 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2024-10-18T08:30:06.857146079"
+        "timestamp": "2025-05-12T09:06:05.270806802"
     },
     "sarscov2 - snpeff + ensemblvep": {
         "content": [
@@ -253,10 +253,10 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2024-10-18T08:29:31.390244289"
+        "timestamp": "2025-05-12T09:05:25.763430673"
     },
     "sarscov2 - ensemblvep - no scatter": {
         "content": [
@@ -330,9 +330,9 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2024-10-18T08:26:42.202930396"
+        "timestamp": "2025-05-12T09:03:00.46848908"
     }
 }


### PR DESCRIPTION
Ensure bcftools concatenation always occurs in the same order, no matter what order the vcf files arrive in the channel.