### PR TITLE
fix: sentieon modules version topics

### DIFF
--- a/modules/nf-core/sentieon/rsemcalculateexpression/meta.yml
+++ b/modules/nf-core/sentieon/rsemcalculateexpression/meta.yml
@@ -76,13 +76,6 @@ output:
           description: RSEM logs
           pattern: "*.log"
           ontologies: []
-  versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
   bam_star:
     - - meta:
           type: map
@@ -116,6 +109,67 @@ output:
           description: Transcript BAM file (optional)
           pattern: "*.transcript.bam"
           ontologies: []
+  versions_rsem:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - rsem:
+          type: string
+          description: The tool name
+      - 'rsem-calculate-expression --version | sed -e "s/Current version: RSEM v//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_star:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - star:
+          type: string
+          description: The tool name
+      - STAR --version | sed -e "s/STAR_//g":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version 2>&1 | sed -e "s/sentieon-genomics-//g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - rsem:
+          type: string
+          description: The tool name
+      - 'rsem-calculate-expression --version | sed -e "s/Current version: RSEM v//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - star:
+          type: string
+          description: The tool name
+      - STAR --version | sed -e "s/STAR_//g":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - sentieon driver --version 2>&1 | sed -e "s/sentieon-genomics-//g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@FriederikeHanssen"
 maintainers:

--- a/modules/nf-core/sentieon/rsemcalculateexpression/tests/main.nf.test
+++ b/modules/nf-core/sentieon/rsemcalculateexpression/tests/main.nf.test
@@ -47,7 +47,7 @@ nextflow_process {
                     process.out.counts_gene,
                     process.out.counts_transcript,
                     process.out.stat,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -93,7 +93,7 @@ nextflow_process {
                     process.out.counts_gene,
                     process.out.counts_transcript,
                     process.out.stat,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() },
                 { assert path(process.out.logs.get(0).get(1)).exists() }
             )
