### PR TITLE
downgrade multiqc version to accommodate ARM

### DIFF
--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::multiqc=1.29
+  - bioconda::multiqc=1.28

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -4,7 +4,7 @@ process MULTIQC {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/multiqc:1.29--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.29--pyhdfd78af_0' }"
+        'biocontainers/multiqc:1.28--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,7 +3,7 @@ process MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.29--pyhdfd78af_0' :
+        'https://depot.galaxyproject.org/singularity/multiqc:1.28--pyhdfd78af_0' :
         'biocontainers/multiqc:1.28--pyhdfd78af_0' }"
 
     input:

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "multiqc_versions_single": {
         "content": [
             [
-                "versions.yml:md5,c1fe644a37468f6dae548d98bc72c2c1"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {
@@ -17,7 +17,7 @@
                 "multiqc_report.html",
                 "multiqc_data",
                 "multiqc_plots",
-                "versions.yml:md5,c1fe644a37468f6dae548d98bc72c2c1"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {
@@ -29,7 +29,7 @@
     "multiqc_versions_config": {
         "content": [
             [
-                "versions.yml:md5,c1fe644a37468f6dae548d98bc72c2c1"
+                "versions.yml:md5,b05075d2d2b4f485c0d627a5c8e475b2"
             ]
         ],
         "meta": {


### PR DESCRIPTION
On my ARM laptop the multiqc module fails with an error that appears to be CPU specific. 
My specs: 
```
Chip: Apple M4 Max
OS: 15.5 (24F74) 
```

Invocation:
```
nextflow run main.nf -profile docker,arm,test
```

Error:
```
Command error:
  .command.sh: line 11:    33 Illegal instruction     multiqc --force .
```
Downgrading from 1.29 to 1.28 fixes the issue.

This can be easily verified:

`.test.command.sh`
```
#!/usr/bin/bash
multiqc .
```

```
docker run --rm -it --platform=linux/amd64 -u $(id -u):$(id -g) -v "$PWD":/data -w /data quay.io/biocontainers/multiqc:1.29--pyhdfd78af_0 bash .test.command.sh
# .test.command.sh: line 2:     7 Illegal instruction     multiqc .
docker run --rm -it --platform=linux/amd64 -u $(id -u):$(id -g) -v "$PWD":/data -w /data quay.io/biocontainers/multiqc:1.28--pyhdfd78af_0 bash .test.command.sh

#/// MultiQC 🔍 v1.28
#
#     version_check | MultiQC Version v1.29 now available!
#       file_search | Search path: /data
#         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 10/10  
#           multiqc | No analysis results found. Cleaning up…
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Use BioConda and BioContainers if possible to fulfill software requirements.
