### PR TITLE
Fix genome BAM dedup log reused for transcriptome dedup

### DIFF
--- a/subworkflows/nf-core/bam_dedup_umi/main.nf
+++ b/subworkflows/nf-core/bam_dedup_umi/main.nf
@@ -65,7 +65,7 @@ workflow BAM_DEDUP_UMI {
             ch_sorted_transcriptome_bam
         )
         UMI_DEDUP_TRANSCRIPTOME = BAM_DEDUP_STATS_SAMTOOLS_UMICOLLAPSE_TRANSCRIPTOME
-        ch_dedup_log = ch_dedup_log.mix(UMI_DEDUP_GENOME.out.dedup_stats)
+        ch_dedup_log = ch_dedup_log.mix(UMI_DEDUP_TRANSCRIPTOME.out.dedup_stats)
 
     } else if (umi_dedup_tool == "umitools") {
         BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_TRANSCRIPTOME (
@@ -73,7 +73,7 @@ workflow BAM_DEDUP_UMI {
             umitools_dedup_stats
         )
         UMI_DEDUP_TRANSCRIPTOME = BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_TRANSCRIPTOME
-        ch_dedup_log = ch_dedup_log.mix(UMI_DEDUP_GENOME.out.deduplog)
+        ch_dedup_log = ch_dedup_log.mix(UMI_DEDUP_TRANSCRIPTOME.out.deduplog)
     }
 
     // 3. Restore name sorting


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## Description

Genome BAM deduplication log (`UMI_DEDUP_GENOME.out.deduplog`) is being reused for transcriptome deduplication, leading to a duplicate log in `ch_dedup_log` and input file name collisions downstream.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!