### PR TITLE
Container for FASTQSCREEN_FASTQSCREEN should include bismark

### DIFF
--- a/modules/nf-core/fastqscreen/buildfromindex/main.nf
+++ b/modules/nf-core/fastqscreen/buildfromindex/main.nf
@@ -3,8 +3,8 @@ process FASTQSCREEN_BUILDFROMINDEX {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastq-screen:0.15.3--pl5321hdfd78af_0':
-        'biocontainers/fastq-screen:0.15.3--pl5321hdfd78af_0'}"
+        'oras://community.wave.seqera.io/library/bismark_bowtie2_bowtie_bwa_pruned:31508998395cbdaa':
+        'community.wave.seqera.io/library/bismark_bowtie2_bowtie_bwa_pruned:69fcf8201a02da7e'}"
 
     input:
     val(genome_names)

--- a/modules/nf-core/fastqscreen/fastqscreen/main.nf
+++ b/modules/nf-core/fastqscreen/fastqscreen/main.nf
@@ -4,8 +4,8 @@ process FASTQSCREEN_FASTQSCREEN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastq-screen:0.15.3--pl5321hdfd78af_0':
-        'biocontainers/fastq-screen:0.15.3--pl5321hdfd78af_0'}"
+        'oras://community.wave.seqera.io/library/bismark_bowtie2_bowtie_bwa_pruned:31508998395cbdaa':
+        'community.wave.seqera.io/library/bismark_bowtie2_bowtie_bwa_pruned:69fcf8201a02da7e'}"
 
     input:
     tuple val(meta), path(reads)  // .fastq files


### PR DESCRIPTION
Fixes #8757

I replaced the BioContainers container with one created on Seqera containers.

## PR checklist

Closes #8757

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
