### PR TITLE
Adding mem2 switch to fasta_index_bismark_bwameth subworkflow

### DIFF
--- a/subworkflows/nf-core/fasta_index_bismark_bwameth/main.nf
+++ b/subworkflows/nf-core/fasta_index_bismark_bwameth/main.nf
@@ -13,6 +13,7 @@ workflow FASTA_INDEX_BISMARK_BWAMETH {
     bwameth_index    // channel: [ val(meta), [ bwameth index ] ]
     aligner          // string: bismark, bismark_hisat or bwameth
     collecthsmetrics // boolean: whether to run picard collecthsmetrics
+    use_mem2         // boolean: generate mem2 index if no index provided, and bwameth is selected
 
     main:
 
@@ -87,10 +88,17 @@ workflow FASTA_INDEX_BISMARK_BWAMETH {
             ch_bwameth_index = ch_bwameth_index_branched.unzipped.mix(UNTAR.out.untar)
             ch_versions      = ch_versions.mix(UNTAR.out.versions)
         } else {
-            BWAMETH_INDEX (
-                ch_fasta,
-                false
-            )
+            if (use_mem2) {
+                BWAMETH_INDEX (
+                    ch_fasta,
+                    true
+                )
+            } else {
+                BWAMETH_INDEX (
+                    ch_fasta,
+                    false
+                )
+            }
             ch_bwameth_index = BWAMETH_INDEX.out.index
             ch_versions      = ch_versions.mix(BWAMETH_INDEX.out.versions)
         }

--- a/subworkflows/nf-core/fasta_index_bismark_bwameth/meta.yml
+++ b/subworkflows/nf-core/fasta_index_bismark_bwameth/meta.yml
@@ -43,6 +43,10 @@ input:
       type: boolean
       description: |
         Whether to run picard collecthsmetrics tool
+  - use_mem2:
+      type: boolean
+      description: |
+        Build a mem2 index when bwameth is chosen as an aligner, and an index path is not supplied
 output:
   - fasta:
       type: file

--- a/subworkflows/nf-core/fasta_index_bismark_bwameth/tests/main.nf.test
+++ b/subworkflows/nf-core/fasta_index_bismark_bwameth/tests/main.nf.test
@@ -25,6 +25,7 @@ nextflow_workflow {
                 input[3] = [] // bwameth_index
                 input[4] = "bismark" // aligner
                 input[5] = false // collecthsmetrics
+                input[6] = false // use_mem2
                 """
             }
         }
@@ -54,6 +55,7 @@ nextflow_workflow {
                 input[3] = [] // bwameth_index
                 input[4] = "bismark" // aligner
                 input[5] = false // collecthsmetrics
+                input[6] = false // use_mem2
                 """
             }
         }
@@ -83,6 +85,7 @@ nextflow_workflow {
                 input[3] = [] // bwameth_index
                 input[4] = "bismark_hisat" // aligner
                 input[5] = false // collecthsmetrics
+                input[6] = false // use_mem2
                 """
             }
         }
@@ -112,6 +115,7 @@ nextflow_workflow {
                 input[3] = [] // bwameth_index
                 input[4] = "bismark_hisat" // aligner
                 input[5] = false // collecthsmetrics
+                input[6] = false // use_mem2
                 """
             }
         }
@@ -141,6 +145,37 @@ nextflow_workflow {
                 input[3] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/Bwameth_Index.tar.gz', checkIfExists: true).map { it -> [ [:], it ] }
                 input[4] = "bwameth" // aligner
                 input[5] = false // collecthsmetrics
+                input[6] = false // use_mem2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    workflow.out.fasta,
+                    workflow.out.fasta_index,
+                    workflow.out.bismark_index,
+                    workflow.out.bwameth_index,
+                    workflow.out.versions
+                    ).match() }
+            )
+        }
+    }
+
+    test("Params: bwameth | download fasta index | download bwameth mem2 index") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa.gz', checkIfExists: true).map { it -> [ [:], it ] }
+                input[1] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa.fai', checkIfExists: true).map { it -> [ [:], it ] }
+                input[2] = [] // bismark index
+                input[3] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/Bwameth_mem2_Index.tar.gz', checkIfExists: true).map { it -> [ [:], it ] }
+                input[4] = "bwameth" // aligner
+                input[5] = false // collecthsmetrics
+                input[6] = true // use_mem2
                 """
             }
         }
@@ -170,6 +205,37 @@ nextflow_workflow {
                 input[3] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/Bwameth_Index.tar.gz', checkIfExists: true).map { it -> [ [:], it ] }
                 input[4] = "bwameth" // aligner
                 input[5] = false // collecthsmetrics
+                input[6] = false // use_mem2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    workflow.out.fasta,
+                    workflow.out.fasta_index,
+                    workflow.out.bismark_index,
+                    workflow.out.bwameth_index,
+                    workflow.out.versions
+                    ).match() }
+            )
+        }
+    }
+
+    test("Params: bwameth | generate fasta index | download bwameth mem2 index") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa.gz', checkIfExists: true).map { it -> [ [:], it ] }
+                input[1] = [] //fasta index
+                input[2] = [] // bismark index
+                input[3] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/Bwameth_mem2_Index.tar.gz', checkIfExists: true).map { it -> [ [:], it ] }
+                input[4] = "bwameth" // aligner
+                input[5] = false // collecthsmetrics
+                input[6] = true // use_mem2
                 """
             }
         }
