### PR TITLE
fix(juicertools/pre): correctly export java memory options

### DIFF
--- a/modules/nf-core/juicertools/pre/main.nf
+++ b/modules/nf-core/juicertools/pre/main.nf
@@ -29,7 +29,7 @@ process JUICERTOOLS_PRE {
     def prefix   = task.ext.prefix ?: "${meta.id}"
     input_genome = genome_id       ?: chromsizes
     """
-    export JAVA_OPTS='"-Xms${task.memory.toMega()/4}m" "-Xmx${task.memory.toGiga()}g"'
+    export _JAVA_OPTIONS="-Xms${task.memory.toMega().intdiv(4)}m -Xmx${task.memory.toGiga()}g"
 
     juicer_tools pre \\
         --threads ${task.cpus} \\


### PR DESCRIPTION
Correctly export the `_JAVA_OPTIONS` envvar so that juicertools can allocate memory.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
