### PR TITLE
Update scvitools modules

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -34,9 +34,7 @@ jobs:
   nf-test-changes:
     name: nf-test-changes
     runs-on:
-      - runs-on=${{ github.run_id }}-nf-test-changes
-      - runner=4cpu-linux-x64
-      - image=ubuntu22-full-x64
+      - ubuntu-latest
     outputs:
       # Expose detected tags as 'modules' and 'workflows' output variables
       paths: ${{ steps.list.outputs.components }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -34,7 +34,9 @@ jobs:
   nf-test-changes:
     name: nf-test-changes
     runs-on:
-      - ubuntu-latest
+      - runs-on=${{ github.run_id }}-nf-test-changes
+      - runner=4cpu-linux-x64
+      - image=ubuntu22-full-x64
     outputs:
       # Expose detected tags as 'modules' and 'workflows' output variables
       paths: ${{ steps.list.outputs.components }}

--- a/modules/nf-core/scvitools/scar/environment.yml
+++ b/modules/nf-core/scvitools/scar/environment.yml
@@ -3,8 +3,5 @@
 channels:
   - conda-forge
   - bioconda
-
 dependencies:
-  - conda-forge::jaxlib=0.4.31
-  - conda-forge::python=3.12.7
-  - conda-forge::scvi-tools=1.2.0
+  - conda-forge::scvi-tools=1.3.3

--- a/modules/nf-core/scvitools/scar/main.nf
+++ b/modules/nf-core/scvitools/scar/main.nf
@@ -4,11 +4,14 @@ process SCVITOOLS_SCAR {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9b/9b999caba5a5a6bc19bd324d9f1ac28e092a750140b453071956ebc304b7c4aa/data':
-        'community.wave.seqera.io/library/scvi-tools:1.2.0--680d378b86801b8a' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c8764e4208e9639a54d636fc65c839c55dedbfd68def57baea90d1d2007d6a7f/data':
+        'community.wave.seqera.io/library/scvi-tools:1.3.3--df115aabdccb7d6b' }"
 
     input:
     tuple val(meta), path(filtered), path(unfiltered)
+    val(input_layer)
+    val(output_layer)
+    val(max_epochs)
 
     output:
     tuple val(meta), path("*.h5ad"), emit: h5ad
@@ -19,9 +22,6 @@ process SCVITOOLS_SCAR {
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
-    input_layer = task.ext.input_layer ?: "X"
-    output_layer = task.ext.output_layer ?: "scar"
-    max_epochs = task.ext.max_epochs ?: ""
     template 'scar.py'
 
     stub:

--- a/modules/nf-core/scvitools/scar/main.nf
+++ b/modules/nf-core/scvitools/scar/main.nf
@@ -12,6 +12,7 @@ process SCVITOOLS_SCAR {
     val(input_layer)
     val(output_layer)
     val(max_epochs)
+    val(n_batch)
 
     output:
     tuple val(meta), path("*.h5ad"), emit: h5ad

--- a/modules/nf-core/scvitools/scar/meta.yml
+++ b/modules/nf-core/scvitools/scar/meta.yml
@@ -29,12 +29,26 @@ input:
         type: file
         description: AnnData file containing filtered data (without empty droplets)
         pattern: "*.h5ad"
-        ontologies: []
+        ontologies:
+          - edam: "http://edamontology.org/format_3590" # HDF5 format
     - unfiltered:
         type: file
         description: AnnData file containing unfiltered data (with empty droplets)
         pattern: "*.h5ad"
-        ontologies: []
+        ontologies:
+          - edam: "http://edamontology.org/format_3590" # HDF5 format
+  - input_layer:
+      type: string
+      description: Layer to use as input. Defaults to `X`.
+  - output_layer:
+      type: string
+      description: Layer to save the denoised counts to. Defaults to `scar`.
+  - max_epochs:
+      type: int
+      description: Maximum number of epochs to train the model. Defaults to the [heuristic default](https://docs.scvi-tools.org/en/stable/api/reference/scvi.model.get_max_epochs_heuristic.html#scvi.model.get_max_epochs_heuristic).
+  - n_batch:
+      type: int
+      description: Number of batches to use for generating the ambient profile. Defaults to 1. This can be increased to prevent out-of-memory errors.
 output:
   h5ad:
     - - meta:
@@ -46,7 +60,8 @@ output:
           type: file
           description: AnnData file containing decontaminated counts as `adata.X`
           pattern: "*.h5ad"
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_3590" # HDF5 format
   versions:
     - versions.yml:
         type: file

--- a/modules/nf-core/scvitools/scar/meta.yml
+++ b/modules/nf-core/scvitools/scar/meta.yml
@@ -44,10 +44,10 @@ input:
       type: string
       description: Layer to save the denoised counts to. Defaults to `scar`.
   - max_epochs:
-      type: int
+      type: integer
       description: Maximum number of epochs to train the model. Defaults to the [heuristic default](https://docs.scvi-tools.org/en/stable/api/reference/scvi.model.get_max_epochs_heuristic.html#scvi.model.get_max_epochs_heuristic).
   - n_batch:
-      type: int
+      type: integer
       description: Number of batches to use for generating the ambient profile. Defaults to 1. This can be increased to prevent out-of-memory errors.
 output:
   h5ad:

--- a/modules/nf-core/scvitools/scar/templates/scar.py
+++ b/modules/nf-core/scvitools/scar/templates/scar.py
@@ -1,64 +1,51 @@
 #!/usr/bin/env python3
 
-import platform
-
 import anndata as ad
 import scvi
 from scipy.sparse import csr_matrix
 from scvi.external import SCAR
 from threadpoolctl import threadpool_limits
+import yaml
 
 threadpool_limits(int("${task.cpus}"))
 
 scvi.settings.seed = 0
 
 
-def format_yaml_like(data: dict, indent: int = 0) -> str:
-    """Formats a dictionary to a YAML-like string.
-
-    Args:
-        data (dict): The dictionary to format.
-        indent (int): The current indentation level.
-
-    Returns:
-        str: A string formatted as YAML.
-    """
-    yaml_str = ""
-    for key, value in data.items():
-        spaces = "    " * indent
-        if isinstance(value, dict):
-            yaml_str += f"{spaces}{key}:\\n{format_yaml_like(value, indent + 1)}"
-        else:
-            yaml_str += f"{spaces}{key}: {value}\\n"
-    return yaml_str
-
-
 adata = ad.read_h5ad("${filtered}")
 adata_unfiltered = ad.read_h5ad("${unfiltered}")
 
-SCAR.setup_anndata(adata, layer=None if "${input_layer}" == "X" else "${input_layer}")
+input_layer = "${input_layer ?: 'X'}"
+output_layer = "${output_layer ?: 'scar'}"
+max_epochs = "${max_epochs ?: ''}"
+
+SCAR.setup_anndata(adata, layer=None if input_layer == "X" else input_layer)
 SCAR.get_ambient_profile(adata, adata_unfiltered)
 
 vae = SCAR(adata)
 
 # Prevent errors like https://discourse.scverse.org/t/scvi-21618-problem/2294
 vae.train(
-    max_epochs=int("${max_epochs}") if "${max_epochs}" else None,
+    max_epochs=int(max_epochs) if max_epochs else None,
     early_stopping=True,
     datasplitter_kwargs={"drop_last": True},
 )
 
-if "${output_layer}" == "X":
+if output_layer == "X":
     adata.X = csr_matrix(vae.get_denoised_counts())
 else:
-    adata.layers["${output_layer}"] = csr_matrix(vae.get_denoised_counts())
+    adata.layers[output_layer] = csr_matrix(vae.get_denoised_counts())
 
 del adata.uns["_scvi_uuid"], adata.uns["_scvi_manager_uuid"]
 
 adata.write_h5ad("${prefix}.h5ad")
 
 # Versions
-versions = {"${task.process}": {"python": platform.python_version(), "scvi": scvi.__version__}}
+versions = {
+    "${task.process}": {
+        "scvi": scvi.__version__
+    }
+}
 
 with open("versions.yml", "w") as f:
-    f.write(format_yaml_like(versions))
+    f.write(yaml.dump(versions))

--- a/modules/nf-core/scvitools/scar/templates/scar.py
+++ b/modules/nf-core/scvitools/scar/templates/scar.py
@@ -18,9 +18,10 @@ adata_unfiltered = ad.read_h5ad("${unfiltered}")
 input_layer = "${input_layer ?: 'X'}"
 output_layer = "${output_layer ?: 'scar'}"
 max_epochs = "${max_epochs ?: ''}"
+n_batch = int("${n_batch ?: 1}")
 
 SCAR.setup_anndata(adata, layer=None if input_layer == "X" else input_layer)
-SCAR.get_ambient_profile(adata, adata_unfiltered)
+SCAR.get_ambient_profile(adata, adata_unfiltered, n_batch=n_batch)
 
 vae = SCAR(adata)
 

--- a/modules/nf-core/scvitools/scar/templates/scar.py
+++ b/modules/nf-core/scvitools/scar/templates/scar.py
@@ -20,6 +20,9 @@ output_layer = "${output_layer ?: 'scar'}"
 max_epochs = "${max_epochs ?: ''}"
 n_batch = int("${n_batch ?: 1}")
 
+if input_layer != "X" and input_layer not in adata.layers:
+    raise ValueError(f"Input layer {input_layer} not found in adata.layers")
+
 SCAR.setup_anndata(adata, layer=None if input_layer == "X" else input_layer)
 SCAR.get_ambient_profile(adata, adata_unfiltered, n_batch=n_batch)
 

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test
@@ -14,8 +14,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad', checkIfExists: true),
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_raw_matrix_5k.h5ad', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = []
                 input[2] = []
@@ -38,11 +38,35 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad', checkIfExists: true),
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_raw_matrix_5k.h5ad', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = 'X'
                 input[2] = 'X'
+                input[3] = 1
+                input[4] = 3
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Should run with custom input and output layers") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                ]
+                input[1] = 'counts'
+                input[2] = 'denoised'
                 input[3] = 1
                 input[4] = 3
                 """
@@ -62,8 +86,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad', checkIfExists: true),
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_raw_matrix_5k.h5ad', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = 'invalid'
                 input[2] = 'denoised'
@@ -87,8 +111,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad', checkIfExists: true),
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_raw_matrix_5k.h5ad', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = []
                 input[2] = []

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test
@@ -27,7 +27,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out.versions,
+                    file(process.out.h5ad[0][1]).name
+                ).match() }
             )
         }
     }
@@ -51,7 +54,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out.versions,
+                    file(process.out.h5ad[0][1]).name
+                ).match() }
             )
         }
     }
@@ -75,7 +81,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out.versions,
+                    file(process.out.h5ad[0][1]).name
+                ).match() }
             )
         }
     }

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test
@@ -14,8 +14,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad', checkIfExists: true),
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_raw_matrix_5k.h5ad', checkIfExists: true)
                 ]
                 input[1] = []
                 input[2] = []
@@ -38,35 +38,11 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad', checkIfExists: true),
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_raw_matrix_5k.h5ad', checkIfExists: true)
                 ]
                 input[1] = 'X'
                 input[2] = 'X'
-                input[3] = 1
-                input[4] = 3
-                """
-            }
-        }
-        then {
-            assertAll(
-                { assert process.success },
-                { assert snapshot(process.out).match() }
-            )
-        }
-    }
-
-    test("Should run with custom input and output layers") {
-        when {
-            process {
-                """
-                input[0] = [
-                    [ id:'test' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
-                ]
-                input[1] = 'counts'
-                input[2] = 'denoised'
                 input[3] = 1
                 input[4] = 3
                 """
@@ -86,8 +62,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad', checkIfExists: true),
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_raw_matrix_5k.h5ad', checkIfExists: true)
                 ]
                 input[1] = 'invalid'
                 input[2] = 'denoised'
@@ -111,8 +87,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad', checkIfExists: true),
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_raw_matrix_5k.h5ad', checkIfExists: true)
                 ]
                 input[1] = []
                 input[2] = []

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test
@@ -20,6 +20,7 @@ nextflow_process {
                 input[1] = []
                 input[2] = []
                 input[3] = 1
+                input[4] = 3
                 """
             }
         }
@@ -45,6 +46,7 @@ nextflow_process {
                 input[1] = []
                 input[2] = []
                 input[3] = 1
+                input[4] = 3
                 """
             }
         }

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test
@@ -8,7 +8,7 @@ nextflow_process {
     tag "scvitools/scar"
     tag "scvitools"
 
-    test("test_scar") {
+    test("Should run with default parameters") {
         when {
             process {
                 """
@@ -32,7 +32,78 @@ nextflow_process {
         }
     }
 
-    test("test_scar - stub") {
+        test("Should run from X to X") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                ]
+                input[1] = 'X'
+                input[2] = 'X'
+                input[3] = 1
+                input[4] = 3
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Should run with custom input and output layers") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                ]
+                input[1] = 'counts'
+                input[2] = 'denoised'
+                input[3] = 1
+                input[4] = 3
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Should fail with invalid input layer") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
+                ]
+                input[1] = 'invalid'
+                input[2] = 'denoised'
+                input[3] = 1
+                input[4] = 3
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.failed }
+            )
+        }
+    }
+
+    test("Should run with default parameters - stub") {
         options '-stub'
 
         when {

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test
@@ -2,7 +2,6 @@ nextflow_process {
     name 'Test Process SCVITOOLS_SCAR'
     script '../main.nf'
     process 'SCVITOOLS_SCAR'
-    config './nextflow.config'
 
     tag "modules"
     tag "modules_nfcore"
@@ -15,9 +14,12 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file("https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad", checkIfExists: true),
-                    file("https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/samples/SAMN14430799_raw_matrix_5k.h5ad", checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
                 ]
+                input[1] = []
+                input[2] = []
+                input[3] = 1
                 """
             }
         }
@@ -37,9 +39,12 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ], // meta map
-                    file("https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/samples/SAMN14430799_custom_emptydrops_filter_matrix_5k.h5ad", checkIfExists: true),
-                    file("https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/samples/SAMN14430799_raw_matrix_5k.h5ad", checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_raw_matrix.h5ad', checkIfExists: true)
                 ]
+                input[1] = []
+                input[2] = []
+                input[3] = 1
                 """
             }
         }

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
+                        "test.h5ad:md5,6dfb08913479d02e350e3226974a5458"
                     ]
                 ],
                 "1": [
@@ -18,7 +18,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
+                        "test.h5ad:md5,6dfb08913479d02e350e3226974a5458"
                     ]
                 ],
                 "versions": [
@@ -30,7 +30,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T18:43:36.896937872"
+        "timestamp": "2025-08-03T22:50:04.004967931"
     },
     "Should run from X to X": {
         "content": [
@@ -40,7 +40,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,2e21cfb014d1fae67f6f51d00a024804"
+                        "test.h5ad:md5,3c209811a17cc4f6c8cb526b9b4d0572"
                     ]
                 ],
                 "1": [
@@ -51,7 +51,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,2e21cfb014d1fae67f6f51d00a024804"
+                        "test.h5ad:md5,3c209811a17cc4f6c8cb526b9b4d0572"
                     ]
                 ],
                 "versions": [
@@ -63,7 +63,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T18:44:34.781089313"
+        "timestamp": "2025-08-03T22:50:23.709662857"
     },
     "Should run with default parameters - stub": {
         "content": [
@@ -102,26 +102,16 @@
         "content": [
             {
                 "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,245d6ad6eb03d500b1abdbe97be9e613"
-                    ]
+                    
                 ],
                 "1": [
-                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+                    
                 ],
                 "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,245d6ad6eb03d500b1abdbe97be9e613"
-                    ]
+                    
                 ],
                 "versions": [
-                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+                    
                 ]
             }
         ],
@@ -129,6 +119,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T18:45:31.509128385"
+        "timestamp": "2025-08-03T22:47:14.379374316"
     }
 }

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -11,7 +11,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,ee55dcf6be5d3b14c78b5f6e90bca80f"
+                    "versions.yml:md5,f6c25be06bfb18cdf3e82e50985d9a9b"
                 ],
                 "h5ad": [
                     [
@@ -22,47 +22,37 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,ee55dcf6be5d3b14c78b5f6e90bca80f"
+                    "versions.yml:md5,f6c25be06bfb18cdf3e82e50985d9a9b"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2024-11-01T22:13:47.031925127"
+        "timestamp": "2025-08-03T17:51:01.269369396"
     },
     "test_scar": {
         "content": [
             {
                 "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,6dfb08913479d02e350e3226974a5458"
-                    ]
+                    
                 ],
                 "1": [
-                    "versions.yml:md5,5a7a7b2094bb4abc3384d85d463e7e1f"
+                    
                 ],
                 "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,6dfb08913479d02e350e3226974a5458"
-                    ]
+                    
                 ],
                 "versions": [
-                    "versions.yml:md5,5a7a7b2094bb4abc3384d85d463e7e1f"
+                    
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2024-11-01T22:13:22.986373532"
+        "timestamp": "2025-08-03T17:50:47.998550844"
     }
 }

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -36,16 +36,26 @@
         "content": [
             {
                 "0": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
+                    ]
                 ],
                 "1": [
-                    
+                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
                 ],
                 "h5ad": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
+                    ]
                 ],
                 "versions": [
-                    
+                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
                 ]
             }
         ],
@@ -53,6 +63,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T17:50:47.998550844"
+        "timestamp": "2025-08-03T18:26:18.540765715"
     }
 }

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -1,69 +1,29 @@
 {
     "Should run with default parameters": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
-                ],
-                "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
-                ]
-            }
+            [
+                "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+            ],
+            "test.h5ad:md5,ea9bfe20c650f5ec739fe5c78fc52220"
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T18:43:36.896937872"
+        "timestamp": "2025-08-03T23:03:33.598077877"
     },
     "Should run from X to X": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,2e21cfb014d1fae67f6f51d00a024804"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
-                ],
-                "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,2e21cfb014d1fae67f6f51d00a024804"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
-                ]
-            }
+            [
+                "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+            ],
+            "test.h5ad:md5,ea9bfe20c650f5ec739fe5c78fc52220"
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T18:44:34.781089313"
+        "timestamp": "2025-08-03T23:04:44.19715466"
     },
     "Should run with default parameters - stub": {
         "content": [
@@ -100,35 +60,15 @@
     },
     "Should run with custom input and output layers": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,245d6ad6eb03d500b1abdbe97be9e613"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
-                ],
-                "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,245d6ad6eb03d500b1abdbe97be9e613"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
-                ]
-            }
+            [
+                "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+            ],
+            "test.h5ad:md5,ea9bfe20c650f5ec739fe5c78fc52220"
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T18:45:31.509128385"
+        "timestamp": "2025-08-03T23:05:52.352559392"
     }
 }

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "test_scar - stub": {
+    "Should run with default parameters": {
         "content": [
             {
                 "0": [
@@ -7,22 +7,22 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,f6c25be06bfb18cdf3e82e50985d9a9b"
+                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
                 ],
                 "h5ad": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,f6c25be06bfb18cdf3e82e50985d9a9b"
+                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
                 ]
             }
         ],
@@ -30,9 +30,9 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T17:51:01.269369396"
+        "timestamp": "2025-08-03T18:43:36.896937872"
     },
-    "test_scar": {
+    "Should run from X to X": {
         "content": [
             {
                 "0": [
@@ -40,7 +40,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
+                        "test.h5ad:md5,2e21cfb014d1fae67f6f51d00a024804"
                     ]
                 ],
                 "1": [
@@ -51,7 +51,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
+                        "test.h5ad:md5,2e21cfb014d1fae67f6f51d00a024804"
                     ]
                 ],
                 "versions": [
@@ -63,6 +63,72 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T18:26:18.540765715"
+        "timestamp": "2025-08-03T18:44:34.781089313"
+    },
+    "Should run with default parameters - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f6c25be06bfb18cdf3e82e50985d9a9b"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,f6c25be06bfb18cdf3e82e50985d9a9b"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-08-03T18:46:00.064617892"
+    },
+    "Should run with custom input and output layers": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,245d6ad6eb03d500b1abdbe97be9e613"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,245d6ad6eb03d500b1abdbe97be9e613"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-08-03T18:45:31.509128385"
     }
 }

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -4,7 +4,7 @@
             [
                 "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
             ],
-            "test.h5ad:md5,ea9bfe20c650f5ec739fe5c78fc52220"
+            "test.h5ad"
         ],
         "meta": {
             "nf-test": "0.9.2",
@@ -17,7 +17,7 @@
             [
                 "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
             ],
-            "test.h5ad:md5,ea9bfe20c650f5ec739fe5c78fc52220"
+            "test.h5ad"
         ],
         "meta": {
             "nf-test": "0.9.2",
@@ -63,7 +63,7 @@
             [
                 "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
             ],
-            "test.h5ad:md5,ea9bfe20c650f5ec739fe5c78fc52220"
+            "test.h5ad"
         ],
         "meta": {
             "nf-test": "0.9.2",

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,6dfb08913479d02e350e3226974a5458"
+                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
                     ]
                 ],
                 "1": [
@@ -18,7 +18,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,6dfb08913479d02e350e3226974a5458"
+                        "test.h5ad:md5,87b48f82ecd098304a6fdb8aa9e3eeb6"
                     ]
                 ],
                 "versions": [
@@ -30,7 +30,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T22:50:04.004967931"
+        "timestamp": "2025-08-03T18:43:36.896937872"
     },
     "Should run from X to X": {
         "content": [
@@ -40,7 +40,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,3c209811a17cc4f6c8cb526b9b4d0572"
+                        "test.h5ad:md5,2e21cfb014d1fae67f6f51d00a024804"
                     ]
                 ],
                 "1": [
@@ -51,7 +51,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,3c209811a17cc4f6c8cb526b9b4d0572"
+                        "test.h5ad:md5,2e21cfb014d1fae67f6f51d00a024804"
                     ]
                 ],
                 "versions": [
@@ -63,7 +63,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T22:50:23.709662857"
+        "timestamp": "2025-08-03T18:44:34.781089313"
     },
     "Should run with default parameters - stub": {
         "content": [
@@ -102,16 +102,26 @@
         "content": [
             {
                 "0": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,245d6ad6eb03d500b1abdbe97be9e613"
+                    ]
                 ],
                 "1": [
-                    
+                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
                 ],
                 "h5ad": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,245d6ad6eb03d500b1abdbe97be9e613"
+                    ]
                 ],
                 "versions": [
-                    
+                    "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
                 ]
             }
         ],
@@ -119,6 +129,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T22:47:14.379374316"
+        "timestamp": "2025-08-03T18:45:31.509128385"
     }
 }

--- a/modules/nf-core/scvitools/scar/tests/nextflow.config
+++ b/modules/nf-core/scvitools/scar/tests/nextflow.config
@@ -1,5 +1,0 @@
-process {
-      withName: SCVITOOLS_SCAR {
-         ext.max_epochs = 1
-     }
- } 

--- a/modules/nf-core/scvitools/solo/environment.yml
+++ b/modules/nf-core/scvitools/solo/environment.yml
@@ -3,9 +3,5 @@
 channels:
   - conda-forge
   - bioconda
-
 dependencies:
-  - conda-forge::anndata=0.10.9
-  - conda-forge::jaxlib=0.4.31
-  - conda-forge::python=3.12.7
-  - conda-forge::scvi-tools=1.2.0
+  - conda-forge::scvi-tools=1.3.3

--- a/modules/nf-core/scvitools/solo/main.nf
+++ b/modules/nf-core/scvitools/solo/main.nf
@@ -4,13 +4,15 @@ process SCVITOOLS_SOLO {
     label 'process_gpu'
 
     conda "${moduleDir}/environment.yml"
-    container "${ task.ext.use_gpu ? 'docker.io/nicotru/scvitools-gpu:cuda-12' :
+    container "${ task.ext.use_gpu ? 'ghcr.io/scverse/scvi-tools:py3.12-cu12-1.3.3-' :
         workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9b/9b999caba5a5a6bc19bd324d9f1ac28e092a750140b453071956ebc304b7c4aa/data':
-        'community.wave.seqera.io/library/scvi-tools:1.2.0--680d378b86801b8a' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c8764e4208e9639a54d636fc65c839c55dedbfd68def57baea90d1d2007d6a7f/data':
+        'community.wave.seqera.io/library/scvi-tools:1.3.3--df115aabdccb7d6b' }"
 
     input:
     tuple val(meta), path(h5ad)
+    val(batch_key)
+    val(max_epochs)
 
     output:
     tuple val(meta), path("*.h5ad"), emit: h5ad
@@ -22,8 +24,6 @@ process SCVITOOLS_SOLO {
 
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
-    batch_key = task.ext.batch_key ?: ""
-    max_epochs = task.ext.max_epochs ?: ""
     template 'solo.py'
 
     stub:
@@ -36,8 +36,6 @@ process SCVITOOLS_SOLO {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python3 -c 'import platform; print(platform.python_version())')
-        anndata: \$(python3 -c 'import anndata; print(anndata.__version__)')
         scvi: \$(python3 -c 'import scvi; print(scvi.__version__)')
     END_VERSIONS
     """

--- a/modules/nf-core/scvitools/solo/meta.yml
+++ b/modules/nf-core/scvitools/solo/meta.yml
@@ -30,7 +30,7 @@ input:
       type: string
       description: Column in adata.obs to use as batch. If not provided, the entire dataset is treated as a single batch.
   - max_epochs:
-      type: int
+      type: integer
       description: Maximum number of epochs to train the model. Defaults to the [heuristic default](https://docs.scvi-tools.org/en/stable/api/reference/scvi.model.get_max_epochs_heuristic.html#scvi.model.get_max_epochs_heuristic).
 output:
   h5ad:

--- a/modules/nf-core/scvitools/solo/meta.yml
+++ b/modules/nf-core/scvitools/solo/meta.yml
@@ -19,33 +19,38 @@ input:
         type: map
         description: |
           Groovy Map containing sample information
-          e.g. `[ id:'sample1', single_end:false ]`
-
+          e.g. `[ id:'sample1' ]`
     - h5ad:
         type: file
         description: H5AD anndata object
         pattern: "*.h5ad"
-
-        ontologies: []
+        ontologies:
+          - edam: "http://edamontology.org/format_3590" # HDF5 format
+  - batch_key:
+      type: string
+      description: Column in adata.obs to use as batch. If not provided, the entire dataset is treated as a single batch.
+  - max_epochs:
+      type: int
+      description: Maximum number of epochs to train the model. Defaults to the [heuristic default](https://docs.scvi-tools.org/en/stable/api/reference/scvi.model.get_max_epochs_heuristic.html#scvi.model.get_max_epochs_heuristic).
 output:
   h5ad:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. `[ id:'sample1', single_end:false ]`
+            e.g. `[ id:'sample1' ]`
       - "*.h5ad":
           type: file
           description: H5AD anndata object without doublets
           pattern: "*.h5ad"
-
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_3590" # HDF5 format
   predictions:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
-            e.g. `[ id:'sample1', single_end:false ]`
+            e.g. `[ id:'sample1' ]`
       - "*.pkl":
           type: file
           description: pandas dataframe containing the doublet classification

--- a/modules/nf-core/scvitools/solo/templates/solo.py
+++ b/modules/nf-core/scvitools/solo/templates/solo.py
@@ -40,7 +40,7 @@ train_model(model)
 
 adata.obs["doublet"] = False
 
-batches = adata.obs["batch"].unique() if batch_key else [0]
+batches = adata.obs[batch_key].unique() if batch_key else [0]
 for batch in batches:
     model = SOLO.from_scvi_model(model, restrict_to_batch=batch if len(batches) > 1 else None)
 

--- a/modules/nf-core/scvitools/solo/templates/solo.py
+++ b/modules/nf-core/scvitools/solo/templates/solo.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import platform
 
 os.environ["MPLCONFIGDIR"] = "./tmp"
 
@@ -11,6 +10,7 @@ import torch
 from scvi.external import SOLO
 from scvi.model import SCVI
 from threadpoolctl import threadpool_limits
+import yaml
 
 torch.set_float32_matmul_precision("medium")
 scvi.settings.seed = 0
@@ -18,38 +18,19 @@ scvi.settings.seed = 0
 threadpool_limits(int("${task.cpus}"))
 scvi.settings.num_threads = int("${task.cpus}")
 
-
-def format_yaml_like(data: dict, indent: int = 0) -> str:
-    """Formats a dictionary to a YAML-like string.
-
-    Args:
-        data (dict): The dictionary to format.
-        indent (int): The current indentation level.
-
-    Returns:
-        str: A string formatted as YAML.
-    """
-    yaml_str = ""
-    for key, value in data.items():
-        spaces = "    " * indent
-        if isinstance(value, dict):
-            yaml_str += f"{spaces}{key}:\\n{format_yaml_like(value, indent + 1)}"
-        else:
-            yaml_str += f"{spaces}{key}: {value}\\n"
-    return yaml_str
-
+batch_key = "${batch_key ?: ''}"
+max_epochs = "${max_epochs ?: ''}"
 
 def train_model(model):
     if "${task.ext.use_gpu}" == "true":
         model.to_device(0)
 
-    model.train(max_epochs=int("${max_epochs}") if "${max_epochs}" else None, datasplitter_kwargs={"drop_last": True})
-
+    model.train(max_epochs=int(max_epochs) if max_epochs else None, datasplitter_kwargs={"drop_last": True})
 
 adata = ad.read_h5ad("${h5ad}")
 
-if "${batch_key}":
-    SCVI.setup_anndata(adata, batch_key="${batch_key}")
+if batch_key:
+    SCVI.setup_anndata(adata, batch_key=batch_key)
 else:
     SCVI.setup_anndata(adata)
 
@@ -59,7 +40,7 @@ train_model(model)
 
 adata.obs["doublet"] = False
 
-batches = adata.obs["batch"].unique() if "${batch_key}" else [0]
+batches = adata.obs["batch"].unique() if batch_key else [0]
 for batch in batches:
     model = SOLO.from_scvi_model(model, restrict_to_batch=batch if len(batches) > 1 else None)
 
@@ -86,11 +67,9 @@ adata.write_h5ad("${prefix}.h5ad")
 
 versions = {
     "${task.process}": {
-        "python": platform.python_version(),
-        "anndata": ad.__version__,
         "scvi": scvi.__version__,
     }
 }
 
 with open("versions.yml", "w") as f:
-    f.write(format_yaml_like(versions))
+    f.write(yaml.dump(versions))

--- a/modules/nf-core/scvitools/solo/templates/solo.py
+++ b/modules/nf-core/scvitools/solo/templates/solo.py
@@ -22,8 +22,6 @@ batch_key = "${batch_key ?: ''}"
 max_epochs = "${max_epochs ?: ''}"
 
 def train_model(model):
-    scvi.settings.seed = 0
-
     if "${task.ext.use_gpu}" == "true":
         model.to_device(0)
 
@@ -35,8 +33,6 @@ if batch_key:
     SCVI.setup_anndata(adata, batch_key=batch_key)
 else:
     SCVI.setup_anndata(adata)
-
-scvi.settings.seed = 0
 
 model = SCVI(adata)
 

--- a/modules/nf-core/scvitools/solo/templates/solo.py
+++ b/modules/nf-core/scvitools/solo/templates/solo.py
@@ -22,6 +22,8 @@ batch_key = "${batch_key ?: ''}"
 max_epochs = "${max_epochs ?: ''}"
 
 def train_model(model):
+    scvi.settings.seed = 0
+
     if "${task.ext.use_gpu}" == "true":
         model.to_device(0)
 
@@ -33,6 +35,8 @@ if batch_key:
     SCVI.setup_anndata(adata, batch_key=batch_key)
 else:
     SCVI.setup_anndata(adata)
+
+scvi.settings.seed = 0
 
 model = SCVI(adata)
 

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test
@@ -3,21 +3,22 @@ nextflow_process {
     name "Test Process SCVITOOLS_SOLO"
     script "../main.nf"
     process "SCVITOOLS_SOLO"
-    config "./nextflow.config"
 
     tag "modules"
     tag "modules_nfcore"
     tag "scvitools"
     tag "scvitools/solo"
 
-    test("solo") {
+    test("Should run without batch column") {
         when {
             process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file("https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad", checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
                 ]
+                input[1] = []
+                input[2] = 1
                 """
             }
         }
@@ -31,7 +32,7 @@ nextflow_process {
 
     }
 
-    test("solo - stub") {
+    test("Should run with batch column - stub") {
 
         options "-stub"
 
@@ -40,8 +41,10 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file("https://raw.githubusercontent.com/nf-core/test-datasets/scdownstream/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad", checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
                 ]
+                input[1] = []
+                input[2] = 1
                 """
             }
         }

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = []
                 input[2] = 1
@@ -26,7 +26,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    anndata(process.out.h5ad[0][1]).n_obs
+                ).match() }
             )
         }
 
@@ -38,7 +41,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = 'sample'
                 input[2] = 1
@@ -49,7 +52,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    anndata(process.out.h5ad[0][1]).n_obs
+                ).match() }
             )
         }
 
