### PR TITLE
update krakentools version 1.2.1

### DIFF
--- a/modules/nf-core/krakentools/combinekreports/environment.yml
+++ b/modules/nf-core/krakentools/combinekreports/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::krakentools=1.2
+  - bioconda::krakentools=1.2.1

--- a/modules/nf-core/krakentools/combinekreports/main.nf
+++ b/modules/nf-core/krakentools/combinekreports/main.nf
@@ -3,8 +3,8 @@ process KRAKENTOOLS_COMBINEKREPORTS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/krakentools:1.2--pyh5e36f6f_0':
-        'biocontainers/krakentools:1.2--pyh5e36f6f_0' }"
+        'https://depot.galaxyproject.org/singularity/krakentools:1.2.1--pyh7e72e81_0':
+        'biocontainers/krakentools:1.2.1--pyh7e72e81_0 '}"
 
     input:
     tuple val(meta), path(kreports)
@@ -19,7 +19,7 @@ process KRAKENTOOLS_COMBINEKREPORTS {
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def VERSION = '1.2.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     combine_kreports.py \\
         -r ${kreports} \\
@@ -35,7 +35,7 @@ process KRAKENTOOLS_COMBINEKREPORTS {
     stub:
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def VERSION = '1.2.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     touch ${prefix}.txt
 

--- a/modules/nf-core/krakentools/combinekreports/main.nf
+++ b/modules/nf-core/krakentools/combinekreports/main.nf
@@ -4,7 +4,7 @@ process KRAKENTOOLS_COMBINEKREPORTS {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/krakentools:1.2.1--pyh7e72e81_0':
-        'biocontainers/krakentools:1.2.1--pyh7e72e81_0 '}"
+        'biocontainers/krakentools:1.2.1--pyh7e72e81_0'}"
 
     input:
     tuple val(meta), path(kreports)

--- a/modules/nf-core/krakentools/combinekreports/tests/main.nf.test.snap
+++ b/modules/nf-core/krakentools/combinekreports/tests/main.nf.test.snap
@@ -7,30 +7,30 @@
                         {
                             "id": "test"
                         },
-                        "test.txt:md5,481c4b987b922979baf74f2ce8d88b02"
+                        "test.txt:md5,c231bfcdde47a43336a418b21bb2f98d"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,a907962abbd9f5dcd34c9e8a4e6100d0"
+                    "versions.yml:md5,137d7ae913c0bcd07516cea679058630"
                 ],
                 "txt": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.txt:md5,481c4b987b922979baf74f2ce8d88b02"
+                        "test.txt:md5,c231bfcdde47a43336a418b21bb2f98d"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a907962abbd9f5dcd34c9e8a4e6100d0"
+                    "versions.yml:md5,137d7ae913c0bcd07516cea679058630"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-08-07T09:12:42.382189"
+        "timestamp": "2025-08-06T16:35:18.136336434"
     },
     "sarscov2 - metagenome - kraken report - stub": {
         "content": [
@@ -44,7 +44,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,a907962abbd9f5dcd34c9e8a4e6100d0"
+                    "versions.yml:md5,137d7ae913c0bcd07516cea679058630"
                 ],
                 "txt": [
                     [
@@ -55,14 +55,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a907962abbd9f5dcd34c9e8a4e6100d0"
+                    "versions.yml:md5,137d7ae913c0bcd07516cea679058630"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-08-07T09:12:46.705759"
+        "timestamp": "2025-08-06T16:35:24.11877101"
     }
 }

--- a/modules/nf-core/krakentools/extractkrakenreads/environment.yml
+++ b/modules/nf-core/krakentools/extractkrakenreads/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::krakentools=1.2
+  - bioconda::krakentools=1.2.1

--- a/modules/nf-core/krakentools/extractkrakenreads/main.nf
+++ b/modules/nf-core/krakentools/extractkrakenreads/main.nf
@@ -6,7 +6,7 @@ process KRAKENTOOLS_EXTRACTKRAKENREADS {
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/krakentools:1.2.1--pyh7e72e81_0':
-        'biocontainers/krakentools:1.2.1--pyh7e72e81_0 '}"
+        'biocontainers/krakentools:1.2.1--pyh7e72e81_0'}"
 
     input:
     val taxid // Separated by spaces

--- a/modules/nf-core/krakentools/extractkrakenreads/main.nf
+++ b/modules/nf-core/krakentools/extractkrakenreads/main.nf
@@ -5,8 +5,8 @@ process KRAKENTOOLS_EXTRACTKRAKENREADS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/krakentools:1.2--pyh5e36f6f_0':
-        'biocontainers/krakentools:1.2--pyh5e36f6f_0'}"
+        'https://depot.galaxyproject.org/singularity/krakentools:1.2.1--pyh7e72e81_0':
+        'biocontainers/krakentools:1.2.1--pyh7e72e81_0 '}"
 
     input:
     val taxid // Separated by spaces
