### PR TITLE
update regex in `FASTQ_FASTQC_UMITOOLS_TRIMGALORE` subworkflow, closes #8576

### DIFF
--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -14,7 +14,7 @@ def getTrimGaloreReadsAfterFiltering(log_file) {
     def filtered_reads = 0
     log_file.eachLine { line ->
         def total_reads_matcher = line =~ /([\d\.]+)\ssequences processed in total/
-        def filtered_reads_matcher = line =~ /shorter than the length cutoff[^:]+:\s([\d\.]+)/
+        def filtered_reads_matcher = line =~ /shorter than the length cutoff[^:]+:\s*([\d\.]+)/
         if (total_reads_matcher) {
             total_reads = total_reads_matcher[0][1].toFloat()
         }


### PR DESCRIPTION
This PR updates the `getTrimGaloreReadsAfterFiltering` function in  `FASTQ_FASTQC_UMITOOLS_TRIMGALORE` to correctly parse the number of reads removed due to being shorter than the minimum length cutoff in TrimGalore logs.

### Why this change is necessary
The original regex used to extract the number of filtered reads expected exactly one standard space after the colon in the line. However, in actual TrimGalore logs, the whitespace after the colon can be a tab or multiple/non-standard spaces, which caused the regex to fail silently. As a result, filtered_reads was not matched, and the function returned the total number of reads processed — giving a misleading count of reads that passed filtering.

### What was changed
Updated the regex to:

`/shorter than the length cutoff[^:]+:\s*([\d\.]+)/`
This keeps the original colon handling but changes `\s` to `\s*`, allowing the pattern to match any amount or type of whitespace (spaces, tabs, etc.) after the colon.

This ensures that the filtered read count is correctly extracted from the log, and that the function accurately returns the number of reads retained after trimming.

## PR checklist

Closes #8576 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
