### PR TITLE
Tidy cooler/cload inputs

### DIFF
--- a/modules/nf-core/cooler/cload/environment.yml
+++ b/modules/nf-core/cooler/cload/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::cooler=0.10.3
+  - bioconda::cooler=0.10.4

--- a/modules/nf-core/cooler/cload/main.nf
+++ b/modules/nf-core/cooler/cload/main.nf
@@ -1,5 +1,5 @@
 process COOLER_CLOAD {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
@@ -8,27 +8,28 @@ process COOLER_CLOAD {
         'biocontainers/cooler:0.10.3--pyhdfd78af_0' }"
 
     input:
-    tuple val(meta), path(pairs), path(index), val(cool_bin)
-    path chromsizes
+    tuple val(meta), path(contacts), path(index)
+    tuple val(meta2), path(chromsizes)
+    val(mode)
+    val(cool_bin)
 
     output:
-    tuple val(meta), path("*.cool"), val(cool_bin), emit: cool
-    path "versions.yml"                           , emit: versions
+    tuple val(meta), path("*.cool"), emit: cool
+    path "versions.yml"            , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
+    def args   = task.ext.args   ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def nproc  = args.contains('pairix') || args.contains('tabix')? "--nproc $task.cpus" : ''
-
+    def nproc  = mode in ["pairix", "tabix"] ? "--nproc ${task.cpus}" : ""
     """
-    cooler cload \\
-        $args \\
-        $nproc \\
+    cooler cload ${mode} \\
+        ${args} \\
+        ${nproc} \\
         ${chromsizes}:${cool_bin} \\
-        $pairs \\
+        ${contacts} \\
         ${prefix}.cool
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/cooler/cload/main.nf
+++ b/modules/nf-core/cooler/cload/main.nf
@@ -4,8 +4,8 @@ process COOLER_CLOAD {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/cooler:0.10.3--pyhdfd78af_0' :
-        'biocontainers/cooler:0.10.3--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/cooler:0.10.4--pyhdfd78af_0' :
+        'biocontainers/cooler:0.10.4--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(contacts), path(index)

--- a/modules/nf-core/cooler/cload/meta.yml
+++ b/modules/nf-core/cooler/cload/meta.yml
@@ -20,21 +20,33 @@ input:
         description: |
           Groovy Map containing sample information
           e.g. [ id:'test', single_end:false ]
-    - pairs:
+    - contacts:
         type: file
-        description: Path to contacts (i.e. read pairs) file.
-        ontologies: []
+        description: Path to contacts (e.g. read pairs, pairix, tabix) file.
+        ontologies: 
+          - edam: http://edamontology.org/format_3475 # TSV
     - index:
         type: file
         description: Path to index file of the contacts.
-        ontologies: []
-    - cool_bin:
-        type: integer
-        description: Bins size in bp
-  - chromsizes:
-      type: file
-      description: Path to a chromsizes file.
-      ontologies: []
+        ontologies: 
+          - edam: http://edamontology.org/format_3475 # TSV
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - chromsizes:
+        type: file
+        description: Path to a chromsizes file.
+        ontologies:
+          - edam: http://edamontology.org/format_3475 # TSV
+  - mode:
+      type: integer
+      description: |
+        Input mode for cooler cload - one of pairs, pairix, tabix
+  - cool_bin:
+      type: integer
+      description: Bins size in bp
 output:
   cool:
     - - meta:
@@ -43,11 +55,6 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
       - "*.cool":
-          type: file
-          description: Output COOL file path
-          pattern: "*.cool"
-          ontologies: []
-      - cool_bin:
           type: file
           description: Output COOL file path
           pattern: "*.cool"

--- a/modules/nf-core/cooler/cload/tests/main.nf.test
+++ b/modules/nf-core/cooler/cload/tests/main.nf.test
@@ -4,117 +4,159 @@ nextflow_process {
     config "./nextflow.config"
     script "../main.nf"
     process "COOLER_CLOAD"
-   
+
     tag "modules"
     tag "modules_nfcore"
     tag "cooler"
     tag "cooler/cload"
-    tag "cooler/dump"    
-    
+    tag "cooler/dump"
+
     test("test_cooler_cload_pairix") {
         when {
+
             params {
-                module_args = 'pairix'
+                module_args = ""
             }
-            process {
-                """
-                input[0] = [[id:'test_pairix', single_end:false],// meta map
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz', checkIfExists:true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz.px2', checkIfExists:true),
-                    2000000
-                ]
-                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes', checkIfExists:true)
-                """
-            }
-        }
-        then {
-            assertAll(
-                { assert process.success },
-                { assert snapshot(
-                    process.out.versions,
-                    process.out.cool.collect{file(it[1]).name}
-                ).match() }
-            )
-        }
-    }
-    
-    
-    test("test_cooler_cload_pairs") {
-        
-        when {
-            params {
-                module_args = 'pairs --chrom1 1 --pos1 2 --chrom2 4 --pos2 5 -N'
-            }
-            process {
-                """
-                input[0] = [[id:'test_pairs', single_end:false],// meta map
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.sample1.pairs', checkIfExists:true),
-                    [],
-                    2000000
-                ]
-                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes', checkIfExists:true)
-                """
-            }
-        }
-        then {
-            assertAll(
-                { assert process.success },
-                { assert snapshot(
-                    process.out.versions,
-                    process.out.cool.collect{file(it[1]).name}
-                ).match() }
-            )
-        }
-    }
-    
-    
-    test("test_cooler_cload_tabix") {
-        when {
-            params {
-                module_args = 'tabix'
-            }
-            process {
-                """
-                input[0] = [[id:'test_tabix', single_end:false],// meta map
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.sorted.possrt.txt.gz', checkIfExists:true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.sorted.possrt.txt.gz.tbi', checkIfExists:true),
-                    2000000
-                    ]
-                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes',checkIfExists:true)
-                """
-            }
-        }
-        then {
-            assertAll(
-                { assert process.success },
-                { assert snapshot(
-                    process.out.versions,
-                    process.out.cool.collect{file(it[1]).name}
-                ).match() }
-            )
-        }
-    }
-    
-    
-    test("test_cooler_cload_pairix - stub") {
-        options '-stub'
-        when {
-            params {
-                module_args = 'pairix'
-            }
+
             process {
                 """
                 input[0] = [
                     [id:'test_pairix', single_end:false],// meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz', checkIfExists:true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz.px2', checkIfExists:true),
-                    2000000
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz.px2', checkIfExists:true)
                 ]
