### PR TITLE
Subworkflow mmseqs fasta cluster

### DIFF
--- a/subworkflows/nf-core/mmseqs_fasta_cluster/main.nf
+++ b/subworkflows/nf-core/mmseqs_fasta_cluster/main.nf
@@ -1,0 +1,50 @@
+include { MMSEQS_CREATEDB  } from '../../../modules/nf-core/mmseqs/createdb/main'
+include { MMSEQS_CLUSTER   } from '../../../modules/nf-core/mmseqs/cluster/main'
+include { MMSEQS_LINCLUST  } from '../../../modules/nf-core/mmseqs/linclust/main'
+include { MMSEQS_CREATETSV } from '../../../modules/nf-core/mmseqs/createtsv/main'
+
+workflow MMSEQS_FASTA_CLUSTER {
+    take:
+    sequences       // tuple val(meta), path(fasta)
+    clustering_tool // string: ["linclust", "cluster"]
+
+    main:
+    ch_versions       = Channel.empty()
+    ch_clustering_tsv = Channel.empty()
+
+    MMSEQS_CREATEDB( sequences )
+    ch_versions = ch_versions.mix( MMSEQS_CREATEDB.out.versions )
+
+    if (clustering_tool == 'cluster') {
+        cluster_res = MMSEQS_CLUSTER( MMSEQS_CREATEDB.out.db )
+        ch_versions = ch_versions.mix( MMSEQS_CLUSTER.out.versions )
+    } else if (clustering_tool == 'linclust') {
+        cluster_res = MMSEQS_LINCLUST( MMSEQS_CREATEDB.out.db )
+        ch_versions = ch_versions.mix( MMSEQS_LINCLUST.out.versions )
+    }
+
+    // Join to ensure in sync in case of multiple sequence files
+    ch_input_for_createtsv = MMSEQS_CREATEDB.out.db
+        .join(cluster_res.db_cluster)
+        .multiMap { meta, db, db_cluster ->
+            db: [ meta, db ]
+            db_cluster: [ meta, db_cluster ]
+        }
+
+    MMSEQS_CREATETSV( ch_input_for_createtsv.db_cluster, ch_input_for_createtsv.db, ch_input_for_createtsv.db )
+    ch_versions = ch_versions.mix( MMSEQS_CREATETSV.out.versions )
+    ch_clustering_tsv = MMSEQS_CREATETSV.out.tsv
+
+    // Join to ensure in sync in case of multiple sequence files
+    ch_clustering_output = sequences
+        .join(MMSEQS_CREATETSV.out.tsv)
+        .multiMap { meta, seqs, clusters ->
+            seqs: [meta, seqs]
+            clusters: [meta, clusters]
+        }
+
+    emit:
+    versions = ch_versions
+    seqs     = ch_clustering_output.seqs
+    clusters = ch_clustering_output.clusters
+}

--- a/subworkflows/nf-core/mmseqs_fasta_cluster/meta.yml
+++ b/subworkflows/nf-core/mmseqs_fasta_cluster/meta.yml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "MMSEQS_FASTA_CLUSTER"
+description: Subworkflow that generates a clustering TSV file from a set of amino acid sequence within a FASTA file.
+keywords:
+  - fasta
+  - sequences
+  - cluster
+  - linclust
+  - mmseqs
+components:
+  - mmseqs/createdb
+  - mmseqs/cluster
+  - mmseqs/linclust
+  - mmseqs/createtsv
+input:
+  - sequences:
+      type: file
+      description: |
+        Amino acid fasta file containing amino acid sequences for clustering.
+  - clustering_tool:
+      type: string
+      description: |
+        Clustering tool to use for generating the clustering. Options are 'linclust' or 'cluster'.
+output:
+  - versions:
+      type: file
+      description: |
+        Versions file containing the software versions used in the workflow.
+  - seqs:
+      type: file
+      description: The input FASTA file mapped to its corresponding clustering tsv, per input entry.
+  - clusters:
+      type: file
+      description: Clustering file mapped to its corresponding input FASTA file.
+authors:
+  - "@vagkaratzas"
+maintainers:
+  - "@vagkaratzas"

--- a/subworkflows/nf-core/mmseqs_fasta_cluster/tests/main.nf.test
+++ b/subworkflows/nf-core/mmseqs_fasta_cluster/tests/main.nf.test
@@ -5,6 +5,14 @@ nextflow_workflow {
     workflow "MMSEQS_FASTA_CLUSTER"
     config './nextflow.config'
 
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/mmseqs_fasta_cluster"
+    tag "mmseqs/createdb"
+    tag "mmseqs/cluster"
+    tag "mmseqs/linclust"
+    tag "mmseqs/createtsv"
+
     test("fasta - linclust") {
 
         when {

--- a/subworkflows/nf-core/mmseqs_fasta_cluster/tests/main.nf.test
+++ b/subworkflows/nf-core/mmseqs_fasta_cluster/tests/main.nf.test
@@ -1,0 +1,108 @@
+nextflow_workflow {
+
+    name "Test Subworkflow MMSEQS_FASTA_CLUSTER"
+    script "../main.nf"
+    workflow "MMSEQS_FASTA_CLUSTER"
+    config './nextflow.config'
+
+    test("fasta - linclust") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test_linclust' ],
+                    file(params.modules_testdata_base_path + '../../proteinfamilies/test_data/mgnifams_input_small.fa', checkIfExists: true)
+                ])
+                input[1] = 'linclust'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    file(workflow.out.clusters[0][1]).name,
+                    path(workflow.out.clusters[0][1]).readLines().size(),
+                    workflow.out.versions.collect { path(it).yaml }.unique()
+                    ).match() }
+            )
+        }
+    }
+
+    test("fasta - cluster") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test_cluster' ],
+                    file(params.modules_testdata_base_path + '../../proteinfamilies/test_data/mgnifams_input_small.fa', checkIfExists: true)
+                ])
+                input[1] = 'cluster'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    file(workflow.out.clusters[0][1]).name,
+                    path(workflow.out.clusters[0][1]).readLines().size(),
+                    workflow.out.versions.collect { path(it).yaml }.unique()
+                    ).match() }
+            )
+        }
+    }
+
+    test("fasta - linclust - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test_linclust_stub' ],
+                    file(params.modules_testdata_base_path + '../../proteinfamilies/test_data/mgnifams_input_small.fa', checkIfExists: true)
+                ])
+                input[1] = 'linclust'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+    test("fasta - cluster - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test_cluster_stub' ],
+                    file(params.modules_testdata_base_path + '../../proteinfamilies/test_data/mgnifams_input_small.fa', checkIfExists: true)
+                ])
+                input[1] = 'cluster'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+}

