### PR TITLE
add new module: deeptools/multibigwigsummary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         additional_dependencies:
           - prettier@3.5.0
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.1
+    rev: 0.33.2
     hooks:
       - id: check-jsonschema
         name: "Match meta.ymls in one of the subdirectories of modules/nf-core"
@@ -27,7 +27,7 @@ repos:
 
   # use ruff for python files
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.1
+    rev: v0.12.5
     hooks:
       - id: ruff
         files: \.py$

--- a/modules/nf-core/deeptools/multibigwigsummary/environment.yml
+++ b/modules/nf-core/deeptools/multibigwigsummary/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::deeptools=3.5.6

--- a/modules/nf-core/deeptools/multibigwigsummary/main.nf
+++ b/modules/nf-core/deeptools/multibigwigsummary/main.nf
@@ -1,0 +1,48 @@
+process DEEPTOOLS_MULTIBIGWIGSUMMARY {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/deeptools:3.5.6--pyhdfd78af_0':
+        'biocontainers/deeptools:3.5.6--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(bigwigs), val(labels)
+
+    output:
+    tuple val(meta), path("*.npz") , emit: matrix
+    path  "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "all_bigwig"
+    def label  = labels ? "--labels ${labels.join(' ')}" : ''
+    """
+    multiBigwigSummary bins \\
+        $args \\
+        $label \\
+        --bwfiles ${bigwigs.join(' ')} \\
+        --numberOfProcessors $task.cpus \\
+        --outFileName ${prefix}.bigwigSummary.npz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        deeptools: \$(multiBigwigSummary --version | sed -e "s/multiBigwigSummary //g")
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "all_bigwig"
+    """
+    touch ${prefix}.bigwigSummary.npz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        deeptools: \$(multiBigwigSummary --version | sed -e "s/multiBigwigSummary //g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/deeptools/multibigwigsummary/meta.yml
+++ b/modules/nf-core/deeptools/multibigwigsummary/meta.yml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "deeptools_multibigwigsummary"
+description: Computes the average scores for each of the files in every genomic region
+keywords:
+  - bigwig
+  - deeptools
+  - plot
+  - heatmap
+  - matrix
+tools:
+  - "deeptools":
+      description: "A set of user-friendly tools for normalization and visualization of deep-sequencing data"
+      homepage: "https://deeptools.readthedocs.io/en/develop/"
+      documentation: "https://deeptools.readthedocs.io/en/develop/"
+      tool_dev_url: "https://github.com/deeptools/deepTools/"
+      doi: "10.1093/nar/gku365"
+      licence: ["GPL v3"]
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - bigwigs:
+        type: file
+        description: Two or more bigWig files
+        pattern: "*.{bigWig,bw}"
+    - labels:
+        type: list
+        description: Labels for the bigWig files used in the matrix
+
+output:
+  matrix:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.npz":
+          type: file
+          description: Matrix file from multiBigwigSummary
+          pattern: "*.npz"
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+
+authors:
+  - "@ugoiannacchero"
+  - "@daisymut"
+
+maintainers:
+  - "@ugoiannacchero"
+  - "@daisymut"

--- a/modules/nf-core/deeptools/multibigwigsummary/tests/main.nf.test
+++ b/modules/nf-core/deeptools/multibigwigsummary/tests/main.nf.test
@@ -1,0 +1,67 @@
+nextflow_process {
+
+    name "Test Process DEEPTOOLS_MULTIBIGWIGSUMMARY"
+    script "../main.nf"
+    process "DEEPTOOLS_MULTIBIGWIGSUMMARY"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "deeptools"
+    tag "deeptools/multibigwigsummary"
+
+    test("sarscov2 - bigwig") {
+
+        when {
+            process {
+                """
+                def bigwig1 = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bigwig/test.bigwig', checkIfExists: true)
+                def bigwig2 = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bigwig/test.bigwig', checkIfExists: true).copyTo('test2.bigwig')
+
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [ bigwig1, bigwig2 ],
+                    [ "test_bigwig1", "test_bigwig2" ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.matrix.get(0).get(1)).name,
+                                process.out.versions)
+                                .match()
+                }
+            )
+        }
+
+    }
+
+    test("sarscov2 - bigwig - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                def bigwig1 = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bigwig/test.bigwig', checkIfExists: true)
+                def bigwig2 = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bigwig/test.bigwig', checkIfExists: true).copyTo('test2.bigwig')
+
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [ bigwig1, bigwig2 ],
+                    [ "test_bigwig1", "test_bigwig2" ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/deeptools/multibigwigsummary/tests/main.nf.test.snap
+++ b/modules/nf-core/deeptools/multibigwigsummary/tests/main.nf.test.snap
@@ -1,0 +1,50 @@
+{
+    "sarscov2 - bigwig - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "all_bigwig.bigwigSummary.npz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,09e49452477fbd0b76a68692b16796a7"
+                ],
+                "matrix": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "all_bigwig.bigwigSummary.npz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,09e49452477fbd0b76a68692b16796a7"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-29T10:16:00.900831879"
+    },
+    "sarscov2 - bigwig": {
+        "content": [
+            "all_bigwig.bigwigSummary.npz",
+            [
+                "versions.yml:md5,09e49452477fbd0b76a68692b16796a7"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-29T10:15:50.113067001"
+    }
+}


### PR DESCRIPTION
add a new deeptools module multiBigwigSummary to support cases where coverage is already normalized (BigWig input). This is needed to generate .npz matrices for downstream analyses like PCA, correlation heatmaps, and plotProfile.

## PR checklist

Closes #8818 (https://github.com/nf-core/modules/issues/8818

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [X] Remove all TODO statements.
- [X] Emit the `versions.yml` file.
- [X] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [X] Add a resource `label`
- [X] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [X] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
