### PR TITLE
feat(yallhap/classify): Add new module for Y-chromosome haplogroup classification

### DIFF
--- a/modules/nf-core/yallhap/classify/environment.yml
+++ b/modules/nf-core/yallhap/classify/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::yallhap=0.4.0

--- a/modules/nf-core/yallhap/classify/main.nf
+++ b/modules/nf-core/yallhap/classify/main.nf
@@ -1,0 +1,46 @@
+process YALLHAP_CLASSIFY {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/yallhap:0.4.0--pyhdfd78af_0':
+        'biocontainers/yallhap:0.4.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(vcf), path(tbi)
+    tuple val(meta2), path(tree)
+    tuple val(meta3), path(snp_db)
+
+    output:
+    tuple val(meta), path("*.json"), emit: json, optional: true
+    tuple val(meta), path("*.tsv") , emit: tsv , optional: true
+    tuple val("${task.process}"), val('yallhap'), eval("yallhap --version | sed 's/.*version //'"), emit: versions_yallhap, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def format = task.ext.format ?: 'json'
+    def output_ext = format == 'tsv' ? 'tsv' : 'json'
+    """
+    yallhap \\
+        classify \\
+        ${vcf} \\
+        --tree ${tree} \\
+        --snp-db ${snp_db} \\
+        --format ${format} \\
+        --output ${prefix}.${output_ext} \\
+        ${args}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def format = task.ext.format ?: 'json'
+    def output_ext = format == 'tsv' ? 'tsv' : 'json'
+    """
+    touch ${prefix}.${output_ext}
+    """
+}

--- a/modules/nf-core/yallhap/classify/meta.yml
+++ b/modules/nf-core/yallhap/classify/meta.yml
@@ -1,0 +1,109 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "yallhap_classify"
+description: Y-chromosome haplogroup classification from VCF files
+keywords:
+  - haplogroups
+  - Y-chromosome
+  - ydna
+  - ancient DNA
+  - classify
+  - phylogenetics
+tools:
+  - "yallhap":
+      description: "Modern Y-chromosome haplogroup inference tool supporting modern and ancient DNA with probabilistic confidence scoring"
+      homepage: "https://github.com/trianglegrrl/yallHap"
+      documentation: "https://github.com/trianglegrrl/yallHap#readme"
+      tool_dev_url: "https://github.com/trianglegrrl/yallHap"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - vcf:
+        type: file
+        description: VCF file containing Y-chromosome variants
+        pattern: "*.{vcf,vcf.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_3016 # VCF
+    - tbi:
+        type: file
+        description: Index file for the VCF (optional for uncompressed VCF)
+        pattern: "*.{tbi,csi}"
+        ontologies:
+          - edam: http://edamontology.org/format_3700 # Tabix index
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference tree information
+          e.g. [ id:'yfull' ]
+    - tree:
+        type: file
+        description: YFull phylogenetic tree in JSON format
+        pattern: "*.json"
+        ontologies:
+          - edam: http://edamontology.org/format_3464 # JSON
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing SNP database information
+          e.g. [ id:'ybrowse_grch38' ]
+    - snp_db:
+        type: file
+        description: SNP database CSV file (YBrowse format) with variant positions
+        pattern: "*.csv"
+        ontologies:
+          - edam: http://edamontology.org/format_3752 # CSV
+output:
+  json:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.json":
+          type: file
+          description: JSON file containing haplogroup classification results
+          pattern: "*.json"
+          ontologies:
+            - edam: http://edamontology.org/format_3464 # JSON
+  tsv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.tsv":
+          type: file
+          description: TSV file containing haplogroup classification results
+          pattern: "*.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  versions_yallhap:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - yallhap:
+          type: string
+          description: The tool name
+      - "yallhap --version | sed 's/.*version //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - yallhap:
+          type: string
+          description: The tool name
+      - "yallhap --version | sed 's/.*version //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@trianglegrrl"
+maintainers:
+  - "@trianglegrrl"

--- a/modules/nf-core/yallhap/classify/tests/main.nf.test
+++ b/modules/nf-core/yallhap/classify/tests/main.nf.test
@@ -1,0 +1,55 @@
+
+nextflow_process {
+
+    name "Test Process YALLHAP_CLASSIFY"
+    script "../main.nf"
+    process "YALLHAP_CLASSIFY"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "yallhap"
+    tag "yallhap/classify"
+
+    test("homo_sapiens - chrY vcf - stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                // Create minimal stub files for testing
+                def vcf_file = file("\${workDir}/test_chrY.vcf.gz")
+                vcf_file.text = ""
+                def tbi_file = file("\${workDir}/test_chrY.vcf.gz.tbi")
+                tbi_file.text = ""
+                def tree_file = file("\${workDir}/yfull_tree.json")
+                tree_file.text = "{}"
+                def snp_db_file = file("\${workDir}/ybrowse_snps.csv")
+                snp_db_file.text = "name,grch38_pos,ancestral,derived,haplogroup"
+
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    vcf_file,
+                    tbi_file
+                ]
+                input[1] = [
+                    [ id:'yfull' ],
+                    tree_file
+                ]
+                input[2] = [
+                    [ id:'ybrowse' ],
+                    snp_db_file
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/yallhap/classify/tests/main.nf.test.snap
+++ b/modules/nf-core/yallhap/classify/tests/main.nf.test.snap
@@ -1,0 +1,49 @@
+{
+    "homo_sapiens - chrY vcf - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "YALLHAP_CLASSIFY",
+                        "yallhap",
+                        "0.1.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv": [
+                    
+                ],
+                "versions_yallhap": [
+                    [
+                        "YALLHAP_CLASSIFY",
+                        "yallhap",
+                        "0.1.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2026-01-19T19:58:07.267441"
+    }
+}


### PR DESCRIPTION
## IMPORTANT: Requires this test-datasets PR:

https://github.com/nf-core/test-datasets/pull/1842

## Summary

Add new module `yallhap/classify` for Y-chromosome haplogroup classification from VCF files.

**yallhap** is a modern Y-chromosome haplogroup inference tool that supports:
- Modern and ancient DNA samples (with configurable depth/quality thresholds)
- Probabilistic confidence scoring with QC metrics
- YFull phylogenetic tree and YBrowse SNP database
- GRCh37, GRCh38, and T2T reference genomes
- JSON and TSV output formats

### Module inputs
- VCF file with Y-chromosome variants (+ optional index)
- YFull tree JSON file
- YBrowse SNP database CSV file

### Module outputs
- JSON or TSV file with haplogroup classification, confidence scores, and SNP statistics

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `nf-core modules lint yallhap/classify` passes (47 tests, 2 warnings about container links pending bioconda build propagation)
- [x] Local stub test runs successfully
- [x] Tested locally with real ancient DNA data (Kennewick Man sample → correctly classified as Q-L53)

## Notes

The container link warnings are expected - yallhap 0.4.0 is available on bioconda but containers may still be building/propagating.

For ancient DNA samples with low coverage, users should pass `--min-depth 1 --min-quality 0` via `ext.args`.