@@ -199,6 +265,37 @@ nextflow_workflow {
                 input[3] = [] // bwameth index
                 input[4] = "bwameth" // aligner
                 input[5] = false // collecthsmetrics
+                input[6] = false // use_mem2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    workflow.out.fasta,
+                    workflow.out.fasta_index,
+                    workflow.out.bismark_index,
+                    workflow.out.bwameth_index,
+                    workflow.out.versions
+                    ).match() }
+            )
+        }
+    }
+
+    test("Params: bwameth | generate fasta index | generate bwameth mem2 index") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa.gz', checkIfExists: true).map { it -> [ [:], it ] }
+                input[1] = [] // fasta_index
+                input[2] = [] // bismark index
+                input[3] = [] // bwameth index
+                input[4] = "bwameth" // aligner
+                input[5] = false // collecthsmetrics
+                input[6] = true // use_mem2
                 """
             }
         }
@@ -228,6 +325,37 @@ nextflow_workflow {
                 input[3] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/Bwameth_Index.tar.gz', checkIfExists: true).map { it -> [ [:], it ] }
                 input[4] = "bwameth" // aligner
                 input[5] = true // collecthsmetrics
+                input[6] = false // use_mem2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    workflow.out.fasta,
+                    workflow.out.fasta_index,
+                    workflow.out.bismark_index,
+                    workflow.out.bwameth_index,
+                    workflow.out.versions
+                    ).match() }
+            )
+        }
+    }
+
+    test("Params: bwameth | generate fasta index | download bwameth mem2 index | collecthsmetrics") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/genome.fa.gz', checkIfExists: true).map { it -> [ [:], it ] }
+                input[1] = [] //fasta index
+                input[2] = [] // bismark index
+                input[3] = Channel.fromPath('https://github.com/nf-core/test-datasets/raw/methylseq/reference/Bwameth_mem2_Index.tar.gz', checkIfExists: true).map { it -> [ [:], it ] }
+                input[4] = "bwameth" // aligner
+                input[5] = true // collecthsmetrics
+                input[6] = true // use_mem2
                 """
             }
         }

--- a/subworkflows/nf-core/fasta_index_bismark_bwameth/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_index_bismark_bwameth/tests/main.nf.test.snap
@@ -105,6 +105,54 @@
         },
         "timestamp": "2024-12-13T18:05:15.908870474"
     },
