### PR TITLE
Draft: Nftest migration metaphlan3

### DIFF
--- a/modules/nf-core/metaphlan3/metaphlan3/tests/main.nf.test
+++ b/modules/nf-core/metaphlan3/metaphlan3/tests/main.nf.test
@@ -1,7 +1,6 @@
 nextflow_process {
 
     name "Test Process METAPHLAN3_METAPHLAN3"
-    config "./nextflow.config"
     script "../main.nf"
     process "METAPHLAN3_METAPHLAN3"
 
@@ -10,81 +9,166 @@ nextflow_process {
     tag "metaphlan"
     tag "untar"
 
-    // config './nextflow.config'
-
     setup {
         run("UNTAR") {
             script "../../../untar/main.nf"
             process {
             """
             input[0] = [
-                        [ id:'test' ], // meta map
-                        file(params.modules_testdata_base_path + 'modules/data/delete_me/metaphlan_database.tar.gz', checkIfExists: true)
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'delete_me/metaphlan_database.tar.gz', checkIfExists: true)
             ]
             """
             }
         }
     }
 
+
+
     test("metaphlan3 single-end") {
 
         when {
-            // params {
-            //     module_args  = ''
-            //     module_args2 = '--var_type SNP --sensitivity 99.0'
-            // }
             process {
                 """
                 input[0] = [
-                    [ id:'test' ],
-                    [ single_end:true ],
-                    [ params.modules_testdata_base_path + 'modules/data/delete_me/metaphlan_database', checkIfExists: true ]
+                    [ id:'test', single_end:true ],
+                    [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
                 ]
+                input[1] = UNTAR.out.untar.map{it[1]}
                 """
             }
         }
         then {
             assert process.success
             assertAll(
+                // { assert snapshot(process.out).match() },
+                { assert path(process.out.biom[0][1]).text.contains('"format": "Biological Observation Matrix 1.0.0","format_url": "http://biom-format.org","generated_by"') },
                 { assert snapshot(
-                    process.out
-                    ).match()
-                }
+                    process.out.bt2out,
+                    process.out.profile
+                    ).match()}
             )
         }
     }
 
+    // excluded because process expects DB
+    // test("metaphlan3 single-end no DB") {
 
-    // test("homo sapiens -- stub") {
-    //     options '-stub'
     //     when {
-    //         params {
-    //             module_args  = ''
-    //             module_args2 = '--var_type SNP --sensitivity 99.0'
-    //         }
     //         process {
     //             """
-    //             input[0] = [[id:'test'],
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz', checkIfExists:true),
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz.tbi', checkIfExists:true),
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/variantrecalibrator/test2.recal', checkIfExists:true),
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/variantrecalibrator/test2.recal.idx', checkIfExists:true),
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/variantrecalibrator/test2.tranches', checkIfExists:true)
-    //                 ]
-    //             input[1] = [[:],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)]
-    //             input[2] = [[:],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)]
+    //             input[0] = [
+    //                 [ id:'test', single_end:true ],
+    //                 [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ]
+    //             ]
+    //             input[1] = []
     //             """
     //         }
     //     }
     //     then {
     //         assert process.success
     //         assertAll(
+    //             { assert path(process.out.biom[0][1]).text.contains('"format": "Biological Observation Matrix 1.0.0","format_url": "http://biom-format.org","generated_by"') },
     //             { assert snapshot(
-    //                 process.out,
-    //                 path(process.out.versions[0]).yaml
-    //                 ).match()
-    //             }
+    //                 process.out.bt2out,
+    //                 process.out.profile
+    //                 ).match()}
     //         )
     //     }
     // }
