### PR TITLE
Fix UnboundLocalError for transcripts - addmostseverepli/consequence

### DIFF
--- a/modules/nf-core/custom/addmostsevereconsequence/resources/usr/bin/add_most_severe_consequence.py
+++ b/modules/nf-core/custom/addmostsevereconsequence/resources/usr/bin/add_most_severe_consequence.py
@@ -68,6 +68,7 @@ def construct_most_severe_consequence_info(
 
     columns = line.strip().split()
     info_fields = columns[7].split(";")
+    transcripts = []
     for field in info_fields:
         if field.startswith("CSQ="):
             transcripts = field.split("CSQ=")[1].split(",")

--- a/modules/nf-core/custom/addmostseverepli/resources/usr/bin/add_most_severe_pli.py
+++ b/modules/nf-core/custom/addmostseverepli/resources/usr/bin/add_most_severe_pli.py
@@ -46,6 +46,7 @@ def construct_most_severe_pli_info(line: str, pli_ind: int) -> list:
 
     columns = line.strip().split()
     info_fields = columns[7].split(";")
+    transcripts = []
     for field in info_fields:
         if field.startswith("CSQ="):
             transcripts = field.split("CSQ=")[1].split(",")


### PR DESCRIPTION
Ensure that the transcripts variable is always initialized before use to prevent UnboundLocalError:

```
Traceback (most recent call last):
  File "/home/training.imgge/add_most_severe_pli.py", line 129, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/training.imgge/add_most_severe_pli.py", line 125, in main
    write_pli_annotated_vcf(in_vcf, out_vcf)
  File "/home/training.imgge/add_most_severe_pli.py", line 90, in write_pli_annotated_vcf
    vcf_record = construct_most_severe_pli_info(line, pli_ind)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/training.imgge/add_most_severe_pli.py", line 53, in construct_most_severe_pli_info
    pli_values = parse_vep_transcripts(transcripts, pli_ind)
                                       ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'transcripts' where it is not associated with a value
```

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
