### PR TITLE
hostile properly sorting paired reads by simple filename instead of whole path 

### DIFF
--- a/modules/nf-core/hostile/clean/main.nf
+++ b/modules/nf-core/hostile/clean/main.nf
@@ -8,21 +8,22 @@ process HOSTILE_CLEAN {
         : 'community.wave.seqera.io/library/hostile:2.0.2--a7f5e5d341b6b94b'}"
 
     input:
-    tuple val(meta), path(reads, stageAs: "input_reads/")
+    tuple val(meta)          , path(reads, stageAs: "input_reads/")
     tuple val(reference_name), path(reference_dir)
 
     output:
     tuple val(meta), path('*.fastq.gz'), emit: fastq
-    tuple val(meta), path('*.json'), emit: json
-    path 'versions.yml', emit: versions
+    tuple val(meta), path('*.json')    , emit: json
+    path 'versions.yml'                , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    def reads_cmd = meta.single_end ? "--fastq1 ${[reads].flatten()[0]}" : "--fastq1 ${reads.sort()[0]} --fastq2 ${reads.sort()[1]}"
+    def args         = task.ext.args ?: ''
+    def prefix       = task.ext.prefix ?: "${meta.id}"
+    def sorted_reads = meta.single_end ? [reads].flatten() : reads.sort { it.simpleName }
+    def reads_cmd    = meta.single_end ? "--fastq1 ${sorted_reads[0]}" : "--fastq1 ${sorted_reads[0]} --fastq2 ${sorted_reads[1]}"
     """
     export HOSTILE_CACHE_DIR=${reference_dir}
 
@@ -46,13 +47,14 @@ process HOSTILE_CLEAN {
     """
 
     stub:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
-    def reads_cmd = meta.single_end ? "--fastq1 ${reads}" : "--fastq1 ${reads.sort()[0]} --fastq2 ${reads.sort()[1]}"
-    def fake_read2 = !meta.single_end ? "echo '' | gzip -c > ${prefix}.clean_2.fastq.gz" : ""
+    def args         = task.ext.args ?: ''
+    def prefix       = task.ext.prefix ?: "${meta.id}"
+    def sorted_reads = meta.single_end ? [reads].flatten() : reads.sort { it.simpleName }
+    def reads_cmd    = meta.single_end ? "--fastq1 ${sorted_reads[0]}" : "--fastq1 ${sorted_reads[0]} --fastq2 ${sorted_reads[1]}"
+    def fake_read2   = !meta.single_end ? "echo '' | gzip -c > ${prefix}.clean_2.fastq.gz" : ""
     """
     export HOSTILE_CACHE_DIR=${reference_dir}
-    
+
     echo "hostile \\
         clean \\
         ${args} \\

--- a/modules/nf-core/hostile/clean/meta.yml
+++ b/modules/nf-core/hostile/clean/meta.yml
@@ -5,7 +5,6 @@ keywords:
   - hostile
   - decontamination
   - human removal
-  - download
   - host removal
   - clean
 tools:
@@ -34,7 +33,6 @@ input:
         type: string
         description: |
           Name of the reference to align against and thus remove mapped reads to.
-          Typically corresponds
     - reference_dir:
         type: directory
         description: |
@@ -52,10 +50,9 @@ output:
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
       - "*.fastq.gz":
-          type: map
+          type: file
           description: |
-            Groovy Map containing sample information
-            e.g. `[ id:'sample1', single_end:false ]`
+            Cleaned FASTQ files with host reads removed
           pattern: "*.{fastq,fq,fastq.gz,fq.gz}"
           ontologies:
             - edam: "http://edamontology.org/format_1930"
@@ -66,10 +63,9 @@ output:
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
       - "*.json":
-          type: map
+          type: file
           description: |
-            Groovy Map containing sample information
-            e.g. `[ id:'sample1', single_end:false ]`
+            JSON report containing statistics from hostile cleaning
           pattern: "*.json"
           ontologies:
             - edam: "http://edamontology.org/format_3464"

--- a/modules/nf-core/hostile/clean/tests/main.nf.test
+++ b/modules/nf-core/hostile/clean/tests/main.nf.test
@@ -81,8 +81,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                        path(process.out.fastq[0][1][0]).linesGzip.size(),
-                        path(process.out.fastq[0][1][1]).linesGzip.size(),
+                        process.out.fastq,
                         process.out.versions,
                         path(process.out.versions.get(0)).yaml,
                         path(process.out.json[0][1]).readLines().any{ it.contains('\"reads_removed\": 0')}

--- a/modules/nf-core/hostile/clean/tests/main.nf.test.snap
+++ b/modules/nf-core/hostile/clean/tests/main.nf.test.snap
@@ -54,8 +54,18 @@
     },
     "fastq - paired-end": {
         "content": [
-            1066944,
-            1066944,
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.clean_1.fastq.gz:md5,6de988b85909e6529bad0022703bcab2",
+                        "test_2.clean_2.fastq.gz:md5,539acd65e93bf16a5ace7d6034e704c7"
+                    ]
+                ]
+            ],
             [
                 "versions.yml:md5,ada5e72cc34942b0eccc41d073c4247f"
             ],
@@ -67,10 +77,10 @@
             true
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-09-11T09:45:49.548712599"
+        "timestamp": "2025-11-09T16:15:42.374481236"
     },
     "fastq - single-end": {
         "content": [


### PR DESCRIPTION
@maia-munteanu had an issue while trying to create `fastq_fetch_clean_hostile` subworkflow.
Staging paths can mix files for paired-end reads.
The fix here hopefully fixes that ;)

Meta.yml and paired-end test updated.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Emit the `versions.yml` file.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
