### PR TITLE
`last/maf-convert`: stop exporting `fasta` when converting to `cram`.

### DIFF
--- a/modules/nf-core/last/mafconvert/main.nf
+++ b/modules/nf-core/last/mafconvert/main.nf
@@ -21,7 +21,7 @@ process LAST_MAFCONVERT {
     tuple val(meta), path("*.blast.gz"),           optional:true, emit: blast_gz
     tuple val(meta), path("*.blasttab.gz"),        optional:true, emit: blasttab_gz
     tuple val(meta), path("*.chain.gz"),           optional:true, emit: chain_gz
-    tuple val(meta), path("*.cram"), path(fasta),  optional:true, emit: cram
+    tuple val(meta), path("*.cram"),               optional:true, emit: cram
     tuple val(meta), path("*.gff.gz"),             optional:true, emit: gff_gz
     tuple val(meta), path("*.html.gz"),            optional:true, emit: html_gz
     tuple val(meta), path("*.psl.gz"),             optional:true, emit: psl_gz

--- a/modules/nf-core/last/mafconvert/meta.yml
+++ b/modules/nf-core/last/mafconvert/meta.yml
@@ -155,11 +155,6 @@ output:
           description: Pairwise alignment in CRAM format (optional)
           pattern: "*.cram"
           ontologies: []
-      - fasta:
-          type: file
-          description: Genome file to recover sequences from the CRAM file (optional)
-          pattern: "*.{fasta,fasta.gz,fasta.bgz,fasta.bgzf}"
-          ontologies: []
   gff_gz:
     - - meta:
           type: map

--- a/modules/nf-core/last/mafconvert/tests/main.nf.test
+++ b/modules/nf-core/last/mafconvert/tests/main.nf.test
@@ -124,7 +124,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.cram.collect { cram(it[1], it[2]).getReadsMD5() },
+                    process.out.cram.collect { cram(it[1], it[1].replaceAll(/[^\/]+\.cram$/, 'genome.fasta')).getReadsMD5() },
                     process.out.versions
                 ).match() }
             )


### PR DESCRIPTION
Exporting the `fasta` genome file was only needed because I could not find a way to discover the path to the genome file during the module's regression tests.  However, this caused race conditions in _nf-core/pairgenomealign_ when the module would output many identical genome files to the pipeline's results folder, causing it to crash when the genome file was large.  So I spent more time thinking and found a much simpler way to access the genome file during tests…

`nf-core lint` reports that `samtools` and `last` are outdated. I will fix that in a separate PR.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
