### PR TITLE
Make some gfastats inputs optional

### DIFF
--- a/modules/nf-core/gfastats/main.nf
+++ b/modules/nf-core/gfastats/main.nf
@@ -33,7 +33,7 @@ process GFASTATS {
     def ebed              = exclude_bed ? "--exclude-bed $exclude_bed" : ""
     def sak               = instructions ? "--swiss-army-knife $instructions" : ""
     def output_sequences  = out_fmt ? "--out-format ${prefix}.${out_fmt}.gz" : ""
-    def genome_size_input = genomesize ? "${genome_size}" : ""
+    def genome_size_input = genome_size ? "${genome_size}" : ""
     def target_input      = target ? "${target}" : ""
     """
     gfastats \\


### PR DESCRIPTION
The genome size and header targets arguments are optional inputs to gfastats - this allows them to be unspecified in the gfastats module.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
