### PR TITLE
Allow cram in hmmcopy/readcounter and add stubs

### DIFF
--- a/modules/nf-core/hmmcopy/gccounter/main.nf
+++ b/modules/nf-core/hmmcopy/gccounter/main.nf
@@ -19,12 +19,23 @@ process HMMCOPY_GCCOUNTER {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}_gc"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     gcCounter \\
         $args \\
         ${fasta} > ${prefix}.wig
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmmcopy: $VERSION
+    END_VERSIONS
+    """
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}_gc"
+    def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    """
+    touch ${prefix}.wig
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/hmmcopy/gccounter/tests/main.nf.test
+++ b/modules/nf-core/hmmcopy/gccounter/tests/main.nf.test
@@ -15,7 +15,29 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - stub") {
+        options '-stub'
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                 """

--- a/modules/nf-core/hmmcopy/gccounter/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmcopy/gccounter/tests/main.nf.test.snap
@@ -1,14 +1,13 @@
 {
-    "sarscov2": {
+    "sarscov2 - stub": {
         "content": [
             {
                 "0": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
-                        "test.wig:md5,59ad14bc5aaa903187d7b248c9490deb"
+                        "test_gc.wig:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -20,14 +19,50 @@
                 "wig": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
-                        "test.wig:md5,59ad14bc5aaa903187d7b248c9490deb"
+                        "test_gc.wig:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ]
             }
         ],
-        "timestamp": "2023-12-05T20:28:45.583524"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-25T12:42:02.095961639"
+    },
+    "sarscov2": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_gc.wig:md5,59ad14bc5aaa903187d7b248c9490deb"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,cd17bfc158836c7ef20dc6a6df75cb98"
+                ],
+                "versions": [
+                    "versions.yml:md5,cd17bfc158836c7ef20dc6a6df75cb98"
+                ],
+                "wig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_gc.wig:md5,59ad14bc5aaa903187d7b248c9490deb"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-25T12:41:49.614838776"
     }
 }

--- a/modules/nf-core/hmmcopy/generatemap/main.nf
+++ b/modules/nf-core/hmmcopy/generatemap/main.nf
@@ -1,5 +1,5 @@
 process HMMCOPY_GENERATEMAP {
-    tag "$bam"
+    tag "$fasta"
     label 'process_long'
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
@@ -20,7 +20,6 @@ process HMMCOPY_GENERATEMAP {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     # build required indexes
@@ -32,6 +31,16 @@ process HMMCOPY_GENERATEMAP {
     generateMap.pl \\
         $args \\
         $fasta
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmmcopy: \$(echo $VERSION)
+    END_VERSIONS
+    """
+    stub:
+    def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    """
+    touch ${fasta}.map.bw
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/hmmcopy/generatemap/tests/main.nf.test
+++ b/modules/nf-core/hmmcopy/generatemap/tests/main.nf.test
@@ -15,7 +15,29 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - stub") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                 """

--- a/modules/nf-core/hmmcopy/generatemap/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmcopy/generatemap/tests/main.nf.test.snap
@@ -1,12 +1,11 @@
 {
-    "sarscov2": {
+    "sarscov2 - stub": {
         "content": [
             {
                 "0": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
                         "genome.fasta.map.bw:md5,7ad68224a1e40287978284c387e8eb70"
                     ]
@@ -17,8 +16,7 @@
                 "bigwig": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
                         "genome.fasta.map.bw:md5,7ad68224a1e40287978284c387e8eb70"
                     ]
@@ -28,6 +26,43 @@
                 ]
             }
         ],
-        "timestamp": "2023-12-05T20:33:23.775132"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-25T12:54:00.589317127"
+    },
+    "sarscov2": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.map.bw:md5,7ad68224a1e40287978284c387e8eb70"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,dcde422176ba18a356b63b813bc00247"
+                ],
+                "bigwig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.map.bw:md5,7ad68224a1e40287978284c387e8eb70"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,dcde422176ba18a356b63b813bc00247"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-25T12:53:46.600859534"
     }
 }

