### PR TITLE
anota2seq: wrong variable name for batch assignment

### DIFF
--- a/modules/nf-core/anota2seq/anota2seqrun/templates/anota2seqrun.r
+++ b/modules/nf-core/anota2seq/anota2seqrun/templates/anota2seqrun.r
@@ -319,7 +319,7 @@ anota2seqDataSetFromMatrix_args <- list(
 )
 
 if (! is.null(opt\$samples_batch_col)){
-    anota2seqDataSetFromMatrix_args\$batchVec <- samples[rnaseq_samples, opt\$samples_batch_col]
+    anota2seqDataSetFromMatrix_args\$batchVec <- sample.sheet[rnaseq_samples, opt\$samples_batch_col]
 }
 
 ads <- do.call(anota2seqDataSetFromMatrix, anota2seqDataSetFromMatrix_args)


### PR DESCRIPTION
Assignment of samples to batches did not work, because a variable was misnamed. This PR fixes the variable name. I have confirmed that batch assignment then works as expected.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Remove all TODO statements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`