### PR TITLE
Add original image in Dockerfile

### DIFF
--- a/modules/nf-core/force/cube/Dockerfile
+++ b/modules/nf-core/force/cube/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/nfcore/force:3.8.01
+FROM davidfrantz/force:3.8.01


### PR DESCRIPTION
Following a [discussion on Slack](https://nfcore.slack.com/archives/CJRH30T6V/p1750332391291719) we decided that Dockerfiles should hold a reference to the original images 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`