### PR TITLE
feat(fastp): accept adapter_fasta as part of main input channel

### DIFF
--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -8,8 +8,7 @@ process FASTP {
         'community.wave.seqera.io/library/fastp:1.0.1--c8b87fe62dcc103c' }"
 
     input:
-    tuple val(meta), path(reads)
-    path  adapter_fasta
+    tuple val(meta), path(reads), path(adapter_fasta)
     val   discard_trimmed_pass
     val   save_trimmed_fail
     val   save_merged

--- a/modules/nf-core/fastp/tests/main.nf.test
+++ b/modules/nf-core/fastp/tests/main.nf.test
@@ -13,14 +13,19 @@ nextflow_process {
 
             process {
                 """
+                adapter_fasta        = [] // empty list for no adapter file!
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -35,7 +40,8 @@ nextflow_process {
                     process.out.reads,
                     process.out.reads_fail,
                     process.out.reads_merged,
-                    process.out.versions).match() }
+                    process.out.versions).match()
+                }
             )
         }
     }
@@ -46,20 +52,22 @@ nextflow_process {
 
             process {
                 """
-                adapter_fasta     = []
-                save_trimmed_pass = true
-                save_trimmed_fail = false
-                save_merged       = false
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
 
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -85,14 +93,19 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -118,14 +131,19 @@ nextflow_process {
 
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = true
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -151,15 +169,22 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = true
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -184,15 +209,22 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = false
-                input[4] = true
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -217,15 +249,22 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true)
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
                 ])
-                input[1] =  Channel.of([ file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true) ])
+                input[1] = false
                 input[2] = false
-                input[3] = false
-                input[4] = true
+                input[3] = true
                 """
             }
         }
@@ -250,14 +289,20 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = true
-                input[3] = false
-                input[4] = false
+
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -285,15 +330,22 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = true
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -324,14 +376,19 @@ nextflow_process {
 
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -352,20 +409,20 @@ nextflow_process {
 
             process {
                 """
-                adapter_fasta     = []
-                save_trimmed_pass = true
-                save_trimmed_fail = false
-                save_merged       = false
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
 
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -386,14 +443,19 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -414,14 +476,19 @@ nextflow_process {
 
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = true
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -442,15 +509,20 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = true
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = true
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -470,15 +542,20 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = false
-                input[3] = false
-                input[4] = true
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -498,15 +575,22 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true)
+                discard_trimmed_pass = false
+                save_trimmed_fail    = false
+                save_merged          = true
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ],
+                    adapter_fasta
                 ])
