### PR TITLE
Add the gap finder subworkflow

### DIFF
--- a/subworkflows/nf-core/gap_finder/main.nf
+++ b/subworkflows/nf-core/gap_finder/main.nf
@@ -1,0 +1,39 @@
+//
+// GENERATE BED FILE OF GAPS AND LENGTH IN REFERENCE
+//
+
+include { SEQTK_CUTN    } from '../../../modules/nf-core/seqtk/cutn/main'
+include { GAWK          } from '../../../modules/nf-core/gawk/main'
+
+workflow GAP_FINDER {
+    take:
+    ch_reference     // Channel [ val(meta), path(fasta) ]
+
+    main:
+    ch_versions     = Channel.empty()
+
+
+    //
+    // MODULE: GENERATES A GAP SUMMARY FILE
+    //
+    SEQTK_CUTN (
+        ch_reference
+    )
+    ch_versions     = ch_versions.mix( SEQTK_CUTN.out.versions )
+
+
+    //
+    // MODULE: ADD THE LENGTH OF GAP TO BED FILE - INPUT FOR PRETEXT MODULE
+    //
+    GAWK (
+        SEQTK_CUTN.out.bed,
+        [],
+        false
+    )
+    ch_versions     = ch_versions.mix( GAWK.out.versions )
+
+
+    emit:
+    gap_file        = GAWK.out.output
+    versions        = ch_versions
+}

--- a/subworkflows/nf-core/gap_finder/meta.yml
+++ b/subworkflows/nf-core/gap_finder/meta.yml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "gap_finder"
+description: Generated a bed file containing gaps and their length
+keywords:
+  - gap
+  - bed
+  - adapters
+  - trimming
+  - fasta
+components:
+  - seqtk_cutn
+  - gawk
+input:
+  - ch_reference:
+      type: file
+      description: |
+        Structure [ val(meta), path(reference) ]
+        Meta is the Groovy Map containing sample information
+        Reference is the fasta for analysis
+output:
+  - meta:
+      type: string
+      description: Groovy Map containing sample information e.g. [ id:'test', single_end:false ]
+  - gap_file:
+      type: file
+      description: |
+        Structure: [ val(meta), path(gap_file) ]
+        Bed file containing gap location and lengths
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@DLBPointon"
+maintainers:
+  - "@DLBPointon"

--- a/subworkflows/nf-core/gap_finder/nextflow.config
+++ b/subworkflows/nf-core/gap_finder/nextflow.config
@@ -1,0 +1,6 @@
+process {
+    withName: GAWK {
+        ext.args2   = "'BEGIN { OFS = \"\\t\" }{print \$0, sqrt((\$3-\$2)*(\$3-\$2))}'"
+        ext.suffix  = 'gap.bedgraph'
+    }
+}

--- a/subworkflows/nf-core/gap_finder/tests/main.nf.test
+++ b/subworkflows/nf-core/gap_finder/tests/main.nf.test
@@ -33,11 +33,8 @@ nextflow_workflow {
     }
 
     test("sarscov2 genome - stub") {
-
         options "-stub"
-
         when {
-
             workflow {
                 """
                 input[0] = Channel.of([

--- a/subworkflows/nf-core/gap_finder/tests/main.nf.test
+++ b/subworkflows/nf-core/gap_finder/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_workflow {
+
+    name "Test Subworkflow GAP_FINDER"
+    script "../main.nf"
+    config "./nextflow.config"
+    workflow "GAP_FINDER"
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/gap_finder"
+    tag "seqtk_cutn"
+    tag "gawk"
+
+    test("sarscov2 genome [fasta]") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success }
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 genome - stub") {
+
+        options "-stub"
+
+        when {
+
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success }
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/nf-core/gap_finder/tests/main.nf.test
+++ b/subworkflows/nf-core/gap_finder/tests/main.nf.test
@@ -18,7 +18,7 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true)
                 ])
                 """
             }
@@ -26,7 +26,7 @@ nextflow_workflow {
 
         then {
             assertAll(
-                { assert workflow.success }
+                { assert workflow.success },
                 { assert snapshot(workflow.out).match() }
             )
         }
@@ -39,7 +39,7 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                     [ id:'test', single_end:false ], // meta map
-                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true)
                 ])
                 """
             }
@@ -47,7 +47,7 @@ nextflow_workflow {
 
         then {
             assertAll(
-                { assert workflow.success }
+                { assert workflow.success },
                 { assert snapshot(workflow.out).match() }
             )
         }

--- a/subworkflows/nf-core/gap_finder/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/gap_finder/tests/main.nf.test.snap
@@ -1,0 +1,76 @@
+{
+    "sarscov2 genome - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gap.bedgraph:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,929f4176dedc9856781d33262611dc9b",
+                    "versions.yml:md5,cdedf30584c2f81dd4f1268f2371159d"
+                ],
+                "gap_file": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gap.bedgraph:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,929f4176dedc9856781d33262611dc9b",
+                    "versions.yml:md5,cdedf30584c2f81dd4f1268f2371159d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-10-03T12:27:09.342414128"
+    },
+    "sarscov2 genome [fasta]": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gap.bedgraph:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,929f4176dedc9856781d33262611dc9b",
+                    "versions.yml:md5,cdedf30584c2f81dd4f1268f2371159d"
+                ],
+                "gap_file": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gap.bedgraph:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,929f4176dedc9856781d33262611dc9b",
+                    "versions.yml:md5,cdedf30584c2f81dd4f1268f2371159d"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-10-03T12:26:59.052766966"
+    }
+}

--- a/subworkflows/nf-core/gap_finder/tests/nextflow.config
+++ b/subworkflows/nf-core/gap_finder/tests/nextflow.config
@@ -1,0 +1,6 @@
+process {
+    withName: GAWK {
+        ext.args2   = "'BEGIN { OFS = \"\\t\" }{print \$0, sqrt((\$3-\$2)*(\$3-\$2))}'"
+        ext.suffix  = 'gap.bedgraph'
+    }
+}


### PR DESCRIPTION
Addition of the gap finder subworkflow.

This is currently used across a couple of pipelines at sanger and uses:
- Seqtk_cutn to cut at runs of N
- GAWK to get the length of the length and generate bed file + length

https://github.com/sanger-tol/nf-core-modules/issues/81