### PR TITLE
Fix CheckM2 database download

### DIFF
--- a/modules/nf-core/checkm2/databasedownload/main.nf
+++ b/modules/nf-core/checkm2/databasedownload/main.nf
@@ -6,7 +6,7 @@ def downloadZenodoApiEntry(zenodo_id) {
     conn.setRequestProperty('User-Agent', "Nextflow ${nextflow.version ?: ''}".trim())
 
     def api_text = conn.getInputStream().getText('UTF-8')
-    def parser = new groovy.json.JsonSlurper()
+    def parser   = new groovy.json.JsonSlurper()
 
     return parser.parseText(api_text)
 }
@@ -30,12 +30,12 @@ process CHECKM2_DATABASEDOWNLOAD {
     task.ext.when == null || task.ext.when
 
     script:
-    def args        = task.ext.args ?: ''
-    zenodo_id       = db_zenodo_id ?: 14897628  // Default to version 3 if no ID provided
-    api_data        = downloadZenodoApiEntry(zenodo_id)
-    db_version      = api_data.metadata.version
-    checksum        = api_data.files[0].checksum.replaceFirst(/^md5:/, "md5=")
-    meta            = [id: 'checkm2_db', version: db_version]
+    def args   = task.ext.args ?: ''
+    zenodo_id  = db_zenodo_id ?: 14897628  // Default to version 3 if no ID provided
+    api_data   = downloadZenodoApiEntry(zenodo_id)
+    db_version = api_data.metadata.version
+    checksum   = api_data.files[0].checksum.replaceFirst(/^md5:/, "md5=")
+    meta       = [id: 'checkm2_db', version: db_version]
     """
     # Automatic download is broken when using singularity/apptainer (https://github.com/chklovski/CheckM2/issues/73)
     # So it's necessary to download the database manually

--- a/modules/nf-core/checkm2/databasedownload/main.nf
+++ b/modules/nf-core/checkm2/databasedownload/main.nf
@@ -1,3 +1,16 @@
+def downloadZenodoApiEntry(zenodo_id) {
+    // Download metadata from Zenodo API, setting "Accept: application/json" header
+    def api_url  = "https://zenodo.org/api/records/${zenodo_id}"
+    def conn     = new URL(api_url).openConnection()
+    conn.setRequestProperty('Accept', 'application/json')
+    conn.setRequestProperty('User-Agent', "Nextflow ${nextflow.version ?: ''}".trim())
+
+    def api_text = conn.getInputStream().getText('UTF-8')
+    def parser = new groovy.json.JsonSlurper()
+
+    return parser.parseText(api_text)
+}
+
 process CHECKM2_DATABASEDOWNLOAD {
     label 'process_single'
 
@@ -19,7 +32,7 @@ process CHECKM2_DATABASEDOWNLOAD {
     script:
     def args        = task.ext.args ?: ''
     zenodo_id       = db_zenodo_id ?: 14897628  // Default to version 3 if no ID provided
-    api_data        = (new groovy.json.JsonSlurper()).parseText(file("https://zenodo.org/api/records/${zenodo_id}").text)
+    api_data        = downloadZenodoApiEntry(zenodo_id)
     db_version      = api_data.metadata.version
     checksum        = api_data.files[0].checksum.replaceFirst(/^md5:/, "md5=")
     meta            = [id: 'checkm2_db', version: db_version]

--- a/modules/nf-core/galah/tests/nextflow.config
+++ b/modules/nf-core/galah/tests/nextflow.config
@@ -1,6 +1,6 @@
 process {
     withName: 'CHECKM2_PREDICT' {
-        ext.args = "--extension gz"
+        ext.args = "--extension gz --lowmem"
     }
     withName: 'GAWK' {
         ext.args2 = "'BEGIN {FS = OFS = \"\\t\"} NR == 1 {print \$0} NR > 1 {\$1=\$1\".fna\"; print \$0}'"


### PR DESCRIPTION
This PR attempts to solve the following error:
```
Server returned HTTP response code: 406 for URL: https://zenodo.org/api/records/14897628 -- Check script 'modules/nf-core/checkm2/databasedownload/main.nf' at line: 22
```
This seems to happen becase the Zenodo API expects the `application/json` content type, but `file()` doesn't set it.
The solution implemented here creates the HTTP request manually, setting the neccesary header.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
