### PR TITLE
Add force-tile-extent module

### DIFF
--- a/.github/skip_nf_test.json
+++ b/.github/skip_nf_test.json
@@ -43,6 +43,7 @@
         "modules/nf-core/fcs/fcsadaptor",
         "modules/nf-core/fcs/fcsgx",
         "modules/nf-core/force/cube",
+        "modules/nf-core/force/tileextent",
         "modules/nf-core/ganon/buildcustom",
         "modules/nf-core/ganon/classify",
         "modules/nf-core/ganon/report",

--- a/modules/nf-core/force/tileextent/Dockerfile
+++ b/modules/nf-core/force/tileextent/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/nfcore/force:3.8.01
+FROM davidfrantz/force:3.8.01

--- a/modules/nf-core/force/tileextent/Dockerfile
+++ b/modules/nf-core/force/tileextent/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/nfcore/force:3.8.01

--- a/modules/nf-core/force/tileextent/main.nf
+++ b/modules/nf-core/force/tileextent/main.nf
@@ -1,5 +1,5 @@
 process FORCE_TILEEXTENT {
-    tag { aoi.simpleName }
+    tag "${aoi.simpleName}"
     label 'process_single'
 
     container "nf-core/force:3.8.01"

--- a/modules/nf-core/force/tileextent/main.nf
+++ b/modules/nf-core/force/tileextent/main.nf
@@ -1,6 +1,7 @@
 process FORCE_TILEEXTENT {
     tag "${aoi.simpleName}"
     label 'process_single'
+    stageInMode 'copy' // needed by the module to work properly when aoi is a shapefile
 
     container "nf-core/force:3.8.01"
 

--- a/modules/nf-core/force/tileextent/main.nf
+++ b/modules/nf-core/force/tileextent/main.nf
@@ -6,7 +6,7 @@ process FORCE_TILEEXTENT {
 
     input:
     path aoi
-    path "tmp/datacube-definition.prj"
+    path(datacube_definition, stageAs: "tmp/datacube-definition.prj")
     path shapefile_dbf
     path shapefile_prj
     path shapefile_shx

--- a/modules/nf-core/force/tileextent/main.nf
+++ b/modules/nf-core/force/tileextent/main.nf
@@ -1,0 +1,43 @@
+process FORCE_TILEEXTENT {
+    tag { aoi.simpleName }
+    label 'process_single'
+
+    container "nf-core/force:3.8.01"
+
+    input:
+    path aoi
+    path "tmp/datacube-definition.prj"
+    path shapefile_dbf
+    path shapefile_prj
+    path shapefile_shx
+
+    output:
+    path "tile_allow.txt", emit: tile_allow
+    path "versions.yml"  , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    force-tile-extent -d tmp/ -a tile_allow.txt $aoi
+    rm -r tmp
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        force: \$(force-tile-extent -v)
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    """
+    touch tile_allow.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        force: \$(force-tile-extent -v)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/force/tileextent/meta.yml
+++ b/modules/nf-core/force/tileextent/meta.yml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "force_tileextent"
+description: |
+  Compute valid tiles for a given datacube definition and area of interest.
+  This list can be used by downstream analysis tasks to limit processing to the area of interest when satellite data covers a larger region.
+keywords:
+  - satellite data
+  - extent
+  - tile
+  - datacube
+tools:
+  - "force":
+      description: |
+        A all-in-one tool for processing satellite data.
+        Specialized on medium resolution data such as Landsat or Sentinel imagery.
+      homepage: "https://davidfrantz.github.io/code/force/"
+      documentation: "https://force-eo.readthedocs.io/en/latest/index.html"
+      tool_dev_url: "https://github.com/davidfrantz/force"
+      doi: "10.3390/rs11091124"
+      licence: ["GPL-3.0"]
+      identifier: ""
+
+input:
+  - - aoi:
+        type: file
+        description: Vector file (either shapefile geometry or geopackage) defining the area of interest.
+        pattern: "*.{shp,gpkg}"
+  - - tmp/datacube-definition.prj:
+        type: file
+        description: Datacube file in FORCE format defining the properties of the targeted datacube.
+        pattern: "*.{prj}"
+  - - shapefile_dbf:
+        type: file
+        description: Optional attribute table for shapefiles. Required if aoi is a shapefile.
+        pattern: "*.{dbf}"
+  - - shapefile_prj:
+        type: file
+        description: Optional projection for shapefiles. Required if aoi is a shapefile.
+        pattern: "*.{prj}"
+  - - shapefile_shx:
+        type: file
+        description: Optional shape index for shapefiles. Required if aoi is a shapefile.
+        pattern: "*.{shx}"
+
+output:
+  - tile_allow:
+      - "tile_allow.txt":
+          type: file
+          description: List of allowed datacube tiles. Each line contains an tile identifier.
+          pattern: "tile_allow.txt"
+  - versions:
+      - "versions.yml":
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+
+authors:
+  - "@Felix-Kummer"
+maintainers:
+  - "@Felix-Kummer"

--- a/modules/nf-core/force/tileextent/meta.yml
+++ b/modules/nf-core/force/tileextent/meta.yml
@@ -26,7 +26,7 @@ input:
         type: file
         description: Vector file (either shapefile geometry or geopackage) defining the area of interest.
         pattern: "*.{shp,gpkg}"
-  - - tmp/datacube-definition.prj:
+  - - datacube_definition:
         type: file
         description: Datacube file in FORCE format defining the properties of the targeted datacube.
         pattern: "*.{prj}"

--- a/modules/nf-core/force/tileextent/tests/main.nf.test
+++ b/modules/nf-core/force/tileextent/tests/main.nf.test
@@ -1,0 +1,85 @@
+nextflow_process {
+
+    name "Test Process FORCE_TILEEXTENT"
+    script "../main.nf"
+    process "FORCE_TILEEXTENT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "force"
+    tag "force/tileextent"
+
+    test("force-tile-extent - gpkg") {
+
+        when {
+            process {
+                """
+                input[0] = file(params.modules_testdata_base_path + "earth_sciences/vector/gpkg/crete.gpkg")
+                input[1] = file(params.modules_testdata_base_path + "earth_sciences/datacubes/datacube-definition.prj")
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("force-tile-extent - shp") {
+
+        config "./nextflow.shp.config"
+
+        when {
+            process {
+                """
+                input[0] = file(params.modules_testdata_base_path + "/earth_sciences/vector/shp/denmark.shp")
+                input[1] = file(params.modules_testdata_base_path + "/earth_sciences/datacubes/datacube-definition.prj")
+                input[2] = file(params.modules_testdata_base_path + "/earth_sciences/vector/shp/denmark.dbf")
+                input[3] = file(params.modules_testdata_base_path + "/earth_sciences/vector/shp/denmark.prj")
+                input[4] = file(params.modules_testdata_base_path + "/earth_sciences/vector/shp/denmark.shx")
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("force-tile-extent - gpkg - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = file(params.modules_testdata_base_path + "earth_sciences/vector/gpkg/crete.gpkg")
+                input[1] = file(params.modules_testdata_base_path + "earth_sciences/datacubes/datacube-definition.prj")
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/force/tileextent/tests/main.nf.test
+++ b/modules/nf-core/force/tileextent/tests/main.nf.test
@@ -34,8 +34,6 @@ nextflow_process {
 
     test("force-tile-extent - shp") {
 
-        config "./nextflow.shp.config"
-
         when {
             process {
                 """

--- a/modules/nf-core/force/tileextent/tests/main.nf.test.snap
+++ b/modules/nf-core/force/tileextent/tests/main.nf.test.snap
@@ -6,13 +6,13 @@
                     "tile_allow.txt:md5,3428a70fcfcfb2ce50e5c65e369fbf75"
                 ],
                 "1": [
-                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                    "versions.yml:md5,6b3d57b4f9567d44e502036809c80e2f"
                 ],
                 "tile_allow": [
                     "tile_allow.txt:md5,3428a70fcfcfb2ce50e5c65e369fbf75"
                 ],
                 "versions": [
-                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                    "versions.yml:md5,6b3d57b4f9567d44e502036809c80e2f"
                 ]
             }
         ],
@@ -20,7 +20,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.2"
         },
-        "timestamp": "2025-06-13T14:50:25.958732993"
+        "timestamp": "2025-06-13T15:16:51.909565499"
     },
     "force-tile-extent - gpkg - stub": {
         "content": [
@@ -29,13 +29,13 @@
                     "tile_allow.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "1": [
-                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                    "versions.yml:md5,6b3d57b4f9567d44e502036809c80e2f"
                 ],
                 "tile_allow": [
                     "tile_allow.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "versions": [
-                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                    "versions.yml:md5,6b3d57b4f9567d44e502036809c80e2f"
                 ]
             }
         ],
@@ -43,7 +43,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.2"
         },
