### PR TITLE
add ext.args2 directive to cellranger modules

### DIFF
--- a/modules/nf-core/cellranger/count/main.nf
+++ b/modules/nf-core/cellranger/count/main.nf
@@ -21,6 +21,7 @@ process CELLRANGER_COUNT {
         error "CELLRANGER_COUNT module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
     args = task.ext.args ?: ''
+    args2 = task.ext.args2 ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     template "cellranger_count.py"
 

--- a/modules/nf-core/cellranger/count/templates/cellranger_count.py
+++ b/modules/nf-core/cellranger/count/templates/cellranger_count.py
@@ -66,6 +66,7 @@ run(
         "--localcores", "${task.cpus}",
         "--localmem", "${task.memory.toGiga()}",
         *shlex.split("""${args}"""),
+        *shlex.split("""${args2}"""),
     ],
     check=True,
 )

--- a/modules/nf-core/cellranger/mkfastq/main.nf
+++ b/modules/nf-core/cellranger/mkfastq/main.nf
@@ -24,6 +24,7 @@ process CELLRANGER_MKFASTQ {
         error "CELLRANGER_MKFASTQ module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
     def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}" //run_dir (bcl) and id must be different because a folder is created with the id value
     """
     cellranger \\
@@ -33,7 +34,8 @@ process CELLRANGER_MKFASTQ {
         --csv=$csv \\
         --localcores=${task.cpus} \\
         --localmem=${task.memory.toGiga()} \\
-        $args
+        $args \\
+        $args2
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/cellranger/mkgtf/main.nf
+++ b/modules/nf-core/cellranger/mkgtf/main.nf
@@ -20,13 +20,15 @@ process CELLRANGER_MKGTF {
         error "CELLRANGER_MKGTF module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
     def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${gtf.baseName}.filtered"
     """
     cellranger \\
         mkgtf \\
         $gtf \\
         ${prefix}.gtf \\
-        $args
+        $args \\
+        $args2
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/cellranger/mkref/main.nf
+++ b/modules/nf-core/cellranger/mkref/main.nf
@@ -22,6 +22,7 @@ process CELLRANGER_MKREF {
         error "CELLRANGER_MKREF module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
     def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
     // --localcores is passed to the martian runtime and specifies the number of allocated jobs
     // --nthreads is passed to the STAR index generation.
     // see also https://github.com/nf-core/scrnaseq/issues/329
@@ -34,7 +35,8 @@ process CELLRANGER_MKREF {
         --localcores=${task.cpus} \\
         --localmem=${task.memory.toGiga()} \\
         --nthreads=${task.cpus} \\
-        $args
+        $args \\
+        $args2
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/cellranger/mkvdjref/main.nf
+++ b/modules/nf-core/cellranger/mkvdjref/main.nf
@@ -22,10 +22,11 @@ process CELLRANGER_MKVDJREF {
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
         error "CELLRANGER_MKVDJREF module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
-    def args        = task.ext.args ?: ''
-    def gtf_in      = gtf           ? "--genes ${gtf}"      : ""
-    def fasta_in    = fasta         ? "--fasta ${fasta}"    : ""
-    def seqs_in     = seqs          ? "--seqs ${seqs}"      : ""
+    def args        = task.ext.args  ?: ''
+    def args2       = task.ext.args2 ?: ''
+    def gtf_in      = gtf            ? "--genes ${gtf}"      : ""
+    def fasta_in    = fasta          ? "--fasta ${fasta}"    : ""
+    def seqs_in     = seqs           ? "--seqs ${seqs}"      : ""
 
     """
     cellranger \\
@@ -36,7 +37,8 @@ process CELLRANGER_MKVDJREF {
         ${seqs_in} \\
         --localcores=${task.cpus} \\
         --localmem=${task.memory.toGiga()} \\
-        $args
+        $args \\
+        $args2
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/cellranger/multi/main.nf
+++ b/modules/nf-core/cellranger/multi/main.nf
@@ -40,6 +40,7 @@ process CELLRANGER_MULTI {
         error "CELLRANGER_MULTI module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
     args   = task.ext.args   ?: ''
+    args2  = task.ext.args2  ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
 
     // if references + FASTQ are empty, then don't run corresponding analyses

--- a/modules/nf-core/cellranger/multi/templates/cellranger_multi.py
+++ b/modules/nf-core/cellranger/multi/templates/cellranger_multi.py
@@ -174,6 +174,7 @@ run(
         "--localcores=${task.cpus}",
         "--localmem=${task.memory.toGiga()}",
         *shlex.split("""${args}"""),
+        *shlex.split("""${args2}"""),
     ],
     # fmt: on
     check=True,

--- a/modules/nf-core/cellranger/vdj/main.nf
+++ b/modules/nf-core/cellranger/vdj/main.nf
@@ -21,6 +21,7 @@ process CELLRANGER_VDJ {
         error "CELLRANGER_VDJ module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
     def args = task.ext.args ?: ''
+    def args2       = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def reference_name = reference.name
     """
@@ -31,7 +32,8 @@ process CELLRANGER_VDJ {
         --reference=$reference_name \\
         --localcores=${task.cpus} \\
         --localmem=${task.memory.toGiga()} \\
-        $args
+        $args \\
+        $args2
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
dding `ext.args2` to `cellranger` modules, to allow that `ext.args` are used in pipelines, like in `nf-core/scrnaseq` while allowing straightforward customisation for users.

Relates to:

* https://github.com/nf-core/modules/issues/8798
* https://github.com/nf-core/scrnaseq/issues/475


# Question for maintainers

Is this conceptually fine to perform, or should we find a different way of doing it in the pipeline itself?