### PR TITLE
fix: ucsc + gffread version topics + dependent subworkflows

### DIFF
--- a/modules/nf-core/gffread/meta.yml
+++ b/modules/nf-core/gffread/meta.yml
@@ -68,13 +68,29 @@ output:
             is present
           pattern: "*.fasta"
           ontologies: []
+  versions_gffread:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gffread:
+          type: string
+          description: The tool name
+      - gffread --version 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gffread:
+          type: string
+          description: The tool name
+      - gffread --version 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@edmundmiller"
 maintainers:

--- a/modules/nf-core/gffread/tests/main.nf.test.snap
+++ b/modules/nf-core/gffread/tests/main.nf.test.snap
@@ -17,7 +17,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ],
                 "gffread_fasta": [
                     
@@ -33,16 +37,20 @@
                         "test.gtf:md5,1ea0ae98d3388e0576407dc4a24ef428"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                "versions_gffread": [
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-04-09T10:48:56.496187"
+        "timestamp": "2026-01-19T14:04:00.517880519"
     },
     "sarscov2-gff3-gff3": {
         "content": [
@@ -62,7 +70,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ],
                 "gffread_fasta": [
                     
@@ -78,16 +90,20 @@
                 "gtf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                "versions_gffread": [
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-04-09T10:49:00.892782"
+        "timestamp": "2026-01-19T14:04:11.054206957"
     },
     "sarscov2-gff3-gtf-stub": {
         "content": [
@@ -107,7 +123,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ],
                 "gffread_fasta": [
                     
@@ -123,16 +143,20 @@
                         "test.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                "versions_gffread": [
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-04-09T11:11:26.975666"
+        "timestamp": "2026-01-19T14:04:05.79250369"
     },
     "sarscov2-gff3-fasta-stub": {
         "content": [
@@ -152,7 +176,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ],
                 "gffread_fasta": [
                     [
@@ -168,16 +196,20 @@
                 "gtf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                "versions_gffread": [
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-04-09T11:11:44.34792"
+        "timestamp": "2026-01-19T14:04:26.781173161"
     },
     "sarscov2-gff3-gff3-stub": {
         "content": [
@@ -197,7 +229,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ],
                 "gffread_fasta": [
                     
@@ -213,16 +249,20 @@
                 "gtf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                "versions_gffread": [
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-04-09T11:11:35.221671"
+        "timestamp": "2026-01-19T14:04:16.265299123"
     },
     "sarscov2-gff3-fasta": {
         "content": [
@@ -242,7 +282,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ],
                 "gffread_fasta": [
                     [
@@ -258,15 +302,19 @@
                 "gtf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,05f671c6c6e530acedad0af0a5948dbd"
+                "versions_gffread": [
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-04-09T10:54:02.88143"
+        "timestamp": "2026-01-19T14:04:21.551846584"
     }
 }

--- a/modules/nf-core/ucsc/bedclip/main.nf
+++ b/modules/nf-core/ucsc/bedclip/main.nf
@@ -2,7 +2,6 @@ process UCSC_BEDCLIP {
     tag "$meta.id"
     label 'process_medium'
 
-    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ucsc-bedclip:377--h0b8a92a_2' :
@@ -14,7 +13,7 @@ process UCSC_BEDCLIP {
 
     output:
     tuple val(meta), path("*.bedGraph"), emit: bedgraph
-    path "versions.yml"                , emit: versions
+    tuple val("${task.process}"), val('ucsc'), eval("echo $VERSION"), topic: versions, emit: versions_ucsc
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,28 +21,19 @@ process UCSC_BEDCLIP {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '377' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    VERSION = '377' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     bedClip \\
+        $args \\
         $bedgraph \\
         $sizes \\
         ${prefix}.bedGraph
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ucsc: $VERSION
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '377' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    VERSION = '377' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     touch ${prefix}.bedGraph
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ucsc: $VERSION
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/ucsc/bedclip/meta.yml
+++ b/modules/nf-core/ucsc/bedclip/meta.yml
@@ -37,13 +37,29 @@ output:
           description: bedGraph file
           pattern: "*.{bedgraph}"
           ontologies: []
+  versions_ucsc:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ucsc:
+          type: string
+          description: The tool name
+      - echo $VERSION:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ucsc:
+          type: string
+          description: The tool name
+      - echo $VERSION:
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@drpatelh"
 maintainers:

--- a/modules/nf-core/ucsc/bedclip/tests/main.nf.test.snap
+++ b/modules/nf-core/ucsc/bedclip/tests/main.nf.test.snap
@@ -12,7 +12,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,b92248ce2a138ad4d146ac0d9e71fb34"
+                    [
+                        "UCSC_BEDCLIP",
+                        "ucsc",
+                        "377"
+                    ]
                 ],
                 "bedgraph": [
                     [
@@ -23,16 +27,20 @@
                         "test.clip.bedGraph:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,b92248ce2a138ad4d146ac0d9e71fb34"
+                "versions_ucsc": [
+                    [
+                        "UCSC_BEDCLIP",
+                        "ucsc",
+                        "377"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-06-21T10:31:42.86304"
+        "timestamp": "2026-01-19T14:08:43.009868476"
     },
     "sarscov2": {
         "content": [
@@ -47,7 +55,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,b92248ce2a138ad4d146ac0d9e71fb34"
+                    [
+                        "UCSC_BEDCLIP",
+                        "ucsc",
+                        "377"
+                    ]
                 ],
                 "bedgraph": [
                     [
@@ -58,15 +70,19 @@
                         "test.clip.bedGraph:md5,e02395e1f7c593b3f79563067159ebc2"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,b92248ce2a138ad4d146ac0d9e71fb34"
+                "versions_ucsc": [
+                    [
+                        "UCSC_BEDCLIP",
+                        "ucsc",
+                        "377"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-02-07T16:04:04.165478"
+        "timestamp": "2026-01-19T14:08:37.884007523"
     }
 }

--- a/modules/nf-core/ucsc/bedgraphtobigwig/main.nf
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/main.nf
@@ -2,7 +2,6 @@ process UCSC_BEDGRAPHTOBIGWIG {
     tag "$meta.id"
     label 'process_single'
 
-    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/ucsc-bedgraphtobigwig:469--h9b8f530_0' :
@@ -14,7 +13,7 @@ process UCSC_BEDGRAPHTOBIGWIG {
 
     output:
     tuple val(meta), path("*.bigWig"), emit: bigwig
-    path "versions.yml"              , emit: versions
+    tuple val("${task.process}"), val('ucsc'), eval("echo $VERSION"), topic: versions, emit: versions_ucsc
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,28 +21,19 @@ process UCSC_BEDGRAPHTOBIGWIG {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '469' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    VERSION = '469' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     bedGraphToBigWig \\
+        $args \\
         $bedgraph \\
         $sizes \\
         ${prefix}.bigWig
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ucsc: $VERSION
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '469' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    VERSION = '469' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     touch ${prefix}.bigWig
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ucsc: $VERSION
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/ucsc/bedgraphtobigwig/meta.yml
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/meta.yml
@@ -41,13 +41,29 @@ output:
           description: bigWig file
           pattern: "*.{bigWig}"
           ontologies: []
+  versions_ucsc:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ucsc:
+          type: string
+          description: The tool name
+      - echo $VERSION:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ucsc:
+          type: string
+          description: The tool name
+      - echo $VERSION:
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@drpatelh"
 maintainers:

--- a/modules/nf-core/ucsc/bedgraphtobigwig/tests/main.nf.test.snap
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/tests/main.nf.test.snap
@@ -11,7 +11,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,db26514184acfdf220bb2f061382cf8c"
+                    [
+                        "UCSC_BEDGRAPHTOBIGWIG",
+                        "ucsc",
+                        "469"
+                    ]
                 ],
                 "bigwig": [
                     [
@@ -21,16 +25,20 @@
                         "test.bigWig:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,db26514184acfdf220bb2f061382cf8c"
+                "versions_ucsc": [
+                    [
+                        "UCSC_BEDGRAPHTOBIGWIG",
+                        "ucsc",
+                        "469"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-10-18T10:47:58.558813949"
+        "timestamp": "2026-01-19T14:08:59.289945641"
     },
     "Should run without failures": {
         "content": [
@@ -44,7 +52,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,db26514184acfdf220bb2f061382cf8c"
+                    [
+                        "UCSC_BEDGRAPHTOBIGWIG",
+                        "ucsc",
+                        "469"
+                    ]
                 ],
                 "bigwig": [
                     [
@@ -54,15 +66,19 @@
                         "test.bigWig:md5,910ecc7f57e3bbd5fac5a8edba4f615d"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,db26514184acfdf220bb2f061382cf8c"
+                "versions_ucsc": [
+                    [
+                        "UCSC_BEDGRAPHTOBIGWIG",
+                        "ucsc",
+                        "469"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-10-18T10:47:36.476844229"
+        "timestamp": "2026-01-19T14:08:54.132930562"
     }
 }

--- a/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/main.nf
+++ b/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/main.nf
@@ -12,23 +12,17 @@ workflow BEDGRAPH_BEDCLIP_BEDGRAPHTOBIGWIG {
 
     main:
 
-    ch_versions = Channel.empty()
-
     //
     // Clip bedGraph file
     //
     UCSC_BEDCLIP ( bedgraph, sizes )
-    ch_versions = ch_versions.mix(UCSC_BEDCLIP.out.versions.first())
 
     //
     // Convert bedGraph to bigWig
     //
     UCSC_BEDGRAPHTOBIGWIG ( UCSC_BEDCLIP.out.bedgraph, sizes )
-    ch_versions = ch_versions.mix(UCSC_BEDGRAPHTOBIGWIG.out.versions.first())
 
     emit:
     bigwig   = UCSC_BEDGRAPHTOBIGWIG.out.bigwig // channel: [ val(meta), [ bigwig ] ]
     bedgraph = UCSC_BEDCLIP.out.bedgraph        // channel: [ val(meta), [ bedgraph ] ]
-
-    versions = ch_versions                      // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/tests/main.nf.test.snap
@@ -20,10 +20,6 @@
                         "test.clip.bedGraph:md5,e02395e1f7c593b3f79563067159ebc2"
                     ]
                 ],
-                "2": [
-                    "versions.yml:md5,1202cdc73b5829361d5b150dcf7fe865",
-                    "versions.yml:md5,72a7b07bc0e796ff6805c57f7340337f"
-                ],
                 "bedgraph": [
                     [
                         {
@@ -41,18 +37,14 @@
                         },
                         "test.bigWig:md5,910ecc7f57e3bbd5fac5a8edba4f615d"
                     ]
-                ],
-                "versions": [
-                    "versions.yml:md5,1202cdc73b5829361d5b150dcf7fe865",
-                    "versions.yml:md5,72a7b07bc0e796ff6805c57f7340337f"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-10-18T10:48:23.095911334"
+        "timestamp": "2026-01-19T15:37:58.66559"
     },
     "sarscov2 [bedgraph] [genome_sizes] - stub": {
         "content": [
@@ -75,10 +67,6 @@
                         "test.clip.bedGraph:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "2": [
-                    "versions.yml:md5,1202cdc73b5829361d5b150dcf7fe865",
-                    "versions.yml:md5,72a7b07bc0e796ff6805c57f7340337f"
-                ],
                 "bedgraph": [
                     [
                         {
@@ -96,17 +84,13 @@
                         },
                         "test.bigWig:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
-                ],
-                "versions": [
-                    "versions.yml:md5,1202cdc73b5829361d5b150dcf7fe865",
-                    "versions.yml:md5,72a7b07bc0e796ff6805c57f7340337f"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-10-18T10:48:45.587883209"
+        "timestamp": "2026-01-19T15:38:05.023743"
     }
 }

--- a/subworkflows/nf-core/fasta_gxf_busco_plot/main.nf
+++ b/subworkflows/nf-core/fasta_gxf_busco_plot/main.nf
@@ -115,7 +115,6 @@ workflow FASTA_GXF_BUSCO_PLOT {
     )
 
     ch_proteins                                 = EXTRACT_PROTEINS.out.gffread_fasta
-    ch_versions                                 = ch_versions.mix(EXTRACT_PROTEINS.out.versions.first())
 
     // MODULE: BUSCO_BUSCO as BUSCO_ANNOTATION
     ch_busco_annotation_inputs                  = ch_proteins

--- a/subworkflows/nf-core/fasta_gxf_busco_plot/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_gxf_busco_plot/tests/main.nf.test.snap
@@ -46,7 +46,6 @@
                     
                 ],
                 "12": [
-                    "versions.yml:md5,9435355f913e283f60b4fb7ef77dd52a",
                     "versions.yml:md5,cb686e152763c7fcb8c66470d0009e33",
                     "versions.yml:md5,dbf13e5209eaa4072c85333d8a3bb198"
                 ],
@@ -172,17 +171,16 @@
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,9435355f913e283f60b4fb7ef77dd52a",
                     "versions.yml:md5,cb686e152763c7fcb8c66470d0009e33",
                     "versions.yml:md5,dbf13e5209eaa4072c85333d8a3bb198"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-08-16T12:28:46.710071"
+        "timestamp": "2026-01-19T16:34:28.401750055"
     },
     "candidatus_portiera_aleyrodidarum - bacteroides_fragilis - genome": {
         "content": [
@@ -241,15 +239,14 @@
             [
                 "versions.yml:md5,6eb1b0a0d233d60d3a84b1a7405efd83",
                 "versions.yml:md5,94152c7ab96cf38d45d6db3b9f1a25c3",
-                "versions.yml:md5,9435355f913e283f60b4fb7ef77dd52a",
                 "versions.yml:md5,cb686e152763c7fcb8c66470d0009e33",
                 "versions.yml:md5,dbf13e5209eaa4072c85333d8a3bb198"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-08-16T12:28:30.908372"
+        "timestamp": "2026-01-19T16:34:21.018326929"
     }
 }


### PR DESCRIPTION
## Summary

Convert ucsc/bedclip, ucsc/bedgraphtobigwig, and gffread to topic-based version publishing and update dependent subworkflows.

## Changes

### ucsc/bedclip module (version topics)
- Convert `versions.yml` output to topic-based version publishing
- Use VERSION variable in script block for version topics
- Update meta.yml for topic outputs

### ucsc/bedgraphtobigwig module (version topics)
- Convert `versions.yml` output to topic-based version publishing
- Use VERSION variable in script block for version topics
- Update meta.yml for topic outputs

### gffread module (version topics)
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs

### Dependent subworkflows
- bedgraph_bedclip_bedgraphtobigwig (removes `UCSC_BEDCLIP.out.versions` and `UCSC_BEDGRAPHTOBIGWIG.out.versions` mixing)
- fasta_gxf_busco_plot (removes `GFFREAD.out.versions` mixing)

## Context

Split from #9688. Each module triggers only 1 subworkflow (both included).

## Test plan

- [ ] CI tests for ucsc/bedclip module
- [ ] CI tests for ucsc/bedgraphtobigwig module
- [ ] CI tests for gffread module
- [ ] CI tests for dependent subworkflows

🤖 Generated with [Claude Code](https://claude.ai/code)