### PR TITLE
update gatk3 containers

### DIFF
--- a/modules/nf-core/gatk/unifiedgenotyper/main.nf
+++ b/modules/nf-core/gatk/unifiedgenotyper/main.nf
@@ -4,7 +4,7 @@ process GATK_UNIFIEDGENOTYPER {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/gatk_tabix:a2335099d7b82cfb'
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/19/194eeac04775f5e88453dcc831c6de7b36839fe17d0bbd8e1bca6d9ab41cdba2/data'
         : 'community.wave.seqera.io/library/gatk_tabix:efe73d760b0a026c'}"
 
     input:


### PR DESCRIPTION
This updates the containers used by gatk3 to sequera wave containers. The mulled biocontainer  was having problems running on the GH runner. 
See https://github.com/nf-core/eager/actions/runs/21064061754/job/60577190179?pr=1164

Adding versions to topic at the moment would create a host of additional work for me at nf-core eager template merge, so I will not do this yet. I intend to do this in a separate PR.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
