### PR TITLE
Fix missing version from subworkflow snapshot

### DIFF
--- a/subworkflows/nf-core/bam_create_som_pon_gatk/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_create_som_pon_gatk/tests/main.nf.test
@@ -51,6 +51,7 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                { assert snapshot(workflow.out.versions).match("versions") },
                 { assert snapshot(file(workflow.out.mutect2_vcf.get(0).get(1)).name).match("test1.vcf.gz") },
                 { assert snapshot(file(workflow.out.mutect2_index.get(0).get(1)).name).match("test1.vcf.gz.tbi") },
                 { assert snapshot(file(workflow.out.mutect2_stats.get(0).get(1)).name).match("test1.vcf.gz.stats") },

--- a/subworkflows/nf-core/bam_create_som_pon_gatk/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_create_som_pon_gatk/tests/main.nf.test.snap
@@ -19,6 +19,21 @@
         },
         "timestamp": "2024-02-14T06:59:54.102164313"
     },
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,372aff89fa24a61afed05026b9300345",
+                "versions.yml:md5,4e7c726474b7a321e56c5260ad8ab209",
+                "versions.yml:md5,4e7c726474b7a321e56c5260ad8ab209",
+                "versions.yml:md5,b21263bb2f8ab5733906245941e30e77"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2025-12-10T15:46:00.217316738"
+    },
     "test_panel.vcf.gz.tbi": {
         "content": [
             "test_panel.vcf.gz.tbi"

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
@@ -486,7 +486,8 @@ nextflow_workflow {
                 { assert bowtie2RrnaCount == 10 },   // 10 reads aligned to rRNA reference
                 { assert snapshot(
                     selines.join('\n').md5(),
-                    processed_ribo_removal_lint_report.md5()
+                    processed_ribo_removal_lint_report.md5(),
+                    workflow.out.versions
                 ).match() }
             )
         }

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test.snap
@@ -50,12 +50,23 @@
     "homo_sapiens single-end [fastq] fastp bowtie2": {
         "content": [
             "b423f619ae31c22b2bf99bdcb89bf852",
-            "5c1e74518dd70e4f1506b4f64da7b5f3"
+            "5c1e74518dd70e4f1506b4f64da7b5f3",
+            [
+                "versions.yml:md5,32dd6a2d25ace29928423400082ed21e",
+                "versions.yml:md5,4f417b1f2243b8fdbb4d500d297275d7",
+                "versions.yml:md5,62a1dcf235b26d36556128000350f873",
+                "versions.yml:md5,65b00c07a75fb33c090cfdc3caf6c670",
+                "versions.yml:md5,703785e3662b35a0d9e533f0047fee5c",
+                "versions.yml:md5,7da162ffef1721b87e11194d10acaeee",
+                "versions.yml:md5,916a9eda18796248d67f0775546401a1",
+                "versions.yml:md5,9c1eaf84889a0aa32a7e224bb59cc614",
+                "versions.yml:md5,e22c32ec91f95bda4130664671ca7cea"
+            ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-28T11:03:31.491281"
+        "timestamp": "2025-12-10T15:09:04.590361686"
     }
 }

--- a/subworkflows/nf-core/fastq_remove_rrna/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_remove_rrna/tests/main.nf.test
@@ -78,6 +78,7 @@ nextflow_workflow {
                 { assert pelines2.size() == 16636 },
                 { assert sortmernaRrnaCount == 20 },  // 10 pairs = 20 individual reads (100% detection)
                 { assert snapshot(
+                    workflow.out.versions,
                     pelines1.join('\n').md5(),
                     pelines2.join('\n').md5()
                 ).match() }
@@ -126,6 +127,7 @@ nextflow_workflow {
                 { assert pelines2.size() == 16648 },
                 { assert ribodetectorRrnaCount == 7 },  // 7 pairs detected (70% - ML model misses some)
                 { assert snapshot(
+                    workflow.out.versions,
                     sortedLines1.join('\n').md5(),
                     sortedLines2.join('\n').md5()
                 ).match() }
@@ -171,6 +173,7 @@ nextflow_workflow {
                 { assert pelines2.size() == 16636 },
                 { assert bowtie2RrnaCount == 17 },  // 17 mates aligned to rRNA reference
                 { assert snapshot(
+                    workflow.out.versions,
                     pelines1.join('\n').md5(),
                     pelines2.join('\n').md5()
                 ).match() }
@@ -233,6 +236,7 @@ nextflow_workflow {
                 { assert selines.size() == 16636 },  // 4159 reads × 4 lines/read
                 { assert bowtie2RrnaCount == 10 },   // 10 reads aligned to rRNA reference
                 { assert snapshot(
+                    workflow.out.versions,
                     selines.join('\n').md5()
                 ).match() }
             )
@@ -290,6 +294,7 @@ nextflow_workflow {
                 { assert selines.size() == 16636 },  // 4159 reads × 4 lines/read
                 { assert sortmernaRrnaCount == 10 },  // 10 reads detected (100% detection)
                 { assert snapshot(
+                    workflow.out.versions,
                     selines.join('\n').md5()
                 ).match() }
             )
@@ -333,6 +338,7 @@ nextflow_workflow {
             // even when the same rRNA databases are provided multiple times
             assertAll(
                 { assert workflow.success },
+                { assert snapshot(workflow.out.versions).match() },
                 { assert pelines1.size() >= 0 },  // Should have some reads
                 { assert pelines2.size() >= 0 },  // Should have some reads
                 { assert !workflow.stderr.contains("Duplicate entry") },  // No duplicate header errors in stderr

--- a/subworkflows/nf-core/fastq_remove_rrna/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_remove_rrna/tests/main.nf.test.snap
@@ -1,55 +1,95 @@
 {
     "homo_sapiens single-end [fastq] bowtie2": {
         "content": [
+            [
+                "versions.yml:md5,2cfbbdad4c4dcdfacedeb20ec188145b",
+                "versions.yml:md5,5edeace71a857688bae03f7a5c102caf",
+                "versions.yml:md5,98dd18ffc97251b8a24e611b27ba12af",
+                "versions.yml:md5,cb634680924d1a6f4c7de81a23a2e992"
+            ],
             "bdea4e3bbdbb7c301ff578b9d8976fb6"
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-28T11:51:37.291482561"
+        "timestamp": "2025-12-10T15:48:50.273951118"
     },
     "homo_sapiens single-end [fastq] sortmerna": {
         "content": [
+            [
+                "versions.yml:md5,d375aebf400213ebbd6e104a331b27ae"
+            ],
             "bdea4e3bbdbb7c301ff578b9d8976fb6"
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-28T11:51:50.835424985"
+        "timestamp": "2025-12-10T15:49:01.125046076"
+    },
+    "homo_sapiens paired-end [fastq] bowtie2 with duplicate rrna databases": {
+        "content": [
+            [
+                "versions.yml:md5,2cfbbdad4c4dcdfacedeb20ec188145b",
+                "versions.yml:md5,2cfbbdad4c4dcdfacedeb20ec188145b",
+                "versions.yml:md5,5edeace71a857688bae03f7a5c102caf",
+                "versions.yml:md5,5edeace71a857688bae03f7a5c102caf",
+                "versions.yml:md5,98dd18ffc97251b8a24e611b27ba12af",
+                "versions.yml:md5,a9810676328a1650fc826978ae8eb96b",
+                "versions.yml:md5,bee00b6ec637b583decca8bd9c9eacd0"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2025-12-10T15:49:36.940527491"
     },
     "homo_sapiens paired-end [fastq] sortmerna": {
         "content": [
+            [
+                "versions.yml:md5,d375aebf400213ebbd6e104a331b27ae"
+            ],
             "bdea4e3bbdbb7c301ff578b9d8976fb6",
             "1b83618177abebeb38c29d2258efdd4f"
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-28T11:49:53.980824473"
+        "timestamp": "2025-12-10T15:48:17.279619846"
     },
     "homo_sapiens paired-end [fastq] ribodetector": {
         "content": [
+            [
+                "versions.yml:md5,acaf2e83db2526761adf39c912b0037c"
+            ],
             "ec0260bcdeef6af8a9b6d470eafb5603",
             "a0ef8564218df5741dee81f03db13600"
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-29T18:27:41.89909077"
+        "timestamp": "2025-12-10T15:48:30.322253019"
     },
     "homo_sapiens paired-end [fastq] bowtie2": {
         "content": [
+            [
+                "versions.yml:md5,2cfbbdad4c4dcdfacedeb20ec188145b",
+                "versions.yml:md5,5edeace71a857688bae03f7a5c102caf",
+                "versions.yml:md5,98dd18ffc97251b8a24e611b27ba12af",
+                "versions.yml:md5,a9810676328a1650fc826978ae8eb96b",
+                "versions.yml:md5,bee00b6ec637b583decca8bd9c9eacd0"
+            ],
             "4ef4e259208497288aaefaa88770975d",
             "63198a2af4a4a8fb949b01a8b2c4cb7c"
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-28T11:51:24.742227098"
+        "timestamp": "2025-12-10T15:48:40.498006186"
     }
 }


### PR DESCRIPTION
In #9543, it was identified that some subworkflow tests do not snapshot the versions channel.

This PR addresses this issue.