### PR TITLE
Move YaHS inputs to single tuple

### DIFF
--- a/modules/nf-core/yahs/environment.yml
+++ b/modules/nf-core/yahs/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::yahs=1.2a.2
+  - bioconda::yahs=1.2.2

--- a/modules/nf-core/yahs/main.nf
+++ b/modules/nf-core/yahs/main.nf
@@ -11,10 +11,10 @@ process YAHS {
     tuple val(meta), path(fasta), path(fai), path(hic_map)
 
     output:
-    tuple val(meta), path("*scaffolds_final.fa") , emit: scaffolds_fasta,  optional: true
-    tuple val(meta), path("*scaffolds_final.agp"), emit: scaffolds_agp,    optional: true
-    tuple val(meta), path("*bin")                , emit: binary
-    path "versions.yml"                          , emit: versions
+    tuple val(meta), path("*.fa") , emit: scaffolds_fasta,  optional: true
+    tuple val(meta), path("*.agp"), emit: scaffolds_agp,    optional: true
+    tuple val(meta), path("*.bin"), emit: binary
+    path "versions.yml"           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/yahs/main.nf
+++ b/modules/nf-core/yahs/main.nf
@@ -4,8 +4,8 @@ process YAHS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/yahs:1.2--he4a0461_1':
-        'biocontainers/yahs:1.2--he4a0461_1' }"
+        'https://depot.galaxyproject.org/singularity/yahs:1.2.2--h577a1d6_1':
+        'biocontainers/yahs:1.2.2--h577a1d6_1' }"
 
     input:
     tuple val(meta), path(fasta), path(fai), path(hic_map)
