### PR TITLE
Pin python version in conda environment for GTDBTK modules to match containers

### DIFF
--- a/modules/nf-core/gtdbtk/classifywf/environment.yml
+++ b/modules/nf-core/gtdbtk/classifywf/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::gtdbtk=2.5.2
+  - conda-forge::python=3.13.7

--- a/modules/nf-core/gtdbtk/gtdbtoncbimajorityvote/environment.yml
+++ b/modules/nf-core/gtdbtk/gtdbtoncbimajorityvote/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::gtdbtk=2.5.2
+  - conda-forge::python=3.13.7


### PR DESCRIPTION
This is a quick work around to: https://github.com/Ecogenomics/GtdbTk/issues/669 to allow release of mag 5.1.0

After which I will tackle the conda recipe (where this should really be fixed)

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