-                input[1] =  Channel.of([ file(params.modules_testdata_base_path + 'delete_me/fastp/adapters.fasta', checkIfExists: true) ])
-                input[2] = false
-                input[3] = false
-                input[4] = true
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -526,14 +610,19 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:true ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = true
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }
@@ -553,15 +642,20 @@ nextflow_process {
         when {
             process {
                 """
+                adapter_fasta        = []
+                discard_trimmed_pass = true
+                save_trimmed_fail    = false
+                save_merged          = false
+
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ],
+                    adapter_fasta
                 ])
-                input[1] = []
-                input[2] = true
-                input[3] = false
-                input[4] = false
+                input[1] = discard_trimmed_pass
+                input[2] = save_trimmed_fail
+                input[3] = save_merged
                 """
             }
         }

--- a/modules/nf-core/fastp/tests/main.nf.test.snap
+++ b/modules/nf-core/fastp/tests/main.nf.test.snap
@@ -96,7 +96,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.fastp.json:md5,8073d8e7bd8966ece6c8177a784d016b"
+                    "test.fastp.json:md5,a0e39e496f79f8b37f20c55f2e611d6e"
                 ]
             ],
             [
@@ -123,9 +123,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:54:30.613836"
+        "timestamp": "2025-09-19T12:27:11.432444"
     },
     "test_fastp_paired_end_merged_adapterlist": {
         "content": [
@@ -135,7 +135,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.fastp.json:md5,538d8d0527d9c98a4c1f49bebbac1df0"
+                    "test.fastp.json:md5,449d5202d2e09f66b9ae1c2f2849a12a"
                 ]
             ],
             [
@@ -168,9 +168,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:54:55.200243"
+        "timestamp": "2025-09-19T12:23:53.497392"
     },
     "test_fastp_single_end_qc_only": {
         "content": [
@@ -180,7 +180,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.fastp.json:md5,dac771d6fc18baf9bd0b7067bdc04d52"
+                    "test.fastp.json:md5,f0db0803679eca7f135ba4489496d2e9"
                 ]
             ],
             [
@@ -207,9 +207,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:55:00.224217"
+        "timestamp": "2025-09-19T12:20:23.814164"
     },
     "test_fastp_paired_end_trim_fail": {
         "content": [
@@ -247,7 +247,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.fastp.json:md5,23ba6ce04e9d1c49bad55741a0e7eced"
+                    "test.fastp.json:md5,70c70783642ecdb82dc8451d713ca70c"
                 ]
             ],
             [
@@ -256,9 +256,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:54:45.32191"
+        "timestamp": "2025-09-19T12:20:13.716471"
     },
     "fastp - stub test_fastp_interleaved": {
         "content": [
@@ -708,7 +708,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.fastp.json:md5,6f716765d4cee428c41a4b361bb0db07"
+                    "test.fastp.json:md5,7d3a2d5ea96c8db30ef2a11516e36a91"
                 ]
             ],
             [
@@ -741,9 +741,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:54:50.001244"
+        "timestamp": "2025-09-19T12:20:17.598196"
     },
     "test_fastp_paired_end - stub": {
         "content": [
@@ -860,7 +860,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.fastp.json:md5,26b6549bf45cafb7b1127a8d32338754"
+                    "test.fastp.json:md5,1c45c822fe013fdfce6b1659ee18ec33"
                 ]
             ],
             [
@@ -884,9 +884,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:54:25.511975"
+        "timestamp": "2025-09-19T12:19:57.719338"
     },
     "test_fastp_single_end_trim_fail - stub": {
         "content": [
@@ -1145,7 +1145,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.fastp.json:md5,c4e4093a100ef3fa9740620d42bf90c4"
+                    "test.fastp.json:md5,aac7d0ed4b8d573b983cfce1b5549ebb"
                 ]
             ],
             [
@@ -1154,9 +1154,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:54:35.970659"
+        "timestamp": "2025-09-19T12:20:06.184183"
     },
     "test_fastp_single_end_trim_fail": {
         "content": [
@@ -1166,7 +1166,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.fastp.json:md5,27307e0f9154fc37e1cb84f207bf33e0"
+                    "test.fastp.json:md5,1c45c822fe013fdfce6b1659ee18ec33"
                 ]
             ],
             [
@@ -1179,13 +1179,7 @@
                 ]
             ],
             [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "test.fail.fastq.gz:md5,3e4aaadb66a5b8fc9b881bf39c227abd"
-                ]
+                
             ],
             [
                 
@@ -1196,9 +1190,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:54:40.611616"
+        "timestamp": "2025-09-19T12:20:09.94798"
     },
     "test_fastp_paired_end_qc_only": {
         "content": [
@@ -1208,7 +1202,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.fastp.json:md5,f411d75c34448fcad813ccd9b3d0fa3d"
+                    "test.fastp.json:md5,2a26610bf61babb14f4a190fb9e3776f"
                 ]
             ],
             [
@@ -1235,9 +1229,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-09-11T09:55:04.894274"
+        "timestamp": "2025-09-19T12:20:27.636917"
     },
     "test_fastp_paired_end_qc_only - stub": {
         "content": [


### PR DESCRIPTION
- Updated `FASTP` process to accept `adapter_fasta` as part of the main input tuple.
- Modified all relevant test cases to provide `adapter_fasta` in the input tuple.
- Ensures adapter file(s) can be passed dynamically per sample, improving flexibility and compatibility with workflows.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