@@ -61,7 +67,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = 'invalid'
                 input[2] = 1
@@ -86,7 +92,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = []
                 input[2] = 1

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = []
                 input[2] = 1
@@ -26,10 +26,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-                    process.out,
-                    anndata(process.out.h5ad[0][1]).n_obs
-                ).match() }
+                { assert snapshot(process.out).match() }
             )
         }
 
@@ -41,7 +38,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = 'sample'
                 input[2] = 1
@@ -52,10 +49,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-                    process.out,
-                    anndata(process.out.h5ad[0][1]).n_obs
-                ).match() }
+                { assert snapshot(process.out).match() }
             )
         }
 
@@ -67,7 +61,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = 'invalid'
                 input[2] = 1
@@ -92,7 +86,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [id: 'test'],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                    file('https://github.com/nf-core/test-datasets/raw/876e5c90169736ddd52d7f6c38d935e57a86007a/samples/SAMN14430799_custom_emptydrops_filter_matrix.h5ad', checkIfExists: true)
                 ]
                 input[1] = []
                 input[2] = 1

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test
@@ -27,8 +27,9 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out,
-                    anndata(process.out.h5ad[0][1]).n_obs
+                    process.out.versions,
+                    file(process.out.h5ad[0][1]).name,
+                    file(process.out.predictions[0][1]).name
                 ).match() }
             )
         }
