### PR TITLE
Automated nf-test snapshot update workflow

### DIFF
--- a/.github/actions/nf-test-action/action.yml
+++ b/.github/actions/nf-test-action/action.yml
@@ -120,6 +120,15 @@ runs:
           echo "| ⚠️ | No test results found | ${{ inputs.profile }} | ${{ inputs.shard }}/${{ inputs.total_shards }} |" >> $GITHUB_STEP_SUMMARY
         fi
 
+    - name: Upload updated snapshots on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: updated-snapshots-${{ inputs.profile }}-${{ inputs.shard }}
+        path: |
+          **/*.nf.test.snap
+        retention-days: 30
+
     - name: Clean up
       if: always()
       shell: bash

--- a/.github/scripts/check-snapshot-failures.js
+++ b/.github/scripts/check-snapshot-failures.js
@@ -1,0 +1,60 @@
+/**
+ * Check for nf-test snapshot failures and post helpful comment
+ */
+async function checkSnapshotFailures({ github, context, core }) {
+    // Only run on pull requests
+    if (!context.payload.pull_request) {
+        console.log("Not a pull request, skipping snapshot failure check");
+        return;
+    }
+
+    const prNumber = context.payload.pull_request.number;
+
+    // Look for existing bot comments about snapshot failures
+    const comments = await github.rest.issues.listComments({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+    });
+
+    const botComments = comments.data.filter(
+        (comment) => comment.user.login === "nf-core-bot" && comment.body.includes("nf-test failures detected"),
+    );
+
+    const commentBody = `⚠️ **nf-test failures detected**
+
+The nf-test workflow has failed. If the failures are due to snapshot mismatches (expected outputs don't match actual outputs), you can automatically update them by commenting:
+
+\`\`\`
+@nf-core-bot update snapshots
+\`\`\`
+
+This will:
+- Download any updated snapshots from this failed CI run
+- Commit them directly to your PR
+- Much faster than re-running tests locally! 🚀
+
+**Note:** This only works if the failures are due to snapshot mismatches. For other test failures, you'll need to fix the underlying issues first.`;
+
+    if (botComments.length > 0) {
+        // Update the existing comment
+        await github.rest.issues.updateComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: botComments[0].id,
+            body: commentBody,
+        });
+        console.log("Updated existing snapshot failure comment");
+    } else {
+        // Create a new comment
+        await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+            body: commentBody,
+        });
+        console.log("Created new snapshot failure comment");
+    }
+}
+
+module.exports = { checkSnapshotFailures };

--- a/.github/scripts/update-snapshots.js
+++ b/.github/scripts/update-snapshots.js
@@ -1,0 +1,111 @@
+/**
+ * Update nf-test snapshots from CI artifacts
+ */
+
+/**
+ * Find snapshot artifacts from failed nf-test workflow runs
+ */
+async function findSnapshotArtifacts({ github, context, core }) {
+    // React to comment
+    await github.rest.reactions.createForIssueComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: context.payload.comment.id,
+        content: "eyes",
+    });
+
+    // Find latest failed nf-test workflow runs (both regular and GPU)
+    const workflows = ["nf-test.yml", "nf-test-gpu.yml"];
+    let allFailedRuns = [];
+
+    for (const workflowId of workflows) {
+        const runs = await github.rest.actions.listWorkflowRuns({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: workflowId,
+            status: "completed",
+            conclusion: "failure",
+            per_page: 10,
+        });
+
+        allFailedRuns = allFailedRuns.concat(runs.data.workflow_runs);
+    }
+
+    if (allFailedRuns.length === 0) {
+        await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.issue.number,
+            body: "❌ **No failed nf-test runs found**\n\nI couldn't find any recent failed nf-test or nf-test-gpu workflow runs. Make sure the CI tests have run and failed due to snapshot mismatches first.",
+        });
+        return;
+    }
+
+    // Sort by created_at to get the most recent failed run
+    allFailedRuns.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+    const latestFailedRun = allFailedRuns[0];
+    console.log("Found failed run:", latestFailedRun.id);
+
+    // Get artifacts from the failed run
+    const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        run_id: latestFailedRun.id,
+    });
+
+    const snapshotArtifacts = artifacts.data.artifacts.filter((artifact) =>
+        artifact.name.startsWith("updated-snapshots-"),
+    );
+
+    if (snapshotArtifacts.length === 0) {
+        await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.issue.number,
+            body: "🤔 **No snapshot artifacts found**\n\nThe failed CI run didn't upload any snapshot artifacts. This might mean:\n- Tests failed for reasons other than snapshot mismatches\n- The test failures occurred before snapshots could be generated",
+        });
+        return;
+    }
+
+    console.log("Found snapshot artifacts:", snapshotArtifacts.length);
+    core.setOutput("run_id", latestFailedRun.id);
+    core.setOutput("has_artifacts", "true");
+}
+
+/**
+ * Commit updated snapshots and provide feedback
+ */
+async function commitSnapshots({ github, context, require }) {
+    const { execSync } = require("child_process");
+
+    // Check if there are changes
+    try {
+        execSync("git diff --quiet", { stdio: "inherit" });
+        // No changes
+        await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.issue.number,
+            body: "🤔 **Artifacts found but no changes**\n\nI found snapshot artifacts but they didn't result in any changes. The snapshots may already be up to date.",
+        });
+    } catch (error) {
+        // There are changes, commit them
+        execSync('git config user.email "core@nf-co.re"');
+        execSync('git config user.name "nf-core-bot"');
+        execSync('git add "**/*.nf.test.snap"');
+        execSync('git commit -m "[automated] Update nf-test snapshots from CI artifacts"');
+        execSync("git push");
+
+        await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.issue.number,
+            body: "✅ **Snapshots updated from CI artifacts!**\n\nI found updated snapshots from the failed CI run and committed them to this PR. Much faster than re-running tests! 🚀",
+        });
+    }
+}
+
+module.exports = {
+    findSnapshotArtifacts,
+    commitSnapshots,
+};

