### PR TITLE
Deprecate mash_db argument in gtdbtk/classifywf

### DIFF
--- a/modules/nf-core/gtdbtk/classifywf/main.nf
+++ b/modules/nf-core/gtdbtk/classifywf/main.nf
@@ -11,7 +11,6 @@ process GTDBTK_CLASSIFYWF {
     tuple val(meta)   , path("bins/*")
     tuple val(db_name), path(db)
     val use_pplacer_scratch_dir
-    path mash_db
 
     output:
     tuple val(meta), path("${prefix}")                               , emit: gtdb_outdir
@@ -33,7 +32,6 @@ process GTDBTK_CLASSIFYWF {
     def args            = task.ext.args ?: ''
     prefix              = task.ext.prefix ?: "${meta.id}"
     def pplacer_scratch = use_pplacer_scratch_dir ? "--scratch_dir pplacer_tmp" : ""
-    def mash_mode       = mash_db ? "--mash_db ${mash_db}" : "--skip_ani_screen"
     """
     export GTDBTK_DATA_PATH="\$(find -L ${db} -name 'metadata' -type d -exec dirname {} \\;)"
 
@@ -47,7 +45,6 @@ process GTDBTK_CLASSIFYWF {
         --prefix "${prefix}" \\
         --out_dir ${prefix} \\
         --cpus ${task.cpus} \\
-        ${mash_mode} \\
         ${pplacer_scratch}
 
     mv ${prefix}/gtdbtk.log "${prefix}/${prefix}.log"

--- a/modules/nf-core/gtdbtk/classifywf/meta.yml
+++ b/modules/nf-core/gtdbtk/classifywf/meta.yml
@@ -45,13 +45,6 @@ input:
   - use_pplacer_scratch_dir:
       type: boolean
       description: Set to true to reduce pplacer memory usage by writing to disk (slower)
-  - mash_db:
-      type: file
-      description: The local copy of the Mash sketch database used by GTDB-tk if `ani_screen`
-        mode is used (optional)
-      pattern: "*.msh"
-      ontologies:
-        - edam: http://edamontology.org/format_3911 # msh
 output:
   gtdb_outdir:
     - - meta:

--- a/modules/nf-core/gtdbtk/classifywf/tests/main.nf.test
+++ b/modules/nf-core/gtdbtk/classifywf/tests/main.nf.test
@@ -46,7 +46,6 @@ nextflow_process {
                     ]
                 input[1] = UNTAR.out.untar
                 input[2] = false
-                input[3] = []
                 """
             }
         }
@@ -90,7 +89,6 @@ nextflow_process {
                     ]
                 input[1] = [[:],[]]
                 input[2] = false
-                input[3] = []
                 """
             }
         }

--- a/modules/nf-core/gtdbtk/gtdbtoncbimajorityvote/tests/main.nf.test
+++ b/modules/nf-core/gtdbtk/gtdbtoncbimajorityvote/tests/main.nf.test
@@ -37,7 +37,6 @@ nextflow_process {
                 ]
             input[1] = UNTAR.out.untar
             input[2] = false
-            input[3] = []
             """
             }
         }


### PR DESCRIPTION
This input type has been deprecated in the latest GTDB-Tk release.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
