### PR TITLE
Update to correct malformed version

### DIFF
--- a/modules/nf-core/blobtk/plot/main.nf
+++ b/modules/nf-core/blobtk/plot/main.nf
@@ -46,8 +46,8 @@ process BLOBTK_PLOT {
         -o ${prefix}.png
 
     cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            blobtk: \$(blobtk --version | cut -d' ' -f2)
+    "${task.process}":
+        blobtk: \$(blobtk --version | cut -d' ' -f2)
     END_VERSIONS
     """
 

--- a/modules/nf-core/blobtk/plot/tests/main.nf.test.snap
+++ b/modules/nf-core/blobtk/plot/tests/main.nf.test.snap
@@ -10,14 +10,14 @@
                 ]
             ],
             [
-                "versions.yml:md5,9088ecc5a86071ec5a538c50b17f899a"
+                "versions.yml:md5,9855c180bfc28c1fd411132466496d76"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-09-05T11:24:19.79753548"
+        "timestamp": "2025-09-10T10:49:45.919675817"
     },
     "bacteroides fragilis - fasta - stub": {
         "content": [
@@ -50,6 +50,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-09-05T11:24:27.215825139"
+        "timestamp": "2025-09-10T10:49:53.414843461"
     }
 }


### PR DESCRIPTION
Correction to version information in blobtk_plots

A tab got introduced into the version array, which doesn't kill linting but does kill the version collection in a pipeline.