### PR TITLE
Replace busybox with coreutils sort for genmod modules

### DIFF
--- a/modules/nf-core/genmod/annotate/environment.yml
+++ b/modules/nf-core/genmod/annotate/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::genmod=3.10.2
+  - conda-forge::python=3.11.14

--- a/modules/nf-core/genmod/annotate/main.nf
+++ b/modules/nf-core/genmod/annotate/main.nf
@@ -4,8 +4,8 @@ process GENMOD_ANNOTATE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genmod:3.10.2--pyh7e72e81_0':
-        'biocontainers/genmod:3.10.2--pyh7e72e81_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/31/31b331bee43c7ff070bdde5460a4102ba31c3bfb0ee0d70197001ff011036555/data' :
+        'community.wave.seqera.io/library/genmod_python:31b2fba4d3b7ba6f' }"
 
     input:
     tuple val(meta), path(input_vcf)

--- a/modules/nf-core/genmod/compound/environment.yml
+++ b/modules/nf-core/genmod/compound/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::genmod=3.10.2
+  - conda-forge::python=3.11.14

--- a/modules/nf-core/genmod/compound/main.nf
+++ b/modules/nf-core/genmod/compound/main.nf
@@ -4,8 +4,8 @@ process GENMOD_COMPOUND {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genmod:3.10.2--pyh7e72e81_0':
-        'biocontainers/genmod:3.10.2--pyh7e72e81_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/31/31b331bee43c7ff070bdde5460a4102ba31c3bfb0ee0d70197001ff011036555/data' :
+        'community.wave.seqera.io/library/genmod_python:31b2fba4d3b7ba6f' }"
 
     input:
     tuple val(meta), path(input_vcf)

--- a/modules/nf-core/genmod/models/environment.yml
+++ b/modules/nf-core/genmod/models/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::genmod=3.10.2
+  - conda-forge::python=3.11.14

--- a/modules/nf-core/genmod/models/main.nf
+++ b/modules/nf-core/genmod/models/main.nf
@@ -4,8 +4,8 @@ process GENMOD_MODELS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genmod:3.10.2--pyh7e72e81_0':
-        'biocontainers/genmod:3.10.2--pyh7e72e81_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/31/31b331bee43c7ff070bdde5460a4102ba31c3bfb0ee0d70197001ff011036555/data' :
+        'community.wave.seqera.io/library/genmod_python:31b2fba4d3b7ba6f' }"
 
     input:
     tuple val(meta), path(input_vcf), path (fam)

--- a/modules/nf-core/genmod/score/environment.yml
+++ b/modules/nf-core/genmod/score/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::genmod=3.10.2
+  - conda-forge::python=3.11.14

--- a/modules/nf-core/genmod/score/main.nf
+++ b/modules/nf-core/genmod/score/main.nf
@@ -4,8 +4,8 @@ process GENMOD_SCORE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genmod:3.10.2--pyh7e72e81_0':
-        'biocontainers/genmod:3.10.2--pyh7e72e81_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/31/31b331bee43c7ff070bdde5460a4102ba31c3bfb0ee0d70197001ff011036555/data' :
+        'community.wave.seqera.io/library/genmod_python:31b2fba4d3b7ba6f' }"
 
     input:
     tuple val(meta), path(input_vcf), path (fam)


### PR DESCRIPTION
genmod relies on the system having coreutils sort installed for certain steps. Seqera containers comes with coreutils. 

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
