### PR TITLE
Fix sample name mangling in tximport

### DIFF
--- a/modules/nf-core/tximeta/tximport/templates/tximport.r
+++ b/modules/nf-core/tximeta/tximport/templates/tximport.r
@@ -73,10 +73,10 @@ read_transcript_info <- function(tinfo_path){
     }
 
     transcript_info <- read.csv(tinfo_path, sep="\t", header = TRUE,
-                                col.names = c("tx", "gene_id", "gene_name"))
+                                col.names = c("tx", "gene_id", "gene_name"), check.names = FALSE)
 
     extra <- setdiff(rownames(txi[[1]]), as.character(transcript_info[["tx"]]))
-    transcript_info <- rbind(transcript_info, data.frame(tx=extra, gene_id=extra, gene_name=extra))
+    transcript_info <- rbind(transcript_info, data.frame(tx=extra, gene_id=extra, gene_name=extra, check.names = FALSE))
     transcript_info <- transcript_info[match(rownames(txi[[1]]), transcript_info[["tx"]]), ]
     rownames(transcript_info) <- transcript_info[["tx"]]
 
@@ -131,7 +131,7 @@ txi <- tximport(fns, type = '$quant_type', txOut = TRUE, dropInfReps = dropInfRe
 transcript_info <- read_transcript_info('$tx2gene')
 
 # Make coldata just to appease the summarizedexperiment
-coldata <- data.frame(files = fns, names = names)
+coldata <- data.frame(files = fns, names = names, check.names = FALSE)
 rownames(coldata) <- coldata[["names"]]
 
 # Create initial SummarizedExperiment object


### PR DESCRIPTION
## Description

Fixes https://github.com/nf-core/rnaseq/issues/1445

This PR fixes an issue where R's `data.frame()` function was automatically modifying sample names, causing downstream errors when trying to match sample IDs between count matrices and samplesheet metadata.

### The Problem

R's `data.frame()` automatically modifies column/row names when `check.names=TRUE` (the default):
- Sample names starting with numbers get an "X" prepended: `1A2` → `X1A2`
- Hyphens get converted to dots: `D10-D` → `D10.D`
- Other special characters are also modified

This caused the `SUMMARIZEDEXPERIMENT` process to fail with:
```
Error in findColumnWithAllEntries(ids, metadata) : 
  No column contains all vector entries
```

### Root Cause

While PR #6638 partially fixed this by adding `check.names = FALSE` to the `build_table()` function, it missed three additional locations where `data.frame()` and `read.csv()` calls were made without this parameter.

The most critical one was at line 134 where `coldata` is created - this directly sets the sample names that become column names in all output matrices.

### Changes Made

Added `check.names = FALSE` to three function calls in `tximport.r`:

1. **Line 76**: `read.csv()` when reading transcript info
2. **Line 79**: `data.frame()` when creating extra transcript info rows  
3. **Line 134**: `data.frame()` when creating coldata (**main bug fix**)

### Testing

This fix ensures that sample names are preserved exactly as provided in the input, preventing mismatches downstream. Users can now safely use:
- Sample names starting with numbers (e.g., `1A2`, `5B2`)
- Sample names with hyphens (e.g., `sample-1`, `D10-D`)
- Any other valid sample name format

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Ensure the test suite passes (`nf-test test path/to/test.nf.test`)
- [ ] Usage Documentation in `docs/usage.md` is updated
- [ ] Output Documentation in `docs/output.md` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated (including new tool citations and authors/contributors)