### PR TITLE
fix: standalone modules version topics (bracken, sylph, hisat2, rsem)

### DIFF
--- a/modules/nf-core/bracken/bracken/main.nf
+++ b/modules/nf-core/bracken/bracken/main.nf
@@ -14,7 +14,7 @@ process BRACKEN_BRACKEN {
     output:
     tuple val(meta), path(bracken_report)        , emit: reports
     tuple val(meta), path(bracken_kraken_style_report), emit: txt
-    path "versions.yml"          , emit: versions
+    tuple val("${task.process}"), val('bracken'), eval('bracken -v | cut -f2 -d"v"'), topic: versions, emit: versions_bracken
 
     when:
     task.ext.when == null || task.ext.when
@@ -31,25 +31,14 @@ process BRACKEN_BRACKEN {
         -i '${kraken_report}' \\
         -o '${bracken_report}' \\
         -w '${bracken_kraken_style_report}'
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bracken: \$(echo \$(bracken -v) | cut -f2 -d'v')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     bracken_report = "${prefix}.tsv"
     bracken_kraken_style_report = "${prefix}.kraken2.report_bracken.txt"
     """
     touch ${prefix}.tsv
     touch ${bracken_kraken_style_report}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bracken: \$(echo \$(bracken -v) | cut -f2 -d'v')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/bracken/bracken/meta.yml
+++ b/modules/nf-core/bracken/bracken/meta.yml
@@ -60,13 +60,29 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
           pattern: "*.txt"
+  versions_bracken:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bracken:
+          type: string
+          description: The tool name
+      - bracken -v | cut -f2 -d"v":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bracken:
+          type: string
+          description: The tool name
+      - bracken -v | cut -f2 -d"v":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@Midnighter"
 maintainers:

--- a/modules/nf-core/bracken/bracken/tests/main.nf.test.snap
+++ b/modules/nf-core/bracken/bracken/tests/main.nf.test.snap
@@ -21,7 +21,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ],
                 "reports": [
                     [
@@ -41,16 +45,20 @@
                         "test.kraken2.report_bracken.txt:md5,ca0fbeedc4353b5fdd081688823a33df"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                "versions_bracken": [
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:17:09.050813"
+        "timestamp": "2026-01-19T14:03:31.299124251"
     },
     "sarscov2 - paired-end - fastq - genus config": {
         "content": [
@@ -74,7 +82,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ],
                 "reports": [
                     [
@@ -94,16 +106,20 @@
                         "test.kraken2.report_bracken.txt:md5,2ce58814420a3690da1f08e10e8d3a30"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                "versions_bracken": [
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:17:22.479694"
+        "timestamp": "2026-01-19T14:03:38.094543816"
     },
     "sarscov2 - paired-end - fastq": {
         "content": [
@@ -127,7 +143,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ],
                 "reports": [
                     [
@@ -147,16 +167,20 @@
                         "test.kraken2.report_bracken.txt:md5,ca0fbeedc4353b5fdd081688823a33df"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                "versions_bracken": [
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:17:35.489383"
+        "timestamp": "2026-01-19T14:03:44.706209228"
     },
     "sarscov2 - stub - fastq": {
         "content": [
@@ -178,7 +202,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ],
                 "reports": [
                     [
@@ -196,15 +224,19 @@
                         "test.kraken2.report_bracken.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                "versions_bracken": [
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:17:47.183592"
+        "timestamp": "2026-01-19T14:03:50.763300237"
     }
 }

--- a/modules/nf-core/hisat2/extractsplicesites/main.nf
+++ b/modules/nf-core/hisat2/extractsplicesites/main.nf
@@ -12,7 +12,7 @@ process HISAT2_EXTRACTSPLICESITES {
 
     output:
     tuple val(meta), path("*.splice_sites.txt"), emit: txt
-    path "versions.yml"                        , emit: versions
+    tuple val("${task.process}"), val('hisat2'), eval('hisat2 --version | grep -o "version [^ ]*" | cut -d " " -f 2'), topic: versions, emit: versions_hisat2
 
     when:
     task.ext.when == null || task.ext.when
@@ -20,20 +20,14 @@ process HISAT2_EXTRACTSPLICESITES {
     script:
     def args = task.ext.args ?: ''
     """
-    hisat2_extract_splice_sites.py $gtf > ${gtf.baseName}.splice_sites.txt
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        hisat2: \$(hisat2 --version | grep -o 'version [^ ]*' | cut -d ' ' -f 2)
-    END_VERSIONS
+    hisat2_extract_splice_sites.py \\
+        $args \\
+        $gtf \\
+        > ${gtf.baseName}.splice_sites.txt
     """
 
     stub:
     """
     touch ${gtf.baseName}.splice_sites.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        hisat2: \$(hisat2 --version | grep -o 'version [^ ]*' | cut -d ' ' -f 2)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/hisat2/extractsplicesites/meta.yml
+++ b/modules/nf-core/hisat2/extractsplicesites/meta.yml
@@ -38,13 +38,29 @@ output:
           description: Splice sites in txt file
           pattern: "*.txt"
           ontologies: []
+  versions_hisat2:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - hisat2:
+          type: string
+          description: The tool name
+      - hisat2 --version | grep -o "version [^ ]*" | cut -d " " -f 2:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - hisat2:
+          type: string
+          description: The tool name
+      - hisat2 --version | grep -o "version [^ ]*" | cut -d " " -f 2:
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@ntoda03"
   - "@ramprasadn"

--- a/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test
+++ b/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test
@@ -28,7 +28,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert path("${process.out.txt[0][1]}").exists() },
-                { assert snapshot(process.out.versions).match() }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith("versions") }).match() }
             )
         }
     }

