### PR TITLE
fix: kraken2 version topics + dependent subworkflows

### DIFF
--- a/modules/nf-core/kraken2/kraken2/main.nf
+++ b/modules/nf-core/kraken2/kraken2/main.nf
@@ -18,7 +18,8 @@ process KRAKEN2_KRAKEN2 {
     tuple val(meta), path('*.unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
     tuple val(meta), path('*classifiedreads.txt')   , optional:true, emit: classified_reads_assignment
     tuple val(meta), path('*report.txt')                           , emit: report
-    path "versions.yml"                                            , emit: versions
+    tuple val("${task.process}"), val('kraken2'), eval('kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//"'), topic: versions, emit: versions_kraken2
+    tuple val("${task.process}"), val('pigz'), eval('pigz --version 2>&1 | sed "s/pigz //g"'), topic: versions, emit: versions_pigz
 
     when:
     task.ext.when == null || task.ext.when
@@ -48,22 +49,12 @@ process KRAKEN2_KRAKEN2 {
         $reads
 
     $compress_reads_command
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def paired       = meta.single_end ? "" : "--paired"
     def classified   = meta.single_end ? "${prefix}.classified.fastq.gz"   : "${prefix}.classified_1.fastq.gz ${prefix}.classified_2.fastq.gz"
     def unclassified = meta.single_end ? "${prefix}.unclassified.fastq.gz" : "${prefix}.unclassified_1.fastq.gz ${prefix}.unclassified_2.fastq.gz"
-    def readclassification_option = save_reads_assignment ? "--output ${prefix}.kraken2.classifiedreads.txt" : "--output /dev/null"
-    def compress_reads_command = save_output_fastqs ? "pigz -p $task.cpus *.fastq" : ""
 
     """
     touch ${prefix}.kraken2.report.txt
@@ -74,12 +65,6 @@ process KRAKEN2_KRAKEN2 {
     if [ "$save_reads_assignment" == "true" ]; then
         touch ${prefix}.kraken2.classifiedreads.txt
     fi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 
 }

--- a/modules/nf-core/kraken2/kraken2/meta.yml
+++ b/modules/nf-core/kraken2/kraken2/meta.yml
@@ -91,13 +91,48 @@ output:
             and not classified reads.
           pattern: "*.{report.txt}"
           ontologies: []
+  versions_kraken2:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - kraken2:
+          type: string
+          description: The tool name
+      - kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_pigz:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - pigz:
+          type: string
+          description: The tool name
+      - pigz --version 2>&1 | sed "s/pigz //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - kraken2:
+          type: string
+          description: The tool name
+      - kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - pigz:
+          type: string
+          description: The tool name
+      - pigz --version 2>&1 | sed "s/pigz //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test
@@ -48,7 +48,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1) ==~ ".*/test.classified.fastq.gz" },
@@ -91,7 +91,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1).get(0)
@@ -133,7 +133,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                     process.out.classified_reads_assignment,
                 ).match()
             },
@@ -164,7 +164,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1) ==~ ".*/test.classified.fastq.gz" },
@@ -196,7 +196,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1).get(0)

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test.snap
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test.snap
@@ -10,15 +10,28 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.04.8"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-29T10:39:33.16840511"
+        "timestamp": "2026-01-19T17:22:36.682041524"
     },
     "paired_end - stub": {
         "content": [
@@ -31,15 +44,28 @@
                     "test.kraken2.report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.04.8"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-29T10:57:46.285333986"
+        "timestamp": "2026-01-19T17:22:59.824433284"
     },
     "sarscov2 custom_prefix - stub": {
         "content": [
@@ -76,15 +102,28 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-09-26T10:40:12.99538483"
+        "timestamp": "2026-01-19T17:22:42.807626617"
     },
     "sarscov2 illumina single end [fastq] + save_reads_assignment": {
         "content": [
@@ -97,9 +136,22 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ],
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            },
             [
                 [
                     {
@@ -111,10 +163,10 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-04T16:53:38.496195464"
+        "timestamp": "2026-01-19T17:22:48.87201447"
     },
     "single_end - stub": {
         "content": [
@@ -127,14 +179,27 @@
                     "test.kraken2.report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
-            [
-                "versions.yml:md5,3f1efbca96594bcbd7759bd992f3ffda"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.04.8"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-29T10:44:44.698158761"
+        "timestamp": "2026-01-19T17:22:54.351663948"
     }
 }

--- a/subworkflows/nf-core/fastq_contam_seqtk_kraken/main.nf
+++ b/subworkflows/nf-core/fastq_contam_seqtk_kraken/main.nf
@@ -14,8 +14,7 @@ workflow FASTQ_CONTAM_SEQTK_KRAKEN {
         kraken2_db  //string:  [mandatory] path to Kraken2 DB to use for screening
 
     main:
-        ch_reports  = Channel.empty()
-        ch_versions = Channel.empty()
+        ch_reports  = channel.empty()
 
         // Combine all combinations of reads with sample_size(s).
         // Note using more than 1 sample_size can cause file collisions
@@ -37,10 +36,8 @@ workflow FASTQ_CONTAM_SEQTK_KRAKEN {
                 false,
                 false
         )
-        ch_versions = ch_versions.mix(KRAKEN2.out.versions.first())
         ch_reports  = ch_reports.mix(KRAKEN2.out.report)
 
     emit:
         reports  = ch_reports     // channel: [ [meta], log  ]
-        versions = ch_versions    // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-core/fastq_contam_seqtk_kraken/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_contam_seqtk_kraken/tests/main.nf.test.snap
@@ -20,9 +20,6 @@
                         "test.25000.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,43876089a57eebe0df779bf1dddcca2f"
-                ],
                 "reports": [
                     [
                         {
@@ -40,9 +37,6 @@
                         },
                         "test.25000.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                     ]
-                ],
-                "versions": [
-                    "versions.yml:md5,43876089a57eebe0df779bf1dddcca2f"
                 ]
             }
         ],
@@ -73,9 +67,6 @@
                         "test.25000.kraken2.report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,43876089a57eebe0df779bf1dddcca2f"
-                ],
                 "reports": [
                     [
                         {
@@ -93,18 +84,10 @@
                         },
                         "test.25000.kraken2.report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
-                ],
-                "versions": [
-                    "versions.yml:md5,43876089a57eebe0df779bf1dddcca2f"
                 ]
             },
             [
-                {
-                    "FASTQ_CONTAM_SEQTK_KRAKEN:KRAKEN2": {
-                        "kraken2": "2.1.6",
-                        "pigz": 2.8
-                    }
-                }
+
             ]
         ],
         "meta": {
@@ -126,9 +109,6 @@
                         "test.25000.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,43876089a57eebe0df779bf1dddcca2f"
-                ],
                 "reports": [
                     [
                         {
@@ -138,9 +118,6 @@
                         },
                         "test.25000.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                     ]
-                ],
-                "versions": [
-                    "versions.yml:md5,43876089a57eebe0df779bf1dddcca2f"
                 ]
             }
         ],

--- a/subworkflows/nf-core/fastq_extract_kraken_krakentools/main.nf
+++ b/subworkflows/nf-core/fastq_extract_kraken_krakentools/main.nf
@@ -9,10 +9,9 @@ workflow FASTQ_EXTRACT_KRAKEN_KRAKENTOOLS {
     val_taxid // string: taxonomic ids, separated by spaces
 
     main:
-    ch_versions = Channel.empty()
+    ch_versions = channel.empty()
 
     KRAKEN2_KRAKEN2 ( ch_reads, ch_db, true, true )
-    ch_versions = ch_versions.mix(KRAKEN2_KRAKEN2.out.versions.first())
 
     KRAKENTOOLS_EXTRACTKRAKENREADS ( val_taxid, KRAKEN2_KRAKEN2.out.classified_reads_assignment, KRAKEN2_KRAKEN2.out.classified_reads_fastq, KRAKEN2_KRAKEN2.out.report )
     ch_versions = ch_versions.mix( KRAKENTOOLS_EXTRACTKRAKENREADS.out.versions.first() )
@@ -20,6 +19,6 @@ workflow FASTQ_EXTRACT_KRAKEN_KRAKENTOOLS {
     emit:
     kraken2_report          = KRAKEN2_KRAKEN2.out.report                                 // channel: [ val(meta), path ]
     extracted_kraken2_reads = KRAKENTOOLS_EXTRACTKRAKENREADS.out.extracted_kraken2_reads // channel: [ val(meta), [ fastq.gz/fasta.gz ] ]
-    multiqc_files           = KRAKEN2_KRAKEN2.out.report.map{it[1]}                      // channel: [ path ]
+    multiqc_files           = KRAKEN2_KRAKEN2.out.report.map{ _meta, report -> report }  // channel: [ path ]
     versions                = ch_versions                                                // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-core/fastq_extract_kraken_krakentools/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_extract_kraken_krakentools/tests/main.nf.test.snap
@@ -24,8 +24,7 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "3": [
-                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
-                    "versions.yml:md5,8a29ef9cfde33f451ea87a53947031e1"
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -49,16 +48,15 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "versions": [
-                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
-                    "versions.yml:md5,8a29ef9cfde33f451ea87a53947031e1"
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-09-26T10:42:32.854553878"
+        "timestamp": "2026-01-19T15:44:34.794254"
     },
     "sarscov2 illumina paired end with fastq output [fastq]": {
         "content": [
@@ -88,8 +86,7 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "3": [
-                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
-                    "versions.yml:md5,8a29ef9cfde33f451ea87a53947031e1"
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -116,16 +113,15 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "versions": [
-                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
-                    "versions.yml:md5,8a29ef9cfde33f451ea87a53947031e1"
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-09-26T10:42:41.750050399"
+        "timestamp": "2026-01-19T15:44:46.97389"
     },
     "sarscov2 illumina paired end with parents [fastq]": {
         "content": [
@@ -155,8 +151,7 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "3": [
-                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
-                    "versions.yml:md5,8a29ef9cfde33f451ea87a53947031e1"
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe"
                 ],
                 "extracted_kraken2_reads": [
                     [
@@ -183,15 +178,14 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ],
                 "versions": [
-                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe",
-                    "versions.yml:md5,8a29ef9cfde33f451ea87a53947031e1"
+                    "versions.yml:md5,06b939977ab0c1f20d25fe32b0f478fe"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-09-26T10:42:50.996960608"
+        "timestamp": "2026-01-19T15:44:58.876767"
     }
 }


### PR DESCRIPTION
## Summary

Convert kraken2 to topic-based version publishing and update dependent subworkflows.

## Changes

### kraken2 module (version topics)
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs
- Update tests and regenerate snapshots

### Dependent subworkflows
Remove `KRAKEN2.out.versions` mixing (now handled by topics):
- fastq_contam_seqtk_kraken
- fastq_extract_kraken_krakentools

## Context

Split from #9688. kraken2 only triggers 3 components (all included in this PR).

## Test plan

- [ ] CI tests for kraken2 module
- [ ] CI tests for dependent subworkflows

🤖 Generated with [Claude Code](https://claude.ai/code)