--- a/modules/nf-core/hmmcopy/mapcounter/main.nf
+++ b/modules/nf-core/hmmcopy/mapcounter/main.nf
@@ -12,19 +12,30 @@ process HMMCOPY_MAPCOUNTER {
 
     output:
     tuple val(meta), path("*.wig"), emit: wig
-    path "versions.yml"               , emit: versions
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}_map"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     mapCounter \\
         $args \\
         $bigwig > ${prefix}.wig
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmmcopy: \$(echo $VERSION)
+    END_VERSIONS
+    """
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}_map"
+    def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    """
+    touch ${prefix}.wig
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/hmmcopy/mapcounter/tests/main.nf.test
+++ b/modules/nf-core/hmmcopy/mapcounter/tests/main.nf.test
@@ -9,7 +9,7 @@ nextflow_process {
     tag "hmmcopy"
     tag "hmmcopy/mapcounter"
     tag "hmmcopy/generatemap"
-    
+
     test("sarscov2") {
 
         setup {
@@ -18,7 +18,7 @@ nextflow_process {
                 process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ]
                 """
@@ -42,5 +42,39 @@ nextflow_process {
         }
 
     }
+
+    test("sarscov2 - stub") {
+        options '-stub'
+        setup {
+            run("HMMCOPY_GENERATEMAP") {
+                script "../../generatemap/main.nf"
+                process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                """
+            }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = HMMCOPY_GENERATEMAP.out.bigwig
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
 
 }

--- a/modules/nf-core/hmmcopy/mapcounter/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmcopy/mapcounter/tests/main.nf.test.snap
@@ -1,14 +1,13 @@
 {
-    "sarscov2": {
+    "sarscov2 - stub": {
         "content": [
             {
                 "0": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
-                        "test.wig:md5,e2d39dc204ed31c1ce372d633a42560f"
+                        "test_map.wig:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -20,14 +19,50 @@
                 "wig": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
-                        "test.wig:md5,e2d39dc204ed31c1ce372d633a42560f"
+                        "test_map.wig:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ]
             }
         ],
-        "timestamp": "2023-12-05T20:39:11.896139"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-25T12:50:06.259711276"
+    },
+    "sarscov2": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_map.wig:md5,e2d39dc204ed31c1ce372d633a42560f"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f844b0387edf6df955f0096df1291780"
+                ],
+                "versions": [
+                    "versions.yml:md5,f844b0387edf6df955f0096df1291780"
+                ],
+                "wig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_map.wig:md5,e2d39dc204ed31c1ce372d633a42560f"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-25T12:49:42.975558837"
     }
 }

--- a/modules/nf-core/hmmcopy/readcounter/environment.yml
+++ b/modules/nf-core/hmmcopy/readcounter/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::hmmcopy=0.1.1
+  - bioconda::samtools=1.22.1

