### PR TITLE
Fix jamsineSV ext.args2 usage

### DIFF
--- a/modules/nf-core/jasminesv/main.nf
+++ b/modules/nf-core/jasminesv/main.nf
@@ -24,6 +24,7 @@ process JASMINESV {
     def args    = task.ext.args ?: ''
     def args2   = task.ext.args2 ?: ''
     def args3   = task.ext.args3 ?: ''
+    def args4   = task.ext.args4 ?: ''
     def prefix  = task.ext.prefix ?: "${meta.id}"
 
     def make_bam = bams ? "ls *.bam > bams.txt" : ""
@@ -33,7 +34,7 @@ process JASMINESV {
     def chr_norm_argument = chr_norm ? "chr_norm_file=${chr_norm}" : ""
 
     def first_vcf = vcfs[0].name.replaceAll(".gz\$", "")
-    def unzip_inputs = vcfs.collect { it.name.endsWith(".vcf.gz") ? "    bgzip -d --threads ${task.cpus} ${args2} ${it}" : "" }.join("\n")
+    def unzip_inputs = vcfs.collect { it.name.endsWith(".vcf.gz") ? "    bgzip -d --threads ${task.cpus} ${args4} ${it}" : "" }.join("\n")
 
     vcfs.each { vcf ->
         if ("$vcf".startsWith("${prefix}.vcf")) error "Input and output names are the same, set prefix in module configuration to disambiguate!"


### PR DESCRIPTION
Add new `args4` for the `bgzip -d` command so that `iris_args` work properly with `args2`. This should preserve backwards compatibility (although the module was broken if you used `args2`) for anyone using `args3` (for the `bgzip -c` command) already

## PR checklist

Closes #8946 

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
