### PR TITLE
fix(mitohifi): Update mitohifi to topic versions, add log, and tweak module operation

### DIFF
--- a/modules/nf-core/mitohifi/findmitoreference/main.nf
+++ b/modules/nf-core/mitohifi/findmitoreference/main.nf
@@ -16,9 +16,10 @@ process MITOHIFI_FINDMITOREFERENCE {
     tuple val(meta), val(species)
 
     output:
-    tuple val(meta), path("*.fasta"), emit: fasta
-    tuple val(meta), path("*.gb")   , emit: gb
-    path "versions.yml"             , emit: versions
+    tuple val(meta), path("*.fasta"), path("*.gb"), emit: reference
+    // WARN: Incorrect version information is provided by tool on CLI. Please update this string when bumping container versions.
+    // old version command: \$(mitohifi.py -v | sed 's/.* //')
+    tuple val("${task.process}"), val('mitohifi'), eval('echo 3.2.3'), emit: versions_mitohifi, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,8 +31,6 @@ process MITOHIFI_FINDMITOREFERENCE {
     }
 
     def args         = task.ext.args ?: ''
-    // WARN: Incorrect version information is provided by tool on CLI. Please update this string when bumping container versions.
-    def VERSION      = '3.2.3'
     def ncbi_api_key = secrets.NCBI_API_KEY ? "--ncbi-api-key \$NCBI_API_KEY" : ""
     """
     findMitoReference.py \\
@@ -39,24 +38,11 @@ process MITOHIFI_FINDMITOREFERENCE {
         --species "$species" \\
         --outfolder . \\
         $args
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        mitohifi: ${VERSION}
-    END_VERSIONS
     """
 
     stub:
-    // WARN: Incorrect version information is provided by tool on CLI. Please update this string when bumping container versions.
-    def VERSION = '3.2.3'
     """
     touch accession.fasta
     touch accession.gb
-
-    ## old version command: \$(mitohifi.py -v | sed 's/.* //')
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        mitohifi: ${VERSION}
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/mitohifi/findmitoreference/meta.yml
+++ b/modules/nf-core/mitohifi/findmitoreference/meta.yml
@@ -33,7 +33,7 @@ input:
           be fetched
         pattern: "[A-Z]?[a-z]* [a-z]*"
 output:
-  fasta:
+  reference:
     - - meta:
           type: map
           description: |
@@ -45,25 +45,33 @@ output:
           pattern: "*.{fasta,fa}"
           ontologies:
             - edam: http://edamontology.org/format_1929 # FASTA
-  gb:
-    - - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
       - "*.gb":
           type: file
           description: Downloaded mitochondrial genome in Genbank format
           pattern: "*.gb"
           ontologies:
             - edam: http://edamontology.org/format_1936 # GenBank
+  versions_mitohifi:
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - mitohifi:
+          type: string
+          description: The name of the tool
+      - echo 3.2.3:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - mitohifi:
+          type: string
+          description: The name of the tool
+      - echo 3.2.3:
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@verku"
 maintainers:

--- a/modules/nf-core/mitohifi/findmitoreference/tests/main.nf.test.snap
+++ b/modules/nf-core/mitohifi/findmitoreference/tests/main.nf.test.snap
@@ -7,46 +7,40 @@
                         {
                             "id": "test"
                         },
-                        "NC_016949.1.fasta:md5,7ff7cc26c8af448127adc7c58a29b711"
+                        "NC_016949.1.fasta:md5,7ff7cc26c8af448127adc7c58a29b711",
+                        "NC_016949.1.gb:md5,501056213478f9c7ab50b1437cd2b7fe"
                     ]
                 ],
                 "1": [
                     [
-                        {
-                            "id": "test"
-                        },
-                        "NC_016949.1.gb:md5,501056213478f9c7ab50b1437cd2b7fe"
+                        "MITOHIFI_FINDMITOREFERENCE",
+                        "mitohifi",
+                        "3.2.3"
                     ]
                 ],
-                "2": [
-                    "versions.yml:md5,a27cd2130904385aca2a6e09203f3528"
-                ],
-                "fasta": [
+                "reference": [
                     [
                         {
                             "id": "test"
                         },
-                        "NC_016949.1.fasta:md5,7ff7cc26c8af448127adc7c58a29b711"
-                    ]
-                ],
-                "gb": [
-                    [
-                        {
-                            "id": "test"
-                        },
+                        "NC_016949.1.fasta:md5,7ff7cc26c8af448127adc7c58a29b711",
                         "NC_016949.1.gb:md5,501056213478f9c7ab50b1437cd2b7fe"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,a27cd2130904385aca2a6e09203f3528"
+                "versions_mitohifi": [
+                    [
+                        "MITOHIFI_FINDMITOREFERENCE",
+                        "mitohifi",
+                        "3.2.3"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-08-14T14:37:07.75671862"
+        "timestamp": "2026-01-19T12:10:36.030927"
     },
     "mitohifi - findmitoreference - stub": {
         "content": [
@@ -56,45 +50,39 @@
                         {
                             "id": "test"
                         },
-                        "accession.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "accession.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "accession.gb:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
                     [
-                        {
-                            "id": "test"
-                        },
-                        "accession.gb:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "MITOHIFI_FINDMITOREFERENCE",
+                        "mitohifi",
+                        "3.2.3"
                     ]
                 ],
-                "2": [
-                    "versions.yml:md5,a27cd2130904385aca2a6e09203f3528"
-                ],
-                "fasta": [
+                "reference": [
                     [
                         {
                             "id": "test"
                         },
-                        "accession.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "gb": [
-                    [
-                        {
-                            "id": "test"
-                        },
+                        "accession.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
                         "accession.gb:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,a27cd2130904385aca2a6e09203f3528"
+                "versions_mitohifi": [
+                    [
+                        "MITOHIFI_FINDMITOREFERENCE",
+                        "mitohifi",
+                        "3.2.3"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-07-31T10:24:49.138082031"
+        "timestamp": "2026-01-19T12:10:39.371714"
     }
 }

--- a/modules/nf-core/mitohifi/mitohifi/main.nf
+++ b/modules/nf-core/mitohifi/mitohifi/main.nf
@@ -6,9 +6,8 @@ process MITOHIFI_MITOHIFI {
     container 'ghcr.io/marcelauliano/mitohifi:3.2.3'
 
     input:
-    tuple val(meta) , path(input)
-    tuple val(meta2), path(ref_fa)
-    tuple val(meta3), path(ref_gb)
+    tuple val(meta) , path(input, arity: '1..*')
+    tuple val(meta2), path(ref_fa), path(ref_gb)
     val input_mode
     val mito_code
 
@@ -29,7 +28,10 @@ process MITOHIFI_MITOHIFI {
     tuple val(meta), path("potential_contigs/")             , emit: potential_contigs          , optional: true
     tuple val(meta), path("reads_mapping_and_assembly/")    , emit: reads_mapping_and_assembly , optional: true
     tuple val(meta), path("shared_genes.tsv")               , emit: shared_genes               , optional: true
-    path  "versions.yml"                                    , emit: versions
+    tuple val(meta), path("*.log")                          , emit: log
+    // WARN: Incorrect version information is provided by tool on CLI. Please update this string when bumping container versions.
+    // old version command: \$(mitohifi.py -v | sed 's/.* //')
+    tuple val("${task.process}"), val('mitohifi'), eval('echo 3.2.3'), emit: versions_mitohifi, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -37,39 +39,52 @@ process MITOHIFI_MITOHIFI {
     script:
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        error "MitoHiFi module does not support Conda. Please use Docker / Singularity instead."
+        error "Error: MitoHiFi module does not support Conda. Please use Docker / Singularity instead."
     }
 
-    def args      = task.ext.args ?: ''
-    def input_arg = ""
-    if(input_mode == "contigs") {
-        input_arg = "-c ${input}"
-    } else if(input_mode == "reads"){
-        input_arg = "-r ${input}"
-    } else {
+    // Check input compression
+    def isGzipped = input.collect { f -> file(f).getExtension() == "gz" }
+    if (isGzipped.any() && input_mode == "contigs") {
+        error("Error: Running Mitohifi in contigs mode requires uncompressed input!")
+    }
+    if (isGzipped.any() && !isGzipped.every()) {
+        error("Error: MitoHiFi requires all inputs to either be uncompressed or compressed!")
+    }
+
+    // Set up the input mode argument
+    def modeMap = [contigs: '-c', reads: '-r']
+    if (!modeMap.containsKey(input_mode)) {
         error "Error: invalid MitoHiFi input mode: ${input_mode}. Must be either 'contigs' or 'reads'!"
     }
-    // WARN: Incorrect version information is provided by tool on CLI. Please update this string when bumping container versions.
-    def VERSION   = '3.2.3'
+    def input_mode_arg = modeMap[input_mode]
+
+    // Concatenate inputs together if more than one. We have to do this via a call to
+    // cat as using process substitution doesn't work as the inputs are passed to
+    // other subshells
+    def temp_ext = isGzipped.every() ? "fa.gz" : "fa"
+    def concatenate_command = input.size() > 1 ? "cat ${input} > temp_input.${temp_ext}" : ""
+    def input_string = input.size() > 1 ? "temp_input.${temp_ext}" : "${input}"
+    def cleanup = input.size() > 1 ? "rm temp_input.${temp_ext}" : ""
+
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
+    ${concatenate_command}
+
     mitohifi.py \\
-        ${input_arg} \\
+        ${input_mode_arg} ${input_string} \\
         -f ${ref_fa} \\
         -g ${ref_gb} \\
         -o ${mito_code} \\
         -t $task.cpus \\
-        ${args}
+        ${args} \\
+        | tee ${prefix}.log
 
-    ## old version command: \$(mitohifi.py -v | sed 's/.* //')
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        mitohifi: ${VERSION}
-    END_VERSIONS
+    ${cleanup}
     """
 
     stub:
-    // WARN: Incorrect version information is provided by tool on CLI. Please update this string when bumping container versions.
-    def VERSION = '3.2.3'
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch final_mitogenome.fasta
     touch final_mitogenome.gb
@@ -81,6 +96,8 @@ process MITOHIFI_MITOHIFI {
     touch final_mitogenome.annotation.png
     touch final_mitogenome.coverage.png
     touch shared_genes.tsv
+    touch shared_genes.tsv
+    touch ${prefix}.log
 
     mkdir contigs_circularization
     mkdir contigs_filtering
@@ -88,10 +105,5 @@ process MITOHIFI_MITOHIFI {
     mkdir final_mitogenome_choice
     mkdir potential_contigs
     mkdir reads_mapping_and_assembly
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        mitohifi: ${VERSION}
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/mitohifi/mitohifi/meta.yml
+++ b/modules/nf-core/mitohifi/mitohifi/meta.yml
@@ -37,11 +37,6 @@ input:
         pattern: "*.{fa,fasta}"
         ontologies:
           - edam: http://edamontology.org/format_1929 # FASTA
-  - - meta3:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
     - ref_gb:
         type: file
         description: Reference mitochondrial genome annotation
@@ -246,14 +241,41 @@ output:
           pattern: "shared_genes.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: directory
+          description: Log file describing Mitohifi run
+          pattern: "*.log"
+          ontologies:
+            - edam: http://edamontology.org/data_3671 # Text
+  versions_mitohifi:
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - mitohifi:
+          type: string
+          description: The name of the tool
+      - echo 3.2.3:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - mitohifi:
+          type: string
+          description: The name of the tool
+      - echo 3.2.3:
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@ksenia-krasheninnikova"
+  - "@prototaxites"
 maintainers:
   - "@ksenia-krasheninnikova"

--- a/modules/nf-core/mitohifi/mitohifi/tests/main.nf.test
+++ b/modules/nf-core/mitohifi/mitohifi/tests/main.nf.test
@@ -40,17 +40,12 @@ nextflow_process {
                 input[1] = Channel.of(
                     [
                         [id: "ref"],
-                        file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true)
-                    ]
-                )
-                input[2] = Channel.of(
-                    [
-                        [id: "ref"],
+                        file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true),
                         file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.gb", checkIfExists: true)
                     ]
                 )
-                input[3] = Channel.of('contigs')
-                input[4] = Channel.of(5)
+                input[2] = Channel.of('contigs')
+                input[3] = Channel.of(5)
                 """
             }
         }
@@ -69,7 +64,7 @@ nextflow_process {
                     process.out.final_mitogenome_coverage,
                     process.out.shared_genes,
                     process.out.contigs_annotations,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
             )
@@ -91,17 +86,12 @@ nextflow_process {
                 input[1] = Channel.of(
                     [
                         [id: "ref"],
-                        file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true)
-                    ]
-                )
-                input[2] = Channel.of(
-                    [
-                        [id: "ref"],
+                        file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true),
                         file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.gb", checkIfExists: true)
                     ]
                 )
-                input[3] = Channel.of('reads')
-                input[4] = Channel.of(5)
+                input[2] = Channel.of('reads')
+                input[3] = Channel.of(5)
                 """
             }
         }
