### PR TITLE
PYDAMAGE_FILTER: Move args to compatible place

### DIFF
--- a/modules/nf-core/pydamage/filter/main.nf
+++ b/modules/nf-core/pydamage/filter/main.nf
@@ -1,18 +1,18 @@
 process PYDAMAGE_FILTER {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/pydamage:1.0--pyhdfd78af_0' :
-        'biocontainers/pydamage:1.0--pyhdfd78af_0' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/pydamage:1.0--pyhdfd78af_0'
+        : 'biocontainers/pydamage:1.0--pyhdfd78af_0'}"
 
     input:
     tuple val(meta), path(csv)
 
     output:
     tuple val(meta), path("${prefix}_pydamage_filtered_results.csv"), emit: csv
-    path "versions.yml"           , emit: versions
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -25,9 +25,9 @@ process PYDAMAGE_FILTER {
     export MPLCONFIGDIR=./tmp
 
     pydamage \\
+        ${args} \\
         filter \\
-        $args \\
-        $csv
+        ${csv}
 
     mv pydamage_results/pydamage_filtered_results.csv ${prefix}_pydamage_filtered_results.csv
 


### PR DESCRIPTION
Moves `args` call to before `filter` subcommand, as this is where the parameter options for [`-t` filter  parameter](https://pydamage.readthedocs.io/en/latest/CLI.html#pydamage) goes (and there are no further arguments that come [after](https://pydamage.readthedocs.io/en/latest/CLI.html#pydamage-filter)

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
