### PR TITLE
Collect the most accurate alignment statistic.

### DIFF
--- a/modules/nf-core/last/train/main.nf
+++ b/modules/nf-core/last/train/main.nf
@@ -34,7 +34,9 @@ process LAST_TRAIN {
 
     echo "id\tsubstitution_percent_identity\tlast -t\tlast -a\tlast -A\tlast -b\tlast -B\tlast -S"         > ${prefix}.train.tsv
     printf "\$(basename ${prefix}.train .target.train)\t"                                                 >> ${prefix}.train.tsv
-    grep 'substitution percent identity' ${prefix}.train | tail -n 1 | awk '{print \$5}' | tr '\\n' '\\t' >> ${prefix}.train.tsv
+    # Do not take the last 'substitution percent identity' value; it is calculated from a matrix rounded to integers
+    grep 'substitution percent identity' ${prefix}.train |
+        tail -n 2 | head -n 1 | awk '{print \$5}'                                        | tr '\\n' '\\t' >> ${prefix}.train.tsv
     grep 'last -t' ${prefix}.train | tail -n 1 | awk '{print \$2}'   | sed -e 's/-t//'   | tr '\\n' '\\t' >> ${prefix}.train.tsv
     grep 'last -a' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\\n' '\\t' >> ${prefix}.train.tsv
     grep 'last -A' ${prefix}.train | tail -n 1 | awk '{print \$3}'                       | tr '\\n' '\\t' >> ${prefix}.train.tsv

--- a/modules/nf-core/last/train/tests/main.nf.test.snap
+++ b/modules/nf-core/last/train/tests/main.nf.test.snap
@@ -70,7 +70,7 @@
                             "id": "contigs",
                             "single_end": false
                         },
-                        "contigs.train.tsv:md5,a2fca4aabda82f0aa481085ce5258886"
+                        "contigs.train.tsv:md5,c8721d9cabf1e2b7c0d2d3dac9ed3db8"
                     ]
                 ],
                 "2": [
@@ -82,7 +82,7 @@
                             "id": "contigs",
                             "single_end": false
                         },
-                        "contigs.train.tsv:md5,a2fca4aabda82f0aa481085ce5258886"
+                        "contigs.train.tsv:md5,c8721d9cabf1e2b7c0d2d3dac9ed3db8"
                     ]
                 ],
                 "param_file": [
@@ -101,8 +101,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.8"
         },
-        "timestamp": "2025-03-10T11:02:48.369194"
+        "timestamp": "2025-10-20T14:56:15.004824885"
     }
 }


### PR DESCRIPTION
The `last/train` module collects the wrong value for percent identity.

This statistic is reported multiple times in the output file of `last-train` as its value converges with training.  However, the final value is computed from a matrix that was rounded to small integers, which makes it less accurate that the one before the last.

This PR fixes this issue.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