@@ -140,7 +140,7 @@ nextflow_process {
                 { assert path(process.out.stat.get(0).get(1)).exists() },
                 { assert path(process.out.logs.get(0).get(1)).exists() },
                 { assert snapshot(
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }

--- a/modules/nf-core/sentieon/rsemcalculateexpression/tests/main.nf.test.snap
+++ b/modules/nf-core/sentieon/rsemcalculateexpression/tests/main.nf.test.snap
@@ -1,9 +1,29 @@
 {
     "homo_sapiens - stub": {
         "content": [
-            [
-                "versions.yml:md5,2c37927aa617a24c43688228944f4a96"
-            ]
+            {
+                "versions_rsem": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.2",
@@ -44,9 +64,29 @@
                     ]
                 ]
             ],
-            [
-                "versions.yml:md5,253b43edb079232ffcdf0b741134cce9"
-            ]
+            {
+                "versions_rsem": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.2",
@@ -87,9 +127,29 @@
                     ]
                 ]
             ],
-            [
-                "versions.yml:md5,253b43edb079232ffcdf0b741134cce9"
-            ]
+            {
+                "versions_rsem": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_RSEMCALCULATEEXPRESSION",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.2",

--- a/modules/nf-core/sentieon/rsemcalculateexpression/tests/nextflow.config
+++ b/modules/nf-core/sentieon/rsemcalculateexpression/tests/nextflow.config
@@ -12,12 +12,13 @@ process {
 
 }
 
-env {
-    // NOTE This is how pipeline users will use Sentieon in real world use
-    SENTIEON_LICENSE = "$SENTIEON_LICSRVR_IP"
-    // NOTE This should only happen in GitHub actions or nf-core MegaTests
-    SENTIEON_AUTH_MECH = "$SENTIEON_AUTH_MECH"
-    SENTIEON_AUTH_DATA = secrets.SENTIEON_AUTH_DATA
-    // NOTE This is how pipeline users will test out Sentieon with a license file
-    // nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)
-}
+// Sentieon environment configuration
+// NOTE This is how pipeline users will use Sentieon in real world use
+env.SENTIEON_LICENSE    = System.getenv('SENTIEON_LICSRVR_IP') ?: ''
+
+// NOTE This should only happen in GitHub actions or nf-core MegaTests
+env.SENTIEON_AUTH_MECH  = System.getenv('SENTIEON_AUTH_MECH') ?: ''
+env.SENTIEON_AUTH_DATA  = secrets.SENTIEON_AUTH_DATA ?: ''
+
+// NOTE This is how pipeline users will test out Sentieon with a license file
+// nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)

--- a/modules/nf-core/sentieon/rsempreparereference/meta.yml
+++ b/modules/nf-core/sentieon/rsempreparereference/meta.yml
@@ -37,13 +37,67 @@ output:
         description: Fasta file of transcripts
         pattern: "rsem/*transcripts.fa"
         ontologies: []
+  versions_rsem:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - rsem:
+          type: string
+          description: The tool name
+      - 'rsem-calculate-expression --version | sed -e "s/Current version: RSEM v//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_star:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - star:
+          type: string
+          description: The tool name
+      - 'STAR --version | sed -e "s/STAR_//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version 2>&1 | sed -e "s/sentieon-genomics-//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - rsem:
+          type: string
+          description: The tool name
+      - 'rsem-calculate-expression --version | sed -e "s/Current version: RSEM v//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - star:
+          type: string
+          description: The tool name
+      - 'STAR --version | sed -e "s/STAR_//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version 2>&1 | sed -e "s/sentieon-genomics-//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@FriederikeHanssen"
 maintainers:

--- a/modules/nf-core/sentieon/rsempreparereference/tests/main.nf.test
+++ b/modules/nf-core/sentieon/rsempreparereference/tests/main.nf.test
@@ -28,7 +28,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.index,
                     process.out.transcript_fasta,
-                    path(process.out.versions[0]).yaml
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }

--- a/modules/nf-core/sentieon/rsempreparereference/tests/main.nf.test.snap
+++ b/modules/nf-core/sentieon/rsempreparereference/tests/main.nf.test.snap
@@ -11,7 +11,25 @@
                     "genome.transcripts.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "2": [
-                    "versions.yml:md5,5701c66cf1e2c8475b2903d95df99db5"
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "3": [
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ],
+                "4": [
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "sentieon",
+                        "202503.01"
+                    ]
                 ],
                 "index": [
                     [
@@ -21,8 +39,26 @@
                 "transcript_fasta": [
                     "genome.transcripts.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
-                "versions": [
-                    "versions.yml:md5,5701c66cf1e2c8475b2903d95df99db5"
+                "versions_rsem": [
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "star",
+                        "2.7.10b"
+                    ]
                 ]
             }
         ],
@@ -50,11 +86,27 @@
                 "genome.transcripts.fa:md5,050c521a2719c2ae48267c1e65218f29"
             ],
             {
-                "SENTIEON_RSEMPREPAREREFERENCE": {
-                    "rsem": "1.3.1",
-                    "star": null,
-                    "sentieon": 202503.01
-                }
+                "versions_rsem": [
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "rsem",
+                        "1.3.1"
+                    ]
+                ],
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_RSEMPREPAREREFERENCE",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
             }
         ],
         "meta": {

--- a/modules/nf-core/sentieon/rsempreparereference/tests/nextflow.config
+++ b/modules/nf-core/sentieon/rsempreparereference/tests/nextflow.config
@@ -1,9 +1,10 @@
-env {
-    // NOTE This is how pipeline users will use Sentieon in real world use
-    SENTIEON_LICENSE = "$SENTIEON_LICSRVR_IP"
-    // NOTE This should only happen in GitHub actions or nf-core MegaTests
-    SENTIEON_AUTH_MECH = "$SENTIEON_AUTH_MECH"
-    SENTIEON_AUTH_DATA = secrets.SENTIEON_AUTH_DATA
-    // NOTE This is how pipeline users will test out Sentieon with a license file
-    // nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)
-}
+// Sentieon environment configuration
+// NOTE This is how pipeline users will use Sentieon in real world use
+env.SENTIEON_LICENSE    = System.getenv('SENTIEON_LICSRVR_IP') ?: ''
+
+// NOTE This should only happen in GitHub actions or nf-core MegaTests
+env.SENTIEON_AUTH_MECH  = System.getenv('SENTIEON_AUTH_MECH') ?: ''
+env.SENTIEON_AUTH_DATA  = secrets.SENTIEON_AUTH_DATA ?: ''
+
+// NOTE This is how pipeline users will test out Sentieon with a license file
+// nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)

--- a/modules/nf-core/sentieon/staralign/meta.yml
+++ b/modules/nf-core/sentieon/staralign/meta.yml
@@ -88,13 +88,26 @@ output:
           description: STAR log progress file
           pattern: "*Log.progress.out"
           ontologies: []
-  versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+  versions_star:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - star:
+          type: string
+          description: The tool name
+      - 'sentieon STAR --version | sed -e "s/STAR_//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_sentieon:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version 2>&1 | sed -e "s/sentieon-genomics-//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
   bam:
     - - meta:
           type: map
@@ -242,6 +255,28 @@ output:
           description: STAR output bedGraph format file(s) (optional)
           pattern: "*.bg"
           ontologies: []
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - star:
+          type: string
+          description: The tool name
+      - 'sentieon STAR --version | sed -e "s/STAR_//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sentieon:
+          type: string
+          description: The tool name
+      - 'sentieon driver --version 2>&1 | sed -e "s/sentieon-genomics-//g"':
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@FriederikeHanssen"
 maintainers:

--- a/modules/nf-core/sentieon/staralign/tests/main.nf.test
+++ b/modules/nf-core/sentieon/staralign/tests/main.nf.test
@@ -65,7 +65,7 @@ nextflow_process {
                     process.out.spl_junc_tab,
                     process.out.tab,
                     process.out.wig,
-                    path(process.out.versions[0]).yaml
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -130,7 +130,7 @@ nextflow_process {
                     process.out.spl_junc_tab,
                     process.out.tab,
                     process.out.wig,
-                    path(process.out.versions[0]).yaml
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -194,7 +194,7 @@ nextflow_process {
                     process.out.spl_junc_tab,
                     process.out.tab,
                     process.out.wig,
-                    path(process.out.versions[0]).yaml
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -259,7 +259,7 @@ nextflow_process {
                     process.out.spl_junc_tab,
                     process.out.tab,
                     process.out.wig,
-                    path(process.out.versions[0]).yaml
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -326,7 +326,7 @@ nextflow_process {
                     process.out.spl_junc_tab,
                     process.out.tab,
                     process.out.wig,
-                    path(process.out.versions[0]).yaml
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }

--- a/modules/nf-core/sentieon/staralign/tests/main.nf.test.snap
+++ b/modules/nf-core/sentieon/staralign/tests/main.nf.test.snap
@@ -75,7 +75,18 @@
                     ]
                 ],
                 "16": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ],
+                "17": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
                 ],
                 "2": [
                     [
@@ -306,8 +317,19 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
                 ],
                 "wig": [
                     [
@@ -402,7 +424,18 @@
                     ]
                 ],
                 "16": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ],
+                "17": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
                 ],
                 "2": [
                     [
@@ -633,8 +666,19 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
                 ],
                 "wig": [
                     [
@@ -703,10 +747,20 @@
                 
             ],
             {
-                "SENTIEON_STARALIGN": {
-                    "star": "2.7.10b",
-                    "sentieon": 202503.01
-                }
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
             }
         ],
         "meta": {
@@ -765,10 +819,20 @@
                 
             ],
             {
-                "SENTIEON_STARALIGN": {
-                    "star": "2.7.10b",
-                    "sentieon": 202503.01
-                }
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
             }
         ],
         "meta": {
@@ -853,7 +917,18 @@
                     ]
                 ],
                 "16": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ],
