### PR TITLE
Update RSEQC modules with Seqera Wave containers matching environment.yml

### DIFF
--- a/modules/nf-core/rseqc/bamstat/environment.yml
+++ b/modules/nf-core/rseqc/bamstat/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rseqc=5.0.4
-  - conda-forge::r-base=3.5
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/bamstat/main.nf
+++ b/modules/nf-core/rseqc/bamstat/main.nf
@@ -4,8 +4,8 @@ process RSEQC_BAMSTAT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/rseqc/inferexperiment/environment.yml
+++ b/modules/nf-core/rseqc/inferexperiment/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rseqc=5.0.4
-  - conda-forge::r-base=3.5
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/inferexperiment/main.nf
+++ b/modules/nf-core/rseqc/inferexperiment/main.nf
@@ -4,8 +4,8 @@ process RSEQC_INFEREXPERIMENT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/rseqc/innerdistance/environment.yml
+++ b/modules/nf-core/rseqc/innerdistance/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rseqc=5.0.4
-  - conda-forge::r-base=3.5
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/innerdistance/main.nf
+++ b/modules/nf-core/rseqc/innerdistance/main.nf
@@ -4,8 +4,8 @@ process RSEQC_INNERDISTANCE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/rseqc/junctionannotation/environment.yml
+++ b/modules/nf-core/rseqc/junctionannotation/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rseqc=5.0.4
-  - conda-forge::r-base=3.5
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/junctionannotation/main.nf
+++ b/modules/nf-core/rseqc/junctionannotation/main.nf
@@ -4,8 +4,8 @@ process RSEQC_JUNCTIONANNOTATION {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/rseqc/junctionsaturation/environment.yml
+++ b/modules/nf-core/rseqc/junctionsaturation/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rseqc=5.0.4
-  - conda-forge::r-base=3.5
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/junctionsaturation/main.nf
+++ b/modules/nf-core/rseqc/junctionsaturation/main.nf
@@ -4,8 +4,8 @@ process RSEQC_JUNCTIONSATURATION {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/rseqc/readdistribution/environment.yml
+++ b/modules/nf-core/rseqc/readdistribution/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rseqc=5.0.4
-  - conda-forge::r-base=3.5
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/readdistribution/main.nf
+++ b/modules/nf-core/rseqc/readdistribution/main.nf
@@ -4,8 +4,8 @@ process RSEQC_READDISTRIBUTION {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/rseqc/readduplication/environment.yml
+++ b/modules/nf-core/rseqc/readduplication/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rseqc=5.0.4
-  - conda-forge::r-base=3.5
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/readduplication/main.nf
+++ b/modules/nf-core/rseqc/readduplication/main.nf
@@ -4,8 +4,8 @@ process RSEQC_READDUPLICATION {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/rseqc/splitbam/environment.yml
+++ b/modules/nf-core/rseqc/splitbam/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::rseqc=5.0.4"
+  - bioconda::rseqc=5.0.4
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/splitbam/main.nf
+++ b/modules/nf-core/rseqc/splitbam/main.nf
@@ -4,8 +4,8 @@ process RSEQC_SPLITBAM {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta) , path(bam), path(bai)

--- a/modules/nf-core/rseqc/tin/environment.yml
+++ b/modules/nf-core/rseqc/tin/environment.yml
@@ -5,4 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rseqc=5.0.4
-  - conda-forge::r-base=3.5
+  - conda-forge::r-base=4.3

--- a/modules/nf-core/rseqc/tin/main.nf
+++ b/modules/nf-core/rseqc/tin/main.nf
@@ -4,8 +4,8 @@ process RSEQC_TIN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/rseqc:5.0.4--pyhdfd78af_1' :
-        'biocontainers/rseqc:5.0.4--pyhdfd78af_1' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data' :
+        'community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15' }"
 
     input:
     tuple val(meta), path(bam), path(bai)


### PR DESCRIPTION
## Summary

This PR updates all RSEQC modules to use Seqera Wave containers that are built directly from the environment.yml specifications, ensuring consistency between conda and container execution modes.

### Problem

The previous biocontainers (`rseqc:5.0.4--pyhdfd78af_1`) were not built with the R pin specified in environment.yml. This caused inconsistencies between:
- Running with conda (which would use the pinned R version)
- Running with containers (which used whatever R version biocontainers happened to include)

Additionally, the older R pin (`r-base=3.5`) does not have ARM builds available, preventing ARM compatibility.

### Solution

- Replace biocontainers with Seqera Wave containers built from the exact environment.yml
- Update `r-base` pin from 3.5 to 4.3 (which has ARM builds available)
- Standardize all 9 RSEQC modules to use identical dependencies and containers

### Changes

- **environment.yml**: All 9 modules now specify `rseqc=5.0.4` + `r-base=4.3`
- **main.nf**: All 9 modules now use Wave containers:
  - Docker: `community.wave.seqera.io/library/rseqc_r-base:2e29d2dfda9cef15`
  - Singularity: `https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6f44b7933e2c2b1a340dc9485869974eb032d34e81af83716eb381964ee3e5e7/data`

### Modules affected

- rseqc/bamstat
- rseqc/inferexperiment
- rseqc/innerdistance
- rseqc/junctionannotation
- rseqc/junctionsaturation
- rseqc/readdistribution
- rseqc/readduplication
- rseqc/splitbam
- rseqc/tin

## Test plan

- [ ] Verify container URLs are accessible
- [ ] Run module tests with `--profile docker`
- [ ] Confirm R is available in the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)