### PR TITLE
fix: add optional marker classification outputs to genomad/endtoend

### DIFF
--- a/modules/nf-core/genomad/endtoend/main.nf
+++ b/modules/nf-core/genomad/endtoend/main.nf
@@ -13,6 +13,7 @@ process GENOMAD_ENDTOEND {
 
     output:
     tuple val(meta), path("*_aggregated_classification/*_aggregated_classification.tsv")    , emit: aggregated_classification   , optional: true
+    tuple val(meta), path("*_marker_classification/*_marker_classification.tsv")            , emit: marker_classification       , optional: true
     tuple val(meta), path("*_annotate/*_taxonomy.tsv")                                      , emit: taxonomy
     tuple val(meta), path("*_find_proviruses/*_provirus.tsv")                               , emit: provirus
     tuple val(meta), path("*_score_calibration/*_compositions.tsv")                         , emit: compositions                , optional: true
@@ -63,6 +64,7 @@ process GENOMAD_ENDTOEND {
     mkdir ${filename}_find_proviruses
     touch ${filename}_find_proviruses/${filename}_provirus.tsv
     mkdir ${filename}_marker_classification
+    touch ${filename}_marker_classification/${filename}_marker_classification.tsv
     mkdir ${filename}_nn_classification
     mkdir ${filename}_score_calibration
     touch ${filename}_score_calibration/${filename}_calibrated_aggregated_classification.tsv

--- a/modules/nf-core/genomad/endtoend/meta.yml
+++ b/modules/nf-core/genomad/endtoend/meta.yml
@@ -41,6 +41,16 @@ output:
           type: file
           description: Combined classification scores for each contig/scaffold/chromosome
           pattern: "*_aggregated_classification.tsv"
+  - marker_classification:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*_marker_classification/*_marker_classification.tsv":
+          type: file
+          description: Marker-based classification scores when --disable-nn-classification is used
+          pattern: "*_marker_classification.tsv"
   - taxonomy:
       - meta:
           type: map

--- a/modules/nf-core/genomad/endtoend/tests/main.nf.test
+++ b/modules/nf-core/genomad/endtoend/tests/main.nf.test
@@ -35,6 +35,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.aggregated_classification,
+                    process.out.marker_classification,
                     process.out.taxonomy,
                     process.out.provirus,
                     process.out.compositions,

--- a/modules/nf-core/genomad/endtoend/tests/main.nf.test.snap
+++ b/modules/nf-core/genomad/endtoend/tests/main.nf.test.snap
@@ -9,6 +9,14 @@
                     {
                         "id": "test"
                     },
+                    "genome_marker_classification.tsv:md5,18641cbc4fff1033dfb1d05f6463e176"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
                     "genome_taxonomy.tsv:md5,be8ac66e3ea3a89ee6f41e08db79d0d6"
                 ]
             ],
@@ -77,9 +85,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2025-04-14T12:55:44.013430328"
+        "timestamp": "2025-07-01T22:53:16.308333681"
     },
     "sarscov2 - genome - fasta - stub": {
         "content": [
@@ -92,7 +100,7 @@
                         {
                             "id": "test"
                         },
-                        "genome_taxonomy.tsv:md5,be8ac66e3ea3a89ee6f41e08db79d0d6"
+                        "genome_marker_classification.tsv:md5,18641cbc4fff1033dfb1d05f6463e176"
                     ]
                 ],
                 "10": [
@@ -100,7 +108,7 @@
                         {
                             "id": "test"
                         },
-                        "genome_virus_genes.tsv:md5,f7970779d28256f8adc8347ffc98932c"
+                        "genome_virus.fna.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
                     ]
                 ],
                 "11": [
@@ -108,7 +116,7 @@
                         {
                             "id": "test"
                         },
-                        "genome_virus_proteins.faa.gz:md5,6850bd46dcb921e5cfb23bfbb8fcc12b"
+                        "genome_virus_genes.tsv:md5,f7970779d28256f8adc8347ffc98932c"
                     ]
                 ],
                 "12": [
@@ -116,10 +124,18 @@
                         {
                             "id": "test"
                         },
-                        "genome_virus_summary.tsv:md5,8cbcf95c2ab397da26b6dca8014e86f4"
+                        "genome_virus_proteins.faa.gz:md5,6850bd46dcb921e5cfb23bfbb8fcc12b"
                     ]
                 ],
                 "13": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome_virus_summary.tsv:md5,8cbcf95c2ab397da26b6dca8014e86f4"
+                    ]
+                ],
+                "14": [
                     "versions.yml:md5,4622a27c70440602e43a070716a16681"
                 ],
                 "2": [
@@ -127,7 +143,7 @@
                         {
                             "id": "test"
                         },
-                        "genome_provirus.tsv:md5,93a6bca59b0bf7f57c0b9b60d2e57082"
+                        "genome_taxonomy.tsv:md5,be8ac66e3ea3a89ee6f41e08db79d0d6"
                     ]
                 ],
                 "3": [
@@ -135,13 +151,21 @@
                         {
                             "id": "test"
                         },
-                        "genome_compositions.tsv:md5,9168bea9fe82a979a698d259e1bb906a"
+                        "genome_provirus.tsv:md5,93a6bca59b0bf7f57c0b9b60d2e57082"
                     ]
                 ],
                 "4": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome_compositions.tsv:md5,9168bea9fe82a979a698d259e1bb906a"
+                    ]
                 ],
                 "5": [
+                    
+                ],
+                "6": [
                     [
                         {
                             "id": "test"
@@ -149,7 +173,7 @@
                         "genome_plasmid.fna.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "6": [
+                "7": [
                     [
                         {
                             "id": "test"
@@ -157,7 +181,7 @@
                         "genome_plasmid_genes.tsv:md5,55818cae5a57381b77778076e99605e6"
                     ]
                 ],
-                "7": [
+                "8": [
                     [
                         {
                             "id": "test"
@@ -165,20 +189,12 @@
                         "genome_plasmid_proteins.faa.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "8": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "genome_plasmid_summary.tsv:md5,8c4ddaa8a90da779c11537be0fddb799"
-                    ]
-                ],
                 "9": [
                     [
                         {
                             "id": "test"
                         },
-                        "genome_virus.fna.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                        "genome_plasmid_summary.tsv:md5,8c4ddaa8a90da779c11537be0fddb799"
                     ]
                 ],
                 "aggregated_classification": [
@@ -193,6 +209,14 @@
                             "id": "test"
                         },
                         "genome_compositions.tsv:md5,9168bea9fe82a979a698d259e1bb906a"
+                    ]
+                ],
+                "marker_classification": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome_marker_classification.tsv:md5,18641cbc4fff1033dfb1d05f6463e176"
                     ]
                 ],
                 "plasmid_fasta": [
@@ -282,8 +306,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2025-04-14T12:58:05.749655103"
+        "timestamp": "2025-07-01T23:07:05.526163602"
     }
 }


### PR DESCRIPTION
## Summary
  - Adds optional `marker_classification` output to support both neural network and marker-based classification modes
  - Fixes module failure when using `--disable-nn-classification` flag
  - Updates meta.yml documentation and test snapshots

 ## Changes
  - **main.nf**: Added `marker_classification` output as optional
  - **main.nf**: Updated stub section to create marker classification test files
  - **meta.yml**: Added documentation for new output
  - **tests/main.nf.test**: Added marker_classification to snapshot testing

 ## Background
  When GeNomad runs with `--disable-nn-classification`, it uses marker-based classification instead of neural network classification. This changes the output file structure:
  - With NN enabled: Produces `*_aggregated_classification/` directory and files
  - With NN disabled: Produces `*_marker_classification/` directory instead, no aggregated classification files

 ## Test plan
  - [x] Module passes `nf-core modules lint` (41 tests passed)
  - [x] Updated meta.yml with new output documentation
  - [x] Updated test to include marker_classification in snapshots
  - [x] Both aggregated_classification and marker_classification are marked as optional
  - [x] Existing test configuration already uses `--disable-nn-classification` flag

  🤖 Generated with [Claude Code](https://claude.ai/code)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