+                "17": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
                 ],
                 "2": [
                     [
@@ -1084,8 +1159,19 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
                 ],
                 "wig": [
                     [
@@ -1180,7 +1266,18 @@
                     ]
                 ],
                 "16": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ],
+                "17": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
                 ],
                 "2": [
                     [
@@ -1411,8 +1508,19 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
                 ],
                 "wig": [
                     [
@@ -1481,10 +1589,20 @@
                 
             ],
             {
-                "SENTIEON_STARALIGN": {
-                    "star": "2.7.10b",
-                    "sentieon": 202503.01
-                }
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
             }
         ],
         "meta": {
@@ -1534,10 +1652,20 @@
                 
             ],
             {
-                "SENTIEON_STARALIGN": {
-                    "star": "2.7.10b",
-                    "sentieon": 202503.01
-                }
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
             }
         ],
         "meta": {
@@ -1586,10 +1714,20 @@
                 
             ],
             {
-                "SENTIEON_STARALIGN": {
-                    "star": "2.7.10b",
-                    "sentieon": 202503.01
-                }
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ]
             }
         ],
         "meta": {
@@ -1674,7 +1812,18 @@
                     ]
                 ],
                 "16": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
+                ],
+                "17": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
                 ],
                 "2": [
                     [
@@ -1905,8 +2054,19 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,59e385f30cd29a68b9ea0791b7343457"
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "sentieon",
+                        "202503.01"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "SENTIEON_STARALIGN",
+                        "star",
+                        "2.7.10b"
+                    ]
                 ],
                 "wig": [
                     [

--- a/modules/nf-core/sentieon/staralign/tests/nextflow.arriba.config
+++ b/modules/nf-core/sentieon/staralign/tests/nextflow.arriba.config
@@ -10,12 +10,13 @@ process {
 
 }
 
-env {
-    // NOTE This is how pipeline users will use Sentieon in real world use
-    SENTIEON_LICENSE = "$SENTIEON_LICSRVR_IP"
-    // NOTE This should only happen in GitHub actions or nf-core MegaTests
-    SENTIEON_AUTH_MECH = "$SENTIEON_AUTH_MECH"
-    SENTIEON_AUTH_DATA = secrets.SENTIEON_AUTH_DATA
-    // NOTE This is how pipeline users will test out Sentieon with a license file
-    // nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)
-}
+// Sentieon environment configuration
+// NOTE This is how pipeline users will use Sentieon in real world use
+env.SENTIEON_LICENSE    = System.getenv('SENTIEON_LICSRVR_IP') ?: ''
+
+// NOTE This should only happen in GitHub actions or nf-core MegaTests
+env.SENTIEON_AUTH_MECH  = System.getenv('SENTIEON_AUTH_MECH') ?: ''
+env.SENTIEON_AUTH_DATA  = secrets.SENTIEON_AUTH_DATA ?: ''
+
+// NOTE This is how pipeline users will test out Sentieon with a license file
+// nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)

--- a/modules/nf-core/sentieon/staralign/tests/nextflow.config
+++ b/modules/nf-core/sentieon/staralign/tests/nextflow.config
@@ -10,12 +10,13 @@ process {
 
 }
 
-env {
-    // NOTE This is how pipeline users will use Sentieon in real world use
-    SENTIEON_LICENSE = "$SENTIEON_LICSRVR_IP"
-    // NOTE This should only happen in GitHub actions or nf-core MegaTests
-    SENTIEON_AUTH_MECH = "$SENTIEON_AUTH_MECH"
-    SENTIEON_AUTH_DATA = secrets.SENTIEON_AUTH_DATA
-    // NOTE This is how pipeline users will test out Sentieon with a license file
-    // nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)
-}
+// Sentieon environment configuration
+// NOTE This is how pipeline users will use Sentieon in real world use
+env.SENTIEON_LICENSE    = System.getenv('SENTIEON_LICSRVR_IP') ?: ''
+
+// NOTE This should only happen in GitHub actions or nf-core MegaTests
+env.SENTIEON_AUTH_MECH  = System.getenv('SENTIEON_AUTH_MECH') ?: ''
+env.SENTIEON_AUTH_DATA  = secrets.SENTIEON_AUTH_DATA ?: ''
+
+// NOTE This is how pipeline users will test out Sentieon with a license file
+// nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)

--- a/modules/nf-core/sentieon/staralign/tests/nextflow.starfusion.config
+++ b/modules/nf-core/sentieon/staralign/tests/nextflow.starfusion.config
@@ -10,12 +10,13 @@ process {
 
 }
 
-env {
-    // NOTE This is how pipeline users will use Sentieon in real world use
-    SENTIEON_LICENSE = "$SENTIEON_LICSRVR_IP"
-    // NOTE This should only happen in GitHub actions or nf-core MegaTests
-    SENTIEON_AUTH_MECH = "$SENTIEON_AUTH_MECH"
-    SENTIEON_AUTH_DATA = secrets.SENTIEON_AUTH_DATA
-    // NOTE This is how pipeline users will test out Sentieon with a license file
-    // nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)
-}
+// Sentieon environment configuration
+// NOTE This is how pipeline users will use Sentieon in real world use
+env.SENTIEON_LICENSE    = System.getenv('SENTIEON_LICSRVR_IP') ?: ''
+
+// NOTE This should only happen in GitHub actions or nf-core MegaTests
+env.SENTIEON_AUTH_MECH  = System.getenv('SENTIEON_AUTH_MECH') ?: ''
+env.SENTIEON_AUTH_DATA  = secrets.SENTIEON_AUTH_DATA ?: ''
+
+// NOTE This is how pipeline users will test out Sentieon with a license file
+// nextflow secrets set SENTIEON_LICENSE_BASE64 \$(cat <sentieon_license_file.lic> | base64 -w 0)


### PR DESCRIPTION
## Summary

Convert sentieon modules to topic-based version publishing.

## Modules

### sentieon/rsemcalculateexpression
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs
- Update test config and regenerate snapshots

### sentieon/rsempreparereference
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs
- Update test config and regenerate snapshots

### sentieon/staralign
- Convert `versions.yml` output to topic-based version publishing
- Update meta.yml for topic outputs
- Update test configs and regenerate snapshots

## Context

Split from #9688. These sentieon modules have no external subworkflow dependencies.

## Test plan

- [ ] CI tests for sentieon/rsemcalculateexpression module
- [ ] CI tests for sentieon/rsempreparereference module
- [ ] CI tests for sentieon/staralign module

🤖 Generated with [Claude Code](https://claude.ai/code)