### PR TITLE
adjust COMEBin

### DIFF
--- a/modules/nf-core/comebin/runcomebin/main.nf
+++ b/modules/nf-core/comebin/runcomebin/main.nf
@@ -41,8 +41,12 @@ process COMEBIN_RUNCOMEBIN {
 
     find ${prefix}/comebin_res_bins/*.fa -exec gzip {} \\;
 
-    for filename in ${prefix}/comebin_res_bins/*.fa.gz; do mv "\${filename}" "${prefix}/comebin_res_bins/${prefix}.\$(basename \${filename})"; done; # avoid file name collisions
+    # avoid file name collisions
+    for filename in ${prefix}/comebin_res_bins/*.fa.gz; do
+        mv "\${filename}" "${prefix}/comebin_res_bins/${prefix}.\$(basename \${filename})"
+    done
 
+    # clean up
     rm local_assembly.fasta
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
This is a consequence of https://github.com/nf-core/mag/pull/875.

Two issues are supposed to be improved:
- originally, the tool wrote into the work directory where the input assembly file was linking to, that is solved by copying the assembly into the current work dir and delete it later again (not pretty, but works)
- The output files of the tool were not named pretty, so downstream tools could have file name collisions, that is prevented here.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