@@ -30,7 +30,7 @@ process KRAKENTOOLS_EXTRACTKRAKENREADS {
     def output_reads_command = meta.single_end ? "-o ${prefix}.extracted_kraken2_read.${extension}" : "-o ${prefix}.extracted_kraken2_read_1.${extension} -o2 ${prefix}.extracted_kraken2_read_2.${extension}"
     def gzip_reads_command = meta.single_end ? "gzip ${prefix}.extracted_kraken2_read.${extension}" : "gzip ${prefix}.extracted_kraken2_read_1.${extension}; gzip ${prefix}.extracted_kraken2_read_2.${extension}"
     def report_option = report ? "-r ${report}" : ""
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def VERSION = '1.2.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
     """
     extract_kraken_reads.py \\
@@ -56,7 +56,7 @@ process KRAKENTOOLS_EXTRACTKRAKENREADS {
     def output_reads_command = meta.single_end ? "-o ${prefix}.extracted_kraken2_read.${extension}" : "-o ${prefix}.extracted_kraken2_read_1.${extension} -o2 ${prefix}.extracted_kraken2_read_2.${extension}"
     def gzip_reads_command = meta.single_end ? "gzip ${prefix}.extracted_kraken2_read.${extension}" : "gzip ${prefix}.extracted_kraken2_read_1.${extension}; gzip ${prefix}.extracted_kraken2_read_2.${extension}"
     def report_option = report ? "-r ${report}" : ""
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def VERSION = '1.2.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
 
     """
     if [ "$meta.single_end" == "true" ];

--- a/modules/nf-core/krakentools/extractkrakenreads/tests/main.nf.test.snap
+++ b/modules/nf-core/krakentools/extractkrakenreads/tests/main.nf.test.snap
@@ -12,7 +12,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -24,15 +24,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-02T16:36:41.099221"
+        "timestamp": "2025-08-06T16:48:50.778294434"
     },
     "stub sarscov2 illumina paired end with parents [fastq]": {
         "content": [
@@ -50,7 +50,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -65,15 +65,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-02T16:37:45.838994"
+        "timestamp": "2025-08-06T16:49:43.088361891"
     },
     "stub sarscov2 illumina single end [fastq]": {
         "content": [
@@ -88,7 +88,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -100,7 +100,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ]
             }
         ],
@@ -108,7 +108,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-02-20T11:14:32.273619"
+        "timestamp": "2025-08-06T16:49:22.475347424"
     },
     "stub sarscov2 illumina paired end [fastq]": {
         "content": [
@@ -126,7 +126,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -141,7 +141,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ]
             }
         ],
@@ -149,7 +149,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-02-20T11:14:40.349662"
+        "timestamp": "2025-08-06T16:49:32.226734191"
     },
     "sarscov2 illumina paired end [fastq]": {
         "content": [
@@ -167,7 +167,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -182,15 +182,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-02T16:36:54.707702"
+        "timestamp": "2025-08-06T16:49:01.881010833"
     },
     "sarscov2 illumina paired end with parents [fastq]": {
         "content": [
@@ -208,7 +208,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -223,14 +223,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,eadc0697a548b925488847b75f280be4"
+                    "versions.yml:md5,38d487f7cdb10b71d70ad7f3dbcab947"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-02T16:37:07.797479"
+        "timestamp": "2025-08-06T16:49:12.764511535"
     }
 }

--- a/modules/nf-core/krakentools/kreport2krona/environment.yml
+++ b/modules/nf-core/krakentools/kreport2krona/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::krakentools=1.2
+  - bioconda::krakentools=1.2.1

--- a/modules/nf-core/krakentools/kreport2krona/main.nf
+++ b/modules/nf-core/krakentools/kreport2krona/main.nf
@@ -6,7 +6,7 @@ process KRAKENTOOLS_KREPORT2KRONA {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/krakentools:1.2.1--pyh7e72e81_0':
-        'biocontainers/krakentools:1.2.1--pyh7e72e81_0 '}"
+        'biocontainers/krakentools:1.2.1--pyh7e72e81_0'}"
 
     input:
     tuple val(meta), path(kreport)

