### PR TITLE
migrate autocycler modules to topic versions

### DIFF
--- a/modules/nf-core/autocycler/cluster/main.nf
+++ b/modules/nf-core/autocycler/cluster/main.nf
@@ -17,7 +17,7 @@ process AUTOCYCLER_CLUSTER {
     tuple val(meta), path("$prefix/clustering/*.tsv"),            emit: tsv
     tuple val(meta), path("$prefix/clustering/*.phylip"),         emit: pairwisedistances
     tuple val(meta), path("$prefix/clustering/*.yaml"),           emit: stats
-    path "versions.yml",                                          emit: versions
+    tuple val("${task.process}"), val("autocycler"), eval("autocycler --version |  sed 's/^[^ ]* //'"), emit: versions_autocycler, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,11 +32,6 @@ process AUTOCYCLER_CLUSTER {
 
     mkdir $prefix
     mv clustering $prefix
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 
     stub:
@@ -48,10 +43,5 @@ process AUTOCYCLER_CLUSTER {
     touch $prefix/clustering/clustering.{newick,yaml,tsv}
     touch $prefix/clustering/pairwise_distances.phylip
     touch $prefix/clustering/qc_pass/cluster_000/0_untrimmed.{gfa,yaml}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/autocycler/cluster/meta.yml
+++ b/modules/nf-core/autocycler/cluster/meta.yml
@@ -95,15 +95,31 @@ output:
           pattern: "clustering/*.yaml"
           ontologies:
             - edam: "http://edamontology.org/format_3750" # YAML
+  versions_autocycler:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - "versions.yml":
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: "http://edamontology.org/format_3750" # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
 
 authors:
   - "@dwells-eit"
+  - "@eit-maxlcummins"
 maintainers:
   - "@dwells-eit"

--- a/modules/nf-core/autocycler/cluster/tests/main.nf.test.snap
+++ b/modules/nf-core/autocycler/cluster/tests/main.nf.test.snap
@@ -57,7 +57,11 @@
                     ]
                 ],
                 "6": [
-                    "versions.yml:md5,6c0bd1b1b590f56dd7fa72cc206acfe3"
+                    [
+                        "AUTOCYCLER_CLUSTER",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "clusters": [
                     [
@@ -113,16 +117,20 @@
                         "clustering.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6c0bd1b1b590f56dd7fa72cc206acfe3"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_CLUSTER",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-07T14:06:10.704821304"
+        "timestamp": "2026-01-22T14:45:24.359273368"
     },
     "sarscov2 - assembly - fasta": {
         "content": [
@@ -194,7 +202,11 @@
                     ]
                 ],
                 "6": [
-                    "versions.yml:md5,6c0bd1b1b590f56dd7fa72cc206acfe3"
+                    [
+                        "AUTOCYCLER_CLUSTER",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "clusters": [
                     [
@@ -262,15 +274,19 @@
                         "clustering.tsv:md5,30f7a64acefcc55a1863ff306a2901ac"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6c0bd1b1b590f56dd7fa72cc206acfe3"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_CLUSTER",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-28T10:43:46.382913621"
+        "timestamp": "2026-01-22T14:45:18.802224381"
     }
 }

--- a/modules/nf-core/autocycler/combine/main.nf
+++ b/modules/nf-core/autocycler/combine/main.nf
@@ -14,7 +14,7 @@ process AUTOCYCLER_COMBINE {
     tuple val(meta), path("$prefix/consensus_assembly.fasta"), emit: fasta
     tuple val(meta), path("$prefix/consensus_assembly.gfa"),   emit: gfa
     tuple val(meta), path("$prefix/consensus_assembly.yaml"),  emit: stats
-    path "versions.yml",                                       emit: versions
+    tuple val("${task.process}"), val("autocycler"), eval("autocycler --version |  sed 's/^[^ ]* //'"), emit: versions_autocycler, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,11 +27,6 @@ process AUTOCYCLER_COMBINE {
         $args \\
         -i $clusters \\
         -a $prefix
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 
     stub:
@@ -40,10 +35,5 @@ process AUTOCYCLER_COMBINE {
     """
     mkdir $prefix
     touch $prefix/consensus_assembly.{fasta,gfa,yaml}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/autocycler/combine/meta.yml
+++ b/modules/nf-core/autocycler/combine/meta.yml
@@ -65,15 +65,31 @@ output:
           pattern: "$prefix/consensus_assembly.yaml"
           ontologies:
             - edam: "http://edamontology.org/format_3750" # YAML
+  versions_autocycler:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - "versions.yml":
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: "http://edamontology.org/format_3750" # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
 
 authors:
   - "@dwells-eit"
+  - "@eit-maxlcummins"
 maintainers:
   - "@dwells-eit"

--- a/modules/nf-core/autocycler/combine/tests/main.nf.test.snap
+++ b/modules/nf-core/autocycler/combine/tests/main.nf.test.snap
@@ -30,7 +30,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb"
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "fasta": [
                     [
@@ -59,16 +63,20 @@
                         "consensus_assembly.yaml:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-28T11:15:12.388399773"
+        "timestamp": "2026-01-22T14:45:38.324753395"
     },
     "sarscov2 - assemblies -fasta": {
         "content": [
@@ -200,11 +208,31 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb",
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb",
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb",
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb",
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb"
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "fasta": [
                     [
@@ -332,19 +360,39 @@
                         "consensus_assembly.yaml:md5,a935e95b6c41fcee0858902d797e5613"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb",
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb",
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb",
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb",
-                    "versions.yml:md5,cd4c6e07ce524c5c2296afff8a45fecb"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_COMBINE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-28T11:15:36.324875025"
+        "timestamp": "2026-01-22T14:45:32.940764786"
     }
 }

--- a/modules/nf-core/autocycler/compress/main.nf
+++ b/modules/nf-core/autocycler/compress/main.nf
@@ -14,7 +14,7 @@ process AUTOCYCLER_COMPRESS {
     output:
     tuple val(meta), path("$prefix/*.gfa"),  emit: gfa
     tuple val(meta), path("$prefix/*.yaml"), emit: stats
-    path "versions.yml",                     emit: versions
+    tuple val("${task.process}"), val("autocycler"), eval("autocycler --version |  sed 's/^[^ ]* //'"), emit: versions_autocycler, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -28,11 +28,6 @@ process AUTOCYCLER_COMPRESS {
         -t $task.cpus \\
         -i . \\
         -a ${prefix}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 
     stub:
@@ -42,10 +37,5 @@ process AUTOCYCLER_COMPRESS {
     mkdir $prefix
     touch ${prefix}/input_assemblies.gfa
     touch ${prefix}/input_assemblies.yaml
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/autocycler/compress/meta.yml
+++ b/modules/nf-core/autocycler/compress/meta.yml
@@ -57,15 +57,31 @@ output:
           pattern: "*/*.yaml"
           ontologies:
             - edam: "http://edamontology.org/format_3750" # YAML
+  versions_autocycler:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - "versions.yml":
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: "http://edamontology.org/format_3750" # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
 
 authors:
   - "@dwells-eit"
+  - "@eit-maxlcummins"
 maintainers:
   - "@dwells-eit"

--- a/modules/nf-core/autocycler/compress/tests/main.nf.test.snap
+++ b/modules/nf-core/autocycler/compress/tests/main.nf.test.snap
@@ -21,7 +21,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,842cd4fed38c11bfb1130da4de2ade14"
+                    [
+                        "AUTOCYCLER_COMPRESS",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "gfa": [
                     [
@@ -41,16 +45,20 @@
                         "input_assemblies.yaml:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,842cd4fed38c11bfb1130da4de2ade14"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_COMPRESS",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-28T09:03:44.162388971"
+        "timestamp": "2026-01-22T14:45:49.774504186"
     },
     "sarscov2 - fasta": {
         "content": [
@@ -74,7 +82,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,842cd4fed38c11bfb1130da4de2ade14"
+                    [
+                        "AUTOCYCLER_COMPRESS",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "gfa": [
                     [
@@ -94,15 +106,19 @@
                         "input_assemblies.yaml:md5,2d4d10d343d16ef57c9dceb12d8c6e1c"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,842cd4fed38c11bfb1130da4de2ade14"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_COMPRESS",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-28T09:02:09.484596514"
+        "timestamp": "2026-01-22T14:45:44.085615465"
     }
 }

--- a/modules/nf-core/autocycler/resolve/main.nf
+++ b/modules/nf-core/autocycler/resolve/main.nf
@@ -14,7 +14,7 @@ process AUTOCYCLER_RESOLVE {
     tuple val(meta), path("$prefix/3_bridged.gfa"), emit: bridged
     tuple val(meta), path("$prefix/4_merged.gfa"),  emit: merged
     tuple val(meta), path("$prefix/5_final.gfa"),   emit: resolved
-    path "versions.yml",                            emit: versions
+    tuple val("${task.process}"), val("autocycler"), eval("autocycler --version |  sed 's/^[^ ]* //'"), emit: versions_autocycler, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -31,11 +31,6 @@ process AUTOCYCLER_RESOLVE {
     mv 3_bridged.gfa $prefix
     mv 4_merged.gfa $prefix
     mv 5_final.gfa $prefix
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 
     stub:
@@ -46,10 +41,5 @@ process AUTOCYCLER_RESOLVE {
     touch $prefix/3_bridged.gfa
     touch $prefix/4_merged.gfa
     touch $prefix/5_final.gfa
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/autocycler/resolve/meta.yml
+++ b/modules/nf-core/autocycler/resolve/meta.yml
@@ -65,15 +65,31 @@ output:
           pattern: "5_final.gfa"
           ontologies:
             - edam: "http://edamontology.org/format_3975" #GFA1
+  versions_autocycler:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - "versions.yml":
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: "http://edamontology.org/format_3750" # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
 
 authors:
   - "@dwells-eit"
+  - "@eit-maxlcummins"
 maintainers:
   - "@dwells-eit"

--- a/modules/nf-core/autocycler/resolve/tests/main.nf.test.snap
+++ b/modules/nf-core/autocycler/resolve/tests/main.nf.test.snap
@@ -129,11 +129,31 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e",
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e",
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e",
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e",
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e"
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "bridged": [
                     [
@@ -261,20 +281,40 @@
                         "5_final.gfa:md5,f919ba084f3e6e05481843b7acc7470b"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e",
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e",
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e",
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e",
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-28T11:05:51.541318237"
+        "timestamp": "2026-01-22T14:45:57.542763669"
     },
     "sarscov2 - assemblies -fasta - stub": {
         "content": [
@@ -307,7 +347,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e"
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "bridged": [
                     [
@@ -336,15 +380,19 @@
                         "5_final.gfa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,79bc18dd056bcbf7f1d6315822b6394e"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_RESOLVE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-11-07T15:15:19.170640772"
+        "timestamp": "2026-01-22T14:46:03.097237935"
     }
 }

--- a/modules/nf-core/autocycler/subsample/main.nf
+++ b/modules/nf-core/autocycler/subsample/main.nf
@@ -14,7 +14,7 @@ process AUTOCYCLER_SUBSAMPLE {
 
     output:
     tuple val(meta), path("$prefix/*.fastq.gz"), emit: subsampled_reads
-    path "versions.yml",                         emit: versions
+    tuple val("${task.process}"), val("autocycler"), eval("autocycler --version |  sed 's/^[^ ]* //'"), emit: versions_autocycler, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,11 +32,6 @@ process AUTOCYCLER_SUBSAMPLE {
         --genome_size $genome_size
 
     gzip $prefix/*.fastq
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 
     stub:
@@ -46,10 +41,5 @@ process AUTOCYCLER_SUBSAMPLE {
 
     mkdir $prefix
     echo | gzip > ${prefix}/sample_00.fastq.gz
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/autocycler/subsample/meta.yml
+++ b/modules/nf-core/autocycler/subsample/meta.yml
@@ -46,15 +46,31 @@ output:
           ontologies:
             - edam: "http://edamontology.org/format_1930" # FASTQ
             - edam: "http://edamontology.org/format_3989" # GZIP
+  versions_autocycler:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - "versions.yml":
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: "http://edamontology.org/format_3750" # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
 
 authors:
   - "@dwells-eit"
+  - "@eit-maxlcummins"
 maintainers:
   - "@dwells-eit"

--- a/modules/nf-core/autocycler/subsample/tests/main.nf.test.snap
+++ b/modules/nf-core/autocycler/subsample/tests/main.nf.test.snap
@@ -17,7 +17,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,0abfe90f7bd1d54716b236993073b514"
+                    [
+                        "AUTOCYCLER_SUBSAMPLE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "subsampled_reads": [
                     [
@@ -33,16 +37,20 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,0abfe90f7bd1d54716b236993073b514"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_SUBSAMPLE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-29T08:36:17.505206711"
+        "timestamp": "2026-01-22T14:46:08.947532075"
     },
     "Pseudomonas_fluorescens - fastq_gz - stub": {
         "content": [
@@ -57,7 +65,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,0abfe90f7bd1d54716b236993073b514"
+                    [
+                        "AUTOCYCLER_SUBSAMPLE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "subsampled_reads": [
                     [
@@ -68,15 +80,19 @@
                         "sample_00.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,0abfe90f7bd1d54716b236993073b514"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_SUBSAMPLE",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-29T08:07:36.406154106"
+        "timestamp": "2026-01-22T14:46:14.645125712"
     }
 }

--- a/modules/nf-core/autocycler/trim/main.nf
+++ b/modules/nf-core/autocycler/trim/main.nf
@@ -13,7 +13,7 @@ process AUTOCYCLER_TRIM {
     output:
     tuple val(meta), path("$prefix/*.gfa"),  emit: gfa
     tuple val(meta), path("$prefix/*.yaml"), emit: stats
-    path "versions.yml",                     emit: versions
+    tuple val("${task.process}"), val("autocycler"), eval("autocycler --version |  sed 's/^[^ ]* //'"), emit: versions_autocycler, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,11 +29,6 @@ process AUTOCYCLER_TRIM {
 
     mkdir $prefix
     mv 2_trimmed.{gfa,yaml} $prefix
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 
     stub:
@@ -44,10 +39,5 @@ process AUTOCYCLER_TRIM {
     mkdir $prefix
     touch $prefix/2_trimmed.gfa
     touch $prefix/2_trimmed.yaml
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        autocycler: \$(autocycler --version |  sed 's/^[^ ]* //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/autocycler/trim/meta.yml
+++ b/modules/nf-core/autocycler/trim/meta.yml
@@ -53,15 +53,31 @@ output:
           pattern: "*.yaml"
           ontologies:
             - edam: "http://edamontology.org/format_3750" # YAML
+  versions_autocycler:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - "versions.yml":
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: "http://edamontology.org/format_3750" # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - autocycler:
+          type: string
+          description: The name of the tool
+      - "autocycler --version |  sed 's/^[^ ]* //'":
+          type: eval
+          description: The expression to obtain the version of the tool
 
 authors:
   - "@dwells-eit"
+  - "@eit-maxlcummins"
 maintainers:
   - "@dwells-eit"

--- a/modules/nf-core/autocycler/trim/tests/main.nf.test.snap
+++ b/modules/nf-core/autocycler/trim/tests/main.nf.test.snap
@@ -87,11 +87,31 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7",
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7",
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7",
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7",
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7"
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "gfa": [
                     [
@@ -177,20 +197,40 @@
                         "2_trimmed.yaml:md5,de8ad13f8a9b4b911a08a53b9b88e4bd"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7",
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7",
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7",
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7",
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ],
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-28T10:57:59.014535177"
+        "timestamp": "2026-01-22T14:46:22.073475252"
     },
     "sarscov2 - assemblies -fasta - stub": {
         "content": [
@@ -214,7 +254,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7"
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ],
                 "gfa": [
                     [
@@ -234,15 +278,19 @@
                         "2_trimmed.yaml:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,9d6f2f1409574f288a085c66ba884cb7"
+                "versions_autocycler": [
+                    [
+                        "AUTOCYCLER_TRIM",
+                        "autocycler",
+                        "0.5.2"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-10-28T10:58:04.464338286"
+        "timestamp": "2026-01-22T14:46:27.620416194"
     }
 }


### PR DESCRIPTION
Updating auto cycler modules to migrate versions to topic channels.

## PR checklist
- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [-] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [-] If necessary, include test data in your PR.
- [-] Remove all TODO statements.
- [X] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [X] Follow the naming conventions.
- [-] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [-] Add a resource `label`
- [-] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [-] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`