@@ -53,8 +54,9 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out,
-                    anndata(process.out.h5ad[0][1]).n_obs
+                    process.out.versions,
+                    file(process.out.h5ad[0][1]).name,
+                    file(process.out.predictions[0][1]).name
                 ).match() }
             )
         }

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test
@@ -26,7 +26,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    anndata(process.out.h5ad[0][1]).n_obs
+                ).match() }
             )
         }
 
@@ -49,7 +52,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    anndata(process.out.h5ad[0][1]).n_obs
+                ).match() }
             )
         }
 

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test
@@ -32,6 +32,51 @@ nextflow_process {
 
     }
 
+    test("Should run with batch column") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [id: 'test'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                ]
+                input[1] = 'sample'
+                input[2] = 1
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("Should fail with invalid batch column") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [id: 'test'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/h5ad/SRR28679756_filtered_matrix.h5ad', checkIfExists: true)
+                ]
+                input[1] = 'invalid'
+                input[2] = 1
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.failed }
+            )
+        }
+
+    }
+
     test("Should run with batch column - stub") {
 
         options "-stub"

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "solo - stub": {
+    "Should run without batch column": {
         "content": [
             {
                 "0": [
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "1": [
@@ -15,18 +15,18 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,6c7408ce1b174774a6b19aa314ea27de"
+                    "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ],
                 "h5ad": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "predictions": [
@@ -34,21 +34,21 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,6c7408ce1b174774a6b19aa314ea27de"
+                    "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2024-11-02T15:39:12.932815031"
+        "timestamp": "2025-08-03T17:44:26.79212178"
     },
-    "solo": {
+    "Should run with batch column - stub": {
         "content": [
             {
                 "0": [
@@ -56,7 +56,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
+                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -64,18 +64,18 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,678bf6b22a5008e1255a62a5e3596958"
+                        "test.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,5795405657a070e22e00f994f2a0ed97"
+                    "versions.yml:md5,b04fe43d9ea390fc608cb41bbf9136a3"
                 ],
                 "h5ad": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
+                        "test.h5ad:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "predictions": [
@@ -83,18 +83,18 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,678bf6b22a5008e1255a62a5e3596958"
+                        "test.pkl:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,5795405657a070e22e00f994f2a0ed97"
+                    "versions.yml:md5,b04fe43d9ea390fc608cb41bbf9136a3"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2024-11-02T15:38:47.693995721"
+        "timestamp": "2025-08-03T17:44:44.007844551"
     }
 }

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
@@ -1,103 +1,31 @@
 {
     "Should run without batch column": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
-                ],
-                "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
-                    ]
-                ],
-                "predictions": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
-                ]
-            },
-            3887
+            [
+                "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
+            ],
+            "test.h5ad",
+            "test.pkl"
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T20:55:35.035865271"
+        "timestamp": "2025-08-03T22:24:09.611388977"
     },
     "Should run with batch column": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
-                ],
-                "h5ad": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
-                    ]
-                ],
-                "predictions": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
-                ]
-            },
-            3887
+            [
+                "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
+            ],
+            "test.h5ad",
+            "test.pkl"
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T20:56:08.370948916"
+        "timestamp": "2025-08-03T22:24:40.875872995"
     },
     "Should run with batch column - stub": {
         "content": [

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                        "test.h5ad:md5,39c7eabca0bf57e2edb8c7f593b2e13e"
                     ]
                 ],
                 "1": [
@@ -15,7 +15,7 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                        "test.pkl:md5,967fe330f4109e5f86d9dc83dd23075d"
                     ]
                 ],
                 "2": [
@@ -26,7 +26,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                        "test.h5ad:md5,39c7eabca0bf57e2edb8c7f593b2e13e"
                     ]
                 ],
                 "predictions": [
@@ -34,20 +34,20 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                        "test.pkl:md5,967fe330f4109e5f86d9dc83dd23075d"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
             },