@@ -120,7 +110,56 @@ nextflow_process {
                     process.out.final_mitogenome_coverage,
                     process.out.shared_genes,
                     process.out.contigs_annotations,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions")}
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("mitohifi - mitohifi - deilephila_porcellus - reads mode - multiple inputs") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(
+                    [
+                        [id:"ilDeiPorc1"],
+                        [
+                            file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/ilDeiPorc1.HiFi.reads.fa", checkIfExists: true),
+                            file(params.modules_testdata_base_path + "genomics/homo_sapiens/pacbio/fasta/alz.ccs.fasta", checkIfExists: true)
+                        ]
+                    ]
+                )
+                input[1] = Channel.of(
+                    [
+                        [id: "ref"],
+                        file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true),
+                        file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.gb", checkIfExists: true)
+                    ]
+                )
+                input[2] = Channel.of('reads')
+                input[3] = Channel.of(5)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.fasta,
+                    file(process.out.stats.get(0).get(1)).name, // not stable
+                    process.out.gb,
+                    process.out.gff,
+                    process.out.contigs_annotations,
+                    process.out.coverage_plot,
+                    process.out.final_mitogenome_annotation,
+                    process.out.final_mitogenome_coverage,
+                    process.out.shared_genes,
+                    process.out.contigs_annotations,
+                    process.out.findAll { key, val -> key.startsWith("versions")}
                     ).match()
                 }
             )
