### PR TITLE
Fix issues with chromograph module

### DIFF
--- a/modules/nf-core/chromograph/main.nf
+++ b/modules/nf-core/chromograph/main.nf
@@ -18,7 +18,7 @@ process CHROMOGRAPH {
     tuple val(meta7), path(sites)
 
     output:
-    tuple val(meta), path("*.png"), emit: plots
+    tuple val(meta), path("*.png"), emit: plots, optional: true
     path "versions.yml", emit: versions
 
     when:
@@ -75,5 +75,5 @@ process CHROMOGRAPH {
 // Helper function to generate touch commands
 def touchCmd(euploidy, input_file) {
     def chrs = euploidy ? (1..22) + ['X', 'Y', 'M'] : [1]
-    input_file ? chrs.collect { chr -> "touch ${input_file}_chr${chr}.png" }.join('\n') : ''
+    input_file ? chrs.collect { chr -> "touch ${input_file}_chr${chr}.png" }.join(' ') : ''
 }

--- a/modules/nf-core/chromograph/tests/main.nf.test
+++ b/modules/nf-core/chromograph/tests/main.nf.test
@@ -38,7 +38,10 @@ nextflow_process {
         then {
             assertAll(
             { assert process.success },
-            { assert snapshot(process.out).match() }
+            { assert snapshot(
+                process.out,
+                process.out.versions.collect{ path(it).yaml }
+            ).match() }
             )
         }
     }
@@ -73,7 +76,10 @@ nextflow_process {
         then {
             assertAll(
             { assert process.success },
-            { assert snapshot(process.out).match() }
+            { assert snapshot(
+                process.out,
+                process.out.versions.collect{ path(it).yaml }
+            ).match() }
             )
         }
     }
@@ -111,7 +117,10 @@ nextflow_process {
         then {
             assertAll(
             { assert process.success },
-            { assert snapshot(process.out).match() }
+            { assert snapshot(
+                process.out,
+                process.out.versions.collect{ path(it).yaml }
+            ).match() }
             )
         }
 
@@ -150,7 +159,10 @@ nextflow_process {
         then {
             assertAll(
             { assert process.success },
-            { assert snapshot(process.out).match() }
+             { assert snapshot(
+                process.out,
+                process.out.versions.collect{ path(it).yaml }
+            ).match() }
             )
         }
     }

--- a/modules/nf-core/chromograph/tests/main.nf.test.snap
+++ b/modules/nf-core/chromograph/tests/main.nf.test.snap
@@ -30,13 +30,20 @@
                 "versions": [
                     "versions.yml:md5,26eebbe7ecf582cbc4197f6ccb14fa18"
                 ]
-            }
+            },
+            [
+                {
+                    "CHROMOGRAPH": {
+                        "chromograph": "1.3.1"
+                    }
+                }
+            ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-11-12T16:50:02.807996516"
+        "timestamp": "2025-11-24T14:01:06.162885906"
     },
     "test_chromograph_sites_wig_euploid": {
         "content": [
@@ -165,13 +172,20 @@
                 "versions": [
                     "versions.yml:md5,26eebbe7ecf582cbc4197f6ccb14fa18"
                 ]
-            }
+            },
+            [
+                {
+                    "CHROMOGRAPH": {
+                        "chromograph": "1.3.1"
+                    }
+                }
+            ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-11-12T16:50:08.440144719"
+        "timestamp": "2025-11-24T14:01:11.660229759"
     },
     "test_chromograph_sites_wig_stub": {
         "content": [
@@ -204,13 +218,20 @@
                 "versions": [
                     "versions.yml:md5,26eebbe7ecf582cbc4197f6ccb14fa18"
                 ]
-            }
+            },
+            [
+                {
+                    "CHROMOGRAPH": {
+                        "chromograph": "1.3.1"
+                    }
+                }
+            ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-11-12T16:50:12.957082993"
+        "timestamp": "2025-11-24T14:01:16.077728113"
     },
     "test_chromograph_sites_wig_euploid_stub": {
         "content": [
@@ -275,7 +296,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,44098e3caf6adc824cc68f03f92c1513"
+                    "versions.yml:md5,26eebbe7ecf582cbc4197f6ccb14fa18"
                 ],
                 "plots": [
                     [
@@ -337,14 +358,21 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,44098e3caf6adc824cc68f03f92c1513"
+                    "versions.yml:md5,26eebbe7ecf582cbc4197f6ccb14fa18"
                 ]
-            }
+            },
+            [
+                {
+                    "CHROMOGRAPH": {
+                        "chromograph": "1.3.1"
+                    }
+                }
+            ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-11-12T17:19:11.669837666"
+        "timestamp": "2025-11-24T14:01:20.43021876"
     }
 }


### PR DESCRIPTION
This PR fixes two issues:
- This software may output no files in the input files contain no regions
- Stub version reporting was broken, and included `END_VERSIONS`

Will update versions to topic in a later PR 🙏 

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Emit the `versions.yml` file.
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
