### PR TITLE
Fix import statements for strict syntax compliance

### DIFF
--- a/modules/nf-core/rmarkdownnotebook/parametrize.nf
+++ b/modules/nf-core/rmarkdownnotebook/parametrize.nf
@@ -1,7 +1,3 @@
-import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.DumperOptions
-
-
 /**
  * Multiline code blocks need to have the same indentation level
  * as the `script:` section. This function re-indents code to the specified level.
@@ -18,9 +14,9 @@ def indent_code_block(code, n_spaces) {
  * @returns a line to be inserted in the bash script.
  */
 def dump_params_yml(params) {
-    DumperOptions options = new DumperOptions();
-    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-    def yaml = new Yaml(options)
+    def options = new org.yaml.snakeyaml.DumperOptions();
+    options.setDefaultFlowStyle(org.yaml.snakeyaml.DumperOptions.FlowStyle.BLOCK);
+    def yaml = new org.yaml.snakeyaml.Yaml(options)
     def yaml_str = yaml.dump(params)
 
     // Writing the .params.yml file directly as follows does not work.


### PR DESCRIPTION
Replaces Groovy import statements with fully-qualified class names for strict syntax compliance.

<details>
<summary>Details</summary>

## Changes
This PR fixes 2 strict syntax errors in 1 file by removing Groovy `import` statements and using fully-qualified class names instead.

**Example fix:**
```groovy
// Before
import org.yaml.snakeyaml.Yaml
import org.yaml.snakeyaml.DumperOptions
def yaml = new Yaml(options)

// After  
def dumper_options = new org.yaml.snakeyaml.DumperOptions()
def yaml = new org.yaml.snakeyaml.Yaml(dumper_options)
```

## Why
Nextflow 25.10+ strict syntax mode does not support `import` statements. All classes must be referenced using their fully-qualified names (package.path.ClassName).

## Affected Files
- modules/nf-core/rmarkdownnotebook/parametrize/main.nf

## Testing
- Functionality remains identical
- Pre-commit hooks passed
- Ready for `nextflow lint` validation

---
*This work was completed with AI assistance using Seqera AI.*
</details>