--- a/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test.snap
+++ b/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test.snap
@@ -11,7 +11,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,eeea7231fe197810659b8bad4133aff2"
+                    [
+                        "HISAT2_EXTRACTSPLICESITES",
+                        "hisat2",
+                        "2.2.1"
+                    ]
                 ],
                 "txt": [
                     [
@@ -21,27 +25,37 @@
                         "genome.splice_sites.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,eeea7231fe197810659b8bad4133aff2"
+                "versions_hisat2": [
+                    [
+                        "HISAT2_EXTRACTSPLICESITES",
+                        "hisat2",
+                        "2.2.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-06-20T17:34:13.229903"
+        "timestamp": "2026-01-19T13:53:18.228211649"
     },
     "Should run without failures": {
         "content": [
-            [
-                "versions.yml:md5,eeea7231fe197810659b8bad4133aff2"
-            ]
+            {
+                "versions_hisat2": [
+                    [
+                        "HISAT2_EXTRACTSPLICESITES",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2024-01-18T20:56:30.71763"
+        "timestamp": "2026-01-19T13:53:12.997365366"
     }
 }

--- a/modules/nf-core/rsem/preparereference/meta.yml
+++ b/modules/nf-core/rsem/preparereference/meta.yml
@@ -36,13 +36,48 @@ output:
         description: Fasta file of transcripts
         pattern: "rsem/*transcripts.fa"
         ontologies: []
+  versions_rsem:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - rsem:
+          type: string
+          description: The tool name
+      - 'rsem-calculate-expression --version | sed -e "s/Current version: RSEM v//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_star:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - star:
+          type: string
+          description: The tool name
+      - STAR --version | sed -e "s/STAR_//g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - rsem:
+          type: string
+          description: The tool name
+      - 'rsem-calculate-expression --version | sed -e "s/Current version: RSEM v//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - star:
+          type: string
+          description: The tool name
+      - STAR --version | sed -e "s/STAR_//g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@drpatelh"
   - "@kevinmenden"

--- a/modules/nf-core/rsem/preparereference/tests/main.nf.test
+++ b/modules/nf-core/rsem/preparereference/tests/main.nf.test
@@ -27,7 +27,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(process.out.index).match("index")},
                 { assert snapshot(process.out.transcript_fasta).match("transcript_fasta")},
-                { assert snapshot(process.out.versions).match("versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith("versions") }).match("versions") }
             )
         }
     }

--- a/modules/nf-core/rsem/preparereference/tests/main.nf.test.snap
+++ b/modules/nf-core/rsem/preparereference/tests/main.nf.test.snap
@@ -11,7 +11,18 @@
                     "genome.transcripts.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "2": [
-                    "versions.yml:md5,517611c42f6354d3609db1b35fffa397"
+                    [
+                        "RSEM_PREPAREREFERENCE",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "3": [
+                    [
+                        "RSEM_PREPAREREFERENCE",
+                        "star",
+                        "2.7.10a"
+                    ]
                 ],
                 "index": [
                     [
@@ -21,28 +32,52 @@
                 "transcript_fasta": [
                     "genome.transcripts.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
-                "versions": [
-                    "versions.yml:md5,517611c42f6354d3609db1b35fffa397"
+                "versions_rsem": [
+                    [
+                        "RSEM_PREPAREREFERENCE",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "RSEM_PREPAREREFERENCE",
+                        "star",
+                        "2.7.10a"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T14:24:38.229417"
+        "timestamp": "2026-01-19T14:06:19.387360983"
     },
     "versions": {
         "content": [
-            [
-                "versions.yml:md5,517611c42f6354d3609db1b35fffa397"
-            ]
+            {
+                "versions_rsem": [
+                    [
+                        "RSEM_PREPAREREFERENCE",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "RSEM_PREPAREREFERENCE",
+                        "star",
+                        "2.7.10a"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T14:24:27.489566"
+        "timestamp": "2026-01-19T14:53:27.239498"
     },
     "index": {
         "content": [

--- a/modules/nf-core/sylph/profile/main.nf
+++ b/modules/nf-core/sylph/profile/main.nf
@@ -13,7 +13,7 @@ process SYLPH_PROFILE {
 
     output:
     tuple val(meta), path('*.tsv'), emit: profile_out
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('sylph'), eval('sylph -V | awk "{print \$2}"'), topic: versions, emit: versions_sylph
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,22 +29,11 @@ process SYLPH_PROFILE {
         ${database}\\
         ${input} \\
         -o ${prefix}.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sylph: \$(sylph -V | awk '{print \$2}')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input = meta.single_end ? "${reads}" : "-1 ${reads[0]} -2 ${reads[1]}"
     """
     touch ${prefix}.tsv
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sylph: \$(sylph -V | awk '{print \$2}')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sylph/profile/meta.yml
+++ b/modules/nf-core/sylph/profile/meta.yml
@@ -45,13 +45,29 @@ output:
             and ANIs.
           pattern: "*tsv"
           ontologies: []
+  versions_sylph:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sylph:
+          type: string
+          description: The tool name
+      - sylph -V | awk "{print \$2}":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sylph:
+          type: string
+          description: The tool name
+      - sylph -V | awk "{print \$2}":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@jiahang1234"
   - "@sofstam"

--- a/modules/nf-core/sylph/profile/tests/main.nf.test
+++ b/modules/nf-core/sylph/profile/tests/main.nf.test
@@ -25,7 +25,7 @@ nextflow_process {
         then {
             assert process.success
             assert snapshot(
-                process.out.versions,
+                process.out.findAll { key, val -> key.startsWith("versions") },
                 file(process.out.profile_out[0][1]).readLines()[0]
             ).match()
         }
@@ -49,7 +49,7 @@ nextflow_process {
         then {
             assert process.success
             assert snapshot(
-                process.out.versions,
+                process.out.findAll { key, val -> key.startsWith("versions") },
                 file(process.out.profile_out[0][1]).readLines()[0]
             ).match()
         }

--- a/modules/nf-core/sylph/profile/tests/main.nf.test.snap
+++ b/modules/nf-core/sylph/profile/tests/main.nf.test.snap
@@ -1,29 +1,41 @@
 {
     "sarscov2 illumina paired-end [fastq_gz]": {
         "content": [
-            [
-                "versions.yml:md5,375b8094ea3bcac7fbc91f023399030c"
-            ],
+            {
+                "versions_sylph": [
+                    [
+                        "SYLPH_PROFILE",
+                        "sylph",
+                        "sylph 0.9.0"
+                    ]
+                ]
+            },
             "Sample_file\tGenome_file\tTaxonomic_abundance\tSequence_abundance\tAdjusted_ANI\tEff_cov\tANI_5-95_percentile\tEff_lambda\tLambda_5-95_percentile\tMedian_cov\tMean_cov_geq1\tContainment_ind\tNaive_ANI\tkmers_reassigned\tContig_name"
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-12T08:37:31.364901836"
+        "timestamp": "2026-01-19T13:53:39.426666755"
     },
     "sarscov2 illumina single-end [fastq_gz]": {
         "content": [
-            [
-                "versions.yml:md5,375b8094ea3bcac7fbc91f023399030c"
-            ],
+            {
+                "versions_sylph": [
+                    [
+                        "SYLPH_PROFILE",
+                        "sylph",
+                        "sylph 0.9.0"
+                    ]
+                ]
+            },
             "Sample_file\tGenome_file\tTaxonomic_abundance\tSequence_abundance\tAdjusted_ANI\tEff_cov\tANI_5-95_percentile\tEff_lambda\tLambda_5-95_percentile\tMedian_cov\tMean_cov_geq1\tContainment_ind\tNaive_ANI\tkmers_reassigned\tContig_name"
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-12T08:37:25.178678744"
+        "timestamp": "2026-01-19T13:53:34.383249183"
     },
     "sarscov2 illumina paired-end [fastq_gz]-stub": {
         "content": [
@@ -37,7 +49,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,375b8094ea3bcac7fbc91f023399030c"
+                    [
+                        "SYLPH_PROFILE",
+                        "sylph",
+                        "sylph 0.9.0"
+                    ]
                 ],
                 "profile_out": [
                     [
@@ -47,15 +63,19 @@
                         "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,375b8094ea3bcac7fbc91f023399030c"
+                "versions_sylph": [
+                    [
+                        "SYLPH_PROFILE",
+                        "sylph",
+                        "sylph 0.9.0"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-12T08:37:38.345852673"
+        "timestamp": "2026-01-19T13:53:44.570456167"
     }
 }


### PR DESCRIPTION
## Summary

Convert standalone modules to topic-based version publishing. These modules have no subworkflow dependencies or only test-only triggers with no known issues.

## Modules

### bracken/bracken
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs
- No external dependencies (0 triggers)

### sylph/profile
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs
- No external dependencies (0 triggers)

### hisat2/extractsplicesites
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs
- 1 test-only trigger (fastq_align_hisat2) with no known issues

### rsem/preparereference
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs
- 1 test-only trigger (fastq_align_star) with no known issues

## Context

Split from #9688. These are standalone modules with minimal test trigger dependencies.

## Test plan

- [ ] CI tests for bracken/bracken module
- [ ] CI tests for sylph/profile module
- [ ] CI tests for hisat2/extractsplicesites module
- [ ] CI tests for rsem/preparereference module

🤖 Generated with [Claude Code](https://claude.ai/code)