--- a/modules/nf-core/hmmcopy/readcounter/main.nf
+++ b/modules/nf-core/hmmcopy/readcounter/main.nf
@@ -23,6 +23,8 @@ process HMMCOPY_READCOUNTER {
     def args    = task.ext.args ?: ''
     def prefix  = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+
+    // Note that piping the cram directly into the tool didn't work.
     def convert_cram = bam.Extension == "cram" ? "samtools view -T ${fasta} -h ${bam} -o temp.bam##idx##temp.bam.bai --write-index " : ""
     def input        = bam.Extension == "cram" ? "temp.bam" : "${bam}"
     def cleanup      = bam.Extension == "cram" ? "rm temp.bam{,.bai}" : ""

--- a/modules/nf-core/hmmcopy/readcounter/main.nf
+++ b/modules/nf-core/hmmcopy/readcounter/main.nf
@@ -25,9 +25,10 @@ process HMMCOPY_READCOUNTER {
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
     // Note that piping the cram directly into the tool didn't work.
-    def convert_cram = bam.Extension == "cram" ? "samtools view -T ${fasta} -h ${bam} -o temp.bam##idx##temp.bam.bai --write-index " : ""
-    def input        = bam.Extension == "cram" ? "temp.bam" : "${bam}"
-    def cleanup      = bam.Extension == "cram" ? "rm temp.bam{,.bai}" : ""
+    def convert_cram     = bam.Extension == "cram" ? "samtools view -T ${fasta} -h ${bam} -o temp.bam##idx##temp.bam.bai --write-index " : ""
+    def input            = bam.Extension == "cram" ? "temp.bam" : "${bam}"
+    def cleanup          = bam.Extension == "cram" ? "rm temp.bam{,.bai}" : ""
+    def samtools_version = bam.Extension == "cram" ? "samtools: \$(samtools --version |& sed '1!d ; s/samtools //')" : ""
     """
     ${convert_cram}
 
@@ -40,17 +41,20 @@ process HMMCOPY_READCOUNTER {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         hmmcopy: $VERSION
+        $samtools_version
     END_VERSIONS
     """
     stub:
     def prefix  = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def samtools_version = bam.Extension == "cram" ? "samtools: \$(samtools --version |& sed '1!d ; s/samtools //')" : ""
     """
     touch ${prefix}.wig
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         hmmcopy: $VERSION
+        $samtools_version
     END_VERSIONS
     """
 }

--- a/modules/nf-core/hmmcopy/readcounter/main.nf
+++ b/modules/nf-core/hmmcopy/readcounter/main.nf
@@ -5,7 +5,7 @@ process HMMCOPY_READCOUNTER {
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/hmmcopy:0.1.1--h2e03b76_7' :
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b6/b656ae8c47699d1ae8f4d97995da8fda08aaed7a23d9b7078e034ff0981f7487/data' :
         'community.wave.seqera.io/library/hmmcopy_samtools:875db3767c6d4ea2' }"
 
     input:

--- a/modules/nf-core/hmmcopy/readcounter/main.nf
+++ b/modules/nf-core/hmmcopy/readcounter/main.nf
@@ -6,10 +6,11 @@ process HMMCOPY_READCOUNTER {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/hmmcopy:0.1.1--h2e03b76_7' :
-        'biocontainers/hmmcopy:0.1.1--h2e03b76_7' }"
+        'community.wave.seqera.io/library/hmmcopy_samtools:875db3767c6d4ea2' }"
 
     input:
     tuple val(meta), path(bam), path(bai)
+    tuple val(meta2), path(fasta)
 
     output:
     tuple val(meta), path("*.wig"), emit: wig
@@ -19,13 +20,31 @@ process HMMCOPY_READCOUNTER {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def args    = task.ext.args ?: ''
+    def prefix  = task.ext.prefix ?: "${meta.id}"
     def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def convert_cram = bam.Extension == "cram" ? "samtools view -T ${fasta} -h ${bam} -o temp.bam##idx##temp.bam.bai --write-index " : ""
+    def input        = bam.Extension == "cram" ? "temp.bam" : "${bam}"
+    def cleanup      = bam.Extension == "cram" ? "rm temp.bam{,.bai}" : ""
     """
+    ${convert_cram}
+
     readCounter \\
         $args \\
-        ${bam} > ${prefix}.wig
+        ${input} > ${prefix}.wig
+
+    ${cleanup}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmmcopy: $VERSION
+    END_VERSIONS
+    """
+    stub:
+    def prefix  = task.ext.prefix ?: "${meta.id}"
+    def VERSION = '0.1.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    """
+    touch ${prefix}.wig
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/hmmcopy/readcounter/meta.yml
+++ b/modules/nf-core/hmmcopy/readcounter/meta.yml
@@ -22,14 +22,25 @@ input:
           e.g. [ id:'test', single_end:false ]
     - bam:
         type: file
-        description: BAM/CRAM/SAM file
-        pattern: "*.{bam,cram,sam}"
+        description: BAM/CRAM file
+        pattern: "*.{bam,cram}"
         ontologies: []
     - bai:
         type: file
-        description: BAM index file
+        description: BAM/CRAM index file
         pattern: "*.{bai}"
         ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        type: file
+        description: Genome fasta file. Required when using a CRAM file.
+        ontologies:
+          - edam: "http://edamontology.org/format_1929" # FASTA
+
 output:
   wig:
     - - meta:

--- a/modules/nf-core/hmmcopy/readcounter/tests/main.nf.test
+++ b/modules/nf-core/hmmcopy/readcounter/tests/main.nf.test
@@ -26,7 +26,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+                ).match() }
             )
         }
 
@@ -51,7 +54,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+                ).match() }
             )
         }
 
@@ -74,7 +80,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+                ).match() }
             )
         }
 