-                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes', checkIfExists:true)
+                input[1] = [
+                    [id:'test_pairix', single_end:false],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes', checkIfExists:true)
+                ]
+                input[2] = "pairix"
+                input[3] = 2000000
                 """
             }
         }
+
         then {
+
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.versions,
+                    process.out.cool.collect{file(it[1]).name}
+                ).match() }
+            )
+
+        }
+    }
+
+
+    test("test_cooler_cload_pairs") {
+
+        when {
+
+            params {
+                module_args = '--chrom1 1 --pos1 2 --chrom2 4 --pos2 5 -N'
+            }
+
+            process {
+                """
+                input[0] = [
+                    [id:'test_pairs', single_end:false],// meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.sample1.pairs', checkIfExists:true),
+                    []
+                ]
+                input[1] = [
+                    [id:'test_pairs', single_end:false],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes', checkIfExists:true)
+                ]
+                input[2] = "pairs"
+                input[3] = 2000000
+                """
+            }
+        }
+
+        then {
+
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.versions,
+                    process.out.cool.collect{file(it[1]).name}
+                ).match() }
+            )
+
+        }
+    }
+
+
+    test("test_cooler_cload_tabix") {
+
+        when {
+
+            params {
+                module_args = ""
+            }
+
+            process {
+                """
+                input[0] = [
+                    [id:'test_tabix', single_end:false],// meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.sorted.possrt.txt.gz', checkIfExists:true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.sorted.possrt.txt.gz.tbi', checkIfExists:true)
+                ]
+                input[1] = [
+                    [id:'test_tabix', single_end:false],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes',checkIfExists:true)
+                ]
+                input[2] = "tabix"
+                input[3] = 2000000
+                """
+            }
+        }
+
+        then {
+
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.versions,
+                    process.out.cool.collect{file(it[1]).name}
+                ).match() }
+            )
+
+        }
+
+    }
+
+
+    test("test_cooler_cload_pairix - stub") {
+
+        options '-stub'
+
+        when {
+
+            params {
+                module_args = ""
+            }
+
+            process {
+                """
+                input[0] = [
+                    [id:'test_pairix', single_end:false],// meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz', checkIfExists:true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.GM12878-MboI.pairs.subsample.blksrt.txt.gz.px2', checkIfExists:true)
+                ]
+                input[1] = [
+                    [id:'test_pairix', single_end:false],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/cooler/cload/hg19/hg19.chrom.sizes', checkIfExists:true)
+                ]
+                input[2] = "pairix"
+                input[3] = 2000000
+                """
+            }
+        }
+
+        then {
+
             assertAll(
                 { assert process.success },
                 { assert snapshot(
@@ -122,6 +164,7 @@ nextflow_process {
                     process.out.versions.collect{path(it).yaml}
                 ).match() }
             )
+
         }
     }
 }

--- a/modules/nf-core/cooler/cload/tests/main.nf.test.snap
+++ b/modules/nf-core/cooler/cload/tests/main.nf.test.snap
@@ -25,9 +25,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-03-25T14:36:24.038770556"
+        "timestamp": "2025-08-07T13:13:05.925812998"
     },
     "test_cooler_cload_pairix": {
         "content": [
@@ -53,8 +53,7 @@
                             "id": "test_pairix",
                             "single_end": false
                         },
-                        "test_pairix.cool:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        2000000
+                        "test_pairix.cool:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -66,8 +65,7 @@
                             "id": "test_pairix",
                             "single_end": false
                         },
-                        "test_pairix.cool:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        2000000
+                        "test_pairix.cool:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -84,8 +82,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-03-25T14:38:40.413454489"
+        "timestamp": "2025-08-07T13:13:20.741749922"
     }
 }


### PR DESCRIPTION
- Add meta to chromsizes
- Add val "mode" for input, rather than leaving this to an arg, as it is a required input
- move cool_bin to separate input val as it is a required parameter
- Don't emit cool_bin 
- Bump cooler version to 0.10.4

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