--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -124,6 +124,16 @@ jobs:
           total_shards: ${{ env.TOTAL_SHARDS }}
           paths: "${{ join(fromJson(needs.nf-test-changes.outputs.paths), ' ') }}"
 
+      # Check for snapshot failures and provide helpful comment
+      - name: Check for snapshot failures
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { checkSnapshotFailures } = require('./.github/scripts/check-snapshot-failures.js');
+            return await checkSnapshotFailures({ github, context, core });
+
   confirm-pass-gpu:
     runs-on:
       - runs-on=${{ github.run_id }}-confirm-pass-gpu

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -176,6 +176,16 @@ jobs:
           total_shards: ${{ env.TOTAL_SHARDS }}
           paths: "${{ join(fromJson(steps.filter.outputs.filtered_paths), ' ') }}"
 
+      # Check for snapshot failures and provide helpful comment
+      - name: Check for snapshot failures
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { checkSnapshotFailures } = require('./.github/scripts/check-snapshot-failures.js');
+            return await checkSnapshotFailures({ github, context, core });
+
   confirm-pass-nf-test:
     runs-on:
       - runs-on=${{ github.run_id }}-confirm-pass-nf-test

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,0 +1,64 @@
+name: update-snapshots
+run-name: update nf-test snapshots from CI artifacts (automated)
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  update-snapshots-from-artifacts:
+    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
+    if: >
+      contains(github.event.comment.html_url, '/pull/') &&
+      contains(github.event.comment.body, '@nf-core-bot update snapshots') &&
+      github.repository == 'nf-core/modules'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.nf_core_bot_auth_token }}
+          fetch-depth: 0
+
+      - name: Find snapshot artifacts from failed CI runs
+        id: find-artifacts
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.nf_core_bot_auth_token }}
+          script: |
+            const { findSnapshotArtifacts } = require('./.github/scripts/update-snapshots.js');
+            return await findSnapshotArtifacts({ github, context, core });
+
+      - name: Checkout Pull Request branch
+        if: steps.find-artifacts.outputs.has_artifacts == 'true'
+        run: gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+
+      - name: Download and apply snapshots
+        if: steps.find-artifacts.outputs.has_artifacts == 'true'
+        run: |
+          # Download snapshot artifacts
+          gh run download ${{ steps.find-artifacts.outputs.run_id }} \
+            --pattern "updated-snapshots-*" \
+            --dir ./artifacts
+
+          # Apply snapshots maintaining directory structure
+          find ./artifacts -name "*.nf.test.snap" | while read snap_file; do
+            # Remove the artifact prefix to get the relative path
+            relative_path=$(echo "$snap_file" | sed 's|^./artifacts/[^/]*/||')
+            target_dir=$(dirname "$relative_path")
+            mkdir -p "$target_dir"
+            cp "$snap_file" "$relative_path"
+            echo "Updated: $relative_path"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+
+      - name: Commit updated snapshots
+        if: steps.find-artifacts.outputs.has_artifacts == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.nf_core_bot_auth_token }}
+          script: |
+            const { commitSnapshots } = require('./.github/scripts/update-snapshots.js');
+            return await commitSnapshots({ github, context, require });


### PR DESCRIPTION
Adds a new GitHub Actions workflow that allows automatic updating of nf-test snapshots from failed CI runs via PR comments. Means you don't need to run nf-test locally to update snapshots. Also saves time and resources because you can use the existing results from the failure.

> [!CAUTION]
> Totally untested! 🤠 

Changes:

- **New workflow** (`.github/workflows/update-snapshots.yml`): Triggered by `@nf-core-bot update snapshots` comment
- **Artifact upload** (`.github/actions/nf-test-action/action.yml`): Upload snapshot files when tests fail
- **Helper scripts** (`.github/scripts/update-snapshots.js`): Find artifacts and commit snapshots
- **Failure detection** (`.github/scripts/check-snapshot-failures.js`): Auto-comment on test failures
- **Updated test workflows**: Added failure detection to both `nf-test.yml` and `nf-test-gpu.yml`

How it works:

1. **nf-test fails** → snapshots uploaded as artifacts + helpful comment posted
2. **Comment trigger** → `@nf-core-bot update snapshots` on any PR
3. **Artifact download** → finds latest failed run, downloads snapshot artifacts  
4. **Auto-commit** → applies snapshots and commits to PR branch

## Example Usage

When nf-test fails due to snapshot mismatches:
```
⚠️ nf-test failures detected

The nf-test workflow has failed. If the failures are due to snapshot mismatches, 
you can automatically update them by commenting:

@nf-core-bot update snapshots
```

The bot will then download artifacts and commit updated snapshots directly to the PR.