### PR TITLE
Fix parabricks/deepvariant gVCF output detection

### DIFF
--- a/modules/nf-core/parabricks/deepvariant/main.nf
+++ b/modules/nf-core/parabricks/deepvariant/main.nf
@@ -25,7 +25,7 @@ process PARABRICKS_DEEPVARIANT {
     }
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def output_file = ("--gvcf" =~ task.ext.args)? "${prefix}.g.vcf.gz" : "${prefix}.vcf"
+    def output_file = args.contains("--gvcf") ? "${prefix}.g.vcf.gz" : "${prefix}.vcf"
     def interval_file_command = interval_file ? interval_file.collect{"--interval-file $it"}.join(' ') : ""
     def num_gpus = task.accelerator ? "--num-gpus $task.accelerator.request" : ''
     """
@@ -46,7 +46,7 @@ process PARABRICKS_DEEPVARIANT {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def output_cmd = ("--gvcf" =~ task.ext.args)? "echo '' | gzip > ${prefix}.g.vcf.gz" : "touch ${prefix}.vcf"
+    def output_cmd = args.contains("--gvcf") ? "echo '' | gzip > ${prefix}.g.vcf.gz" : "touch ${prefix}.vcf"
     """
     $output_cmd
 


### PR DESCRIPTION
## Issue
The previous implementation failed when `task.ext.args` was defined as a closure, causing the module to output `.vcf` files even when `--gvcf` was specified, leading to Parabricks errors.

## Description
Fixes gVCF output file detection in the parabricks/deepvariant module.

## Changes
- Replaced regex pattern matching `("--gvcf" =~ args)` with `args.contains("--gvcf")` for more reliable detection