### PR TITLE
split the fastq and fastq_idx outputs from cellranger mkfastq module

### DIFF
--- a/modules/nf-core/cellranger/mkfastq/main.nf
+++ b/modules/nf-core/cellranger/mkfastq/main.nf
@@ -8,7 +8,8 @@ process CELLRANGER_MKFASTQ {
     tuple val(meta), path(csv), path(bcl)
 
     output:
-    tuple val(meta), path("*_outs/outs/fastq_path/**/*.fastq.gz")          , emit: fastq
+    tuple val(meta), path("output/**_S[1-9]*_R?_00?.fastq.gz")             , emit: fastq
+    tuple val(meta), path("output/**_S[1-9]*_I?_00?.fastq.gz")             , optional:true, emit: fastq_idx
     tuple val(meta), path("*_outs/outs/fastq_path/Undetermined*.fastq.gz") , optional:true, emit: undetermined_fastq
     tuple val(meta), path("*_outs/outs/fastq_path/Reports")                , optional:true, emit: reports
     tuple val(meta), path("*_outs/outs/fastq_path/Stats")                  , optional:true, emit: stats


### PR DESCRIPTION
Issue: cellranger mkfastq outputs both fastq and fastq_idx files together which causes issues with some other processes (e.g. falco couldn't process index fastqs in the demultiplex pipeline).

Solution: split the fastq and fastq_idx outputs from cellranger mkfastq module.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