+    "Params: bwameth | generate fasta index | download bwameth mem2 index | collecthsmetrics": {
+        "content": [
+            [
+                [
+                    {
+                        
+                    },
+                    "genome.fa:md5,923a0a268ad29fee3c3437d00f9970de"
+                ]
+            ],
+            [
+                [
+                    {
+                        
+                    },
+                    "genome.fa.fai:md5,84f5b44c25877ac58b154706cc8bc451"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        
+                    },
+                    [
+                        "genome.fa.bwameth.c2t:md5,e51d48ed28fa0c26e2f9c9f13d09403b",
+                        "genome.fa.bwameth.c2t.0123:md5,b42c9bfe6ee171ac14fde2ca784d9bae",
+                        "genome.fa.bwameth.c2t.amb:md5,010a242c6764efb30141868a45d698b3",
+                        "genome.fa.bwameth.c2t.ann:md5,09b4db3d87a2d4dac9e10e807f377110",
+                        "genome.fa.bwameth.c2t.bwt.2bit.64:md5,601423e8ad616988a09caac38cab297f",
+                        "genome.fa.bwameth.c2t.pac:md5,a662d7add09698e25c8152fd2306ec66"
+                    ]
+                ]
+            ],
+            [
+                "versions.yml:md5,b0160273bd1b3b049a2748c02496c6d1",
+                "versions.yml:md5,dfb3bc1adbc94d00aec14dad16eee3df",
+                "versions.yml:md5,ee0146f5d2942f9ff466bf275567515e"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-08T13:01:36.340254828"
+    },
     "Params: bwameth | generate fasta index | generate bwameth index": {
         "content": [
             [
@@ -152,6 +200,54 @@
             "nextflow": "24.10.2"
         },
         "timestamp": "2024-12-13T18:05:42.280318287"
+    },
+    "Params: bwameth | generate fasta index | download bwameth mem2 index": {
+        "content": [
+            [
+                [
+                    {
+                        
+                    },
+                    "genome.fa:md5,923a0a268ad29fee3c3437d00f9970de"
+                ]
+            ],
+            [
+                [
+                    {
+                        
+                    },
+                    "genome.fa.fai:md5,84f5b44c25877ac58b154706cc8bc451"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        
+                    },
+                    [
+                        "genome.fa.bwameth.c2t:md5,e51d48ed28fa0c26e2f9c9f13d09403b",
+                        "genome.fa.bwameth.c2t.0123:md5,b42c9bfe6ee171ac14fde2ca784d9bae",
+                        "genome.fa.bwameth.c2t.amb:md5,010a242c6764efb30141868a45d698b3",
+                        "genome.fa.bwameth.c2t.ann:md5,09b4db3d87a2d4dac9e10e807f377110",
+                        "genome.fa.bwameth.c2t.bwt.2bit.64:md5,601423e8ad616988a09caac38cab297f",
+                        "genome.fa.bwameth.c2t.pac:md5,a662d7add09698e25c8152fd2306ec66"
+                    ]
+                ]
+            ],
+            [
+                "versions.yml:md5,b0160273bd1b3b049a2748c02496c6d1",
+                "versions.yml:md5,dfb3bc1adbc94d00aec14dad16eee3df",
+                "versions.yml:md5,ee0146f5d2942f9ff466bf275567515e"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-08T13:00:49.87732606"
     },
     "Params: bismark_hisat | generate bismark index (hisat2)": {
         "content": [
@@ -371,6 +467,101 @@
             "nextflow": "24.10.2"
         },
         "timestamp": "2025-06-11T20:45:19.092285"
+    },
+    "Params: bwameth | download fasta index | download bwameth mem2 index": {
+        "content": [
+            [
+                [
+                    {
+                        
+                    },
+                    "genome.fa:md5,923a0a268ad29fee3c3437d00f9970de"
+                ]
+            ],
+            [
+                [
+                    {
+                        
+                    },
+                    "/nf-core/test-datasets/raw/methylseq/reference/genome.fa.fai"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        
+                    },
+                    [
+                        "genome.fa.bwameth.c2t:md5,e51d48ed28fa0c26e2f9c9f13d09403b",
+                        "genome.fa.bwameth.c2t.0123:md5,b42c9bfe6ee171ac14fde2ca784d9bae",
+                        "genome.fa.bwameth.c2t.amb:md5,010a242c6764efb30141868a45d698b3",
+                        "genome.fa.bwameth.c2t.ann:md5,09b4db3d87a2d4dac9e10e807f377110",
+                        "genome.fa.bwameth.c2t.bwt.2bit.64:md5,601423e8ad616988a09caac38cab297f",
+                        "genome.fa.bwameth.c2t.pac:md5,a662d7add09698e25c8152fd2306ec66"
+                    ]
+                ]
+            ],
+            [
+                "versions.yml:md5,b0160273bd1b3b049a2748c02496c6d1",
+                "versions.yml:md5,dfb3bc1adbc94d00aec14dad16eee3df"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-08T13:00:28.02504006"
+    },
+    "Params: bwameth | generate fasta index | generate bwameth mem2 index": {
+        "content": [
+            [
+                [
+                    {
+                        
+                    },
+                    "genome.fa:md5,923a0a268ad29fee3c3437d00f9970de"
+                ]
+            ],
+            [
+                [
+                    {
+                        
+                    },
+                    "genome.fa.fai:md5,84f5b44c25877ac58b154706cc8bc451"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        
+                    },
+                    [
+                        "genome.fa.bwameth.c2t:md5,e51d48ed28fa0c26e2f9c9f13d09403b",
+                        "genome.fa.bwameth.c2t.0123:md5,b42c9bfe6ee171ac14fde2ca784d9bae",
+                        "genome.fa.bwameth.c2t.amb:md5,010a242c6764efb30141868a45d698b3",
+                        "genome.fa.bwameth.c2t.ann:md5,09b4db3d87a2d4dac9e10e807f377110",
+                        "genome.fa.bwameth.c2t.bwt.2bit.64:md5,601423e8ad616988a09caac38cab297f",
+                        "genome.fa.bwameth.c2t.pac:md5,a662d7add09698e25c8152fd2306ec66"
+                    ]
+                ]
+            ],
+            [
+                "versions.yml:md5,3a92f9ed1831ae3a68bc15886e7a95a1",
+                "versions.yml:md5,dfb3bc1adbc94d00aec14dad16eee3df",
+                "versions.yml:md5,ee0146f5d2942f9ff466bf275567515e"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-08T12:32:54.266193502"
     },
     "Params: bismark | generate bismark index (bowtie2)": {
         "content": [


### PR DESCRIPTION
Following recent updates to bwameth modules to support bwa-mem2, support for mem2 is being added to the nf-core/methylseq pipeline. This subworkflow update allows mem2 indexes to be generated if no bwameth_index path is passed, with mem2 index tests added as well.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, include test data in your PR. NOTE test data added here: https://github.com/nf-core/test-datasets/pull/1701
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