@@ -144,17 +183,12 @@ nextflow_process {
                 input[1] = Channel.of(
                     [
                         [id: "ref"],
-                        file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true)
-                    ]
-                )
-                input[2] = Channel.of(
-                    [
-                        [id: "ref"],
+                        file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true),
                         file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.gb", checkIfExists: true)
                     ]
                 )
-                input[3] = Channel.of('contigs')
-                input[4] = Channel.of(5)
+                input[2] = Channel.of('contigs')
+                input[3] = Channel.of(5)
                 """
             }
         }

--- a/modules/nf-core/mitohifi/mitohifi/tests/main.nf.test.snap
+++ b/modules/nf-core/mitohifi/mitohifi/tests/main.nf.test.snap
@@ -1,4 +1,90 @@
 {
+    "mitohifi - mitohifi - deilephila_porcellus - reads mode - multiple inputs": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.fasta:md5,f49bee6e046ba58206be0bbb9dc689fd"
+                ]
+            ],
+            "contigs_stats.tsv",
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.gb:md5,10077fa6938d3da1aa875ff6c5585246"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "contigs_annotations.png:md5,0efdb60ca64983f36dd20e9c26a948d4"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "coverage_plot.png:md5,5b21b49d07190f9bee30b19e17c269a0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.annotation.png:md5,93678b20020d52121ebb5e3527317820"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.coverage.png:md5,decea4407ddbae9258f6ca2d4f63cb09"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "shared_genes.tsv:md5,5f5c7498ab370f4a2c9b8e5f8b43befa"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "contigs_annotations.png:md5,0efdb60ca64983f36dd20e9c26a948d4"
+                ]
+            ],
+            {
+                "versions_mitohifi": [
+                    [
+                        "MITOHIFI_MITOHIFI",
+                        "mitohifi",
+                        "3.2.3"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2026-01-19T15:46:06.062753"
+    },
     "mitohifi - mitohifi - deilephila_porcellus - contigs mode": {
         "content": [
             [
@@ -59,15 +145,21 @@
                     "contigs_annotations.png:md5,cfecd6df724c880e98f2a1a79cc77a7e"
                 ]
             ],
-            [
-                "versions.yml:md5,b162f6c6ed3625038a867605484cd250"
-            ]
+            {
+                "versions_mitohifi": [
+                    [
+                        "MITOHIFI_MITOHIFI",
+                        "mitohifi",
+                        "3.2.3"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-08-14T13:57:01.39238231"
+        "timestamp": "2026-01-19T13:05:50.378093"
     },
     "mitohifi - mitohifi - deilephila_porcellus - stub": {
         "content": [
@@ -143,7 +235,19 @@
                     ]
                 ],
                 "16": [
-                    "versions.yml:md5,b162f6c6ed3625038a867605484cd250"
+                    [
+                        {
+                            "id": "ilDeiPorc1"
+                        },
+                        "ilDeiPorc1.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "17": [
+                    [
+                        "MITOHIFI_MITOHIFI",
+                        "mitohifi",
+                        "3.2.3"
+                    ]
                 ],
                 "2": [
                     [
@@ -319,6 +423,14 @@
                         "final_mitogenome.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "log": [
+                    [
+                        {
+                            "id": "ilDeiPorc1"
+                        },
+                        "ilDeiPorc1.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
                 "potential_contigs": [
                     [
                         {
@@ -355,16 +467,20 @@
                         "contigs_stats.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,b162f6c6ed3625038a867605484cd250"
+                "versions_mitohifi": [
+                    [
+                        "MITOHIFI_MITOHIFI",
+                        "mitohifi",
+                        "3.2.3"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-07-31T10:23:03.947249547"
+        "timestamp": "2026-01-19T13:28:49.36922"
     },
     "mitohifi - mitohifi - deilephila_porcellus - reads mode": {
         "content": [
@@ -436,14 +552,20 @@
                     "contigs_annotations.png:md5,0efdb60ca64983f36dd20e9c26a948d4"
                 ]
             ],
-            [
-                "versions.yml:md5,b162f6c6ed3625038a867605484cd250"
-            ]
+            {
+                "versions_mitohifi": [
+                    [
+                        "MITOHIFI_MITOHIFI",
+                        "mitohifi",
+                        "3.2.3"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.0"
         },
-        "timestamp": "2025-08-14T14:11:47.404561584"
+        "timestamp": "2026-01-19T13:28:41.036905"
     }
 }


### PR DESCRIPTION
This PR:

- Updates mitohifi/mitohifi and mitohifi/findmitoreference to topic versions
- Updates mitohifi/findmitoreference to emit outputs in a single tuple, as they are a combined input to mitohifi/mitohifi
- Allows mitohifi/mitohifi to take in multiple input files (e.g. multiple assemblies or read fasta files), temporarily concatenating them before deleting them
- Adds a log file to the mitohifi output
- Adds some input validation to Mitohifi

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
