### PR TITLE
fix(bbmap/bbsplit): robust jshell output parsing for timestamp extraction

### DIFF
--- a/modules/nf-core/bbmap/bbsplit/main.nf
+++ b/modules/nf-core/bbmap/bbsplit/main.nf
@@ -79,7 +79,7 @@ process BBMAP_BBSPLIT {
         done
         find index_writable/ref/genome -name summary.txt | while read -r summary_file; do
             src=\$(grep '^source' "\$summary_file" | cut -f2- -d\$'\\t' | sed 's|.*/ref/|index_writable/ref/|')
-            mod=\$(echo "System.out.println(java.nio.file.Files.getLastModifiedTime(java.nio.file.Paths.get(\\"\$src\\")).toMillis());" | jshell -J-Djdk.lang.Process.launchMechanism=vfork -)
+            mod=\$(echo "System.out.println(java.nio.file.Files.getLastModifiedTime(java.nio.file.Paths.get(\\"\$src\\")).toMillis());" | jshell -J-Djdk.lang.Process.launchMechanism=vfork - 2>/dev/null | grep -oE '^[0-9]{12,14}\$')
             sed -e 's|bbsplit_index/ref|index_writable/ref|' -e "s|^last modified.*|last modified\\t\$mod|" "\$summary_file" > \${summary_file}.tmp && mv \${summary_file}.tmp \${summary_file}
         done
     fi


### PR DESCRIPTION
## Summary

- Fix sed "unterminated 's' command" error when jshell outputs unexpected text
- Suppress Java preferences directory warnings by redirecting stderr
- Filter jshell output to only capture valid millisecond timestamps (12-14 digits)

## Problem

When using a pre-built BBSplit index, the module uses `jshell` to get file modification timestamps. If jshell encounters issues (e.g., can't create user preferences directory), it outputs warnings like:

```
WARNING: Couldn't create user preferences directory. User preferences are unusable.
WARNING: java.io.IOException: No such file or directory
```

This unexpected text ends up in the `$mod` variable and breaks the subsequent sed substitution:

```
sed: -e expression #2, char 160: unterminated `s' command
```

## Solution

```bash
# Before
mod=$(... | jshell -J-Djdk.lang.Process.launchMechanism=vfork -)

# After  
mod=$(... | jshell -J-Djdk.lang.Process.launchMechanism=vfork - 2>/dev/null | grep -oE '^[0-9]{12,14}$')
```

- `2>/dev/null` suppresses stderr (Java warnings)
- `grep -oE '^[0-9]{12,14}$'` extracts only valid millisecond timestamps

## Credit

Reported by Pieter Moris and debugged by Matthias Zepper in [Slack](https://nfcore.slack.com/archives/CE8SSJV3N/p1765213014112749?thread_ts=1764240778.280839&cid=CE8SSJV3N)

🤖 Generated with [Claude Code](https://claude.com/claude-code)