### PR TITLE
Allow JasmineSV to take `bai`   

### DIFF
--- a/modules/nf-core/jasminesv/main.nf
+++ b/modules/nf-core/jasminesv/main.nf
@@ -8,7 +8,7 @@ process JASMINESV {
         'biocontainers/jasminesv:1.1.5--hdfd78af_0' }"
 
     input:
-    tuple val(meta), path(vcfs, arity:'1..*'), path(bams), path(sample_dists)
+    tuple val(meta), path(vcfs, arity:'1..*'), path(bams), path(bais), path(sample_dists)
     tuple val(meta2), path(fasta)
     tuple val(meta3), path(fasta_fai)
     path(chr_norm)

--- a/modules/nf-core/jasminesv/meta.yml
+++ b/modules/nf-core/jasminesv/meta.yml
@@ -29,6 +29,10 @@ input:
         type: list
         description: Optional - The BAM files from which the VCFs were created
         pattern: "*.bam"
+    - bais:
+        type: list
+        description: Optional - The BAM index files from which the VCFs were created
+        pattern: "*.bai"
     - sample_dists:
         type: file
         description: Optional - A txt file containing the distance thresholds for each

--- a/modules/nf-core/jasminesv/tests/main.nf.test
+++ b/modules/nf-core/jasminesv/tests/main.nf.test
@@ -10,7 +10,7 @@ nextflow_process {
 
     config "./nextflow.config"
 
-    test("homo_sapiens - [vcf, vcf2], [], [], [], [], [] - vcf") {
+    test("homo_sapiens - [vcf, vcf2], [], [], [], [], [], [] - vcf") {
 
         when {
             process {
@@ -22,46 +22,6 @@ nextflow_process {
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf", checkIfExists:true),
                     ],
                     [],
-                    []
-                ]
-                input[1] = [[],[]]
-                input[2] = [[],[]]
-                input[3] = []
-                """
-            }
-        }
-
-        then {
-            assertAll(
-                { assert process.success },
-                { assert snapshot(
-                    process.out.collectEntries { key, val ->
-                        if(key.matches("\\d+")) {
-                            // Skip the integer keys
-                            return null
-                        }
-                        if(key == "vcf") {
-                            return [key, val.collect { it.collect { it instanceof Map ? it : path(it).vcf.summary } }]
-                        }
-                        return [key, val]
-                    }.findAll { it != null }
-                ).match() }
-            )
-        }
-
-    }
-
-    test("homo_sapiens - [vcf_gz, vcf_gz2], [], [], [], [], [] - vcf.gz") {
-
-        when {
-            process {
-                """
-                input[0] = [
-                    [ id:"test" ],
-                    [
-                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test_haplotcaller.cnn.vcf.gz", checkIfExists:true),
-                    ],
                     [],
                     []
                 ]
@@ -92,7 +52,49 @@ nextflow_process {
 
     }
 
-    test("homo_sapiens - [vcf, vcf2], [bam, bam2], [], fasta, fai, [] - iris") {
+    test("homo_sapiens - [vcf_gz, vcf_gz2], [], [], [], [], [], [] - vcf.gz") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:"test" ],
+                    [
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test_haplotcaller.cnn.vcf.gz", checkIfExists:true),
+                    ],
+                    [],
+                    [],
+                    []
+                ]
+                input[1] = [[],[]]
+                input[2] = [[],[]]
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.collectEntries { key, val ->
+                        if(key.matches("\\d+")) {
+                            // Skip the integer keys
+                            return null
+                        }
+                        if(key == "vcf") {
+                            return [key, val.collect { it.collect { it instanceof Map ? it : path(it).vcf.summary } }]
+                        }
+                        return [key, val]
+                    }.findAll { it != null }
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - [vcf, vcf2], [bam, bam2], [], [], fasta, fai, [] - iris") {
 
         when {
             params {
@@ -110,6 +112,65 @@ nextflow_process {
                     [
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists:true),
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test2.paired_end.sorted.bam", checkIfExists:true)
+                    ],
+                    [],
+                    []
+                ]
+                input[1] = [
+                    [id:"fasta"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/genome.fasta", checkIfExists:true)
+                ]
+                input[2] = [
+                    [id:"fai"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/genome.fasta.fai", checkIfExists:true)
+                ]
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.collectEntries { key, val ->
+                        if(key.matches("\\d+")) {
+                            // Skip the integer keys
+                            return null
+                        }
+                        if(key == "vcf") {
+                            return [key, val.collect { it.collect { it instanceof Map ? it : path(it).vcf.summary } }]
+                        }
+                        return [key, val]
+                    }.findAll { it != null }
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - [vcf, vcf2], [bam, bam2], [bai1, bai2], [], fasta, fai, [] - iris") {
+
+        when {
+            params {
+                args = "--run_iris"
+                args2 = "threads=1,--pacbio,min_ins_length=30"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:"test" ],
+                    [
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gvcf/test.genome.vcf", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf", checkIfExists:true),
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test2.paired_end.sorted.bam", checkIfExists:true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test2.paired_end.sorted.bam.bai", checkIfExists:true)
                     ],
                     []
                 ]
@@ -164,6 +225,7 @@ nextflow_process {
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists:true),
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test2.paired_end.sorted.bam", checkIfExists:true)
                     ],
+                    [],
                     []
                 ]
                 input[1] = [
@@ -199,7 +261,7 @@ nextflow_process {
 
     }
 
-    test("homo_sapiens - [vcf, vcf2], [], [], [], [], [] - stub") {
+    test("homo_sapiens - [vcf, vcf2], [], [], [], [], [], [] - stub") {
 
         options "-stub"
 
@@ -212,6 +274,7 @@ nextflow_process {
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gvcf/test.genome.vcf", checkIfExists:true),
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gvcf/test2.genome.vcf", checkIfExists:true),
                     ],
+                    [],
                     [],
                     []
                 ]
@@ -231,7 +294,7 @@ nextflow_process {
 
     }
 
-    test("homo_sapiens - [vcf, vcf2], [], [], [], [], [] - empty vcf - not stub, but linting complains otherwise") {
+    test("homo_sapiens - [vcf, vcf2], [], [], [], [], [], [] - empty vcf - not stub, but linting complains otherwise") {
 
         when {
             params {
@@ -244,6 +307,7 @@ nextflow_process {
                     [
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/gvcf/test.genome.vcf", checkIfExists:true),
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/vcf/empty.vcf.gz", checkIfExists:true),                    ],
+                    [],
                     [],
                     []
                 ]

--- a/modules/nf-core/jasminesv/tests/main.nf.test.snap
+++ b/modules/nf-core/jasminesv/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "homo_sapiens - [vcf, vcf2], [], [], [], [], [] - empty vcf - not stub, but linting complains otherwise": {
+    "homo_sapiens - [vcf, vcf2], [bam, bam2], [bai1, bai2], [], fasta, fai, [] - iris": {
         "content": [
             {
                 "vcf": [
@@ -7,7 +7,29 @@
                         {
                             "id": "test"
                         },
-                        "VcfFile [chromosomes=[], sampleCount=1, variantCount=0, phased=true, phasedAutodetect=true]"
+                        "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=205, phased=false, phasedAutodetect=false]"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,41765be9d926daaf66d9f8cc1ae88820"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-12T12:27:56.867507"
+    },
+    "homo_sapiens - [vcf, vcf2], [bam, bam2], [], fasta, fai, txt - normalize": {
+        "content": [
+            {
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "VcfFile [chromosomes=[22], sampleCount=1, variantCount=207, phased=false, phasedAutodetect=false]"
                     ]
                 ],
                 "versions": [
@@ -19,31 +41,9 @@
             "nf-test": "0.9.1",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-02-06T15:10:53.589673221"
+        "timestamp": "2025-02-06T15:09:58.394068285"
     },
-    "homo_sapiens - [vcf, vcf2], [], [], [], [], [] - vcf": {
-        "content": [
-            {
-                "vcf": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=207, phased=false, phasedAutodetect=false]"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,41765be9d926daaf66d9f8cc1ae88820"
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-02-06T15:09:35.406672231"
-    },
-    "homo_sapiens - [vcf_gz, vcf_gz2], [], [], [], [], [] - vcf.gz": {
+    "homo_sapiens - [vcf_gz, vcf_gz2], [], [], [], [], [], [] - vcf.gz": {
         "content": [
             {
                 "vcf": [
@@ -60,12 +60,56 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-02-06T15:09:42.666253059"
+        "timestamp": "2025-09-12T12:27:35.350373"
     },
-    "homo_sapiens - [vcf, vcf2], [], [], [], [], [] - stub": {
+    "homo_sapiens - [vcf, vcf2], [bam, bam2], [], [], fasta, fai, [] - iris": {
+        "content": [
+            {
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=205, phased=false, phasedAutodetect=false]"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,41765be9d926daaf66d9f8cc1ae88820"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-12T12:27:46.287491"
+    },
+    "homo_sapiens - [vcf, vcf2], [], [], [], [], [], [] - vcf": {
+        "content": [
+            {
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=207, phased=false, phasedAutodetect=false]"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,41765be9d926daaf66d9f8cc1ae88820"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-12T12:27:28.001379"
+    },
+    "homo_sapiens - [vcf, vcf2], [], [], [], [], [], [] - stub": {
         "content": [
             {
                 "0": [
@@ -93,12 +137,12 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-02-06T13:19:28.224152765"
+        "timestamp": "2025-09-12T12:28:10.076817"
     },
-    "homo_sapiens - [vcf, vcf2], [bam, bam2], [], fasta, fai, txt - normalize": {
+    "homo_sapiens - [vcf, vcf2], [], [], [], [], [], [] - empty vcf - not stub, but linting complains otherwise": {
         "content": [
             {
                 "vcf": [
@@ -106,7 +150,7 @@
                         {
                             "id": "test"
                         },
-                        "VcfFile [chromosomes=[22], sampleCount=1, variantCount=207, phased=false, phasedAutodetect=false]"
+                        "VcfFile [chromosomes=[], sampleCount=1, variantCount=0, phased=true, phasedAutodetect=true]"
                     ]
                 ],
                 "versions": [
@@ -115,31 +159,9 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
         },
-        "timestamp": "2025-02-06T15:09:58.394068285"
-    },
-    "homo_sapiens - [vcf, vcf2], [bam, bam2], [], fasta, fai, [] - iris": {
-        "content": [
-            {
-                "vcf": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=205, phased=false, phasedAutodetect=false]"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,41765be9d926daaf66d9f8cc1ae88820"
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.1",
-            "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-02-06T15:10:35.020277741"
+        "timestamp": "2025-09-12T12:28:16.79139"
     }
 }


### PR DESCRIPTION
The module currently takes optional `bam` to run the `iris` step. If there are no matching `bai` then the tool regenerates them. To save disk space and compute we can allow the module to take `bai` as input too. 

The bai need to be a separate input to the bam as the bam are written to a file of file names for use with the tool. 

[Relevant Iris source](https://github.com/mkirsche/Iris/blob/232a62962eb71027bf9f5ccd9013fc154151d70b/src/ReadGathering.java#L70)  

## PR checklist

Closes #9027

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
