### PR TITLE
Update doubletdetection module

### DIFF
--- a/modules/nf-core/doubletdetection/environment.yml
+++ b/modules/nf-core/doubletdetection/environment.yml
@@ -1,15 +1,8 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::anndata=0.10.7
-  - conda-forge::louvain=0.8.2
-  - conda-forge::numpy=1.26.4
-  - conda-forge::pip=24.0
-  - conda-forge::python=3.12.3
-  - conda-forge::scipy=1.13.1
+  - conda-forge::pyyaml=6.0.2
   - pip
   - pip:
-      - doubletdetection==4.2
+      - doubletdetection==4.3.0.post1

--- a/modules/nf-core/doubletdetection/environment.yml
+++ b/modules/nf-core/doubletdetection/environment.yml
@@ -3,6 +3,6 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::pyyaml=6.0.2
-  - pip
+  - conda-forge::pip=25.0.1
   - pip:
       - doubletdetection==4.3.0.post1

--- a/modules/nf-core/doubletdetection/main.nf
+++ b/modules/nf-core/doubletdetection/main.nf
@@ -4,7 +4,7 @@ process DOUBLETDETECTION {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/414cdfd17bf902c5a385bc9991cec042446b440fc3b16454e01a3634c923ba29/data'
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/96/96f52092a8472acb59ded59ab5ec4a29a56627f0c78e3cc8a0b916c6bedd67d6/data'
         : 'community.wave.seqera.io/library/pyyaml_pip_doubletdetection:5af145ffec01d7da'}"
 
     input:

--- a/modules/nf-core/doubletdetection/main.nf
+++ b/modules/nf-core/doubletdetection/main.nf
@@ -4,7 +4,7 @@ process DOUBLETDETECTION {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/pyyaml_pip_doubletdetection:d67fd9203a935dfe'
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/414cdfd17bf902c5a385bc9991cec042446b440fc3b16454e01a3634c923ba29/data'
         : 'community.wave.seqera.io/library/pyyaml_pip_doubletdetection:5af145ffec01d7da'}"
 
     input:

--- a/modules/nf-core/doubletdetection/main.nf
+++ b/modules/nf-core/doubletdetection/main.nf
@@ -1,33 +1,30 @@
 process DOUBLETDETECTION {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/87/878a0582c1de0ad7370ad1fbdebd7e786c77d29b064e10a7c09c35a9df3bfb97/data' :
-        'community.wave.seqera.io/library/anndata_louvain_numpy_pip_pruned:9ff7bfd3c5201947' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'oras://community.wave.seqera.io/library/pyyaml_pip_doubletdetection:d67fd9203a935dfe'
+        : 'community.wave.seqera.io/library/pyyaml_pip_doubletdetection:5af145ffec01d7da'}"
 
     input:
     tuple val(meta), path(h5ad)
 
     output:
     tuple val(meta), path("*.h5ad"), emit: h5ad
-    tuple val(meta), path("*.pkl") , emit: predictions
-    path "versions.yml"            , emit: versions
+    tuple val(meta), path("*.pkl"), emit: predictions
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
-    template 'doubletdetection.py'
+    template('doubletdetection.py')
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
     """
-    export MPLCONFIGDIR=./tmp
-    export NUMBA_CACHE_DIR=./tmp
-
     touch ${prefix}.h5ad
     touch ${prefix}.pkl
 

--- a/modules/nf-core/doubletdetection/main.nf
+++ b/modules/nf-core/doubletdetection/main.nf
@@ -12,8 +12,8 @@ process DOUBLETDETECTION {
 
     output:
     tuple val(meta), path("*.h5ad"), emit: h5ad
-    tuple val(meta), path("*.pkl"), emit: predictions
-    path "versions.yml", emit: versions
+    tuple val(meta), path("*.pkl") , emit: predictions
+    path "versions.yml"            , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/doubletdetection/templates/doubletdetection.py
+++ b/modules/nf-core/doubletdetection/templates/doubletdetection.py
@@ -8,31 +8,12 @@ os.environ["NUMBA_CACHE_DIR"] = "./tmp"
 
 import anndata as ad
 import doubletdetection
-
-
-def format_yaml_like(data: dict, indent: int = 0) -> str:
-    """Formats a dictionary to a YAML-like string.
-
-    Args:
-        data (dict): The dictionary to format.
-        indent (int): The current indentation level.
-
-    Returns:
-        str: A string formatted as YAML.
-    """
-    yaml_str = ""
-    for key, value in data.items():
-        spaces = "    " * indent
-        if isinstance(value, dict):
-            yaml_str += f"{spaces}{key}:\\n{format_yaml_like(value, indent + 1)}"
-        else:
-            yaml_str += f"{spaces}{key}: {value}\\n"
-    return yaml_str
+import yaml
 
 
 adata = ad.read_h5ad("${h5ad}")
 
-clf = doubletdetection.BoostClassifier()
+clf = doubletdetection.BoostClassifier(n_jobs=int("${task.cpus}"))
 doublets = clf.fit(adata.X).predict()
 scores = clf.doublet_score()
 
@@ -55,4 +36,4 @@ versions = {
 }
 
 with open("versions.yml", "w") as f:
-    f.write(format_yaml_like(versions))
+    yaml.dump(versions, f)

--- a/modules/nf-core/doubletdetection/tests/main.nf.test
+++ b/modules/nf-core/doubletdetection/tests/main.nf.test
@@ -14,7 +14,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file("https://github.com/nf-core/test-datasets/raw/refs/heads/scdownstream/pbmc/SRR28679759_filtered_matrix.h5ad", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/scrnaseq/h5ad/SRR28679759_filtered_matrix.h5ad", checkIfExists: true)
                 ]
                 """
             }
