### PR TITLE
Fix version in snapaligner/index stub

### DIFF
--- a/modules/nf-core/snapaligner/index/main.nf
+++ b/modules/nf-core/snapaligner/index/main.nf
@@ -37,7 +37,7 @@ process SNAPALIGNER_INDEX {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        snapaligner: \$(snap-aligner 2>&1| head -n 1 | sed 's/^.*version //')
+        snapaligner: \$(snap-aligner 2>&1| head -n 1 | sed 's/^.*version //;s/.\$//')
     END_VERSIONS
     """
     stub:
@@ -50,7 +50,7 @@ process SNAPALIGNER_INDEX {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        snapaligner: \$(snap-aligner 2>&1| head -n 1 | sed 's/^.*version //;s/\.\$//')
+        snapaligner: \$(snap-aligner 2>&1| head -n 1 | sed 's/^.*version //;s/.\$//')
     END_VERSIONS
     """
 }

--- a/modules/nf-core/snapaligner/index/tests/main.nf.test
+++ b/modules/nf-core/snapaligner/index/tests/main.nf.test
@@ -16,13 +16,12 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-				    [id:"test"],
-				    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-				    [],
-				    [],
-				    []
+                    [id:"test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    [],
+                    [],
+                    []
 				]
-
                 """
             }
         }
@@ -32,7 +31,8 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.index[0][1].collect { file(it).name }.toSorted(),
-                    process.out.versions
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
                     ).match()
                 }
             )
@@ -45,13 +45,12 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-				    [id:"test"],
-				    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-				    [],
-				    [],
-				    []
+                    [id:"test"],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    [],
+                    [],
+                    []
 				]
-
                 """
             }
         }
@@ -59,7 +58,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out,
+                    path(process.out.versions[0]).yaml
+                    ).match() }
             )
         }
     }

--- a/modules/nf-core/snapaligner/index/tests/main.nf.test.snap
+++ b/modules/nf-core/snapaligner/index/tests/main.nf.test.snap
@@ -8,14 +8,19 @@
                 "OverflowTable"
             ],
             [
-                "versions.yml:md5,6640e4fe1009b6ff26ec0bedead6e7a7"
-            ]
+                "versions.yml:md5,95aac8dd5ad1521b745c5082478ad2df"
+            ],
+            {
+                "SNAPALIGNER_INDEX": {
+                    "snapaligner": "2.0.3"
+                }
+            }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2024-08-30T21:13:00.310307"
+        "timestamp": "2025-08-27T16:15:20.743705254"
     },
     "test-snapaligner-index-stub": {
         "content": [
@@ -34,7 +39,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,10e43290f46aae214ca55605415227eb"
+                    "versions.yml:md5,95aac8dd5ad1521b745c5082478ad2df"
                 ],
                 "index": [
                     [
@@ -50,14 +55,19 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,10e43290f46aae214ca55605415227eb"
+                    "versions.yml:md5,95aac8dd5ad1521b745c5082478ad2df"
                 ]
+            },
+            {
+                "SNAPALIGNER_INDEX": {
+                    "snapaligner": "2.0.3"
+                }
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2024-08-30T21:06:05.367297"
+        "timestamp": "2025-08-27T16:12:49.221022434"
     }
 }


### PR DESCRIPTION
Trying to use the `path(process.out.versions[0]).yaml` on the stub test here gave:
`com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException: while scanning a quoted scalar`.