### PR TITLE
Add BBSplit stats to MultiQC in fastq_qc_trim_filter_setstrandedness subworkflow

### DIFF
--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -257,6 +257,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         BBMAP_BBSPLIT.out.primary_fastq.set { ch_filtered_reads }
 
         ch_versions = ch_versions.mix(BBMAP_BBSPLIT.out.versions.first())
+        ch_multiqc_files = ch_multiqc_files.mix(BBMAP_BBSPLIT.out.stats)
 
         if (!skip_linting) {
             FQ_LINT_AFTER_BBSPLIT(


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).

## Description of changes

This PR adds BBSplit statistics to the MultiQC output in the `fastq_qc_trim_filter_setstrandedness` subworkflow.

### Changes

- Pass `BBMAP_BBSPLIT.out.stats` to the `ch_multiqc_files` channel

### Why

MultiQC 1.33 introduced support for parsing BBSplit `stats.txt` files, allowing visualization of:
- Per-sample read distribution across reference genomes
- Percentage/count of reads mapped to each reference

This provides users with an overview of reads removed during contaminant filtering.

### Related

- Requested in: https://github.com/nf-core/rnaseq/pull/1662#issuecomment-3643138083
- Similar implementation in sarek: https://github.com/nf-core/sarek/pull/2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)