-        "timestamp": "2025-06-13T14:50:57.893964179"
+        "timestamp": "2025-06-13T15:17:23.741824063"
     },
     "force-tile-extent - shp": {
         "content": [
@@ -52,13 +52,13 @@
                     "tile_allow.txt:md5,f194cf6f608930e6dc31f59453f7ae02"
                 ],
                 "1": [
-                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                    "versions.yml:md5,6b3d57b4f9567d44e502036809c80e2f"
                 ],
                 "tile_allow": [
                     "tile_allow.txt:md5,f194cf6f608930e6dc31f59453f7ae02"
                 ],
                 "versions": [
-                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                    "versions.yml:md5,6b3d57b4f9567d44e502036809c80e2f"
                 ]
             }
         ],
@@ -66,6 +66,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.2"
         },
-        "timestamp": "2025-06-13T14:50:49.162007822"
+        "timestamp": "2025-06-13T15:17:15.400884563"
     }
 }

--- a/modules/nf-core/force/tileextent/tests/main.nf.test.snap
+++ b/modules/nf-core/force/tileextent/tests/main.nf.test.snap
@@ -1,0 +1,71 @@
+{
+    "force-tile-extent - gpkg": {
+        "content": [
+            {
+                "0": [
+                    "tile_allow.txt:md5,3428a70fcfcfb2ce50e5c65e369fbf75"
+                ],
+                "1": [
+                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                ],
+                "tile_allow": [
+                    "tile_allow.txt:md5,3428a70fcfcfb2ce50e5c65e369fbf75"
+                ],
+                "versions": [
+                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-06-13T14:50:25.958732993"
+    },
+    "force-tile-extent - gpkg - stub": {
+        "content": [
+            {
+                "0": [
+                    "tile_allow.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
+                "1": [
+                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                ],
+                "tile_allow": [
+                    "tile_allow.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
+                "versions": [
+                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-06-13T14:50:57.893964179"
+    },
+    "force-tile-extent - shp": {
+        "content": [
+            {
+                "0": [
+                    "tile_allow.txt:md5,f194cf6f608930e6dc31f59453f7ae02"
+                ],
+                "1": [
+                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                ],
+                "tile_allow": [
+                    "tile_allow.txt:md5,f194cf6f608930e6dc31f59453f7ae02"
+                ],
+                "versions": [
+                    "versions.yml:md5,4227a3fca3f3bb7db9a496dcf385542b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.2"
+        },
+        "timestamp": "2025-06-13T14:50:49.162007822"
+    }
+}

--- a/modules/nf-core/force/tileextent/tests/nextflow.shp.config
+++ b/modules/nf-core/force/tileextent/tests/nextflow.shp.config
@@ -1,0 +1,4 @@
+process {
+    // this is required because the module needs all shapefile files in the same directory
+    stageInMode = 'copy'
+}

--- a/modules/nf-core/force/tileextent/tests/nextflow.shp.config
+++ b/modules/nf-core/force/tileextent/tests/nextflow.shp.config
@@ -1,4 +1,0 @@
-process {
-    // this is required because the module needs all shapefile files in the same directory
-    stageInMode = 'copy'
-}


### PR DESCRIPTION
Earth science module that computes a list of allowed FORCE tiles for a given datacube and geometry.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