@@ -24,8 +24,9 @@ process YAHS {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    yahs ${args} \\
+    yahs \\
         -o ${prefix} \\
+        ${args} \\
         ${fasta} \\
         ${hic_map}
 

--- a/modules/nf-core/yahs/main.nf
+++ b/modules/nf-core/yahs/main.nf
@@ -22,7 +22,6 @@ process YAHS {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-
     """
     yahs \\
         -o ${prefix} \\
@@ -37,6 +36,7 @@ process YAHS {
     """
 
     stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}_scaffold_final.fa
     touch ${prefix}_scaffolds_final.agp

--- a/modules/nf-core/yahs/main.nf
+++ b/modules/nf-core/yahs/main.nf
@@ -1,5 +1,5 @@
 process YAHS {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
@@ -8,9 +8,7 @@ process YAHS {
         'biocontainers/yahs:1.2--he4a0461_1' }"
 
     input:
-    tuple val(meta), path(hic_map)
-    path fasta
-    path fai
+    tuple val(meta), path(fasta), path(fai), path(hic_map)
 
     output:
     tuple val(meta), path("*scaffolds_final.fa") , emit: scaffolds_fasta,  optional: true
@@ -26,10 +24,10 @@ process YAHS {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    yahs $args \\
-        -o $prefix \\
-        $fasta \\
-        $hic_map
+    yahs ${args} \\
+        -o ${prefix} \\
+        ${fasta} \\
+        ${hic_map}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/yahs/meta.yml
+++ b/modules/nf-core/yahs/meta.yml
@@ -15,7 +15,6 @@ tools:
       licence: ["MIT"]
       identifier: biotools:yahs
 input:
-  # Only when we have meta
   - - meta:
         type: map
         description: |
@@ -26,28 +25,27 @@ input:
         description: BED file containing coordinates of read alignments
         pattern: "*.{bed,bam,bin}"
         ontologies: []
-  - fasta:
-      type: file
-      description: FASTA reference file
-      pattern: "*.{fasta,fa}"
-      ontologies: []
-  - fai:
-      type: file
-      description: index of the reference file
-      pattern: "*.{fai}"
-      ontologies: []
+    - fasta:
+        type: file
+        description: FASTA reference file
+        pattern: "*.{fasta,fa}"
+        ontologies: []
+    - fai:
+        type: file
+        description: index of the reference file
+        pattern: "*.{fai}"
+        ontologies: []
 output:
-  #Only when we have meta
   scaffolds_fasta:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
-      - "*scaffolds_final.fa":
+      - "*.fa":
           type: file
           description: FASTA file with resulting contigs
-          pattern: "*scaffolds_final.fa"
+          pattern: "*.fa"
           ontologies: []
   scaffolds_agp:
     - - meta:
@@ -55,10 +53,10 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
-      - "*scaffolds_final.agp":
+      - "*.agp":
           type: file
           description: AGP file containing contigs placing coordinates
-          pattern: "*scaffolds_final.agp"
+          pattern: "*.agp"
           ontologies: []
   binary:
     - - meta:
@@ -66,11 +64,11 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
-      - "*bin":
+      - "*.bin":
           type: file
           description: BIN file with alignment results of Hi-C reads to the contigs
             in internal YaHS binary format
-          pattern: "*bin"
+          pattern: "*.bin"
           ontologies: []
   versions:
     - versions.yml:

--- a/modules/nf-core/yahs/meta.yml
+++ b/modules/nf-core/yahs/meta.yml
@@ -20,11 +20,6 @@ input:
         description: |
           Groovy Map containing sample information
           e.g. [ id:'test' ]
-    - hic_map:
-        type: file
-        description: BED file containing coordinates of read alignments
-        pattern: "*.{bed,bam,bin}"
-        ontologies: []
     - fasta:
         type: file
         description: FASTA reference file
@@ -34,6 +29,11 @@ input:
         type: file
         description: index of the reference file
         pattern: "*.{fai}"
+        ontologies: []
+    - hic_map:
+        type: file
+        description: BED file containing coordinates of read alignments
+        pattern: "*.{bed,bam,bin}"
         ontologies: []
 output:
   scaffolds_fasta:

--- a/modules/nf-core/yahs/meta.yml
+++ b/modules/nf-core/yahs/meta.yml
@@ -24,17 +24,21 @@ input:
         type: file
         description: FASTA reference file
         pattern: "*.{fasta,fa}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
     - fai:
         type: file
         description: index of the reference file
         pattern: "*.{fai}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3475 # TSV
     - hic_map:
         type: file
         description: BED file containing coordinates of read alignments
         pattern: "*.{bed,bam,bin}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3003 # BED
+          - edam: http://edamontology.org/format_2572 # BAM
 output:
   scaffolds_fasta:
     - - meta:
@@ -46,7 +50,8 @@ output:
           type: file
           description: FASTA file with resulting contigs
           pattern: "*.fa"
-          ontologies: []
+          ontologies:
+            - edam: http://edamontology.org/format_1929 # FASTA
   scaffolds_agp:
     - - meta:
           type: map
@@ -57,7 +62,8 @@ output:
           type: file
           description: AGP file containing contigs placing coordinates
           pattern: "*.agp"
-          ontologies: []
+          ontologies:
+            - edam: http://edamontology.org/format_3693 # AGP
   binary:
     - - meta:
           type: map
@@ -66,10 +72,10 @@ output:
             e.g. [ id:'test' ]
       - "*.bin":
           type: file
-          description: BIN file with alignment results of Hi-C reads to the contigs
-            in internal YaHS binary format
+          description: |
+            Binary data file with alignment results of Hi-C reads
+            to the contigs in internal YaHS binary format
           pattern: "*.bin"
-          ontologies: []
   versions:
     - versions.yml:
         type: file

--- a/modules/nf-core/yahs/tests/main.nf.test
+++ b/modules/nf-core/yahs/tests/main.nf.test
@@ -1,4 +1,3 @@
-
 nextflow_process {
 
     name "Test Process YAHS"
@@ -32,14 +31,23 @@ nextflow_process {
             }
         }
 
-    test("homo_sapiens-bam-fasta-fai") {
+    test("homo_sapiens - bam - fasta - fai") {
 
         when {
+
+            params {
+                yahs_args = "--no-contig-ec"
+            }
+
             process {
                 """
                 input[0] = SAMTOOLS_VIEW.out.bam
-				input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
-				input[2] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    .combine(
+                        Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true))
+                    )
+                    .combine(
+                        Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true))
+                    )
                 """
             }
         }
@@ -51,5 +59,37 @@ nextflow_process {
             )
         }
     }
+
+    test("homo_sapiens - bam - fasta - fai - stub") {
+
+        options "-stub"
+
+        when {
+
+            params {
+                yahs_args = ""
+            }
+
+            process {
+                """
+                input[0] = SAMTOOLS_VIEW.out.bam
+                    .combine(
+                        Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true))
+                    )
+                    .combine(
+                        Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true))
+                    )
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
 
 }

--- a/modules/nf-core/yahs/tests/main.nf.test
+++ b/modules/nf-core/yahs/tests/main.nf.test
@@ -14,7 +14,7 @@ nextflow_process {
             run("SAMTOOLS_VIEW") {
             script "../../samtools/view"
             process {
-                 """
+                """
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
@@ -36,18 +36,20 @@ nextflow_process {
         when {
 
             params {
+                samtools_view_args = "--output-fmt bam"
                 yahs_args = "--no-contig-ec"
             }
 
             process {
                 """
                 input[0] = SAMTOOLS_VIEW.out.bam
-                    .combine(
-                        Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true))
-                    )
-                    .combine(
-                        Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true))
-                    )
+                    .map { meta, bam ->
+                        [ meta,
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                        bam
+                        ]
+                    }
                 """
             }
         }
@@ -67,6 +69,7 @@ nextflow_process {
         when {
 
             params {
+                samtools_view_args = "--output-fmt bam"
                 yahs_args = ""
             }
 

--- a/modules/nf-core/yahs/tests/main.nf.test
+++ b/modules/nf-core/yahs/tests/main.nf.test
@@ -76,12 +76,13 @@ nextflow_process {
             process {
                 """
                 input[0] = SAMTOOLS_VIEW.out.bam
-                    .combine(
-                        Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true))
-                    )
-                    .combine(
-                        Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true))
-                    )
+                    .map { meta, bam ->
+                        [ meta,
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                        bam
+                        ]
+                    }
                 """
             }
         }

--- a/modules/nf-core/yahs/tests/main.nf.test.snap
+++ b/modules/nf-core/yahs/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "homo_sapiens-bam-fasta-fai": {
+    "homo_sapiens - bam - fasta - fai - stub": {
         "content": [
             {
                 "0": [
@@ -29,9 +29,44 @@
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2024-09-26T22:35:24.103271222"
+        "timestamp": "2025-07-30T14:34:46.832978505"
+    },
+    "homo_sapiens - bam - fasta - fai": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "binary": [
+                    
+                ],
+                "scaffolds_agp": [
+                    
+                ],
+                "scaffolds_fasta": [
+                    
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-07-30T14:34:34.579989637"
     }
 }

--- a/modules/nf-core/yahs/tests/main.nf.test.snap
+++ b/modules/nf-core/yahs/tests/main.nf.test.snap
@@ -3,28 +3,64 @@
         "content": [
             {
                 "0": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffold_final.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "1": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_final.agp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "2": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "3": [
-                    
+                    "versions.yml:md5,37472c36bf654e5ffc7507701c5f280a"
                 ],
                 "binary": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "scaffolds_agp": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_final.agp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "scaffolds_fasta": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffold_final.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "versions": [
-                    
+                    "versions.yml:md5,37472c36bf654e5ffc7507701c5f280a"
                 ]
             }
         ],
@@ -32,34 +68,76 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-30T14:34:46.832978505"
+        "timestamp": "2025-07-31T08:40:53.732150888"
     },
     "homo_sapiens - bam - fasta - fai": {
         "content": [
             {
                 "0": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_final.fa:md5,a767604036a4cd6980ebd24f11e4dd95"
+                    ]
                 ],
                 "1": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_no_break.agp:md5,374235b079d9e1c738c6f12697029b78",
+                            "test_scaffolds_final.agp:md5,374235b079d9e1c738c6f12697029b78"
+                        ]
+                    ]
                 ],
                 "2": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bin:md5,da45a2ec8a97fc24783e9a63373db379"
+                    ]
                 ],
                 "3": [
-                    
+                    "versions.yml:md5,37472c36bf654e5ffc7507701c5f280a"
                 ],
                 "binary": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bin:md5,da45a2ec8a97fc24783e9a63373db379"
+                    ]
                 ],
                 "scaffolds_agp": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_no_break.agp:md5,374235b079d9e1c738c6f12697029b78",
+                            "test_scaffolds_final.agp:md5,374235b079d9e1c738c6f12697029b78"
+                        ]
+                    ]
                 ],
                 "scaffolds_fasta": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_final.fa:md5,a767604036a4cd6980ebd24f11e4dd95"
+                    ]
                 ],
                 "versions": [
-                    
+                    "versions.yml:md5,37472c36bf654e5ffc7507701c5f280a"
                 ]
             }
         ],
@@ -67,6 +145,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-07-30T14:34:34.579989637"
+        "timestamp": "2025-07-31T08:39:33.818621656"
     }
 }

--- a/modules/nf-core/yahs/tests/nextflow.config
+++ b/modules/nf-core/yahs/tests/nextflow.config
@@ -1,6 +1,5 @@
 process {
-    withName: 'test_yahs:YAHS' {
-        ext.prefix = { "${meta.id}" }
-        ext.args = '--no-contig-ec'
+    withName: 'YAHS' {
+        ext.args = params.yahs_args
     }
 }

--- a/modules/nf-core/yahs/tests/nextflow.config
+++ b/modules/nf-core/yahs/tests/nextflow.config
@@ -1,4 +1,8 @@
 process {
+    withName: 'SAMTOOLS_VIEW' {
+        ext.args = params.samtools_view_args
+    }
+
     withName: 'YAHS' {
         ext.args = params.yahs_args
     }


### PR DESCRIPTION
YaHS inputs are conceptually linked - the mapped hic reads correspond to a specific fasta file - so I've put everything in a single input tuple. This makes it easier to run YaHS on multiple assemblies. I don't think there are any official nf-core pipelines using this module yet so hopefully this isn't too troubling.

Also adds a stub test as I noticed that was missing, and moves the args into a param.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
