### PR TITLE
make the meta.yml match the name and order of the main.nf input

### DIFF
--- a/subworkflows/nf-core/fastq_trim_fastp_fastqc/meta.yml
+++ b/subworkflows/nf-core/fastq_trim_fastp_fastqc/meta.yml
@@ -24,17 +24,17 @@ input:
       description: |
         Structure: path(adapter_fasta)
         File in FASTA format containing possible adapters to remove.
-  - val_discard_trimmed:
-      type: boolean
-      description: |
-        Structure: val(discard_trimmed)
-        Specify true to not write any reads that pass trimming thresholds.
-        This can be used to use fastp for the output report only.
   - val_save_trimmed_fail:
       type: boolean
       description: |
         Structure: val(save_trimmed_fail)
         Specify true to save files that failed to pass trimming thresholds ending in `*.fail.fastq.gz`
+  - val_discard_trimmed_pass:
+      type: boolean
+      description: |
+        Structure: val(discard_trimmed)
+        Specify true to not write any reads that pass trimming thresholds.
+        This can be used to use fastp for the output report only.
   - val_save_merged:
       type: boolean
       description: |


### PR DESCRIPTION
This just corrects a typo in the meta.yml. the input `val_discard_trimmed_pass` was called `val_discard_trimmed`. I also re-ordered it to match the main.nf.