### PR TITLE
Bumping container versions

### DIFF
--- a/modules/nf-core/bwameth/align/main.nf
+++ b/modules/nf-core/bwameth/align/main.nf
@@ -4,8 +4,8 @@ process BWAMETH_ALIGN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bwameth:0.2.7--pyh7cba7a3_0' :
-        'biocontainers/bwameth:0.2.7--pyh7cba7a3_0' }"
+        'https://depot.galaxyproject.org/singularity/bwameth:0.2.7--pyh7e72e81_1' :
+        'biocontainers/bwameth:0.2.7--pyh7e72e81_1' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/bwameth/index/main.nf
+++ b/modules/nf-core/bwameth/index/main.nf
@@ -4,8 +4,8 @@ process BWAMETH_INDEX {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/bwameth:0.2.7--pyh7cba7a3_0' :
-        'biocontainers/bwameth:0.2.7--pyh7cba7a3_0' }"
+        'https://depot.galaxyproject.org/singularity/bwameth:0.2.7--pyh7e72e81_1' :
+        'biocontainers/bwameth:0.2.7--pyh7e72e81_1' }"
 
     input:
     tuple val(meta), path(fasta, name:"BwamethIndex/")


### PR DESCRIPTION
Closes https://github.com/nf-core/methylseq/issues/550

bwa-mem2 is supported by bwameth, but the current module container does not have the executable installed. The most recent container on biocontainers adds support for this.