### PR TITLE
ci: Turn arm64 tests off

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -103,7 +103,8 @@ jobs:
         profile: [conda, docker, singularity]
         arch:
           - x64
-          - arm64
+          # FIXME
+          # - arm64
     env:
       NXF_ANSI_LOG: false
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}


### PR DESCRIPTION
Until we can work out a better "skip" if the build is failing mechanism.

Currently, all of the tests that fail are resulting in a large number of "failed" build requests on the wave side, instead of just passing an already made container.
