### PR TITLE
If `${prefix}.fastq.gz` doesn't exist create a symlink to it

### DIFF
--- a/modules/nf-core/fastplong/main.nf
+++ b/modules/nf-core/fastplong/main.nf
@@ -32,6 +32,8 @@ process FASTPLONG {
     def output_file = discard_trimmed_pass ? '' : "--out ${prefix}.fastplong.fastq.gz"
     def report_title = task.ext.report_title ?: "${prefix}_fastplong_report"
     """
+    [ ! -f  ${prefix}.fastq.gz ] && ln -sf $reads ${prefix}.fastq.gz
+
     fastplong \\
         --in ${prefix}.fastq.gz \\
         $output_file \\


### PR DESCRIPTION
Thanks for adding `fastplong` to nf-core!

This PR will:
Create a symlink to `${prefix}.fastq.gz` if it is not already a file.

This is needed because:
If the prefix does not match the file name, currently `fastplong` throws an error because it can't find the reads.

Code taken from the nf-core `fastp` module.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x ] `nf-core modules test fastplong --profile docker`
