### PR TITLE
Add zstd to untar image

### DIFF
--- a/modules/nf-core/untar/main.nf
+++ b/modules/nf-core/untar/main.nf
@@ -4,8 +4,8 @@ process UNTAR {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/52ccce28d2ab928ab862e25aae26314d69c8e38bd41ca9431c67ef05221348aa/data'
-        : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:838ba80435a629f8'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5d18ee243d97f4627bf9a5211058b8beeabd215273bf7f772d6422ba91c4844/data'
+        : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:49568e208231bddc'}"
 
     input:
     tuple val(meta), path(archive)


### PR DESCRIPTION
Adding zstd to the untar image to enable to uncompress `tar.zst` files

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`