### PR TITLE
ribowaltz: Add 'ribowaltz' identifier to QC TSV filenames

### DIFF
--- a/modules/nf-core/ribowaltz/main.nf
+++ b/modules/nf-core/ribowaltz/main.nf
@@ -32,7 +32,7 @@ process RIBOWALTZ {
     template 'ribowaltz.r'
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = "${task.ext.prefix ?: meta.id}.ribowaltz"
     """
     touch ${prefix}.best_offset.txt
     touch ${prefix}.psite_offset.tsv
@@ -45,6 +45,7 @@ process RIBOWALTZ {
     touch ribowaltz_qc/${prefix}.psite_region.tsv
     touch ribowaltz_qc/${prefix}.frames.tsv
     touch ribowaltz_qc/${prefix}.frames_stratified.tsv
+    touch ribowaltz_qc/${prefix}.metaprofile_psite.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/ribowaltz/templates/ribowaltz.r
+++ b/modules/nf-core/ribowaltz/templates/ribowaltz.r
@@ -417,7 +417,7 @@ save_metaprofile_psite_plot <- function(sample_name, df.ls, annotation.df) {
 
 # Set defaults and classes
 opt <- list(
-    output_prefix = ifelse('$task.ext.prefix' == 'null', '$meta.id', '$task.ext.prefix'),
+    output_prefix = paste0(ifelse('$task.ext.prefix' == 'null', '$meta.id', '$task.ext.prefix'), '.ribowaltz'),
     threads = '$task.cpus',
     bam = '$bam',
     gtf = '$gtf',

--- a/modules/nf-core/ribowaltz/tests/main.nf.test.snap
+++ b/modules/nf-core/ribowaltz/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.cds_coverage_psite.tsv.gz:md5,0da44540aaef43a804ff8b0711d3dac2"
+                    "test.ribowaltz.cds_coverage_psite.tsv.gz:md5,0da44540aaef43a804ff8b0711d3dac2"
                 ]
             ]
         ],
@@ -27,7 +27,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.psite_offset.tsv.gz:md5,639eca984c01a687bb6a75c4e5e46b8f"
+                    "test.ribowaltz.psite_offset.tsv.gz:md5,639eca984c01a687bb6a75c4e5e46b8f"
                 ]
             ]
         ],
@@ -46,7 +46,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.codon_coverage_rpf.tsv.gz:md5,0c2d3a92653d987947905a8f37b392bd"
+                    "test.ribowaltz.codon_coverage_rpf.tsv.gz:md5,0c2d3a92653d987947905a8f37b392bd"
                 ]
             ]
         ],
@@ -65,7 +65,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.psite_offset.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test.ribowaltz.psite_offset.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ]
         ],
@@ -84,7 +84,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.cds_coverage_psite.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test.ribowaltz.cds_coverage_psite.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ]
         ],
@@ -127,7 +127,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.psite.tsv.gz:md5,96bf26c683c1884a910001b49e72d2a7"
+                    "test.ribowaltz.psite.tsv.gz:md5,96bf26c683c1884a910001b49e72d2a7"
                 ]
             ]
         ],
@@ -146,7 +146,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.cds_plus42nt_minus27nt_coverage_psite.tsv.gz:md5,78571ed38ff093910be91462724e04a6"
+                    "test.ribowaltz.cds_plus42nt_minus27nt_coverage_psite.tsv.gz:md5,78571ed38ff093910be91462724e04a6"
                 ]
             ]
         ],
@@ -165,7 +165,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.psite.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test.ribowaltz.psite.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ]
         ],
@@ -184,7 +184,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.codon_coverage_rpf.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test.ribowaltz.codon_coverage_rpf.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ]
         ],
@@ -203,7 +203,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.codon_coverage_psite.tsv.gz:md5,2bbaabeae8659493a03cb6d37f2d142c"
+                    "test.ribowaltz.codon_coverage_psite.tsv.gz:md5,2bbaabeae8659493a03cb6d37f2d142c"
                 ]
             ]
         ],
@@ -222,7 +222,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.codon_coverage_psite.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test.ribowaltz.codon_coverage_psite.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ]
         ],
@@ -241,7 +241,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.best_offset.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test.ribowaltz.best_offset.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ]
         ],
@@ -260,7 +260,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test.best_offset.txt:md5,fe63d53f738385b55b092a12156d72d9"
+                    "test.ribowaltz.best_offset.txt:md5,fe63d53f738385b55b092a12156d72d9"
                 ]
             ]
         ],


### PR DESCRIPTION
## Summary

This PR adds the `ribowaltz` string to the output prefix, ensuring all output files are clearly identifiable as coming from riboWaltz.

## Changes

- Modified the `output_prefix` definition in the R template to append `.ribowaltz`
- Updated the stub `prefix` definition in `main.nf` to match

All output files will now include `.ribowaltz` in their names (e.g., `sample1.ribowaltz.psite_region.tsv`).

## Rationale

This provides clear provenance for all outputs and avoids potential confusion with files from other tools that may have similar generic filenames.

---

**Note:** The `meta.yml` file does not need updates as it already uses glob patterns that match the new filenames.