@@ -49,7 +49,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file("https://github.com/nf-core/test-datasets/raw/refs/heads/scdownstream/pbmc/SRR28679759_filtered_matrix.h5ad", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/scrnaseq/h5ad/SRR28679759_filtered_matrix.h5ad", checkIfExists: true)
                 ]
                 """
             }

--- a/modules/nf-core/doubletdetection/tests/main.nf.test
+++ b/modules/nf-core/doubletdetection/tests/main.nf.test
@@ -13,28 +13,28 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                     [id: 'test'],
-                     file("https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad", checkIfExists: true)
+                    [id: 'test'],
+                    file("https://github.com/nf-core/test-datasets/raw/refs/heads/scdownstream/pbmc/SRR28679759_filtered_matrix.h5ad", checkIfExists: true)
                 ]
                 """
             }
         }
 
         then {
-            def mb = 1024 * 1024
-            def kb = 1024
             assertAll(
                 { assert process.success },
 
-                // Only check if output exists, as phenotype supports no random seeding:
+                // Only check if output exists and has constant size,
+                // as phenotype supports no random seeding:
                 // https://github.com/jacoblevine/PhenoGraph/issues/16
                 { assert path(process.out.h5ad.get(0).get(1)).exists() },
                 { assert path(process.out.predictions.get(0).get(1)).exists() },
 
-                { assert path(process.out.h5ad.get(0).get(1)).size() > 30 * mb },
-                { assert path(process.out.predictions.get(0).get(1)).size() > 50 * kb },
-
-                { assert snapshot(process.out.versions).match("versions") }
+                { assert snapshot(
+                    process.out.versions,
+                    path(process.out.h5ad.get(0).get(1)).size(),
+                    path(process.out.predictions.get(0).get(1)).size()
+                ).match() }
             )
         }
 
@@ -48,8 +48,8 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                     [id: 'test'],
-                     file("https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad", checkIfExists: true)
+                    [id: 'test'],
+                    file("https://github.com/nf-core/test-datasets/raw/refs/heads/scdownstream/pbmc/SRR28679759_filtered_matrix.h5ad", checkIfExists: true)
                 ]
                 """
             }

--- a/modules/nf-core/doubletdetection/tests/main.nf.test.snap
+++ b/modules/nf-core/doubletdetection/tests/main.nf.test.snap
@@ -1,4 +1,18 @@
 {
+    "scdownsteam - h5ad": {
+        "content": [
+            [
+                "versions.yml:md5,a804c82a9b0295aa4b1206a1f63e1e75"
+            ],
+            3262106,
+            148163
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-06-01T12:21:51.179454932"
+    },
     "scdownstream - h5ad - stub": {
         "content": [
             {
@@ -7,7 +21,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_doubletdetection.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -15,18 +29,18 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_doubletdetection.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,b339d31cdc0422b203a26440591e1f12"
+                    "versions.yml:md5,3ed20fc4bca7372f427cb84f3e689992"
                 ],
                 "h5ad": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_doubletdetection.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "predictions": [
@@ -34,30 +48,18 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_doubletdetection.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,b339d31cdc0422b203a26440591e1f12"
+                    "versions.yml:md5,3ed20fc4bca7372f427cb84f3e689992"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.0",
+            "nextflow": "25.04.2"
         },
-        "timestamp": "2024-12-16T13:44:39.288037677"
-    },
-    "versions": {
-        "content": [
-            [
-                "versions.yml:md5,b339d31cdc0422b203a26440591e1f12"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
-        },
-        "timestamp": "2024-12-16T13:44:22.646176321"
+        "timestamp": "2025-06-01T12:22:10.478719663"
     }
 }

--- a/modules/nf-core/doubletdetection/tests/main.nf.test.snap
+++ b/modules/nf-core/doubletdetection/tests/main.nf.test.snap
@@ -2,16 +2,16 @@
     "scdownsteam - h5ad": {
         "content": [
             [
-                "versions.yml:md5,a804c82a9b0295aa4b1206a1f63e1e75"
+                "versions.yml:md5,570b1f0e4067484a0a801d52fbbe31e9"
             ],
             3262106,
-            148163
+            148146
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "25.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-01T12:21:51.179454932"
+        "timestamp": "2025-06-04T08:46:46.020919053"
     },
     "scdownstream - h5ad - stub": {
         "content": [
@@ -21,7 +21,7 @@
                         {
                             "id": "test"
                         },
-                        "test_doubletdetection.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -29,7 +29,7 @@
                         {
                             "id": "test"
                         },
-                        "test_doubletdetection.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "2": [
@@ -40,7 +40,7 @@
                         {
                             "id": "test"
                         },
-                        "test_doubletdetection.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "predictions": [
@@ -48,7 +48,7 @@
                         {
                             "id": "test"
                         },
-                        "test_doubletdetection.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -57,9 +57,9 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "25.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-01T12:22:10.478719663"
+        "timestamp": "2025-06-04T08:46:53.835580091"
     }
 }


### PR DESCRIPTION
This updates the tool version, adds the pyyaml dependency to prevent boiler plate code und switches to using smaller test data