### PR TITLE
Fix sawfish discover

### DIFF
--- a/modules/nf-core/sawfish/discover/main.nf
+++ b/modules/nf-core/sawfish/discover/main.nf
@@ -12,7 +12,7 @@ process SAWFISH_DISCOVER {
     tuple val(meta2), path(fasta)
     tuple val(meta3), path(expected_cn_bed)
     tuple val(meta4), path(maf_vcf)
-    tuple val(meta5), path(cnv_exclude_regions)
+    tuple val(meta5), path(cnv_exclude_regions_bed)
 
     output:
     tuple val(meta), path("versions.yml")                           , emit: versions
@@ -44,7 +44,7 @@ process SAWFISH_DISCOVER {
     prefix = task.ext.prefix ?: "${meta.id}"
     def expected_cn = expected_cn_bed ? "--expected-cn ${expected_cn_bed}" : ""
     def maf = maf_vcf ? "--maf ${maf_vcf}" : ""
-    def cnv_exclude_regions = cnv_exclude_regions ? "--cnv-excluded-regions ${cnv_exclude_regions}" : ""
+    def cnv_exclude_regions = cnv_exclude_regions_bed ? "--cnv-excluded-regions ${cnv_exclude_regions_bed}" : ""
 
     """
     sawfish \\
@@ -68,7 +68,7 @@ process SAWFISH_DISCOVER {
     stub:
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
-    def expected_cn_bed = expected_cn_bed ? "touch ${prefix}/expected.copy.number.bed": ''
+    def expected_cn = expected_cn_bed ? "touch ${prefix}/expected.copy.number.bed": ''
     def maf_mpack = maf_vcf ? "touch  ${prefix}/maf.mpack": ''
     def copynum_files = !args.contains('--disable-cnv') ? """
         touch ${prefix}/copynum.bedgraph
@@ -98,7 +98,7 @@ process SAWFISH_DISCOVER {
     touch ${prefix}/expected.copy.number.bed
 
     ${copynum_files}
-    ${expected_cn_bed}
+    ${expected_cn}
     ${maf_mpack}
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/sawfish/discover/meta.yml
+++ b/modules/nf-core/sawfish/discover/meta.yml
@@ -69,10 +69,9 @@ input:
         description: |
           Groovy Map containing additional information
           e.g. [ id:'cnv' ]
-    - cnv_exclude_regions:
+    - cnv_exclude_regions_bed:
         type: file
-        description: Regions of the genome to exclude from CNV analysis, in BED
-          format.
+        description: BED file containing regions to exclude from CNV calling
         pattern: "*.bed"
         ontologies: []
 output:


### PR DESCRIPTION
Fix nextflow language server error: `expected_cn/cnv_exclude_regions` is already declared. 

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
