### PR TITLE
Update duplicate file pattern

### DIFF
--- a/modules/nf-core/scanpy/hashsolo/main.nf
+++ b/modules/nf-core/scanpy/hashsolo/main.nf
@@ -11,10 +11,10 @@ process SCANPY_HASHSOLO {
     tuple val(meta), path(data), val(cell_hashing_columns)
 
     output:
-    tuple val(meta), path("*_hashsolo.csv")       , emit: assignment
-    tuple val(meta), path("*_hashsolo.h5ad")      , emit: h5ad
-    tuple val(meta), path("*_params_hashsolo.csv"), emit: params
-    path "versions.yml"                           , emit: versions
+    tuple val(meta), path("*_assignment_hashsolo.csv"), emit: assignment
+    tuple val(meta), path("*_hashsolo.h5ad")          , emit: h5ad
+    tuple val(meta), path("*_params_hashsolo.csv")    , emit: params
+    path "versions.yml"                               , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,8 +27,7 @@ process SCANPY_HASHSOLO {
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}_hashsolo.csv
-    touch ${prefix}_hashsolo.jpg
+    touch ${prefix}_assignment_hashsolo.csv
     touch ${prefix}_hashsolo.h5ad
     touch ${prefix}_params_hashsolo.csv
 

--- a/modules/nf-core/scanpy/hashsolo/meta.yml
+++ b/modules/nf-core/scanpy/hashsolo/meta.yml
@@ -42,11 +42,11 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
-      - "*_hashsolo.csv":
+      - "*_assignment_hashsolo.csv":
           type: file
           description: |
             CSV file containing hashsolo assignment results
-          pattern: "*_hashsolo.csv"
+          pattern: "*_assignment_hashsolo.csv"
           ontologies:
             - edam: http://edamontology.org/format_3752 # CSV
   h5ad:

--- a/modules/nf-core/scanpy/hashsolo/templates/hashsolo.py
+++ b/modules/nf-core/scanpy/hashsolo/templates/hashsolo.py
@@ -36,7 +36,7 @@ class Arguments:
 
         self.prefix               = "$task.ext.prefix" if "$task.ext.prefix" != "null" else "$meta.id"
 
-        self.path_assignment = self.prefix + "_hashsolo.csv"
+        self.path_assignment = self.prefix + "_assignment_hashsolo.csv"
         # self.path_plot       = self.prefix + "_hashsolo.jpg"
         self.path_h5ad       = self.prefix + "_hashsolo.h5ad"
         self.path_params     = self.prefix + "_params_hashsolo.csv"

--- a/modules/nf-core/scanpy/hashsolo/tests/main.nf.test.snap
+++ b/modules/nf-core/scanpy/hashsolo/tests/main.nf.test.snap
@@ -7,10 +7,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,a970a5192150b1832a3efea197c882cd",
-                            "test_params_hashsolo.csv:md5,83172b1ea6c6e2eb1c5f63ab73708320"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,a970a5192150b1832a3efea197c882cd"
                     ]
                 ],
                 "1": [
@@ -26,7 +23,7 @@
                         {
                             "id": "test"
                         },
-                        "test_params_hashsolo.csv:md5,83172b1ea6c6e2eb1c5f63ab73708320"
+                        "test_params_hashsolo.csv:md5,17ed9d21353013b8547ac829874ff514"
                     ]
                 ],
                 "3": [
@@ -37,10 +34,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,a970a5192150b1832a3efea197c882cd",
-                            "test_params_hashsolo.csv:md5,83172b1ea6c6e2eb1c5f63ab73708320"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,a970a5192150b1832a3efea197c882cd"
                     ]
                 ],
                 "h5ad": [
@@ -56,7 +50,7 @@
                         {
                             "id": "test"
                         },
-                        "test_params_hashsolo.csv:md5,83172b1ea6c6e2eb1c5f63ab73708320"
+                        "test_params_hashsolo.csv:md5,17ed9d21353013b8547ac829874ff514"
                     ]
                 ],
                 "versions": [
@@ -68,7 +62,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-10T15:10:01.495741883"
+        "timestamp": "2025-08-11T06:12:34.257211014"
     },
     "hto_data_10x - stub": {
         "content": [
@@ -78,10 +72,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_params_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -108,10 +99,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_params_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "h5ad": [
@@ -137,9 +125,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-09T12:54:44.932582"
+        "timestamp": "2025-08-11T06:12:55.413127431"
     },
     "hto_data_h5ad (generated, no real data)": {
         "content": [
@@ -149,10 +137,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,e6ffa5719d0dc3d2236ced778327b50c",
-                            "test_params_hashsolo.csv:md5,8ad0466b1f5300cc91d5757819a51d2e"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,e6ffa5719d0dc3d2236ced778327b50c"
                     ]
                 ],
                 "1": [
@@ -168,7 +153,7 @@
                         {
                             "id": "test"
                         },
-                        "test_params_hashsolo.csv:md5,8ad0466b1f5300cc91d5757819a51d2e"
+                        "test_params_hashsolo.csv:md5,7054d81f10cb650a72f9dea5bb23f44b"
                     ]
                 ],
                 "3": [
@@ -179,10 +164,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,e6ffa5719d0dc3d2236ced778327b50c",
-                            "test_params_hashsolo.csv:md5,8ad0466b1f5300cc91d5757819a51d2e"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,e6ffa5719d0dc3d2236ced778327b50c"
                     ]
                 ],
                 "h5ad": [
@@ -198,7 +180,7 @@
                         {
                             "id": "test"
                         },
-                        "test_params_hashsolo.csv:md5,8ad0466b1f5300cc91d5757819a51d2e"
+                        "test_params_hashsolo.csv:md5,7054d81f10cb650a72f9dea5bb23f44b"
                     ]
                 ],
                 "versions": [
@@ -220,7 +202,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-10T15:11:51.220470381"
+        "timestamp": "2025-08-11T06:13:04.472233033"
     },
     "generated h5ad": {
         "content": [
@@ -271,10 +253,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,8cdd1b5a8c910c2842518cb3caac541d",
-                            "test_params_hashsolo.csv:md5,16ed7759994a0a6ff2894e03195730e9"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,8cdd1b5a8c910c2842518cb3caac541d"
                     ]
                 ],
                 "1": [
@@ -290,7 +269,7 @@
                         {
                             "id": "test"
                         },
-                        "test_params_hashsolo.csv:md5,16ed7759994a0a6ff2894e03195730e9"
+                        "test_params_hashsolo.csv:md5,c9e859256e6d28dc03049496b7eee509"
                     ]
                 ],
                 "3": [
@@ -301,10 +280,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,8cdd1b5a8c910c2842518cb3caac541d",
-                            "test_params_hashsolo.csv:md5,16ed7759994a0a6ff2894e03195730e9"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,8cdd1b5a8c910c2842518cb3caac541d"
                     ]
                 ],
                 "h5ad": [
@@ -320,7 +296,7 @@
                         {
                             "id": "test"
                         },
-                        "test_params_hashsolo.csv:md5,16ed7759994a0a6ff2894e03195730e9"
+                        "test_params_hashsolo.csv:md5,c9e859256e6d28dc03049496b7eee509"
                     ]
                 ],
                 "versions": [
@@ -342,7 +318,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-10T15:12:00.09266188"
+        "timestamp": "2025-08-11T06:13:12.760175521"
     },
     "hto_matrix": {
         "content": [
@@ -516,10 +492,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_params_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -546,10 +519,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test_params_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "h5ad": [
@@ -585,9 +555,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-09T12:21:54.943353"
+        "timestamp": "2025-08-11T06:13:22.084772685"
     },
     "generated h5ad - stub": {
         "content": [
@@ -638,10 +608,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,dabd4b9a92e90c0030d86110fce3be40",
-                            "test_params_hashsolo.csv:md5,fe7e3a218355154bf5d9a819986518c1"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,dabd4b9a92e90c0030d86110fce3be40"
                     ]
                 ],
                 "1": [
@@ -657,7 +624,7 @@
                         {
                             "id": "test"
                         },
-                        "test_params_hashsolo.csv:md5,fe7e3a218355154bf5d9a819986518c1"
+                        "test_params_hashsolo.csv:md5,4b992e5daf73b8f23f5d847df32dc177"
                     ]
                 ],
                 "3": [
@@ -668,10 +635,7 @@
                         {
                             "id": "test"
                         },
-                        [
-                            "test_hashsolo.csv:md5,dabd4b9a92e90c0030d86110fce3be40",
-                            "test_params_hashsolo.csv:md5,fe7e3a218355154bf5d9a819986518c1"
-                        ]
+                        "test_assignment_hashsolo.csv:md5,dabd4b9a92e90c0030d86110fce3be40"
                     ]
                 ],
                 "h5ad": [
@@ -687,7 +651,7 @@
                         {
                             "id": "test"
                         },
-                        "test_params_hashsolo.csv:md5,fe7e3a218355154bf5d9a819986518c1"
+                        "test_params_hashsolo.csv:md5,4b992e5daf73b8f23f5d847df32dc177"
                     ]
                 ],
                 "versions": [
@@ -699,6 +663,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-08-10T15:10:11.204617906"
+        "timestamp": "2025-08-11T06:12:44.782219305"
     }
 }


### PR DESCRIPTION
- `SCANPY_HASHSOLO.out.assignment` returned a list of `[assignment, params]` because the pattern wasn't clearly.
- This small PR removes this duplicate file pattern