### PR TITLE
Adding bwa-mem2 mode test to bwameth/align

### DIFF
--- a/modules/nf-core/bwameth/align/tests/main.nf.test
+++ b/modules/nf-core/bwameth/align/tests/main.nf.test
@@ -118,4 +118,49 @@ nextflow_process {
             )
         }
     }
+
+    test("sarscov2 methylated single_end [fastq] - mem2") {
+
+        setup {
+            run("BWAMETH_INDEX", alias: "BWAMETH_INDEX_MEM2") {
+                script "../../../bwameth/index/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of([
+                        [ id:'test' ], // meta map
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ])
+                    input[1] = true
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                                [ id:'test', single_end:true ], // meta map
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test.methylated_1.fastq.gz', checkIfExists: true)
+                       ])
+                input[1] = Channel.of([
+                                [ id:'test' ], // meta map
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                       input[2] = BWAMETH_INDEX_MEM2.out.index
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                               bam(process.out.bam[0][1]).getReadsMD5(),
+                               process.out.versions
+                               ).match()
+                       }
+            )
+        }
+    }
 }

--- a/modules/nf-core/bwameth/align/tests/main.nf.test.snap
+++ b/modules/nf-core/bwameth/align/tests/main.nf.test.snap
@@ -1,4 +1,17 @@
 {
+    "sarscov2 methylated single_end [fastq] - mem2": {
+        "content": [
+            "5fdda0ada69daa3956c65a24c9d1c1e0",
+            [
+                "versions.yml:md5,c00660f78aeab4fabe00092c70656098"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-04T10:56:52.404713876"
+    },
     "sarscov2 methylated single_end [fastq]": {
         "content": [
             "5fdda0ada69daa3956c65a24c9d1c1e0",


### PR DESCRIPTION
bwameth supports bwa-mem2 but no test has been added to use bwa-mem2 indexes. This uses the recent update to bwameth/index that allows bwameth index to build bwa-mem2 indexes and generates a test bam files using them (https://github.com/nf-core/modules/pull/8838).

Requested by @mashehu in this thread: https://github.com/nf-core/modules/pull/8793

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`