--- a/modules/nf-core/krakentools/kreport2krona/main.nf
+++ b/modules/nf-core/krakentools/kreport2krona/main.nf
@@ -5,8 +5,8 @@ process KRAKENTOOLS_KREPORT2KRONA {
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/krakentools:1.2--pyh5e36f6f_0':
-        'biocontainers/krakentools:1.2--pyh5e36f6f_0' }"
+        'https://depot.galaxyproject.org/singularity/krakentools:1.2.1--pyh7e72e81_0':
+        'biocontainers/krakentools:1.2.1--pyh7e72e81_0 '}"
 
     input:
     tuple val(meta), path(kreport)
@@ -21,7 +21,7 @@ process KRAKENTOOLS_KREPORT2KRONA {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def VERSION = '1.2.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     kreport2krona.py \\
         -r ${kreport} \\
@@ -37,7 +37,7 @@ process KRAKENTOOLS_KREPORT2KRONA {
     stub:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    def VERSION = '1.2.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     touch ${prefix}.txt
 

--- a/modules/nf-core/krakentools/kreport2krona/tests/main.nf.test.snap
+++ b/modules/nf-core/krakentools/kreport2krona/tests/main.nf.test.snap
@@ -12,7 +12,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,f4a5d570efec153ab0de3da130394cbb"
+                    "versions.yml:md5,db0f8269d26bb2d1478e8dc21c2ab1f7"
                 ],
                 "txt": [
                     [
@@ -24,15 +24,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,f4a5d570efec153ab0de3da130394cbb"
+                    "versions.yml:md5,db0f8269d26bb2d1478e8dc21c2ab1f7"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "23.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-08-01T21:40:46.959343186"
+        "timestamp": "2025-08-06T16:39:09.512185846"
     },
     "sarscov2 illumina single end [fastq] - stub": {
         "content": [
@@ -47,7 +47,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,f4a5d570efec153ab0de3da130394cbb"
+                    "versions.yml:md5,db0f8269d26bb2d1478e8dc21c2ab1f7"
                 ],
                 "txt": [
                     [
@@ -59,14 +59,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,f4a5d570efec153ab0de3da130394cbb"
+                    "versions.yml:md5,db0f8269d26bb2d1478e8dc21c2ab1f7"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "23.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2024-08-02T18:35:32.145822126"
+        "timestamp": "2025-08-06T16:39:18.703801827"
     }
 }

--- a/subworkflows/nf-core/fastq_extract_kraken_krakentools/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_extract_kraken_krakentools/tests/main.nf.test.snap
@@ -24,7 +24,7 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "3": [
-                    "versions.yml:md5,2f2124c7bb4137573d5403589ce57ec7",
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
                     "versions.yml:md5,b0c080c0e98cf9a0f17b647f9eb7a091"
                 ],
                 "extracted_kraken2_reads": [
@@ -49,16 +49,16 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "versions": [
-                    "versions.yml:md5,2f2124c7bb4137573d5403589ce57ec7",
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
                     "versions.yml:md5,b0c080c0e98cf9a0f17b647f9eb7a091"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-02T15:20:57.237975"
+        "timestamp": "2025-08-06T16:49:54.267302105"
     },
     "sarscov2 illumina paired end with fastq output [fastq]": {
         "content": [
@@ -88,7 +88,7 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "3": [
-                    "versions.yml:md5,2f2124c7bb4137573d5403589ce57ec7",
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
                     "versions.yml:md5,b0c080c0e98cf9a0f17b647f9eb7a091"
                 ],
                 "extracted_kraken2_reads": [
@@ -116,16 +116,16 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "versions": [
-                    "versions.yml:md5,2f2124c7bb4137573d5403589ce57ec7",
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
                     "versions.yml:md5,b0c080c0e98cf9a0f17b647f9eb7a091"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-02T15:21:10.833814"
+        "timestamp": "2025-08-06T16:50:05.428982736"
     },
     "sarscov2 illumina paired end with parents [fastq]": {
         "content": [
@@ -155,7 +155,7 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "3": [
-                    "versions.yml:md5,2f2124c7bb4137573d5403589ce57ec7",
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
                     "versions.yml:md5,b0c080c0e98cf9a0f17b647f9eb7a091"
                 ],
                 "extracted_kraken2_reads": [
@@ -183,15 +183,15 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "versions": [
-                    "versions.yml:md5,2f2124c7bb4137573d5403589ce57ec7",
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
                     "versions.yml:md5,b0c080c0e98cf9a0f17b647f9eb7a091"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nextflow": "24.10.4"
         },
-        "timestamp": "2025-06-02T15:21:23.838905"
+        "timestamp": "2025-08-06T16:50:16.445220684"
     }
 }


### PR DESCRIPTION
- version bump in all modules
- updated snapshot files in all modules and subwfs using krakentools
- makes #8851 obsolete

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
