### PR TITLE
adding homer merge peaks, and a peakcalling workflow

### DIFF
--- a/modules/nf-core/homer/mergepeaks/environment.yml
+++ b/modules/nf-core/homer/mergepeaks/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::homer=5.1"

--- a/modules/nf-core/homer/mergepeaks/main.nf
+++ b/modules/nf-core/homer/mergepeaks/main.nf
@@ -1,0 +1,47 @@
+process HOMER_MERGEPEAKS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://community.wave.seqera.io/library/homer:5.1--586e112615c26ca1':
+        'community.wave.seqera.io/library/homer:5.1--851c883b9d1473f9' }"
+
+    input:
+    tuple val(meta), path(peaks)  // peaks can be a list of peak files
+
+    output:
+    tuple val(meta), path("*.txt"), emit: txt
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}" + "_merged_peaks"
+    def peak_files = peaks instanceof List ? peaks.join(' ') : peaks
+    """
+    mergePeaks \\
+        $args \\
+        -prefix ${prefix} \\
+        $peak_files \\
+        > ${prefix}.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        homer: \$(mergePeaks 2>&1 | grep -i "version" | sed 's/.*version //i' || echo "4.11")
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        homer: 4.11
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/homer/mergepeaks/meta.yml
+++ b/modules/nf-core/homer/mergepeaks/meta.yml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "homer_mergepeaks"
+description: Merge peak files from multiple experiments or replicates into a unified peak set
+keywords:
+  - peaks
+  - merge
+  - chipseq
+  - chipexo
+  - consensus
+tools:
+  - homer:
+      description: |
+        HOMER (Hypergeometric Optimization of Motif EnRichment) is a suite of tools for Motif Discovery and next-gen sequencing analysis.
+      homepage: "http://homer.ucsd.edu/homer/index.html"
+      documentation: "http://homer.ucsd.edu/homer/"
+      tool_dev_url: "http://homer.ucsd.edu/homer/ngs/peaks.html"
+      doi: 10.1016/j.molcel.2010.05.004.
+      licence: ["GPL-3.0-or-later"]
+      identifier: biotools:homer
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'merged_peaks' ]
+    - peaks:
+        type: file
+        description: Peak files from HOMER findPeaks in HOMER peak format (*.txt). Can be a single file or list of files.
+        pattern: "*.txt"
+
+output:
+  txt:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'merged_peaks' ]
+      - "*.txt":
+          type: file
+          description: Merged peak file in HOMER peak format
+          pattern: "*.txt"
+          ontologies:
+            - edam: https://bioportal.bioontology.org/ontologies/EDAM?p=classes&conceptid=format_3475 # tsv
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+
+authors:
+  - "@cmatKhan"
+maintainers:
+  - "@cmatKhan"

--- a/modules/nf-core/homer/mergepeaks/tests/main.nf.test
+++ b/modules/nf-core/homer/mergepeaks/tests/main.nf.test
@@ -1,0 +1,124 @@
+nextflow_process {
+
+    name "Test Process HOMER_MERGEPEAKS"
+    script "../main.nf"
+    process "HOMER_MERGEPEAKS"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "homer"
+    tag "homer/mergepeaks"
+    tag "homer/findpeaks"
+    tag "homer/maketagdirectory"
+
+    setup {
+        run("HOMER_MAKETAGDIRECTORY", alias: "MAKETAGDIR_SAMPLE1") {
+            script "../../maketagdirectory/main.nf"
+            config "../../maketagdirectory/tests/bed.config"
+            process {
+                """
+                input[0] = [
+                    [ id:'sample1' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                """
+            }
+        }
+
+        run("HOMER_MAKETAGDIRECTORY", alias: "MAKETAGDIR_SAMPLE2") {
+            script "../../maketagdirectory/main.nf"
+            config "../../maketagdirectory/tests/bed.config"
+            process {
+                """
+                input[0] = [
+                    [ id:'sample2' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test2.bed', checkIfExists: true)
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                """
+            }
+        }
+
+        run("HOMER_FINDPEAKS", alias: "FINDPEAKS_SAMPLE1") {
+            script "../../findpeaks/main.nf"
+            config "./nextflow.config"
+            process {
+                """
+                input[0] = MAKETAGDIR_SAMPLE1.out.tagdir
+                input[1] = []
+                """
+            }
+        }
+
+        run("HOMER_FINDPEAKS", alias: "FINDPEAKS_SAMPLE2") {
+            script "../../findpeaks/main.nf"
+            config "./nextflow.config"
+            process {
+                """
+                input[0] = MAKETAGDIR_SAMPLE2.out.tagdir
+                input[1] = []
+                """
+            }
+        }
+    }
+
+    test("sarscov2 - bed - merge two peak files") {
+
+        when {
+            process {
+                """
+                peaks = Channel.empty()
+                    .mix(
+                        FINDPEAKS_SAMPLE1.out.txt.map { it[1] },
+                        FINDPEAKS_SAMPLE2.out.txt.map { it[1] }
+                    )
+                    .collect()
+                    .map { [ [id:'merged'], it ] }
+
+                input[0] = peaks
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.txt[0][1]).name,
+                    process.out.versions
+                ).match()
+                }
+            )
+        }
+    }
+
+    test("sarscov2 - bed - merge two peak files - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                peaks = Channel.empty()
+                    .mix(
+                        FINDPEAKS_SAMPLE1.out.txt.map { it[1] },
+                        FINDPEAKS_SAMPLE2.out.txt.map { it[1] }
+                    )
+                    .collect()
+                    .map { [ [id:'merged'], it ] }
+
+                input[0] = peaks
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match("stub") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/homer/mergepeaks/tests/main.nf.test.snap
+++ b/modules/nf-core/homer/mergepeaks/tests/main.nf.test.snap
@@ -1,0 +1,48 @@
+{
+    "sarscov2 - bed - merge two peak files": {
+        "content": [
+            "merged_peaks.txt",
+            [
+                "versions.yml:md5,a383523aae5048d4b28718f7ba1d8526"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T13:14:52.683370026"
+    },
+    "stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "merged"
+                        },
+                        "merged_peaks.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,5985f7630d53ae0605c2f459e43439c2"
+                ],
+                "txt": [
+                    [
+                        {
+                            "id": "merged"
+                        },
+                        "merged_peaks.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5985f7630d53ae0605c2f459e43439c2"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T13:14:58.514229717"
+    }
+}

--- a/modules/nf-core/homer/mergepeaks/tests/nextflow.config
+++ b/modules/nf-core/homer/mergepeaks/tests/nextflow.config
@@ -1,0 +1,11 @@
+process {
+    withName: 'FINDPEAKS_SAMPLE1' {
+        ext.args = '-style factor'
+    }
+    withName: 'FINDPEAKS_SAMPLE2' {
+        ext.args = '-style factor'
+    }
+    withName: 'HOMER_MERGEPEAKS' {
+        ext.prefix = 'merged_peaks'
+    }
+}

--- a/subworkflows/nf-core/homer_peakcalling/main.nf
+++ b/subworkflows/nf-core/homer_peakcalling/main.nf
@@ -1,0 +1,138 @@
+/*
+ * Peak calling workflow with HOMER
+ */
+include { HOMER_MAKETAGDIRECTORY                                } from '../../../modules/nf-core/homer/maketagdirectory/main'
+include { HOMER_MAKEUCSCFILE                                    } from '../../../modules/nf-core/homer/makeucscfile/main'
+include { HOMER_FINDPEAKS                                       } from '../../../modules/nf-core/homer/findpeaks/main'
+include { HOMER_MERGEPEAKS                                      } from '../../../modules/nf-core/homer/mergepeaks/main'
+include { HOMER_ANNOTATEPEAKS as HOMER_ANNOTATEPEAKS_INDIVIDUAL } from '../../../modules/nf-core/homer/annotatepeaks/main'
+include { HOMER_ANNOTATEPEAKS as HOMER_ANNOTATEPEAKS_MERGED     } from '../../../modules/nf-core/homer/annotatepeaks/main'
+include { HOMER_POS2BED                                         } from '../../../modules/nf-core/homer/pos2bed/main'
+include { UNZIP                                                 } from '../../../modules/nf-core/unzip/main'
+
+workflow HOMER_PEAKCALLING {
+    take:
+    bam                      // channel: [ val(meta), path(bam) ]
+    fasta                    // channel: path(fasta)
+    gtf                      // channel: path(gtf) or empty channel. If empty channel, no annotation step
+    control                  // channel: [ val(meta), path(control_bam) ] or empty channel
+    uniqmap                  // channel: path(uniqmap) or empty channel
+    merge_peaks              // val: boolean - whether to merge peaks across samples
+    annotate_individual      // val: boolean - whether to annotate individual peak files
+
+    main:
+    if(!gtf && annotate_individual){
+        log.warn "Individual peak annotation requested but no GTF file provided - skipping annotation"
+    }
+    ch_versions = Channel.empty()
+    ch_uniqmap = Channel.empty()
+
+    if (!uniqmap) {
+        ch_uniqmap = []
+    }
+    else if (uniqmap.endsWith('.zip')) {
+        ch_uniqmap = UNZIP([[:], uniqmap]).unzipped_archive.map { it[1] }
+        ch_versions = ch_versions.mix(UNZIP.out.versions)
+    }
+    else {
+        ch_uniqmap = uniqmap
+    }
+
+    //
+    // Create control tag directory if provided
+    //
+    ch_control_tagdir = Channel.empty()
+    if (control) {
+        HOMER_MAKETAGDIRECTORY(
+            control,
+            fasta
+        )
+        ch_control_tagdir = HOMER_MAKETAGDIRECTORY.out.tagdir
+        ch_versions = ch_versions.mix(HOMER_MAKETAGDIRECTORY.out.versions.first())
+    }
+
+    //
+    // Create tag directories for all samples
+    //
+    HOMER_MAKETAGDIRECTORY(
+        bam,
+        fasta
+    )
+    ch_versions = ch_versions.mix(HOMER_MAKETAGDIRECTORY.out.versions.first())
+
+    //
+    // Creating UCSC Visualization Files
+    //
+    HOMER_MAKEUCSCFILE(HOMER_MAKETAGDIRECTORY.out.tagdir)
+    ch_versions = ch_versions.mix(HOMER_MAKEUCSCFILE.out.versions)
+
+    //
+    // Call peaks with or without control
+    //
+    ch_findpeaks_input = ch_control_tagdir
+        ? HOMER_MAKETAGDIRECTORY.out.tagdir.combine(ch_control_tagdir.map { it[1] })
+        : HOMER_MAKETAGDIRECTORY.out.tagdir.map { meta, tagdir -> [meta, tagdir, []] }
+
+    HOMER_FINDPEAKS(
+        ch_findpeaks_input,
+        ch_uniqmap
+    )
+    ch_versions = ch_versions.mix(HOMER_FINDPEAKS.out.versions.first())
+
+    //
+    // Convert peaks to BED format
+    //
+    HOMER_POS2BED(HOMER_FINDPEAKS.out.txt)
+    ch_versions = ch_versions.mix(HOMER_POS2BED.out.versions.first())
+
+    //
+    // Annotate individual peaks if requested
+    //
+    ch_annotated_individual = Channel.empty()
+    if (annotate_individual && gtf) {
+        HOMER_ANNOTATEPEAKS_INDIVIDUAL(
+            HOMER_FINDPEAKS.out.txt,
+            fasta,
+            gtf
+        )
+        ch_annotated_individual = HOMER_ANNOTATEPEAKS_INDIVIDUAL.out.txt
+        ch_versions = ch_versions.mix(HOMER_ANNOTATEPEAKS_INDIVIDUAL.out.versions.first())
+    }
+
+    //
+    // Merge peaks and annotate if requested
+    //
+    ch_merged_peaks = Channel.empty()
+    ch_annotated_merged = Channel.empty()
+
+    if (merge_peaks) {
+        ch_all_peaks = HOMER_FINDPEAKS.out.txt
+            .map { _meta, txt -> txt }
+            .collect()
+            .map { peaks -> [[id: 'merged_peaks'], peaks] }
+
+        HOMER_MERGEPEAKS(ch_all_peaks)
+        ch_merged_peaks = HOMER_MERGEPEAKS.out.txt
+        ch_versions = ch_versions.mix(HOMER_MERGEPEAKS.out.versions)
+
+        if(gtf){
+            HOMER_ANNOTATEPEAKS_MERGED(
+                HOMER_MERGEPEAKS.out.txt,
+                fasta,
+                gtf
+            )
+            ch_annotated_merged = HOMER_ANNOTATEPEAKS_MERGED.out.txt
+            ch_versions = ch_versions.mix(HOMER_ANNOTATEPEAKS_MERGED.out.versions)
+        }
+    }
+
+    emit:
+    tagdir               = HOMER_MAKETAGDIRECTORY.out.tagdir    // channel: [ val(meta), path(tagdir) ]
+    bed_graph            = HOMER_MAKEUCSCFILE.out.bedGraph      // channel: [ val(meta), [ tag_dir/*ucsc.bedGraph.gz ] ]
+    peaks                = HOMER_FINDPEAKS.out.txt              // channel: [ val(meta), path(peaks.txt) ]
+    bed                  = HOMER_POS2BED.out.bed                // channel: [ val(meta), path(peaks.bed) ]
+    merged_peaks         = ch_merged_peaks                      // channel: [ val(meta), path(merged.txt) ] or empty
+    annotated_individual = ch_annotated_individual              // channel: [ val(meta), path(annotated.txt) ] or empty
+    annotated_merged     = ch_annotated_merged                  // channel: [ val(meta), path(annotated.txt) ] or empty
+    versions             = ch_versions                          // channel: [ versions.yml ]
+}

--- a/subworkflows/nf-core/homer_peakcalling/meta.yml
+++ b/subworkflows/nf-core/homer_peakcalling/meta.yml
@@ -1,0 +1,116 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "homer_peakcalling"
+description: Peak calling workflow using HOMER for ChIP-seq, ChIP-exo, and other sequencing data with optional peak merging and annotation
+keywords:
+  - peak calling
+  - chipseq
+  - chipexo
+  - homer
+  - annotation
+  - merge peaks
+components:
+  - homer/maketagdirectory
+  - homer/makeucscfile
+  - homer/findpeaks
+  - homer/mergepeaks
+  - homer/annotatepeaks
+  - homer/pos2bed
+  - unzip
+input:
+  - bam:
+      type: file
+      description: |
+        Channel containing BAM files for peak calling
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.bam"
+  - fasta:
+      type: file
+      description: |
+        Reference genome FASTA file
+        Structure: path(fasta)
+      pattern: "*.{fa,fasta,fa.gz,fasta.gz}"
+  - gtf:
+      type: file
+      description: |
+        Gene annotation GTF file for peak annotation.
+        If an empty channel is passed in, then the subworkflow skips annotation steps.
+        Structure: path(gtf)
+      pattern: "*.gtf"
+  - control:
+      type: file
+      description: |
+        Optional control/input BAM file for peak calling. Can be empty channel.
+        Structure: [ val(meta), path(bam) ] or empty
+      pattern: "*.bam"
+  - uniqmap:
+      type: file
+      description: |
+        Optional uniquely mappable regions file or directory (can be zipped).
+        Can be empty channel.
+        Structure: path(uniqmap) or empty
+      pattern: "*.zip"
+  - merge_peaks:
+      type: boolean
+      description: |
+        Whether to merge peaks across all samples into a consensus peak set. If a gtf
+        is passed in via the input, then the merged peaks are annotated
+  - annotate_individual:
+      type: boolean
+      description: |
+        Whether to annotate individual peak files. If false and merge_peaks is false,
+        no annotation is performed. If no gtf is passed into the subworkflow,
+        annotation steps are not performed regardless of this setting.
+output:
+  - tagdir:
+      type: directory
+      description: |
+        HOMER tag directories for each sample
+        Structure: [ val(meta), path(tagdir) ]
+  - bed_graph:
+      type: file
+      description: |
+        BedGraph files for UCSC genome browser visualization, created from processed tag directories
+        Structure: [ val(meta), path(bedGraph.gz) ]
+      pattern: "*.bedGraph.gz"
+  - peaks:
+      type: file
+      description: |
+        Individual peak files in HOMER format for each sample
+        Structure: [ val(meta), path(peaks.txt) ]
+      pattern: "*.txt"
+  - bed:
+      type: file
+      description: |
+        Individual peak files converted to BED format
+        Structure: [ val(meta), path(peaks.bed) ]
+      pattern: "*.bed"
+  - merged_peaks:
+      type: file
+      description: |
+        Merged consensus peak file in HOMER format (empty if merge_peaks is false)
+        Structure: [ val(meta), path(merged.txt) ]
+      pattern: "*.txt"
+  - annotated_individual:
+      type: file
+      description: |
+        Annotated individual peak files (empty if annotate_individual is false)
+        Structure: [ val(meta), path(annotated.txt) ]
+      pattern: "*.txt"
+  - annotated_merged:
+      type: file
+      description: |
+        Annotated merged peak file (empty if merge_peaks is false)
+        Structure: [ val(meta), path(annotated.txt) ]
+      pattern: "*.txt"
+  - versions:
+      type: file
+      description: |
+        File containing software versions
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@edmundmiller"
+  - "@cmatKhan"
+maintainers:
+  - "@edmundmiller"
+  - "@cmatKhan"

--- a/subworkflows/nf-core/homer_peakcalling/tests/bed.config
+++ b/subworkflows/nf-core/homer_peakcalling/tests/bed.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'HOMER_PEAKCALLING:HOMER_MAKETAGDIRECTORY' {
+        ext.args = "-checkGC -format bed -single"
+    }
+}

--- a/subworkflows/nf-core/homer_peakcalling/tests/main.nf.test
+++ b/subworkflows/nf-core/homer_peakcalling/tests/main.nf.test
@@ -1,0 +1,263 @@
+nextflow_workflow {
+
+    name "Test Workflow HOMER_PEAKCALLING"
+    script "../main.nf"
+    workflow "HOMER_PEAKCALLING"
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/homer_peakcalling"
+    tag "homer"
+    tag "homer/maketagdirectory"
+    tag "homer/makeucscfile"
+    tag "homer/findpeaks"
+    tag "homer/mergepeaks"
+    tag "homer/annotatepeaks"
+    tag "homer/pos2bed"
+
+    test("sarscov2 - bam - no merge, no annotation") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of(
+                    [ [ id: 'sample1' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam', checkIfExists: true) ],
+                    [ [ id: 'sample2' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true) ]
+                )
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                input[3] = []
+                input[4] = []
+                input[5] = false  // merge_peaks
+                input[6] = false  // annotate_individual
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.bed_graph.get(0).get(1)).linesGzip.size(),
+                    workflow.out.peaks,
+                    workflow.out.bed,
+                    workflow.out.merged_peaks,
+                    workflow.out.annotated_individual,
+                    workflow.out.annotated_merged,
+                    path(workflow.out.versions.get(0)).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - bam - merge only, annotate merged") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of(
+                    [ [ id: 'sample1' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam', checkIfExists: true) ],
+                    [ [ id: 'sample2' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true) ]
+                )
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                input[3] = []
+                input[4] = []
+                input[5] = true   // merge_peaks
+                input[6] = false  // annotate_individual
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.bed_graph.get(0).get(1)).linesGzip.size(),
+                    workflow.out.peaks,
+                    workflow.out.bed,
+                    workflow.out.merged_peaks,
+                    workflow.out.annotated_individual,
+                    workflow.out.annotated_merged,
+                    path(workflow.out.versions.get(0)).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - bam - no merge, annotate individual") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of(
+                    [ [ id: 'sample1' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam', checkIfExists: true) ],
+                    [ [ id: 'sample2' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true) ]
+                )
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                input[3] = []
+                input[4] = []
+                input[5] = false  // merge_peaks
+                input[6] = true   // annotate_individual
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.bed_graph.get(0).get(1)).linesGzip.size(),
+                    workflow.out.peaks,
+                    workflow.out.bed,
+                    workflow.out.merged_peaks,
+                    workflow.out.annotated_individual,
+                    workflow.out.annotated_merged,
+                    path(workflow.out.versions.get(0)).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - bam - merge and annotate both") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of(
+                    [ [ id: 'sample1' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam', checkIfExists: true) ],
+                    [ [ id: 'sample2' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true) ]
+                )
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                input[3] = []
+                input[4] = []
+                input[5] = true   // merge_peaks
+                input[6] = true   // annotate_individual
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.bed_graph.get(0).get(1)).linesGzip.size(),
+                    workflow.out.peaks,
+                    workflow.out.bed,
+                    workflow.out.merged_peaks,
+                    workflow.out.annotated_individual,
+                    workflow.out.annotated_merged,
+                    path(workflow.out.versions.get(0)).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - bed - no merge, no annotation") {
+
+        config "./bed.config"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of(
+                    [ [ id: 'sample1' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true) ],
+                    [ [ id: 'sample2' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test2.bed', checkIfExists: true) ]
+                )
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                input[3] = []
+                input[4] = []
+                input[5] = false
+                input[6] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.bed_graph.get(0).get(1)).linesGzip.size(),
+                    workflow.out.peaks,
+                    workflow.out.bed,
+                    workflow.out.merged_peaks,
+                    workflow.out.annotated_individual,
+                    workflow.out.annotated_merged,
+                    path(workflow.out.versions.get(0)).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("GROseq tutorial files with uniqmap") {
+
+        tag "uniqmap"
+        config "./bed.config"
+
+        when {
+            workflow {
+                """
+                input[0] = [
+                    [ id: 'groseq_test' ],
+                    [
+                        file('ftp://ftp.ncbi.nlm.nih.gov/geo/samples/GSM340nnn/GSM340901/suppl/GSM340901_lib1_aligned.bed.gz', checkIfExists: true),
+                        file('ftp://ftp.ncbi.nlm.nih.gov/geo/samples/GSM340nnn/GSM340902/suppl/GSM340902_lib2_aligned.bed.gz', checkIfExists: true)
+                    ],
+                ]
+                input[1] = file('https://hgdownload.soe.ucsc.edu/goldenPath/hg18/chromosomes/chr14.fa.gz', checkIfExists: true)
+                input[2] = []  // gtf - not needed for this test
+                input[3] = []  // control
+                input[4] = file('https://raw.githubusercontent.com/nf-core/test-datasets/nascent/reference/uniqmap.GRCh38_chr21.50nt.zip', checkIfExists: true)
+                input[5] = false  // merge_peaks
+                input[6] = false  // annotate_individual
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.bed_graph.get(0).get(1)).linesGzip.size(),
+                    workflow.out.peaks,
+                    workflow.out.bed,
+                    workflow.out.merged_peaks,
+                    workflow.out.annotated_individual,
+                    workflow.out.annotated_merged,
+                    path(workflow.out.versions.get(0)).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of(
+                    [ [ id: 'sample1' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam', checkIfExists: true) ]
+                )
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                input[3] = []
+                input[4] = []
+                input[5] = true
+                input[6] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/nf-core/homer_peakcalling/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/homer_peakcalling/tests/main.nf.test.snap
@@ -1,0 +1,275 @@
+{
+    "sarscov2 - bam - no merge, no annotation": {
+        "content": [
+            161,
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "HOMER_PEAKCALLING:HOMER_MAKEUCSCFILE": {
+                    "homer": 4.11
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T14:18:11.043391205"
+    },
+    "sarscov2 - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "sample1"
+                        },
+                        [
+                            "genome.1.tags.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "tagAutocorrelation.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "tagCountDistribution.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "tagInfo.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "tagLengthDistribution.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "sample1"
+                        },
+                        "sample1.bedGraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    "versions.yml:md5,dba09d1f0c348a3efff432a992c49d64",
+                    "versions.yml:md5,fd25d2b030dc331d97e63f0b493ffa50"
+                ],
+                "annotated_individual": [
+                    
+                ],
+                "annotated_merged": [
+                    
+                ],
+                "bed": [
+                    
+                ],
+                "bed_graph": [
+                    [
+                        {
+                            "id": "sample1"
+                        },
+                        "sample1.bedGraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "merged_peaks": [
+                    
+                ],
+                "peaks": [
+                    
+                ],
+                "tagdir": [
+                    [
+                        {
+                            "id": "sample1"
+                        },
+                        [
+                            "genome.1.tags.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "tagAutocorrelation.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "tagCountDistribution.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "tagInfo.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "tagLengthDistribution.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,dba09d1f0c348a3efff432a992c49d64",
+                    "versions.yml:md5,fd25d2b030dc331d97e63f0b493ffa50"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T14:27:19.124431749"
+    },
+    "sarscov2 - bam - merge and annotate both": {
+        "content": [
+            161,
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "HOMER_PEAKCALLING:HOMER_MAKEUCSCFILE": {
+                    "homer": 4.11
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T14:25:58.240285349"
+    },
+    "sarscov2 - bam - merge only, annotate merged": {
+        "content": [
+            161,
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "HOMER_PEAKCALLING:HOMER_MAKEUCSCFILE": {
+                    "homer": 4.11
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T14:18:16.707067827"
+    },
+    "sarscov2 - bam - no merge, annotate individual": {
+        "content": [
+            161,
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "HOMER_PEAKCALLING:HOMER_MAKEUCSCFILE": {
+                    "homer": 4.11
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T14:18:22.011661552"
+    },
+    "sarscov2 - bed - no merge, no annotation": {
+        "content": [
+            6,
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "HOMER_PEAKCALLING:HOMER_MAKEUCSCFILE": {
+                    "homer": 4.11
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T14:26:03.587542718"
+    },
+    "GROseq tutorial files with uniqmap": {
+        "content": [
+            15368354,
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "HOMER_PEAKCALLING:HOMER_MAKEUCSCFILE": {
+                    "homer": 4.11
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-05T14:38:12.852334968"
+    }
+}


### PR DESCRIPTION
I needed a peak calling subworkflow for Homer that included annotation and MergePeaks.

This pull adds the homer MergePeaks module. It makes a couple modification to homer_groseq to include the MergePeaks step, and optional annotation.

Thought I'd offer it up -- @edmundmiller , if you're interested, this should function the same as homer_groseq if you pass in an empty channel for the gtf and set merge_peaks to `false`.

Homer also has a major version update (currently most homer modules are 4.11, current is 5.1). If there is any interest in merging this into homer_groseq, then I'd be happy to update the other homer modules, also.