+
+    test("metaphlan3 paired end") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                      file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)]
+                ]
+                input[1] = UNTAR.out.untar.map{it[1]}
+                """
+            }
+        }
+        then {
+            assert process.success
+            assertAll(
+                { assert path(process.out.biom[0][1]).text.contains('"format": "Biological Observation Matrix 1.0.0","format_url": "http://biom-format.org","generated_by"') },
+                { assert snapshot(
+                    process.out.bt2out,
+                    process.out.profile
+                    ).match()}
+            )
+        }
+    }
+
+    test("metaphlan3 sam") {
+
+        setup {
+            run("SAMTOOLS_VIEW"){
+                script "../../../samtools/view/main.nf"
+                process {
+                """
+                input[0] = [
+                    [ id:'test'],
+                    [ file(params.test_data['sarscov2']['illumina']['test_single_end_bam'], checkIfExists: true) ],
+                    []
+                ]
+                input[1] = [[],[]]
+                input[2] = []
+                input[3] = []
+                """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ],
+                    [ SAMTOOLS_VIEW.out.bam.map{it[1]} ]
+                ]
+                input[1] = UNTAR.out.untar.val[0][1]
+                """
+            }
+        }
+        then {
+            assert process.success
+            assertAll(
+                { assert path(process.out.biom[0][1]).text.contains('"format": "Biological Observation Matrix 1.0.0","format_url": "http://biom-format.org","generated_by"') },
+                { assert snapshot(
+                    process.out.bt2out,
+                    process.out.profile
+                    ).match()}
+            )
+        }
+    }
+
+    test("metaphlan3 fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ],
+                    [ file(params.test_data['sarscov2']['genome']['transcriptome_fasta'], checkIfExists: true) ]
+                ]
+                input[1] = UNTAR.out.untar.map{it[1]}
+                """
+            }
+        }
+        then {
+            assert process.success
+            assertAll(
+                { assert path(process.out.biom[0][1]).text.contains('"format": "Biological Observation Matrix 1.0.0","format_url": "http://biom-format.org","generated_by"') },
+                { assert snapshot(
+                    process.out.bt2out,
+                    process.out.profile
+                    ).match()}
+            )
+        }
+    }
+
 }

--- a/modules/nf-core/metaphlan3/metaphlan3/tests/main.nf.test
+++ b/modules/nf-core/metaphlan3/metaphlan3/tests/main.nf.test
@@ -1,0 +1,90 @@
+nextflow_process {
+
+    name "Test Process METAPHLAN3_METAPHLAN3"
+    config "./nextflow.config"
+    script "../main.nf"
+    process "METAPHLAN3_METAPHLAN3"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "metaphlan"
+    tag "untar"
+
+    // config './nextflow.config'
+
+    setup {
+        run("UNTAR") {
+            script "../../../untar/main.nf"
+            process {
+            """
+            input[0] = [
+                        [ id:'test' ], // meta map
+                        file(params.modules_testdata_base_path + 'modules/data/delete_me/metaphlan_database.tar.gz', checkIfExists: true)
+            ]
+            """
+            }
+        }
+    }
+
+    test("metaphlan3 single-end") {
+
+        when {
+            // params {
+            //     module_args  = ''
+            //     module_args2 = '--var_type SNP --sensitivity 99.0'
+            // }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    [ single_end:true ],
+                    [ params.modules_testdata_base_path + 'modules/data/delete_me/metaphlan_database', checkIfExists: true ]
+                ]
+                """
+            }
+        }
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out
+                    ).match()
+                }
+            )
+        }
+    }
+
+
+    // test("homo sapiens -- stub") {
+    //     options '-stub'
+    //     when {
+    //         params {
+    //             module_args  = ''
+    //             module_args2 = '--var_type SNP --sensitivity 99.0'
+    //         }
+    //         process {
+    //             """
+    //             input[0] = [[id:'test'],
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz', checkIfExists:true),
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz.tbi', checkIfExists:true),
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/variantrecalibrator/test2.recal', checkIfExists:true),
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/variantrecalibrator/test2.recal.idx', checkIfExists:true),
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/variantrecalibrator/test2.tranches', checkIfExists:true)
+    //                 ]
+    //             input[1] = [[:],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)]
+    //             input[2] = [[:],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)]
+    //             """
+    //         }
+    //     }
+    //     then {
+    //         assert process.success
+    //         assertAll(
+    //             { assert snapshot(
+    //                 process.out,
+    //                 path(process.out.versions[0]).yaml
+    //                 ).match()
+    //             }
+    //         )
+    //     }
+    // }
+}

--- a/modules/nf-core/metaphlan3/metaphlan3/tests/nextflow.config
+++ b/modules/nf-core/metaphlan3/metaphlan3/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+  withName: 'MODULE' {
+    ext.args = params.module_args
+  }
+}

--- a/modules/nf-core/metaphlan3/metaphlan3/tests/nextflow.config
+++ b/modules/nf-core/metaphlan3/metaphlan3/tests/nextflow.config
@@ -1,5 +1,9 @@
 process {
-  withName: 'MODULE' {
-    ext.args = params.module_args
-  }
+
+    // publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    withName: METAPHLAN3_METAPHLAN3 {
+        ext.args = '--index mpa_v30_CHOCOPhlAn_201901 --add_viruses --bt2_ps very-sensitive-local'
+    }
+
 }

--- a/modules/nf-core/metaphlan3/metaphlan3/tests/nf-test.config
+++ b/modules/nf-core/metaphlan3/metaphlan3/tests/nf-test.config
@@ -1,8 +1,0 @@
-config {
-
-    testsDir "tests"
-    workDir ".nf-test"
-    configFile "tests/nextflow.config"
-    profile ""
-
-}

--- a/modules/nf-core/metaphlan3/metaphlan3/tests/nf-test.config
+++ b/modules/nf-core/metaphlan3/metaphlan3/tests/nf-test.config
@@ -1,0 +1,8 @@
+config {
+
+    testsDir "tests"
+    workDir ".nf-test"
+    configFile "tests/nextflow.config"
+    profile ""
+
+}


### PR DESCRIPTION
Closes #7621 

Description of changes:
This PR migrates unit tests for metaphlan3/metaphlan3 from pytest to nf-test, and makes some minor corrections to these tests, described below.  
- Omitted previous test conditions which checked the hashes of metaphlan database files. Reasoning: these are static input files and do not need to be checked for integrity in this unit test.
- Changed references to the path of test input files to use `params.modules_testdata_base_path`
- Omitted previous test case which called metaphlan3 without a database input. Current implementation of metaphlan3 process appears to fail in absence of a database input. 
- 


- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
