### PR TITLE
Fix ASCAT for both folder or file input

### DIFF
--- a/modules/nf-core/ascat/tests/main.nf.test
+++ b/modules/nf-core/ascat/tests/main.nf.test
@@ -196,7 +196,7 @@ nextflow_process {
                 input[1] = [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/ascat/G1000_alleles_hg38_chr21.txt', checkIfExists: true)]
                 input[2] = [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/ascat/G1000_loci_hg38_chr21.txt', checkIfExists: true)]
                 input[3] = []
-                input[4] = [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)]
+                input[4] = [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)]
                 input[5] = [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/ascat/GC_G1000_hg38_21.txt', checkIfExists: true)]
                 input[6] = [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/ascat/RT_G1000_hg38_21.txt', checkIfExists: true)]
                 """


### PR DESCRIPTION
In #7727 in order to get the code to work with a test input of a single file, a change was made that means that the module doesn't work for a folder input (as is the expected typical use).
This adds some code to enable using either a single file or a folder of files.