### PR TITLE
Update showinf to clean outputs

### DIFF
--- a/modules/nf-core/bftools/showinf/main.nf
+++ b/modules/nf-core/bftools/showinf/main.nf
@@ -22,7 +22,7 @@ process BFTOOLS_SHOWINF {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    export BF_FLAGS='-XX:+DisplayVMOutputToStderr -Xlog:all=warn:stderr'
+    export BF_FLAGS='-XX:+DisplayVMOutputToStderr -Xlog:all=warning:stderr'
     showinf -nopix -no-upgrade -omexml-only \\
         $args \\
         $image > ${prefix}.xml
@@ -38,7 +38,7 @@ process BFTOOLS_SHOWINF {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    export BF_FLAGS='-XX:+DisplayVMOutputToStderr -Xlog:all=warn:stderr'
+    export BF_FLAGS='-XX:+DisplayVMOutputToStderr -Xlog:all=warning:stderr'
     echo '<?xml version="1.0" encoding="UTF-8">' > ${prefix}.xml
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
Some race conditions make the error logs of bftools to go to stdout, affecting the output of the module.
With these new flags we force the logs to stderr.
`BF_FLAGS` is used by bftools for all the JMV options so we can recycle for other modules in the future.
 
## PR checklist
- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
