### PR TITLE
Removed stray "

### DIFF
--- a/modules/nf-core/fcsgx/rungx/main.nf
+++ b/modules/nf-core/fcsgx/rungx/main.nf
@@ -28,13 +28,13 @@ process FCSGX_RUNGX {
     def database = ramdisk_path ?: gxdb
     ( ramdisk_path ?
     """
-    if [ -d ${database}" ]; then
+    if [ -d "${database}" ]; then
         echo "ERROR: Database exists in memory, and may be in use by another process" >&2
         ls -l ${database}
         exit 1
     fi
     # Clean up shared memory on exit
-    trap "rm -rf "${database}" EXIT
+    trap "rm -rf ${database}" EXIT
     # Copy DB to RAM-disk when supplied. Otherwise, rungx is very slow.
     rclone copy ${gxdb} ${database}
 


### PR DESCRIPTION
Removed an stray `"` that was making the module fail when tmpfs was provided.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
