### PR TITLE
fix(anota2seq): add gene IDs and handle empty results

### DIFF
--- a/modules/nf-core/anota2seq/anota2seqrun/main.nf
+++ b/modules/nf-core/anota2seq/anota2seqrun/main.nf
@@ -12,11 +12,11 @@ process ANOTA2SEQ_ANOTA2SEQRUN {
     tuple val(meta2), path(samplesheet), path(counts)
 
     output:
-    tuple val(meta), path("*.translated_mRNA.anota2seq.results.tsv")           , emit: translated_mrna
-    tuple val(meta), path("*.total_mRNA.anota2seq.results.tsv")                , emit: total_mrna
-    tuple val(meta), path("*.translation.anota2seq.results.tsv")               , emit: translation
-    tuple val(meta), path("*.buffering.anota2seq.results.tsv")                 , emit: buffering
-    tuple val(meta), path("*.mRNA_abundance.anota2seq.results.tsv")            , emit: mrna_abundance
+    tuple val(meta), path("*.translated_mRNA.anota2seq.results.tsv")           , emit: translated_mrna, optional: true
+    tuple val(meta), path("*.total_mRNA.anota2seq.results.tsv")                , emit: total_mrna, optional: true
+    tuple val(meta), path("*.translation.anota2seq.results.tsv")               , emit: translation, optional: true
+    tuple val(meta), path("*.buffering.anota2seq.results.tsv")                 , emit: buffering, optional: true
+    tuple val(meta), path("*.mRNA_abundance.anota2seq.results.tsv")            , emit: mrna_abundance, optional: true
     tuple val(meta), path("*.Anota2seqDataSet.rds")                            , emit: rdata
     tuple val(meta), path("*.fold_change.png")                                 , emit: fold_change_plot
     tuple val(meta), path("*.interaction_p_distribution.pdf")                  , emit: interaction_p_distribution_plot                  , optional: true

--- a/modules/nf-core/anota2seq/anota2seqrun/templates/anota2seqrun.r
+++ b/modules/nf-core/anota2seq/anota2seqrun/templates/anota2seqrun.r
@@ -116,6 +116,7 @@ opt <- list(
     reference_level = '$reference',
     target_level = '$target',
     sample_id_col = "sample",
+    gene_id_col = "gene_id",
     samples_pairing_col = NULL,
     samples_batch_col = NULL,
     subset_to_contrast_samples = FALSE,
@@ -366,14 +367,23 @@ for (analysis in c("translated mRNA", "total mRNA", "translation", "buffering", 
         selContrast = 1
     )
 
-    write.table(
-        output,
-        file = paste(opt\$output_prefix, sub(' ', '_', analysis), 'anota2seq.results.tsv', sep = '.'),
-        col.names = TRUE,
-        row.names = FALSE,
-        sep = '\t',
-        quote = FALSE
-    )
+    # Only write file if there are results
+    if (!is.null(output) && nrow(output) > 0) {
+        # Add gene IDs as the first column
+        output_with_genes <- cbind(
+            setNames(data.frame(rownames(output)), opt\$gene_id_col),
+            output
+        )
+
+        write.table(
+            output_with_genes,
+            file = paste(opt\$output_prefix, sub(' ', '_', analysis), 'anota2seq.results.tsv', sep = '.'),
+            col.names = TRUE,
+            row.names = FALSE,
+            sep = '\t',
+            quote = FALSE
+        )
+    }
 }
 
 # Fold change plot

--- a/modules/nf-core/anota2seq/anota2seqrun/tests/main.nf.test
+++ b/modules/nf-core/anota2seq/anota2seqrun/tests/main.nf.test
@@ -38,7 +38,7 @@ nextflow_process {
                     process.out.translated_mrna,
                     process.out.total_mrna,
                     process.out.translation,
-                    process.out.mrna_abundance,
+                    process.out.buffering,
                     process.out.versions,
                     file(process.out.fold_change_plot[0][1]).name,
                     file(process.out.interaction_p_distribution_plot[0][1]).name,

--- a/modules/nf-core/anota2seq/anota2seqrun/tests/main.nf.test.snap
+++ b/modules/nf-core/anota2seq/anota2seqrun/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                     {
                         "id": "treatment_vs_control"
                     },
-                    "treatment_vs_control.translated_mRNA.anota2seq.results.tsv:md5,2c8a7dc1841d2852fc68e5d65e89a8e1"
+                    "treatment_vs_control.translated_mRNA.anota2seq.results.tsv:md5,e777e335d484831520e53c51db75a47c"
                 ]
             ],
             [
@@ -14,7 +14,7 @@
                     {
                         "id": "treatment_vs_control"
                     },
-                    "treatment_vs_control.total_mRNA.anota2seq.results.tsv:md5,69778181d0ec4f50c11c99dfed7e9090"
+                    "treatment_vs_control.total_mRNA.anota2seq.results.tsv:md5,ea8044585fcbf133b284e7a96bf2a4a8"
                 ]
             ],
             [
@@ -22,7 +22,7 @@
                     {
                         "id": "treatment_vs_control"
                     },
-                    "treatment_vs_control.translation.anota2seq.results.tsv:md5,28dca3b6017569e8a8a0702714e7451c"
+                    "treatment_vs_control.translation.anota2seq.results.tsv:md5,99045a6fca60386e8cb5a31a49491688"
                 ]
             ],
             [
@@ -30,7 +30,7 @@
                     {
                         "id": "treatment_vs_control"
                     },
-                    "treatment_vs_control.mRNA_abundance.anota2seq.results.tsv:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    "treatment_vs_control.buffering.anota2seq.results.tsv:md5,d900d02201c6703aba62cd30a10d2ded"
                 ]
             ],
             [
@@ -52,9 +52,9 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-01T14:34:20.085223495"
+        "timestamp": "2025-12-05T12:21:54.259548595"
     }
 }


### PR DESCRIPTION
This PR fixes several issues with the anota2seq module:

## Problems Fixed

1. **Missing gene IDs**: The anota2seq results tables were missing gene identifiers, making it difficult to interpret results
2. **Missing parameter**: The  parameter was used but never defined 
3. **Empty file handling**: When no genes passed significance thresholds, the module would create empty/malformed files
4. **Output expectations**: Nextflow expected files that might not be created

## Changes Made

- **Add  parameter**: Defaults to "gene_id" but configurable
- **Include gene IDs**: Add gene identifiers as the first column in all results tables using  and 
- **Conditional output**: Only write files when there are actual results to avoid empty files
- **Optional outputs**: Mark all results TSV files as optional since they're now conditionally created
- **Update tests**: Modified test to use buffering results instead of empty mRNA_abundance, updated snapshots

## Benefits

- Results tables now include gene identifiers for downstream analysis
- Consistent with other nf-core modules that include gene IDs
- Graceful handling of cases where no genes pass significance thresholds
- More robust error handling

## Testing

- Updated test snapshots with new MD5 hashes reflecting the gene_id column addition
- Test now uses buffering results instead of empty mRNA_abundance results
- All outputs marked as optional to handle conditional file creation

The anota2seq results are now much more usable and consistent with expectations from other differential analysis modules.