-            3887
+            4815
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T20:55:35.035865271"
+        "timestamp": "2025-08-03T21:29:57.083079338"
     },
     "Should run with batch column": {
         "content": [
@@ -57,7 +57,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                        "test.h5ad:md5,39c7eabca0bf57e2edb8c7f593b2e13e"
                     ]
                 ],
                 "1": [
@@ -65,7 +65,7 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                        "test.pkl:md5,967fe330f4109e5f86d9dc83dd23075d"
                     ]
                 ],
                 "2": [
@@ -76,7 +76,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                        "test.h5ad:md5,39c7eabca0bf57e2edb8c7f593b2e13e"
                     ]
                 ],
                 "predictions": [
@@ -84,20 +84,20 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                        "test.pkl:md5,967fe330f4109e5f86d9dc83dd23075d"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
             },
-            3887
+            4815
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T20:56:08.370948916"
+        "timestamp": "2025-08-03T21:30:28.131586867"
     },
     "Should run with batch column - stub": {
         "content": [

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
@@ -40,13 +40,14 @@
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
-            }
+            },
+            3887
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T17:44:26.79212178"
+        "timestamp": "2025-08-03T20:55:35.035865271"
     },
     "Should run with batch column": {
         "content": [
@@ -89,13 +90,14 @@
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
-            }
+            },
+            3887
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T18:54:07.40698107"
+        "timestamp": "2025-08-03T20:56:08.370948916"
     },
     "Should run with batch column - stub": {
         "content": [

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
                     ]
                 ],
                 "1": [
@@ -15,7 +15,7 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                        "test.pkl:md5,194f1260e9353945d4ede4a31906b9c8"
                     ]
                 ],
                 "2": [
@@ -26,7 +26,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
                     ]
                 ],
                 "predictions": [
@@ -34,20 +34,19 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                        "test.pkl:md5,194f1260e9353945d4ede4a31906b9c8"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
-            },
-            3887
+            }
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T20:55:35.035865271"
+        "timestamp": "2025-08-03T22:09:45.870921736"
     },
     "Should run with batch column": {
         "content": [
@@ -57,7 +56,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
                     ]
                 ],
                 "1": [
@@ -65,7 +64,7 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                        "test.pkl:md5,194f1260e9353945d4ede4a31906b9c8"
                     ]
                 ],
                 "2": [
@@ -76,7 +75,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
                     ]
                 ],
                 "predictions": [
@@ -84,20 +83,19 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                        "test.pkl:md5,194f1260e9353945d4ede4a31906b9c8"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
-            },
-            3887
+            }
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T20:56:08.370948916"
+        "timestamp": "2025-08-03T22:11:49.39954177"
     },
     "Should run with batch column - stub": {
         "content": [

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "1": [
@@ -15,7 +15,7 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,194f1260e9353945d4ede4a31906b9c8"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "2": [
@@ -26,7 +26,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "predictions": [
@@ -34,19 +34,20 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,194f1260e9353945d4ede4a31906b9c8"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
-            }
+            },
+            3887
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T22:09:45.870921736"
+        "timestamp": "2025-08-03T20:55:35.035865271"
     },
     "Should run with batch column": {
         "content": [
@@ -56,7 +57,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "1": [
@@ -64,7 +65,7 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,194f1260e9353945d4ede4a31906b9c8"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "2": [
@@ -75,7 +76,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,4e859eaa40faeca36d39de742076f4b1"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "predictions": [
@@ -83,19 +84,20 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,194f1260e9353945d4ede4a31906b9c8"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
-            }
+            },
+            3887
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T22:11:49.39954177"
+        "timestamp": "2025-08-03T20:56:08.370948916"
     },
     "Should run with batch column - stub": {
         "content": [

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
@@ -48,6 +48,55 @@
         },
         "timestamp": "2025-08-03T17:44:26.79212178"
     },
+    "Should run with batch column": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
+                ],
+                "h5ad": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.3"
+        },
+        "timestamp": "2025-08-03T18:54:07.40698107"
+    },
     "Should run with batch column - stub": {
         "content": [
             {

--- a/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/solo/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,39c7eabca0bf57e2edb8c7f593b2e13e"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "1": [
@@ -15,7 +15,7 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,967fe330f4109e5f86d9dc83dd23075d"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "2": [
@@ -26,7 +26,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,39c7eabca0bf57e2edb8c7f593b2e13e"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "predictions": [
@@ -34,20 +34,20 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,967fe330f4109e5f86d9dc83dd23075d"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
             },
-            4815
+            3887
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T21:29:57.083079338"
+        "timestamp": "2025-08-03T20:55:35.035865271"
     },
     "Should run with batch column": {
         "content": [
@@ -57,7 +57,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,39c7eabca0bf57e2edb8c7f593b2e13e"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "1": [
@@ -65,7 +65,7 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,967fe330f4109e5f86d9dc83dd23075d"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "2": [
@@ -76,7 +76,7 @@
                         {
                             "id": "test"
                         },
-                        "test.h5ad:md5,39c7eabca0bf57e2edb8c7f593b2e13e"
+                        "test.h5ad:md5,5f5fe1a25219a082ca72dfd9909614c6"
                     ]
                 ],
                 "predictions": [
@@ -84,20 +84,20 @@
                         {
                             "id": "test"
                         },
-                        "test.pkl:md5,967fe330f4109e5f86d9dc83dd23075d"
+                        "test.pkl:md5,aa30fc98358f538d0a9ad9a06ca608e5"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,6c9c4dfb80bc9f3e68cbf3328f74c6d9"
                 ]
             },
-            4815
+            3887
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.3"
         },
-        "timestamp": "2025-08-03T21:30:28.131586867"
+        "timestamp": "2025-08-03T20:56:08.370948916"
     },
     "Should run with batch column - stub": {
         "content": [

--- a/modules/nf-core/scvitools/solo/tests/nextflow.config
+++ b/modules/nf-core/scvitools/solo/tests/nextflow.config
@@ -1,5 +1,0 @@
-process {
-     withName: SCVITOOLS_SOLO {
-        ext.max_epochs = 1
-    }
-}


### PR DESCRIPTION
Updates scvitools tools to the latest versions, removes exotic `task.ext` fields usage, and adds more tests