--- a/subworkflows/nf-core/mmseqs_fasta_cluster/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/mmseqs_fasta_cluster/tests/main.nf.test.snap
@@ -1,0 +1,164 @@
+{
+    "fasta - cluster": {
+        "content": [
+            "test_cluster.tsv",
+            50000,
+            [
+                {
+                    "MMSEQS_FASTA_CLUSTER:MMSEQS_CREATEDB": {
+                        "mmseqs": "17.b804f"
+                    }
+                },
+                {
+                    "MMSEQS_FASTA_CLUSTER:MMSEQS_CLUSTER": {
+                        "mmseqs": "17.b804f"
+                    }
+                },
+                {
+                    "MMSEQS_FASTA_CLUSTER:MMSEQS_CREATETSV": {
+                        "mmseqs": "17.b804f"
+                    }
+                }
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-26T12:39:11.701219216"
+    },
+    "fasta - linclust - stub": {
+        "content": [
+            {
+                "0": [
+                    "versions.yml:md5,5c9984ac67883d64ddafb5822277e238",
+                    "versions.yml:md5,8a6052ad86fef49b507a35a0af053a53",
+                    "versions.yml:md5,ff51b6662cebbd564d8da6a8f4aaeca2"
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_linclust_stub"
+                        },
+                        "/nf-core/test-datasets/modules/data/../../proteinfamilies/test_data/mgnifams_input_small.fa"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test_linclust_stub"
+                        },
+                        "test_linclust_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "clusters": [
+                    [
+                        {
+                            "id": "test_linclust_stub"
+                        },
+                        "test_linclust_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "seqs": [
+                    [
+                        {
+                            "id": "test_linclust_stub"
+                        },
+                        "/nf-core/test-datasets/modules/data/../../proteinfamilies/test_data/mgnifams_input_small.fa"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5c9984ac67883d64ddafb5822277e238",
+                    "versions.yml:md5,8a6052ad86fef49b507a35a0af053a53",
+                    "versions.yml:md5,ff51b6662cebbd564d8da6a8f4aaeca2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-26T12:39:20.644444531"
+    },
+    "fasta - linclust": {
+        "content": [
+            "test_linclust.tsv",
+            50000,
+            [
+                {
+                    "MMSEQS_FASTA_CLUSTER:MMSEQS_CREATEDB": {
+                        "mmseqs": "17.b804f"
+                    }
+                },
+                {
+                    "MMSEQS_FASTA_CLUSTER:MMSEQS_LINCLUST": {
+                        "mmseqs": "17.b804f"
+                    }
+                },
+                {
+                    "MMSEQS_FASTA_CLUSTER:MMSEQS_CREATETSV": {
+                        "mmseqs": "17.b804f"
+                    }
+                }
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-26T12:37:56.456296736"
+    },
+    "fasta - cluster - stub": {
+        "content": [
+            {
+                "0": [
+                    "versions.yml:md5,5c9984ac67883d64ddafb5822277e238",
+                    "versions.yml:md5,bc998aae9e5d6a6676a5f1b4fde28978",
+                    "versions.yml:md5,ff51b6662cebbd564d8da6a8f4aaeca2"
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_cluster_stub"
+                        },
+                        "/nf-core/test-datasets/modules/data/../../proteinfamilies/test_data/mgnifams_input_small.fa"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test_cluster_stub"
+                        },
+                        "test_cluster_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "clusters": [
+                    [
+                        {
+                            "id": "test_cluster_stub"
+                        },
+                        "test_cluster_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "seqs": [
+                    [
+                        {
+                            "id": "test_cluster_stub"
+                        },
+                        "/nf-core/test-datasets/modules/data/../../proteinfamilies/test_data/mgnifams_input_small.fa"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5c9984ac67883d64ddafb5822277e238",
+                    "versions.yml:md5,bc998aae9e5d6a6676a5f1b4fde28978",
+                    "versions.yml:md5,ff51b6662cebbd564d8da6a8f4aaeca2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-26T12:39:29.616796255"
+    }
+}

--- a/subworkflows/nf-core/mmseqs_fasta_cluster/tests/nextflow.config
+++ b/subworkflows/nf-core/mmseqs_fasta_cluster/tests/nextflow.config
@@ -1,0 +1,7 @@
+process {
+
+    withName: MMSEQS_CREATEDB {
+        ext.prefix = 'db'
+    }
+
+}


### PR DESCRIPTION
New subworkflow that receives a fasta file (or multiple) as input and outputs the respective clustering TSV file (rep\tmember), either via the mmseqs/cluster or the mmseqs/linclust algorithm of choice.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
