### PR TITLE
Experiment: Add GitHub Actions workflow for PR size labeling

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,3 @@
-
 name: labeler
 
 on: [pull_request]


### PR DESCRIPTION
This is an experiment based on a GitHub action @ewels found in another place, to see if these labels can help the community reduce the size of PRs and thus promote faster reviews.

This is part of the solutions discussed at the nf-core retreat 2025: https://nf-co.re/blog/2025/retreat-2025#improving-review-and-development-practices

I will remove the file after a month or so, and see if we felt it was useful.