### PR TITLE
Add task.ext.suffix for CSVTK_CONCAT

### DIFF
--- a/modules/nf-core/csvtk/concat/main.nf
+++ b/modules/nf-core/csvtk/concat/main.nf
@@ -13,8 +13,8 @@ process CSVTK_CONCAT {
     val out_format
 
     output:
-    tuple val(meta), path("${prefix}.${out_extension}"), emit: csv
-    path "versions.yml"                                , emit: versions
+    tuple val(meta), path("${prefix}.${suffix}"), emit: csv
+    path "versions.yml"                         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,9 +22,9 @@ process CSVTK_CONCAT {
     script:
     def args = task.ext.args   ?: ''
     prefix   = task.ext.prefix ?: "${meta.id}"
+    suffix   = task.ext.suffix ?: (out_format == 'tsv' ? 'tsv' : 'csv')
     def delimiter = in_format == "tsv" ? "\t" : (in_format == "csv" ? "," : in_format)
     def out_delimiter = out_format == "tsv" ? "\t" : (out_format == "csv" ? "," : out_format)
-    out_extension = out_format == "tsv" ? 'tsv' : 'csv'
     """
     csvtk \\
         concat \\
@@ -32,7 +32,7 @@ process CSVTK_CONCAT {
         --num-cpus $task.cpus \\
         --delimiter "${delimiter}" \\
         --out-delimiter "${out_delimiter}" \\
-        --out-file ${prefix}.${out_extension} \\
+        --out-file ${prefix}.${suffix} \\
         $csv
 
     cat <<-END_VERSIONS > versions.yml
@@ -43,9 +43,9 @@ process CSVTK_CONCAT {
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
-    out_extension = out_format == "tsv" ? 'tsv' : 'csv'
+    suffix = task.ext.suffix ?: (out_format == 'tsv' ? 'tsv' : 'csv')
     """
-    touch ${prefix}.${out_extension}
+    touch ${prefix}.${suffix}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/csvtk/concat/meta.yml
+++ b/modules/nf-core/csvtk/concat/meta.yml
@@ -40,7 +40,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - ${prefix}.${out_extension}:
+      - ${prefix}.${suffix}:
           type: file
           description: Concatenated CSV/TSV file
           pattern: "*.{csv,tsv}"


### PR DESCRIPTION
This PR adds support for specifying a custom suffix, so pipeline maintainers can work with files beyond just `.csv` and `.tsv`.
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
