### PR TITLE
Bump basicpy container revision

### DIFF
--- a/modules/nf-core/basicpy/main.nf
+++ b/modules/nf-core/basicpy/main.nf
@@ -2,7 +2,7 @@ process BASICPY {
     tag "$meta.id"
     label 'process_single'
 
-    container "docker.io/labsyspharm/basicpy-docker-mcmicro:1.2.0-patch1"
+    container "docker.io/labsyspharm/basicpy-docker-mcmicro:1.2.0-patch2"
 
     input:
     tuple val(meta), path(image)
@@ -20,7 +20,7 @@ process BASICPY {
         error "Basicpy module does not support Conda. Please use Docker / Singularity instead."
     }
     def args    = task.ext.args   ?: ''
-    def VERSION = "1.2.0-patch1" // WARN: Version information not provided by tool on CLI. Please update this string when bumping
+    def VERSION = "1.2.0" // WARN: Version information not provided by tool on CLI. Please update this string when bumping
     """
     /opt/main.py -i $image -o . $args
 
@@ -36,7 +36,7 @@ process BASICPY {
         error "Basicpy module does not support Conda. Please use Docker / Singularity instead."
     }
     def prefix  = task.ext.prefix ?: "${meta.id}"
-    def VERSION = "1.2.0-patch1" // WARN: Version information not provided by tool on CLI. Please update this string when bumping
+    def VERSION = "1.2.0" // WARN: Version information not provided by tool on CLI. Please update this string when bumping
     """
     touch ${prefix}.-dfp.tiff
     touch ${prefix}.-ffp.tiff

--- a/modules/nf-core/basicpy/tests/main.nf.test.snap
+++ b/modules/nf-core/basicpy/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "basicpy - OME-TIFF": {
         "content": [
             [
-                "versions.yml:md5,1391fd5a5745a20016f9824467273113"
+                "versions.yml:md5,8cdc71f773d4a24b30c412d4b7560b05"
             ],
             true,
             true,
@@ -11,9 +11,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-03-12T20:14:46.041882924"
+        "timestamp": "2025-09-25T17:40:59.731127948"
     },
     "basicpy - OME-TIFF - stub": {
         "content": [
@@ -28,7 +28,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,1391fd5a5745a20016f9824467273113"
+                    "versions.yml:md5,8cdc71f773d4a24b30c412d4b7560b05"
                 ],
                 "profiles": [
                     [
@@ -40,14 +40,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,1391fd5a5745a20016f9824467273113"
+                    "versions.yml:md5,8cdc71f773d4a24b30c412d4b7560b05"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-03-12T20:14:53.621168198"
+        "timestamp": "2025-09-25T17:41:02.991040243"
     }
 }


### PR DESCRIPTION
This doesn't change the version of the wrapped basicpy package itself, rather it just points to a new, rebuilt container image with updated dependencies to handle reading a wider variety of image file formats.

Required for nf-core/mcmicro#84.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
