### PR TITLE
Improve catpack/download output structure

### DIFF
--- a/modules/nf-core/catpack/download/main.nf
+++ b/modules/nf-core/catpack/download/main.nf
@@ -15,6 +15,7 @@ process CATPACK_DOWNLOAD {
     tuple val(meta), path("${prefix}/*.names.dmp"), emit: names
     tuple val(meta), path("${prefix}/*.nodes.dmp"), emit: nodes
     tuple val(meta), path("${prefix}/*accession2taxid*.gz"), emit: acc2tax
+    tuple val(meta), path("${prefix}/*.log"), emit: log
     path "versions.yml", emit: versions
 
     when:
@@ -47,10 +48,11 @@ process CATPACK_DOWNLOAD {
         -o ${prefix}/"
 
     mkdir ${prefix}/
-    echo "" | gzip > ${prefix}/cat_db.${db}.gz
-    touch ${prefix}/cat_db.names.dmp
-    touch ${prefix}/cat_db.nodes.dmp
-    echo "" | gzip > ${prefix}/cat_db.accession2taxid.gz
+    echo "" | gzip > ${prefix}/${prefix}.${db}.gz
+    touch ${prefix}/${prefix}.names.dmp
+    touch ${prefix}/${prefix}.nodes.dmp
+    echo "" | gzip > ${prefix}/${prefix}.accession2taxid.gz
+    touch ${prefix}/${prefix}.log
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/catpack/download/main.nf
+++ b/modules/nf-core/catpack/download/main.nf
@@ -11,7 +11,10 @@ process CATPACK_DOWNLOAD {
     tuple val(meta), val(db)
 
     output:
-    tuple val(meta), path("${prefix}/"), emit: rawdb
+    tuple val(meta), path("${prefix}/*.${db}.gz"), emit: fasta
+    tuple val(meta), path("${prefix}/*.names.dmp"), emit: names
+    tuple val(meta), path("${prefix}/*.nodes.dmp"), emit: nodes
+    tuple val(meta), path("${prefix}/*accession2taxid*.gz"), emit: acc2tax
     path "versions.yml", emit: versions
 
     when:
@@ -44,6 +47,10 @@ process CATPACK_DOWNLOAD {
         -o ${prefix}/"
 
     mkdir ${prefix}/
+    echo "" | gzip > ${prefix}/cat_db.${db}.gz
+    touch ${prefix}/cat_db.names.dmp
+    touch ${prefix}/cat_db.nodes.dmp
+    echo "" | gzip > ${prefix}/cat_db.accession2taxid.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/catpack/download/meta.yml
+++ b/modules/nf-core/catpack/download/meta.yml
@@ -36,7 +36,7 @@ output:
       - "${prefix}/*.${db}.gz":
           type: file
           description: FASTA file containing all the NCBI NR or GTDB sequences
-          pattern: "${prefix}/*.${db}.gz"
+          pattern: "*.${db}.gz"
           ontologies:
             - edam: "http://edamontology.org/format_1929"
   - names:
@@ -48,7 +48,7 @@ output:
       - "${prefix}/*.names.dmp":
           type: file
           description: NCBI taxonomy-style names text file
-          pattern: "${prefix}/*.names.dmp"
+          pattern: "*.names.dmp"
           ontologies:
             - edam: "http://edamontology.org/format_1964"
   - nodes:
@@ -60,7 +60,7 @@ output:
       - "${prefix}/*.nodes.dmp":
           type: file
           description: NCBI taxonomy-style nodes text file
-          pattern: "${prefix}/*.nodes.dmp"
+          pattern: "*.nodes.dmp"
           ontologies:
             - edam: "http://edamontology.org/format_1964"
   - acc2tax:
@@ -72,7 +72,19 @@ output:
       - "${prefix}/*accession2taxid*.gz":
           type: file
           description: NCBI taxonomy names accession to taxonomy file
-          pattern: "${prefix}/*accession2taxid*"
+          pattern: "*accession2taxid*"
+          ontologies:
+            - edam: "http://edamontology.org/format_1964"
+  - log:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "${prefix}/*.log":
+          type: file
+          description: Log file of the download process
+          pattern: "*.log"
           ontologies:
             - edam: "http://edamontology.org/format_1964"
 

--- a/modules/nf-core/catpack/download/meta.yml
+++ b/modules/nf-core/catpack/download/meta.yml
@@ -27,18 +27,55 @@ input:
         pattern: "nr|gtdb"
 
 output:
-  - rawdb:
+  - fasta:
       - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "${prefix}/":
-          type: directory
-          description: Directory containing all the required NCBI Nr or GTDB database files required for building into a CAT database
-          pattern: "${db}/"
+      - "${prefix}/*.${db}.gz":
+          type: file
+          description: FASTA file containing all the NCBI NR or GTDB sequences
+          pattern: "${prefix}/*.${db}.gz"
           ontologies:
-            - edam: "http://edamontology.org/data_1049"
+            - edam: "http://edamontology.org/format_1929"
+  - names:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "${prefix}/*.names.dmp":
+          type: file
+          description: NCBI taxonomy-style names text file
+          pattern: "${prefix}/*.names.dmp"
+          ontologies:
+            - edam: "http://edamontology.org/format_1964"
+  - nodes:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "${prefix}/*.nodes.dmp":
+          type: file
+          description: NCBI taxonomy-style nodes text file
+          pattern: "${prefix}/*.nodes.dmp"
+          ontologies:
+            - edam: "http://edamontology.org/format_1964"
+  - acc2tax:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "${prefix}/*accession2taxid*.gz":
+          type: file
+          description: NCBI taxonomy names accession to taxonomy file
+          pattern: "${prefix}/*accession2taxid*"
+          ontologies:
+            - edam: "http://edamontology.org/format_1964"
+
   - versions:
       - "versions.yml":
           type: file

--- a/modules/nf-core/catpack/download/meta.yml
+++ b/modules/nf-core/catpack/download/meta.yml
@@ -24,7 +24,7 @@ input:
     - db:
         type: string
         description: Which database to download
-        pattern: "nr|gtdb"
+        pattern: "nr|GTDB"
 
 output:
   - fasta:

--- a/modules/nf-core/catpack/download/meta.yml
+++ b/modules/nf-core/catpack/download/meta.yml
@@ -47,7 +47,7 @@ output:
             e.g. `[ id:'sample1', single_end:false ]`
       - "${prefix}/*.names.dmp":
           type: file
-          description: NCBI taxonomy-style names text file
+          description: NCBI taxonomy-style names.dmp text file
           pattern: "*.names.dmp"
           ontologies:
             - edam: "http://edamontology.org/format_1964"
@@ -59,7 +59,7 @@ output:
             e.g. `[ id:'sample1', single_end:false ]`
       - "${prefix}/*.nodes.dmp":
           type: file
-          description: NCBI taxonomy-style nodes text file
+          description: NCBI taxonomy-style nodes.dmp text file
           pattern: "*.nodes.dmp"
           ontologies:
             - edam: "http://edamontology.org/format_1964"

--- a/modules/nf-core/catpack/download/tests/main.nf.test.snap
+++ b/modules/nf-core/catpack/download/tests/main.nf.test.snap
@@ -8,23 +8,73 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        [
-                            
-                        ]
+                        "cat_db.nr.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,e1493fe75b3b8cc2bc0cbd1d5ddfad44"
-                ],
-                "rawdb": [
                     [
                         {
                             "id": "nr",
                             "single_end": false
                         },
-                        [
-                            
-                        ]
+                        "cat_db.names.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "nr",
+                            "single_end": false
+                        },
+                        "cat_db.nodes.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "nr",
+                            "single_end": false
+                        },
+                        "cat_db.accession2taxid.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,e1493fe75b3b8cc2bc0cbd1d5ddfad44"
+                ],
+                "acc2tax": [
+                    [
+                        {
+                            "id": "nr",
+                            "single_end": false
+                        },
+                        "cat_db.accession2taxid.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "nr",
+                            "single_end": false
+                        },
+                        "cat_db.nr.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "names": [
+                    [
+                        {
+                            "id": "nr",
+                            "single_end": false
+                        },
+                        "cat_db.names.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "nodes": [
+                    [
+                        {
+                            "id": "nr",
+                            "single_end": false
+                        },
+                        "cat_db.nodes.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -33,9 +83,9 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2024-12-19T16:19:22.533589236"
+        "timestamp": "2025-05-22T00:21:47.801388249"
     }
 }

--- a/modules/nf-core/catpack/download/tests/main.nf.test.snap
+++ b/modules/nf-core/catpack/download/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        "cat_db.nr.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "nr.nr.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "1": [
@@ -17,7 +17,7 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        "cat_db.names.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "nr.names.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "2": [
@@ -26,7 +26,7 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        "cat_db.nodes.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "nr.nodes.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "3": [
@@ -35,10 +35,19 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        "cat_db.accession2taxid.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "nr.accession2taxid.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "4": [
+                    [
+                        {
+                            "id": "nr",
+                            "single_end": false
+                        },
+                        "nr.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
                     "versions.yml:md5,e1493fe75b3b8cc2bc0cbd1d5ddfad44"
                 ],
                 "acc2tax": [
@@ -47,7 +56,7 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        "cat_db.accession2taxid.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "nr.accession2taxid.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "fasta": [
@@ -56,7 +65,16 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        "cat_db.nr.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "nr.nr.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "nr",
+                            "single_end": false
+                        },
+                        "nr.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "names": [
@@ -65,7 +83,7 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        "cat_db.names.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "nr.names.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "nodes": [
@@ -74,7 +92,7 @@
                             "id": "nr",
                             "single_end": false
                         },
-                        "cat_db.nodes.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "nr.nodes.dmp:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -86,6 +104,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.2"
         },
-        "timestamp": "2025-05-22T00:21:47.801388249"
+        "timestamp": "2025-05-22T01:16:45.367749401"
     }
 }


### PR DESCRIPTION
Exposes individual output files generated by `catpack/download` to improve integration with `catpack/prepare`, which expects each input file to be separate.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
