### PR TITLE
catpack/bins: Add bin_suffix as input

### DIFF
--- a/modules/nf-core/catpack/bins/main.nf
+++ b/modules/nf-core/catpack/bins/main.nf
@@ -13,6 +13,7 @@ process CATPACK_BINS {
     tuple val(meta3), path(taxonomy)
     tuple val(meta4), path(proteins)
     tuple val(meta5), path(diamond_table)
+    val(bin_suffix)
 
     output:
     tuple val(meta), path("*.ORF2LCA.txt"), emit: orf2lca
@@ -37,6 +38,7 @@ process CATPACK_BINS {
         -b bins/ \\
         -d ${database} \\
         -t ${taxonomy} \\
+        -s ${bin_suffix} \\
         ${premade_proteins} \\
         ${premade_table} \\
         -o ${prefix} \\

--- a/modules/nf-core/catpack/bins/meta.yml
+++ b/modules/nf-core/catpack/bins/meta.yml
@@ -86,6 +86,10 @@ input:
         ontologies:
           - edam: "http://edamontology.org/format_3751"
 
+  - - bin_suffix:
+        type: string
+        description: Suffix to search for in the input files when `bins` is a directory.
+
 output:
   - orf2lca:
       - meta:

--- a/modules/nf-core/catpack/bins/tests/main.nf.test
+++ b/modules/nf-core/catpack/bins/tests/main.nf.test
@@ -36,6 +36,7 @@ nextflow_process {
                 input[2] = CATPACK_PREPARE.out.taxonomy
                 input[3] = [[:], []]
                 input[4] = [[:], []]
+                input[5] = '.fasta'
                 """
             }
         }
@@ -83,6 +84,7 @@ nextflow_process {
                 input[2] = CATPACK_PREPARE.out.taxonomy
                 input[3] = CATPACK_CONTIGS.out.faa
                 input[4] = [[:], []]
+                input[5] = '.fasta'
                 """
             }
         }
@@ -116,6 +118,7 @@ nextflow_process {
                 input[2] = CATPACK_PREPARE.out.taxonomy
                 input[3] = [[:], []]
                 input[4] = [[:], []]
+                input[5] = '.fasta'
                 """
             }
         }

--- a/modules/nf-core/catpack/summarise/tests/main.nf.test
+++ b/modules/nf-core/catpack/summarise/tests/main.nf.test
@@ -85,6 +85,7 @@ nextflow_process {
                     input[2] = CATPACK_PREPARE.out.taxonomy
                     input[3] = [[:], []]
                     input[4] = [[:], []]
+                    input[5] = '.fasta'
                     """
                     }
                 }


### PR DESCRIPTION
This PR exposes the parameter `--bin_suffix` / `-s` as input in catpack/bins.
This parameter is used when the `bins` parameter is a directory. The application default (`.fna`) it's not suitable for common binning tools, which generates the bin files with `.fa` extension.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
