### PR TITLE
renovate: group infra updates into separate PR and have a shorter schedule cycle

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,12 @@
             matchDatasources: ["conda", "pypi", "docker"],
             automerge: false,
         },
+        {
+            matchManagers: ["github-actions", "npm", "pip_requirements", "pip_setup"],
+            excludePackagePatterns: ["biocontainers/*"],
+            groupName: "Infrastructural dependencies",
+            schedule: ["before 6am on Monday"],
+        },
     ],
     customManagers: [
         {


### PR DESCRIPTION
Should make them stand out a bit more in the large number of possible PRs through renovate