### PR TITLE
fastplong: use provided reads as input

### DIFF
--- a/modules/nf-core/fastplong/main.nf
+++ b/modules/nf-core/fastplong/main.nf
@@ -33,7 +33,7 @@ process FASTPLONG {
     def report_title = task.ext.report_title ?: "${prefix}_fastplong_report"
     """
     fastplong \\
-        --in ${prefix}.fastq.gz \\
+        --in ${reads} \\
         $output_file \\
         --json ${prefix}.fastplong.json \\
         --html ${prefix}.fastplong.html \\


### PR DESCRIPTION
This is a small patch to the fastplong module, which did not use the provided reads as input but assumed a filename based on `meta.id`.