### PR TITLE
Also compute ungapped percent identity scores in `last/split`.

### DIFF
--- a/modules/nf-core/last/split/main.nf
+++ b/modules/nf-core/last/split/main.nf
@@ -30,15 +30,18 @@ process LAST_SPLIT {
             FS="\t";  # Set field separator as tab
             totalMatches = 0;
             totalAlignmentLength = 0;
-            print "Sample\tTotalAlignmentLength\tPercentSimilarity";  # Header for MultiQC
+            totalAlignedBases = 0;
+            print "Sample\tTotalAlignmentLength\tPercentIdentity\tPercentIdentityNoGaps";  # Header for MultiQC
         }
         {
-            totalMatches += \$1 + \$3;  # Sum matches and repMatches
+            totalMatches         += \$1 +       \$3            ;  # Sum matches          and repMatches
             totalAlignmentLength += \$1 + \$2 + \$3 + \$6 + \$8;  # Sum matches, misMatches, repMatches, qBaseInsert, and tBaseInsert
+            totalAlignedBases    += \$1 + \$2 + \$3            ;  # Sum matches, misMatches, repMatches
         }
         END {
-            percentSimilarity = (totalAlignmentLength > 0) ? (totalMatches / totalAlignmentLength * 100) : 0;
-            print "$meta.id" "\t" totalAlignmentLength "\t" percentSimilarity;  # Data in TSV format
+            percentIdentity       = (totalAlignmentLength > 0) ? (totalMatches / totalAlignmentLength * 100) : 0;
+            percentIdentityNoGaps = (totalAlignmentLength > 0) ? (totalMatches / totalAlignedBases    * 100) : 0;
+            print "$meta.id" "\t" totalAlignmentLength "\t" percentIdentity "\t" percentIdentityNoGaps;  # Data in TSV format
         }'
     }
 

--- a/modules/nf-core/last/split/meta.yml
+++ b/modules/nf-core/last/split/meta.yml
@@ -44,7 +44,11 @@ output:
             e.g. `[ id:'sample1', single_end:false ]`
       - "*.tsv":
           type: file
-          description: Alignment summary for MultiQC
+          description: |
+            Summary reporting the total alignment length (including gaps) and the
+            percent identity computed with and without taking gaps in
+            consideration (because there is no standard definition of percent
+            identity).
           pattern: "*.tsv"
   - versions:
       - versions.yml:

--- a/modules/nf-core/last/split/tests/main.nf.test.snap
+++ b/modules/nf-core/last/split/tests/main.nf.test.snap
@@ -15,7 +15,7 @@
                         {
                             "id": "sarscov.contigs.genome"
                         },
-                        "sarscov.contigs.genome.tsv:md5,b625a3b37343e9e6a279b8625d4c2da8"
+                        "sarscov.contigs.genome.tsv:md5,6e4f22bc59654f22c3ef8ae4413cbb12"
                     ]
                 ],
                 "2": [
@@ -34,7 +34,7 @@
                         {
                             "id": "sarscov.contigs.genome"
                         },
-                        "sarscov.contigs.genome.tsv:md5,b625a3b37343e9e6a279b8625d4c2da8"
+                        "sarscov.contigs.genome.tsv:md5,6e4f22bc59654f22c3ef8ae4413cbb12"
                     ]
                 ],
                 "versions": [
@@ -44,9 +44,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2025-03-10T11:00:15.703945"
+        "timestamp": "2025-05-16T11:38:08.055900921"
     },
     "sarscov2 - contigs_genome - stub": {
         "content": [


### PR DESCRIPTION
I am sorry @mashehu; I forgot that `last/split` also computes identity scores.  Can I ask you for a quick check on this one too?  :bow: The AWK code is identical to the one in PR #8480 after I applied your suggestions.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
