### PR TITLE
Update blastn meta.yml

### DIFF
--- a/modules/nf-core/blast/blastn/meta.yml
+++ b/modules/nf-core/blast/blastn/meta.yml
@@ -36,17 +36,17 @@ input:
         description: Directory containing the blast database
         pattern: "*"
   - taxidlist:
-        type: file
-        description: File containing NCBI taxon ids, one per line, for filtering the database.
-        pattern: "*.{txt}"
+      type: file
+      description: File containing NCBI taxon ids, one per line, for filtering the database.
+      pattern: "*.{txt}"
   - taxids:
-        type: string
-        description: Comma-delimited list of NCBI taxon ids for filtering the database.
-        pattern: "^[0-9]+(,[0-9]+)*$"
+      type: string
+      description: Comma-delimited list of NCBI taxon ids for filtering the database.
+      pattern: "^[0-9]+(,[0-9]+)*$"
   - negative_tax:
-        type: boolean
-        description: Use negative filtering (true) to exclude taxon ids or normal filtering (false).
-        pattern: "true or false"
+      type: boolean
+      description: Use negative filtering (true) to exclude taxon ids or normal filtering (false).
+      pattern: "true or false"
 output:
   txt:
     - - meta:


### PR DESCRIPTION
I added that module in https://github.com/nf-core/detaxizer/pull/86. After linting issues the nf-core bot corrected the meta.yml and that required again a [diff](https://github.com/nf-core/detaxizer/pull/86/files#diff-2e472eff007586e39482633d6339d08d68c0dccb4ac7826a151433af24cbc9ee). This should solve the problem.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
