### PR TITLE
Allow all conda channels except for `default` in `environment.yml`

### DIFF
--- a/modules/environment-schema.json
+++ b/modules/environment-schema.json
@@ -7,9 +7,11 @@
         "channels": {
             "type": "array",
             "items": {
-                "enum": ["bioconda", "conda-forge"]
-            },
-            "minItems": 2
+                "type": "string",
+                "not": {
+                    "const": "default"
+                }
+            }
         },
         "dependencies": {
             "type": "array",


### PR DESCRIPTION
Fixes https://github.com/nf-core/tools/issues/3499