### PR TITLE
Fix logic for gVCF vs. VCF

### DIFF
--- a/modules/nf-core/parabricks/deepvariant/main.nf
+++ b/modules/nf-core/parabricks/deepvariant/main.nf
@@ -25,7 +25,7 @@ process PARABRICKS_DEEPVARIANT {
     }
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def output_file = ("--gvcf" =~ task.ext.args)? "${prefix}.g.vcf.gz" : "${prefix}.vcf"
+    def output_file = (task.ext.args =~ "--gvcf")? "${prefix}.g.vcf.gz" : "${prefix}.vcf"
     def interval_file_command = interval_file ? interval_file.collect{"--interval-file $it"}.join(' ') : ""
     def num_gpus = task.accelerator ? "--num-gpus $task.accelerator.request" : ''
     """


### PR DESCRIPTION
I noticed that the output file was set to be a VCF instead of a gVCF when I set `ext.args = "--gvcf --tmp-dir tmp"`.  It seems that the string and pattern were in the wrong order for the `=~` operator.
