### PR TITLE
Improve scrublet batch_col handling

### DIFF
--- a/modules/nf-core/scanpy/scrublet/templates/scrublet.py
+++ b/modules/nf-core/scanpy/scrublet/templates/scrublet.py
@@ -16,7 +16,7 @@ sc.settings.n_jobs = int("${task.cpus}")
 
 adata = sc.read_h5ad("${h5ad}")
 prefix = "${prefix}"
-batch_col = "${batch_col}"
+batch_col = "${batch_col ?: ''}"
 
 kwargs = {}
 if batch_col and adata.obs[batch_col].nunique() > 1:

--- a/modules/nf-core/scanpy/scrublet/tests/main.nf.test
+++ b/modules/nf-core/scanpy/scrublet/tests/main.nf.test
@@ -34,6 +34,80 @@ nextflow_process {
 
     }
 
+    test("Should run with empty string for batch_col") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679759_filtered_matrix.h5ad', checkIfExists: true)
+                    ]
+                )
+                input[1] = ''
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(process.out).match() },
+            { assert "predicted_doublet" in anndata(process.out.h5ad[0][1]).obs.colnames }
+            )
+        }
+
+    }
+
+    test("Should run with empty array for batch_col") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679759_filtered_matrix.h5ad', checkIfExists: true)
+                    ]
+                )
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(process.out).match() },
+            { assert "predicted_doublet" in anndata(process.out.h5ad[0][1]).obs.colnames }
+            )
+        }
+
+    }
+
+
+    test("Should fail with non-existing batch_col") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679759_filtered_matrix.h5ad', checkIfExists: true)
+                    ]
+                )
+                input[1] = 'non_existing_col'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.failed }
+            )
+        }
+
+    }
+
     test("Should run without failures - stub") {
 
         options '-stub'

--- a/modules/nf-core/scanpy/scrublet/tests/main.nf.test.snap
+++ b/modules/nf-core/scanpy/scrublet/tests/main.nf.test.snap
@@ -96,5 +96,103 @@
             "nextflow": "25.04.3"
         },
         "timestamp": "2025-06-23T09:34:50.239866068"
+    },
+    "Should run with empty string for batch_col": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_scrublet.h5ad:md5,e0a7fa8f6e9804ca967a3741bebc7d20"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_scrublet.pkl:md5,43a48e4d0db3979e88a617ec7549fab5"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7b82a4b5cf47958c4d0cb9bba81cce40"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_scrublet.h5ad:md5,e0a7fa8f6e9804ca967a3741bebc7d20"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_scrublet.pkl:md5,43a48e4d0db3979e88a617ec7549fab5"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7b82a4b5cf47958c4d0cb9bba81cce40"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-08-02T14:06:47.499404197"
+    },
+    "Should run with empty array for batch_col": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_scrublet.h5ad:md5,e0a7fa8f6e9804ca967a3741bebc7d20"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_scrublet.pkl:md5,43a48e4d0db3979e88a617ec7549fab5"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7b82a4b5cf47958c4d0cb9bba81cce40"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_scrublet.h5ad:md5,e0a7fa8f6e9804ca967a3741bebc7d20"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_scrublet.pkl:md5,43a48e4d0db3979e88a617ec7549fab5"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7b82a4b5cf47958c4d0cb9bba81cce40"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-08-02T14:07:36.218370923"
     }
 }


### PR DESCRIPTION
Just a small fix, previously empty array inputs (often used as placeholders for missing values) were not handled properly