### PR TITLE
Update and improve CLAIR3

### DIFF
--- a/modules/nf-core/clair3/environment.yml
+++ b/modules/nf-core/clair3/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::clair3=1.0.10"
+  - "bioconda::clair3=1.2.0"

--- a/modules/nf-core/clair3/main.nf
+++ b/modules/nf-core/clair3/main.nf
@@ -4,8 +4,8 @@ process CLAIR3 {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/clair3:1.0.10--py39hd649744_1':
-        'biocontainers/clair3:1.0.10--py39hd649744_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e7/e70b0f4389028f4dc88efde1aac7139927c898cf7add680e14724d97fecd3d32/data':
+        'community.wave.seqera.io/library/clair3:1.2.0--b1b03d4e9d1b6a2e' }"
 
     input:
     tuple val(meta), path(bam), path(bai), val(packaged_model), path(user_model), val(platform)

--- a/modules/nf-core/clair3/main.nf
+++ b/modules/nf-core/clair3/main.nf
@@ -17,6 +17,8 @@ process CLAIR3 {
     tuple val(meta), path("*merge_output.vcf.gz.tbi"),        emit: tbi
     tuple val(meta), path("*phased_merge_output.vcf.gz"),     emit: phased_vcf, optional: true
     tuple val(meta), path("*phased_merge_output.vcf.gz.tbi"), emit: phased_tbi, optional: true
+    tuple val(meta), path("*merge_output.gvcf.gz"),           emit: gvcf, optional: true
+    tuple val(meta), path("*merge_output.gvcf.gz.tbi"),       emit: gtbi, optional: true
     path "versions.yml",                                      emit: versions
 
     when:
@@ -64,6 +66,8 @@ process CLAIR3 {
     touch ${prefix}.phased_merge_output.vcf.gz.tbi
     echo "" | gzip > ${prefix}.merge_output.vcf.gz
     touch ${prefix}.merge_output.vcf.gz.tbi
+    echo "" | gzip > ${prefix}.merge_output.gvcf.gz
+    touch ${prefix}.merge_output.gvcf.gz.tbi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/clair3/main.nf
+++ b/modules/nf-core/clair3/main.nf
@@ -47,6 +47,18 @@ process CLAIR3 {
         --model=$model \\
         $args
 
+    # Rename to add prefix
+    for file in merge_output.vcf.gz \
+            merge_output.vcf.gz.tbi \
+            phased_merge_output.vcf.gz \
+            phased_merge_output.vcf.gz.tbi \
+            merge_output.gvcf.gz \
+            merge_output.gvcf.gz.tbi; do
+    if [ -e "\$file" ]; then
+        mv "\$file" "${prefix}.\$file"
+    fi
+    done
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         clair3: \$(run_clair3.sh  --version |& sed '1!d ; s/Clair3 v//')

--- a/modules/nf-core/clair3/main.nf
+++ b/modules/nf-core/clair3/main.nf
@@ -27,12 +27,7 @@ process CLAIR3 {
     script:
     def model = ""
     if (!user_model) {
-        if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-            model = "\${CONDA_PREFIX}/bin/models/${packaged_model}"
-        }
-        else {
-            model = "/usr/local/bin/models/$packaged_model"
-        }
+        model = "\${CONDA_PREFIX}/bin/models/${packaged_model}"
     }
     if (!packaged_model) {
         model = "$user_model"

--- a/modules/nf-core/clair3/tests/main.nf.test
+++ b/modules/nf-core/clair3/tests/main.nf.test
@@ -9,6 +9,8 @@ nextflow_process {
     tag "clair3"
     tag "untar"
 
+    config "./nextflow.config"
+
     setup {
         run("UNTAR") {
             script "../../../../modules/nf-core/untar/main.nf"
@@ -25,6 +27,9 @@ nextflow_process {
     test("sarscov2 - bam - user_model") {
 
         when {
+            params {
+                args = "--include_all_ctgs"
+            }
             process {
                 """
                 def model_path = UNTAR.out.untar
@@ -52,11 +57,17 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.vcf.collect { path(it[1]).vcf.summary },
+                    process.out.vcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.tbi.collect { file(it[1]).name },
-                    process.out.phased_vcf.collect { path(it[1]).vcf.summary },
+                    process.out.phased_vcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.phased_tbi.collect { file(it[1]).name },
-                    process.out.gvcf.collect { path(it[1]).vcf.summary },
+                    process.out.gvcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.gtbi.collect { file(it[1]).name },
                     process.out.versions)
                     .match()}
@@ -68,6 +79,9 @@ nextflow_process {
     test("sarscov2 - bam - packaged_model") {
 
         when {
+            params {
+                args = "--include_all_ctgs"
+            }
             process {
                 """
                 input[0] = Channel.of([
@@ -94,11 +108,17 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.vcf.collect { path(it[1]).vcf.summary },
+                    process.out.vcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.tbi.collect { file(it[1]).name },
-                    process.out.phased_vcf.collect { path(it[1]).vcf.summary },
+                    process.out.phased_vcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.phased_tbi.collect { file(it[1]).name },
-                    process.out.gvcf.collect { path(it[1]).vcf.summary },
+                    process.out.gvcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.gtbi.collect { file(it[1]).name },
                     process.out.versions)
                     .match()}
@@ -110,6 +130,9 @@ nextflow_process {
     test("sarscov2 - bam - both") {
 
         when {
+            params {
+                args = "--include_all_ctgs"
+            }
             process {
                 """
                 input[0] = Channel.of([
@@ -144,7 +167,7 @@ nextflow_process {
 
         when {
             params {
-                args = "--gvcf"
+                args = "--gvcf --include_all_ctgs"
             }
             process {
                 """
@@ -173,11 +196,17 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.vcf.collect { path(it[1]).vcf.summary },
+                    process.out.vcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.tbi.collect { file(it[1]).name },
-                    process.out.phased_vcf.collect { path(it[1]).vcf.summary },
+                    process.out.phased_vcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.phased_tbi.collect { file(it[1]).name },
-                    process.out.gvcf.collect { path(it[1]).vcf.summary },
+                    process.out.gvcf.collect {
+                        [file(it[1]).name, path(it[1]).vcf.summary]
+                    },
                     process.out.gtbi.collect { file(it[1]).name },
                     process.out.versions)
                     .match()}

--- a/modules/nf-core/clair3/tests/main.nf.test
+++ b/modules/nf-core/clair3/tests/main.nf.test
@@ -52,11 +52,13 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.vcf.collect { file(it[1]).getName() },
-                    process.out.tbi.collect { file(it[1]).getName() },
-                    process.out.versions,
-                    process.out.phased_vcf.collect { file(it[1]).getName() },
-                    process.out.phased_tbi.collect { file(it[1]).getName() })
+                    process.out.vcf.collect { path(it[1]).vcf.summary },
+                    process.out.tbi.collect { file(it[1]).name },
+                    process.out.phased_vcf.collect { path(it[1]).vcf.summary },
+                    process.out.phased_tbi.collect { file(it[1]).name },
+                    process.out.gvcf.collect { path(it[1]).vcf.summary },
+                    process.out.gtbi.collect { file(it[1]).name },
+                    process.out.versions)
                     .match()}
             )
         }
@@ -92,11 +94,13 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.vcf.collect { file(it[1]).getName() },
-                    process.out.tbi.collect { file(it[1]).getName() },
-                    process.out.versions,
-                    process.out.phased_vcf.collect { file(it[1]).getName() },
-                    process.out.phased_tbi.collect { file(it[1]).getName() })
+                    process.out.vcf.collect { path(it[1]).vcf.summary },
+                    process.out.tbi.collect { file(it[1]).name },
+                    process.out.phased_vcf.collect { path(it[1]).vcf.summary },
+                    process.out.phased_tbi.collect { file(it[1]).name },
+                    process.out.gvcf.collect { path(it[1]).vcf.summary },
+                    process.out.gtbi.collect { file(it[1]).name },
+                    process.out.versions)
                     .match()}
             )
         }
@@ -136,6 +140,51 @@ nextflow_process {
 
     }
 
+    test("sarscov2 - bam - user_model - gvcf") {
+
+        when {
+            params {
+                args = "--gvcf"
+            }
+            process {
+                """
+                def model_path = UNTAR.out.untar
+                input[0] = Channel.of([
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    [],
+                ])
+                .join(UNTAR.out.untar)
+                .combine(Channel.of(['hifi']))
+                input[1] = [
+                    [ id:'test'],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                ]
+                input[2] = [
+                    [ id: 'test'],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf.collect { path(it[1]).vcf.summary },
+                    process.out.tbi.collect { file(it[1]).name },
+                    process.out.phased_vcf.collect { path(it[1]).vcf.summary },
+                    process.out.phased_tbi.collect { file(it[1]).name },
+                    process.out.gvcf.collect { path(it[1]).vcf.summary },
+                    process.out.gtbi.collect { file(it[1]).name },
+                    process.out.versions)
+                    .match()}
+            )
+        }
+
+    }
 
     test("sarscov2 - bam - stub") {
 
@@ -173,6 +222,8 @@ nextflow_process {
                         process.out.tbi,
                         process.out.phased_vcf,
                         process.out.phased_tbi,
+                        process.out.gvcf,
+                        process.out.gtbi,
                         process.out.versions)
                         .match()}
             )

--- a/modules/nf-core/clair3/tests/main.nf.test.snap
+++ b/modules/nf-core/clair3/tests/main.nf.test.snap
@@ -40,61 +40,131 @@
                 ]
             ],
             [
-                "versions.yml:md5,10928c13418eced076964d86249aeaf8"
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.merge_output.gvcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.merge_output.gvcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                "versions.yml:md5,bc9f9c29055f993dc8c5c8a3e8d32d1a"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-04-04T09:30:51.327348"
+        "timestamp": "2025-08-27T16:35:29.683171"
     },
     "sarscov2 - bam - packaged_model": {
         "content": [
             [
-                "merge_output.vcf.gz"
+                [
+                    "test.merge_output.vcf.gz",
+                    "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=9, phased=false, phasedAutodetect=false]"
+                ]
             ],
             [
-                "merge_output.vcf.gz.tbi"
+                "test.merge_output.vcf.gz.tbi"
             ],
             [
-                "versions.yml:md5,10928c13418eced076964d86249aeaf8"
+                
             ],
             [
                 
             ],
             [
                 
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,bc9f9c29055f993dc8c5c8a3e8d32d1a"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-04-04T09:30:16.61651"
+        "timestamp": "2025-08-27T17:29:07.231283"
     },
     "sarscov2 - bam - user_model": {
         "content": [
             [
-                "merge_output.vcf.gz"
+                [
+                    "test.merge_output.vcf.gz",
+                    "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=19, phased=false, phasedAutodetect=false]"
+                ]
             ],
             [
-                "merge_output.vcf.gz.tbi"
+                "test.merge_output.vcf.gz.tbi"
             ],
             [
-                "versions.yml:md5,10928c13418eced076964d86249aeaf8"
+                
             ],
             [
                 
             ],
             [
                 
+            ],
+            [
+                
+            ],
+            [
+                "versions.yml:md5,bc9f9c29055f993dc8c5c8a3e8d32d1a"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-04-04T09:29:58.640181"
+        "timestamp": "2025-08-27T17:28:45.940964"
+    },
+    "sarscov2 - bam - user_model - gvcf": {
+        "content": [
+            [
+                [
+                    "test.merge_output.vcf.gz",
+                    "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=19, phased=false, phasedAutodetect=false]"
+                ]
+            ],
+            [
+                "test.merge_output.vcf.gz.tbi"
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    "test.merge_output.gvcf.gz",
+                    "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=457, phased=false, phasedAutodetect=false]"
+                ]
+            ],
+            [
+                "test.merge_output.gvcf.gz.tbi"
+            ],
+            [
+                "versions.yml:md5,bc9f9c29055f993dc8c5c8a3e8d32d1a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-08-27T17:29:40.822342"
     }
 }

--- a/modules/nf-core/clair3/tests/nextflow.config
+++ b/modules/nf-core/clair3/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: "CLAIR3" {
+        ext.args = { params.args ?: "" }
+    }
+}


### PR DESCRIPTION
This PR:
- Bumps Clair3 to v1.2
- Adds support for capturing gVCF outputs
- Adds the `prefix` to output files (old behaviour is supported by setting `ext.prefix = ''`)  

## PR checklist

Closes #8957 

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