--- a/modules/nf-core/hmmcopy/readcounter/tests/main.nf.test
+++ b/modules/nf-core/hmmcopy/readcounter/tests/main.nf.test
@@ -14,10 +14,59 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [ id:'test'], // meta map
+                input[0] = [ [ id:'test'],
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.recalibrated.sorted.bam', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.recalibrated.sorted.bam.bai', checkIfExists: true)
                     ]
+                input[1] = [[], []] // only need fasta for cram
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - cram") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.markduplicates.sorted.cram', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.markduplicates.sorted.cram.crai', checkIfExists: true)
+                    ]
+                input[1] = [ [ id:'fasta'],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - bam - stub") {
+        options '-stub'
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test'],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.recalibrated.sorted.bam', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.recalibrated.sorted.bam.bai', checkIfExists: true)
+                    ]
+                input[1] = [[], []] // only need fasta for cram
                 """
             }
         }

--- a/modules/nf-core/hmmcopy/readcounter/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmcopy/readcounter/tests/main.nf.test.snap
@@ -11,10 +11,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                    "versions.yml:md5,f1ac8b13ecc19ccdce6eb79956ac4884"
                 ],
                 "versions": [
-                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                    "versions.yml:md5,f1ac8b13ecc19ccdce6eb79956ac4884"
                 ],
                 "wig": [
                     [
@@ -24,13 +24,19 @@
                         "test.wig:md5,4682778422b9a2510a3cb70bd13ccd08"
                     ]
                 ]
+            },
+            {
+                "HMMCOPY_READCOUNTER": {
+                    "hmmcopy": "0.1.1",
+                    "samtools": "1.22.1"
+                }
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-25T12:12:17.411504278"
+        "timestamp": "2025-07-26T08:54:29.471154908"
     },
     "homo_sapiens - bam": {
         "content": [
@@ -44,10 +50,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                    "versions.yml:md5,1491d668fbd25d69889f811ac335d785"
                 ],
                 "versions": [
-                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                    "versions.yml:md5,1491d668fbd25d69889f811ac335d785"
                 ],
                 "wig": [
                     [
@@ -57,13 +63,18 @@
                         "test.wig:md5,4682778422b9a2510a3cb70bd13ccd08"
                     ]
                 ]
+            },
+            {
+                "HMMCOPY_READCOUNTER": {
+                    "hmmcopy": "0.1.1"
+                }
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2023-12-05T20:24:04.001722"
+        "timestamp": "2025-07-26T08:54:10.764407042"
     },
     "homo_sapiens - bam - stub": {
         "content": [
@@ -77,10 +88,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                    "versions.yml:md5,1491d668fbd25d69889f811ac335d785"
                 ],
                 "versions": [
-                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                    "versions.yml:md5,1491d668fbd25d69889f811ac335d785"
                 ],
                 "wig": [
                     [
@@ -90,12 +101,17 @@
                         "test.wig:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ]
+            },
+            {
+                "HMMCOPY_READCOUNTER": {
+                    "hmmcopy": "0.1.1"
+                }
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-25T12:30:10.596960941"
+        "timestamp": "2025-07-26T08:54:40.953123578"
     }
 }

--- a/modules/nf-core/hmmcopy/readcounter/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmcopy/readcounter/tests/main.nf.test.snap
@@ -1,4 +1,37 @@
 {
+    "homo_sapiens - cram": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.wig:md5,4682778422b9a2510a3cb70bd13ccd08"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                ],
+                "versions": [
+                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                ],
+                "wig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.wig:md5,4682778422b9a2510a3cb70bd13ccd08"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-25T12:12:17.411504278"
+    },
     "homo_sapiens - bam": {
         "content": [
             {
@@ -26,6 +59,43 @@
                 ]
             }
         ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
         "timestamp": "2023-12-05T20:24:04.001722"
+    },
+    "homo_sapiens - bam - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.wig:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                ],
+                "versions": [
+                    "versions.yml:md5,c3418bf8920d3fbc791d7650d319d1e3"
+                ],
+                "wig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.wig:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-25T12:30:10.596960941"
     }
 }


### PR DESCRIPTION
Adding cram support in hmmcopy/readcounter. Unfortunately this seems to require making a temporary bam file, I tried streaming the input directly but that gave me an error.
Also adding stubs to the other 3 submodules while here.