### PR TITLE
Update bclconvert

### DIFF
--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -14,7 +14,7 @@ process BCLCONVERT {
     tuple val(meta), path("output/**Undetermined_S0*_I?_00?.fastq.gz"), emit: undetermined_idx, optional:true
     tuple val(meta), path("output/Reports")                           , emit: reports
     tuple val(meta), path("output/Logs")                              , emit: logs
-    tuple val(meta), path("**/InterOp/*.bin", includeInputs: true)    , emit: interop         , optional:true
+    tuple val(meta), path("output/InterOp/*.bin")                     , emit: interop         , optional:true
     path("versions.yml")                                              , emit: versions
 
     when:
@@ -61,6 +61,10 @@ process BCLCONVERT {
         --output-directory output \\
         --bcl-input-directory ${input_dir} \\
         --sample-sheet ${samplesheet}
+
+    # copy the InterOp folder contents to ensure it gets picked up when using fusion
+    mkdir -p output/InterOp/
+    cp **/InterOp/*.bin output/InterOp/
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -8,14 +8,14 @@ process BCLCONVERT {
     tuple val(meta), path(samplesheet), path(run_dir)
 
     output:
-    tuple val(meta), path("output/**_S[1-9]*_R?_00?.fastq.gz")           , emit: fastq
-    tuple val(meta), path("output/**_S[1-9]*_I?_00?.fastq.gz")           , optional:true, emit: fastq_idx
-    tuple val(meta), path("output/**Undetermined_S0*_R?_00?.fastq.gz")   , optional:true, emit: undetermined
-    tuple val(meta), path("output/**Undetermined_S0*_I?_00?.fastq.gz")   , optional:true, emit: undetermined_idx
-    tuple val(meta), path("output/Reports")                              , emit: reports
-    tuple val(meta), path("output/Logs")                                 , emit: logs
-    tuple val(meta), path("**/InterOp/*.bin", includeInputs: true), emit: interop
-    path("versions.yml")                                          , emit: versions
+    tuple val(meta), path("output/**_S[1-9]*_R?_00?.fastq.gz")        , emit: fastq
+    tuple val(meta), path("output/**_S[1-9]*_I?_00?.fastq.gz")        , emit: fastq_idx       , optional:true
+    tuple val(meta), path("output/**Undetermined_S0*_R?_00?.fastq.gz"), emit: undetermined    , optional:true
+    tuple val(meta), path("output/**Undetermined_S0*_I?_00?.fastq.gz"), emit: undetermined_idx, optional:true
+    tuple val(meta), path("output/Reports")                           , emit: reports
+    tuple val(meta), path("output/Logs")                              , emit: logs
+    tuple val(meta), path("**/InterOp/*.bin", includeInputs: true)    , emit: interop         , optional:true
+    path("versions.yml")                                              , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -67,4 +67,41 @@ process BCLCONVERT {
         bclconvert: \$(bcl-convert -V 2>&1 | head -n 1 | sed 's/^.*Version //')
     END_VERSIONS
     """
+
+    stub:
+    """
+    mkdir -p output/Reports
+    mkdir -p output/Logs
+    echo "" | gzip > output/Sample1_S1_L001_R1_001.fastq.gz
+    echo "" | gzip > output/Undetermined_S0_L001_R1_001.fastq.gz
+    touch output/Reports/Adapter_Cycle_Metrics.csv
+    touch output/Reports/Adapter_Metrics.csv
+    touch output/Reports/Demultiplex_Stats.csv
+    touch output/Reports/Demultiplex_Tile_Stats.csv
+    touch output/Reports/fastq_list.csv
+    touch output/Reports/Index_Hopping_Counts.csv
+    touch output/Reports/IndexMetricsOut.bin
+    touch output/Reports/Quality_Metrics.csv
+    touch output/Reports/Quality_Tile_Metrics.csv
+    touch output/Reports/RunInfo.xml
+    touch output/Reports/SampleSheet.csv
+    touch output/Reports/Top_Unknown_Barcodes.csv
+    touch output/Logs/Errors.log
+    touch output/Logs/FastqComplete.log
+    touch output/Logs/Info.log
+    touch output/Logs/Warnings.log
+    mkdir -p flowcell/InterOp
+    touch flowcell/InterOp/ControlMetricsOut.bin
+    touch flowcell/InterOp/CorrectedIntMetricsOut.bin
+    touch flowcell/InterOp/ErrorMetricsOut.bin
+    touch flowcell/InterOp/ExtractionMetricsOut.bin
+    touch flowcell/InterOp/IndexMetricsOut.bin
+    touch flowcell/InterOp/QMetricsOut.bin
+    touch flowcell/InterOp/TileMetricsOut.bin
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bclconvert: \$(bcl-convert -V 2>&1 | head -n 1 | sed 's/^.*Version //')
+    END_VERSIONS
+    """
+
 }

--- a/modules/nf-core/bclconvert/main.nf
+++ b/modules/nf-core/bclconvert/main.nf
@@ -64,7 +64,7 @@ process BCLCONVERT {
 
     # copy the InterOp folder contents to ensure it gets picked up when using fusion
     mkdir -p output/InterOp/
-    cp **/InterOp/*.bin output/InterOp/
+    cp -n **/InterOp/*.bin output/InterOp/
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -94,14 +94,14 @@ process BCLCONVERT {
     touch output/Logs/FastqComplete.log
     touch output/Logs/Info.log
     touch output/Logs/Warnings.log
-    mkdir -p flowcell/InterOp
-    touch flowcell/InterOp/ControlMetricsOut.bin
-    touch flowcell/InterOp/CorrectedIntMetricsOut.bin
-    touch flowcell/InterOp/ErrorMetricsOut.bin
-    touch flowcell/InterOp/ExtractionMetricsOut.bin
-    touch flowcell/InterOp/IndexMetricsOut.bin
-    touch flowcell/InterOp/QMetricsOut.bin
-    touch flowcell/InterOp/TileMetricsOut.bin
+    mkdir -p output/InterOp
+    touch output/InterOp/ControlMetricsOut.bin
+    touch output/InterOp/CorrectedIntMetricsOut.bin
+    touch output/InterOp/ErrorMetricsOut.bin
+    touch output/InterOp/ExtractionMetricsOut.bin
+    touch output/InterOp/IndexMetricsOut.bin
+    touch output/InterOp/QMetricsOut.bin
+    touch output/InterOp/TileMetricsOut.bin
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         bclconvert: \$(bcl-convert -V 2>&1 | head -n 1 | sed 's/^.*Version //')

--- a/modules/nf-core/bclconvert/meta.yml
+++ b/modules/nf-core/bclconvert/meta.yml
@@ -94,7 +94,7 @@ output:
     - - meta:
           type: map
           description: Groovy Map containing sample information
-      - "**/InterOp/*.bin":
+      - "output/InterOp/*.bin":
           type: file
           description: Interop files
           pattern: "*.{bin}"

--- a/modules/nf-core/bclconvert/tests/main.nf.test
+++ b/modules/nf-core/bclconvert/tests/main.nf.test
@@ -4,14 +4,17 @@ nextflow_process {
     script "../main.nf"
     process "BCLCONVERT"
     config "./nextflow.config"
+
     tag "bclconvert"
     tag "modules"
     tag "modules_nfcore"
 
-    test("homo sapiens illumina [bcl]") {
+    test("homo_sapiens illumina [bcl]") {
         when {
+            params {
+                module_args = "--force --first-tile-only true"
+            }
             process {
-                //TODO use new test dataset when available, see https://github.com/nf-core/test-datasets/issues/996
                 """
                 input[0] = [
                     [ id: 'test', lane:1 ],
@@ -26,15 +29,87 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.reports,
-                    process.out.versions,
                     process.out.fastq,
-                    file(process.out.logs.get(0).get(1)).list().sort(),
-                    process.out.interop.get(0).get(1).findAll { file(it).name != "IndexMetricsOut.bin" },
-                    ).match()
-                },
-                { assert process.out.undetermined.get(0).get(1) ==~ ".*/Undetermined_S0_L001_R1_001.fastq.gz"},
-                { assert file(process.out.interop.get(0).get(1).find { file(it).name == "IndexMetricsOut.bin" }).exists() }
+                    process.out.fastq_idx,
+                    process.out.undetermined.collect { meta, fastq -> file(fastq).name },
+                    process.out.undetermined_idx,
+                    process.out.reports,
+                    process.out.logs.collect { meta, logs -> file(logs).list().sort() },
+                    process.out.interop.collect { meta, interop ->
+                                                interop.findAll { interopfile ->
+                                                file(interopfile).name != "IndexMetricsOut.bin" } },
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("sars_cov2 illumina [bcl]") {
+        when {
+            params {
+                module_args = "--force --tiles s_1_2101"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id: 'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bcl/SampleSheet.csv', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bcl/200624_A00834_0183_BHMTFYDRXX.tar.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.fastq.collect {
+                        meta, fastqs ->
+                        fastqs.findAll {
+                            fastqfile ->
+                            file(fastqfile).name != "SampleZ_S5_L001_R1_001.fastq.gz"
+                        }
+                    },
+                    process.out.fastq_idx,
+                    process.out.undetermined.collect { meta, fastq -> file(fastq).name },
+                    process.out.undetermined_idx,
+                    process.out.reports,
+                    process.out.logs.collect { meta, logs -> file(logs).list().sort() },
+                    process.out.interop,
+                    process.out.interop.collect { meta, interop ->
+                                                interop.findAll { interopfile ->
+                                                file(interopfile).name != "IndexMetricsOut.bin" } },
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens illumina [bcl] - stub") {
+        options "-stub"
+
+        when {
+            params {
+                module_args = "--force --first-tile-only true"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id: 'test', lane:1 ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.csv', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell.tar.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
             )
         }
     }

--- a/modules/nf-core/bclconvert/tests/main.nf.test.snap
+++ b/modules/nf-core/bclconvert/tests/main.nf.test.snap
@@ -10,13 +10,13 @@
                 ]
             ],
             [
-
+                
             ],
             [
                 "Undetermined_S0_L001_R1_001.fastq.gz"
             ],
             [
-
+                
             ],
             [
                 [
@@ -119,7 +119,7 @@
                     ]
                 ],
                 "1": [
-
+                    
                 ],
                 "2": [
                     [
@@ -131,7 +131,7 @@
                     ]
                 ],
                 "3": [
-
+                    
                 ],
                 "4": [
                     [
@@ -170,21 +170,7 @@
                     ]
                 ],
                 "6": [
-                    [
-                        {
-                            "id": "test",
-                            "lane": 1
-                        },
-                        [
-                            "ControlMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "CorrectedIntMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "ErrorMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "ExtractionMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "IndexMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "QMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "TileMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
+                    
                 ],
                 "7": [
                     "versions.yml:md5,3a54ec728e3eb67bfd5af57ebd36ccab"
@@ -199,24 +185,10 @@
                     ]
                 ],
                 "fastq_idx": [
-
+                    
                 ],
                 "interop": [
-                    [
-                        {
-                            "id": "test",
-                            "lane": 1
-                        },
-                        [
-                            "ControlMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "CorrectedIntMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "ErrorMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "ExtractionMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "IndexMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "QMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "TileMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
+                    
                 ],
                 "logs": [
                     [
@@ -264,7 +236,7 @@
                     ]
                 ],
                 "undetermined_idx": [
-
+                    
                 ],
                 "versions": [
                     "versions.yml:md5,3a54ec728e3eb67bfd5af57ebd36ccab"
@@ -275,7 +247,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-11T20:19:10.184273474"
+        "timestamp": "2025-07-14T09:22:41.336971524"
     },
     "homo_sapiens illumina [bcl]": {
         "content": [
@@ -289,13 +261,13 @@
                 ]
             ],
             [
-
+                
             ],
             [
                 "Undetermined_S0_L001_R1_001.fastq.gz"
             ],
             [
-
+                
             ],
             [
                 [

--- a/modules/nf-core/bclconvert/tests/main.nf.test.snap
+++ b/modules/nf-core/bclconvert/tests/main.nf.test.snap
@@ -170,7 +170,21 @@
                     ]
                 ],
                 "6": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "ControlMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "CorrectedIntMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "ErrorMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "ExtractionMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "IndexMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "QMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "TileMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
                 ],
                 "7": [
                     "versions.yml:md5,3a54ec728e3eb67bfd5af57ebd36ccab"
@@ -188,7 +202,21 @@
                     
                 ],
                 "interop": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "ControlMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "CorrectedIntMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "ErrorMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "ExtractionMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "IndexMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "QMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "TileMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
                 ],
                 "logs": [
                     [
@@ -247,7 +275,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-14T09:22:41.336971524"
+        "timestamp": "2025-07-14T10:27:52.833237245"
     },
     "homo_sapiens illumina [bcl]": {
         "content": [

--- a/modules/nf-core/bclconvert/tests/main.nf.test.snap
+++ b/modules/nf-core/bclconvert/tests/main.nf.test.snap
@@ -1,6 +1,302 @@
 {
-    "homo sapiens illumina [bcl]": {
+    "sars_cov2 illumina [bcl]": {
         "content": [
+            [
+                [
+                    "Sample1_S1_L001_R1_001.fastq.gz:md5,b5489d1964db8db5502eb742cc3ef3ec",
+                    "Sample23_S3_L001_R1_001.fastq.gz:md5,767a1091320320b140288066e29bccc5",
+                    "SampleA_S2_L001_R1_001.fastq.gz:md5,7de2ea88133409f34563f40a0d8c9e55",
+                    "sampletest_S4_L001_R1_001.fastq.gz:md5,c16c7de1b7bffb5e4503f4d94c40f881"
+                ]
+            ],
+            [
+
+            ],
+            [
+                "Undetermined_S0_L001_R1_001.fastq.gz"
+            ],
+            [
+
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        "Adapter_Cycle_Metrics.csv:md5,05fbe7b2b0acdd557d355b448aa88ace",
+                        "Adapter_Metrics.csv:md5,0fa4ac708955417af9d18cec4955552f",
+                        "Demultiplex_Stats.csv:md5,4a3f451faa098156623b55b0f2ff27ee",
+                        "Demultiplex_Tile_Stats.csv:md5,8f6fb58990572c4aa19c0100d8351484",
+                        "IndexMetricsOut.bin:md5,fb16c8a9873e5b5950ae5949126af76c",
+                        "Index_Hopping_Counts.csv:md5,f59474d96afe8218c7590bb240b19690",
+                        "Quality_Metrics.csv:md5,c4622066f85d93b1661c928a46cfc508",
+                        "Quality_Tile_Metrics.csv:md5,e22bc5e2f147695150b02afcccb38c4f",
+                        "RunInfo.xml:md5,f283cb4600235db9261ee1e319b1407e",
+                        "SampleSheet.csv:md5,4113eabae23136cc819c7f15ac5b6aad",
+                        "Top_Unknown_Barcodes.csv:md5,37dbc2860c640fc721820b0217ea0504",
+                        "fastq_list.csv:md5,482cf7fe9b304a900e4ede3bb25b4912"
+                    ]
+                ]
+            ],
+            [
+                [
+                    "Errors.log",
+                    "FastqComplete.txt",
+                    "Info.log",
+                    "Warnings.log"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        "BasecallingMetricsOut.bin:md5,7fb651325cba614d497d376eaf43fef4",
+                        "CorrectedIntMetricsOut.bin:md5,dc8d57282ba9ece9e5fc58a92aa2ac52",
+                        "EmpiricalPhasingMetricsOut.bin:md5,1ef4631faf0a3a3beb31b10fc38a734d",
+                        "EventMetricsOut.bin:md5,dee320ce29bdadde44589aa9439f53ab",
+                        "ExtendedTileMetricsOut.bin:md5,f01d1a9cf8445adf719e652ad7304cf2",
+                        "ExtractionMetricsOut.bin:md5,972f4082ad950baaf42a6d28517d28a8",
+                        "FWHMGridMetricsOut.bin:md5,6e297bafcd845bfd0440d08e1bb27685",
+                        "ImageMetricsOut.bin:md5,ac5d1f0a1f611c0c7c9dd8e6b9e701b1",
+                        "IndexMetricsOut.bin:md5,6d95975d5909eb88f824e6dc8066457d",
+                        "OpticalModelMetricsOut.bin:md5,3eaea5fcf2d353950b1e720c73695ccb",
+                        "PFGridMetricsOut.bin:md5,ae469858ee96ffafbcaf3afb814bdab2",
+                        "QMetrics2030Out.bin:md5,438248760db58917b32f4eccc6c64c39",
+                        "QMetricsByLaneOut.bin:md5,e8254cb4a27846710a2a143296be2d8f",
+                        "QMetricsOut.bin:md5,8f6b83028a42be721200a598161ac5c6",
+                        "RegistrationMetricsOut.bin:md5,b5ebd957aed067b6403d851ba2ce0139",
+                        "TileMetricsOut.bin:md5,21388348d81fa9be326d30ef6d348464"
+                    ]
+                ]
+            ],
+            [
+                [
+                    "BasecallingMetricsOut.bin:md5,7fb651325cba614d497d376eaf43fef4",
+                    "CorrectedIntMetricsOut.bin:md5,dc8d57282ba9ece9e5fc58a92aa2ac52",
+                    "EmpiricalPhasingMetricsOut.bin:md5,1ef4631faf0a3a3beb31b10fc38a734d",
+                    "EventMetricsOut.bin:md5,dee320ce29bdadde44589aa9439f53ab",
+                    "ExtendedTileMetricsOut.bin:md5,f01d1a9cf8445adf719e652ad7304cf2",
+                    "ExtractionMetricsOut.bin:md5,972f4082ad950baaf42a6d28517d28a8",
+                    "FWHMGridMetricsOut.bin:md5,6e297bafcd845bfd0440d08e1bb27685",
+                    "ImageMetricsOut.bin:md5,ac5d1f0a1f611c0c7c9dd8e6b9e701b1",
+                    "OpticalModelMetricsOut.bin:md5,3eaea5fcf2d353950b1e720c73695ccb",
+                    "PFGridMetricsOut.bin:md5,ae469858ee96ffafbcaf3afb814bdab2",
+                    "QMetrics2030Out.bin:md5,438248760db58917b32f4eccc6c64c39",
+                    "QMetricsByLaneOut.bin:md5,e8254cb4a27846710a2a143296be2d8f",
+                    "QMetricsOut.bin:md5,8f6b83028a42be721200a598161ac5c6",
+                    "RegistrationMetricsOut.bin:md5,b5ebd957aed067b6403d851ba2ce0139",
+                    "TileMetricsOut.bin:md5,21388348d81fa9be326d30ef6d348464"
+                ]
+            ],
+            [
+                "versions.yml:md5,3a54ec728e3eb67bfd5af57ebd36ccab"
+            ],
+            {
+                "BCLCONVERT": {
+                    "bclconvert": "4.3.13"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-14T08:32:54.370274551"
+    },
+    "homo_sapiens illumina [bcl] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        "Sample1_S1_L001_R1_001.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        "Undetermined_S0_L001_R1_001.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "3": [
+
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "Adapter_Cycle_Metrics.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Adapter_Metrics.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Demultiplex_Stats.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Demultiplex_Tile_Stats.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "IndexMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Index_Hopping_Counts.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Quality_Metrics.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Quality_Tile_Metrics.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "RunInfo.xml:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "SampleSheet.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Top_Unknown_Barcodes.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "fastq_list.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "Errors.log:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "FastqComplete.log:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Info.log:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Warnings.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "ControlMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "CorrectedIntMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "ErrorMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "ExtractionMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "IndexMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "QMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "TileMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "7": [
+                    "versions.yml:md5,3a54ec728e3eb67bfd5af57ebd36ccab"
+                ],
+                "fastq": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        "Sample1_S1_L001_R1_001.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "fastq_idx": [
+
+                ],
+                "interop": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "ControlMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "CorrectedIntMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "ErrorMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "ExtractionMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "IndexMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "QMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "TileMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "Errors.log:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "FastqComplete.log:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Info.log:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Warnings.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "reports": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        [
+                            "Adapter_Cycle_Metrics.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Adapter_Metrics.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Demultiplex_Stats.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Demultiplex_Tile_Stats.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "IndexMetricsOut.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Index_Hopping_Counts.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Quality_Metrics.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Quality_Tile_Metrics.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "RunInfo.xml:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "SampleSheet.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Top_Unknown_Barcodes.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "fastq_list.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "undetermined": [
+                    [
+                        {
+                            "id": "test",
+                            "lane": 1
+                        },
+                        "Undetermined_S0_L001_R1_001.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "undetermined_idx": [
+
+                ],
+                "versions": [
+                    "versions.yml:md5,3a54ec728e3eb67bfd5af57ebd36ccab"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-11T20:19:10.184273474"
+    },
+    "homo_sapiens illumina [bcl]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "lane": 1
+                    },
+                    "Sample1_S1_L001_R1_001.fastq.gz:md5,0675fb6365322eaafb33c0f8e862b54b"
+                ]
+            ],
+            [
+
+            ],
+            [
+                "Undetermined_S0_L001_R1_001.fastq.gz"
+            ],
+            [
+
+            ],
             [
                 [
                     {
@@ -24,36 +320,36 @@
                 ]
             ],
             [
-                "versions.yml:md5,3a54ec728e3eb67bfd5af57ebd36ccab"
-            ],
-            [
                 [
-                    {
-                        "id": "test",
-                        "lane": 1
-                    },
-                    "Sample1_S1_L001_R1_001.fastq.gz:md5,0675fb6365322eaafb33c0f8e862b54b"
+                    "Errors.log",
+                    "FastqComplete.txt",
+                    "Info.log",
+                    "Warnings.log"
                 ]
             ],
             [
-                "Errors.log",
-                "FastqComplete.txt",
-                "Info.log",
-                "Warnings.log"
+                [
+                    "ControlMetricsOut.bin:md5,6d77b38d0793a6e1ce1e85706e488953",
+                    "CorrectedIntMetricsOut.bin:md5,2bbf84d3be72734addaa2fe794711434",
+                    "ErrorMetricsOut.bin:md5,38c88def138e9bb832539911affdb286",
+                    "ExtractionMetricsOut.bin:md5,7497c3178837eea8f09350b5cd252e99",
+                    "QMetricsOut.bin:md5,7e9f198d53ebdfbb699a5f94cf1ed51c",
+                    "TileMetricsOut.bin:md5,83891751ec1c91a425a524b476b6ca3c"
+                ]
             ],
             [
-                "ControlMetricsOut.bin:md5,6d77b38d0793a6e1ce1e85706e488953",
-                "CorrectedIntMetricsOut.bin:md5,2bbf84d3be72734addaa2fe794711434",
-                "ErrorMetricsOut.bin:md5,38c88def138e9bb832539911affdb286",
-                "ExtractionMetricsOut.bin:md5,7497c3178837eea8f09350b5cd252e99",
-                "QMetricsOut.bin:md5,7e9f198d53ebdfbb699a5f94cf1ed51c",
-                "TileMetricsOut.bin:md5,83891751ec1c91a425a524b476b6ca3c"
-            ]
+                "versions.yml:md5,3a54ec728e3eb67bfd5af57ebd36ccab"
+            ],
+            {
+                "BCLCONVERT": {
+                    "bclconvert": "4.3.13"
+                }
+            }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-06-02T12:35:36.967547"
+        "timestamp": "2025-07-14T08:32:32.783697479"
     }
 }

--- a/modules/nf-core/bclconvert/tests/nextflow.config
+++ b/modules/nf-core/bclconvert/tests/nextflow.config
@@ -1,10 +1,5 @@
 process {
-
-    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-
-    ext.args = {[
-        meta.lane ? "--bcl-only-lane ${meta.lane}" : "",
-        "--force",
-        "--first-tile-only true"
-    ].join(" ").trim()}
+    withName: "BCLCONVERT" {
+        ext.args = params.module_args
+    }
 }


### PR DESCRIPTION
Updating bclconvert to add stub and another test.
I'm also explicitly copying the InterOp folder, because when using fusion filesystem the `includeInputs` doesn't work, and so the module will currently crash.