### PR TITLE
nanoq: fix output path

### DIFF
--- a/modules/nf-core/nanoq/main.nf
+++ b/modules/nf-core/nanoq/main.nf
@@ -1,32 +1,32 @@
 process NANOQ {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nanoq:0.10.0--h031d066_2' :
-        'biocontainers/nanoq:0.10.0--h031d066_2'}"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/nanoq:0.10.0--h031d066_2'
+        : 'biocontainers/nanoq:0.10.0--h031d066_2'}"
 
     input:
     tuple val(meta), path(ontreads)
     val(output_format) //One of the following: fastq, fastq.gz, fastq.bz2, fastq.lzma, fasta, fasta.gz, fasta.bz2, fasta.lzma.
 
     output:
-    tuple val(meta), path("*.{stats,json}")                                           , emit: stats
-    tuple val(meta), path("*_filtered.${output_format}")                              , emit: reads
-    path "versions.yml"                                                               , emit: versions
+    tuple val(meta), path("*.{stats,json}")            , emit: stats
+    tuple val(meta), path("${prefix}.${output_format}"), emit: reads
+    path "versions.yml"                                , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}_filtered"
+    prefix = task.ext.prefix ?: "${meta.id}_filtered"
     """
-    nanoq -i $ontreads \\
+    nanoq -i ${ontreads} \\
         ${args} \\
         -r ${prefix}.stats \\
-        -o ${prefix}.$output_format
+        -o ${prefix}.${output_format}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -36,9 +36,9 @@ process NANOQ {
 
     stub:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}_filtered"
+    prefix = task.ext.prefix ?: "${meta.id}_filtered"
     """
-    echo "" | gzip > ${prefix}.$output_format
+    echo "" | gzip > ${prefix}.${output_format}
     touch ${prefix}.stats
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/nanoq/meta.yml
+++ b/modules/nf-core/nanoq/meta.yml
@@ -48,7 +48,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*_filtered.${output_format}":
+      - "${prefix}.${output_format}":
           type: file
           description: Filtered reads.
           pattern: "*.{fasta,fastq}{,.gz,.bz2,.lzma}"


### PR DESCRIPTION
Fix the output path of the process.
Currently, `*_filtered` is hardcoded. If the prefix is configured to something else, the output file it not matched.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
