### PR TITLE
Fix hisat2/align to support large genome indices (.ht2l)

### DIFF
--- a/modules/nf-core/hisat2/align/main.nf
+++ b/modules/nf-core/hisat2/align/main.nf
@@ -36,7 +36,7 @@ process HISAT2_ALIGN {
     if (meta.single_end) {
         def unaligned = params.save_unaligned ? "--un-gz ${prefix}.unmapped.fastq.gz" : ''
         """
-        INDEX=`find -L ./ -name "*.1.ht2" | sed 's/\\.1.ht2\$//'`
+        INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
         hisat2 \\
             -x \$INDEX \\
             -U $reads \\
@@ -58,7 +58,7 @@ process HISAT2_ALIGN {
     } else {
         def unaligned = params.save_unaligned ? "--un-conc-gz ${prefix}.unmapped.fastq.gz" : ''
         """
-        INDEX=`find -L ./ -name "*.1.ht2" | sed 's/\\.1.ht2\$//'`
+        INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
         hisat2 \\
             -x \$INDEX \\
             -1 ${reads[0]} \\


### PR DESCRIPTION
## Summary

HISAT2 uses `.ht2l` extension instead of `.ht2` for large genome indices. The current module only detects `.ht2` indices, causing failures with large genomes.

## Changes

Updated the index detection command from:
```bash
INDEX=`find -L ./ -name "*.1.ht2" | sed 's/\.1.ht2$//'`
```

To:
```bash
INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\.1.ht2.*$//'`
```

This uses a wildcard glob to match both `.1.ht2` and `.1.ht2l` extensions in a single pattern.

## Related

Related to nf-core/rnaseq#1643

## Testing notes

Automated testing of large genome indices (`.ht2l`) is not feasible because:
1. Large genome indices require >4GB reference genomes to be generated by `hisat2-build`
2. Simply renaming `.ht2` files to `.ht2l` doesn't work - the file formats are fundamentally different

**Manual verification:** When `.ht2l` files are present, the updated `find` command correctly:
- Finds files matching `*.1.ht2l`
- Extracts the correct index base path via `sed`
- HISAT2 correctly invokes `hisat2-align-l` (the large-index variant)

The existing tests continue to pass, verifying no regression for standard `.ht2` indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)