### PR TITLE
feat(subread/featurecounts): Convert to topic-based version emission

### DIFF
--- a/modules/nf-core/subread/featurecounts/main.nf
+++ b/modules/nf-core/subread/featurecounts/main.nf
@@ -13,7 +13,7 @@ process SUBREAD_FEATURECOUNTS {
     output:
     tuple val(meta), path("*featureCounts.tsv"), emit: counts
     tuple val(meta), path("*featureCounts.tsv.summary"), emit: summary
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('subread'), eval("featureCounts -v 2>&1 | sed 's/featureCounts v//'"), emit: versions_subread, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -39,11 +39,6 @@ process SUBREAD_FEATURECOUNTS {
         -s ${strandedness} \\
         -o ${prefix}.featureCounts.tsv \\
         ${bams.join(' ')}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        subread: \$( echo \$(featureCounts -v 2>&1) | sed -e "s/featureCounts v//g")
-    END_VERSIONS
     """
 
     stub:
@@ -51,10 +46,5 @@ process SUBREAD_FEATURECOUNTS {
     """
     touch ${prefix}.featureCounts.tsv
     touch ${prefix}.featureCounts.tsv.summary
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        subread: \$( echo \$(featureCounts -v 2>&1) | sed -e "s/featureCounts v//g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/subread/featurecounts/meta.yml
+++ b/modules/nf-core/subread/featurecounts/meta.yml
@@ -56,13 +56,29 @@ output:
           description: Summary log file
           pattern: "*.featureCounts.tsv.summary"
           ontologies: []
+  versions_subread:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - subread:
+          type: string
+          description: The name of the tool
+      - "featureCounts -v 2>&1 | sed 's/featureCounts v//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - subread:
+          type: string
+          description: The name of the tool
+      - "featureCounts -v 2>&1 | sed 's/featureCounts v//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@ntoda03"
 maintainers:

--- a/modules/nf-core/subread/featurecounts/tests/main.nf.test
+++ b/modules/nf-core/subread/featurecounts/tests/main.nf.test
@@ -26,9 +26,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.counts).match("forward_counts") },
-                { assert snapshot(process.out.summary).match("forward_summary") },
-                { assert snapshot(process.out.versions).match("forward_versions") }
+                { assert snapshot(
+                    process.out.counts,
+                    process.out.summary,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
     }
@@ -74,9 +76,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.counts).match("reverse_counts") },
-                { assert snapshot(process.out.summary).match("reverse_summary") },
-                { assert snapshot(process.out.versions).match("reverse_versions") }
+                { assert snapshot(
+                    process.out.counts,
+                    process.out.summary,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
     }
@@ -122,9 +126,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.counts).match("unstranded_counts") },
-                { assert snapshot(process.out.summary).match("unstranded_summary") },
-                { assert snapshot(process.out.versions).match("unstranded_versions") }
+                { assert snapshot(
+                    process.out.counts,
+                    process.out.summary,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
     }

--- a/modules/nf-core/subread/featurecounts/tests/main.nf.test.snap
+++ b/modules/nf-core/subread/featurecounts/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "forward_counts": {
+    "sarscov2 [bam] - forward": {
         "content": [
             [
                 [
@@ -10,51 +10,32 @@
                     },
                     "test.featureCounts.tsv:md5,21ff44bfaa4a3d8e8b7e749078f7a201"
                 ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
-        },
-        "timestamp": "2024-12-01T11:28:20.989068"
-    },
-    "unstranded_counts": {
-        "content": [
+            ],
             [
                 [
                     {
                         "id": "test",
                         "single_end": true,
-                        "strandedness": "unstranded"
+                        "strandedness": "forward"
                     },
-                    "test.featureCounts.tsv:md5,9474f78d2d1d43613cbc16c10ba15047"
+                    "test.featureCounts.tsv.summary:md5,8f602ff9a8ef467af43294e80b367cdf"
                 ]
-            ]
+            ],
+            {
+                "versions_subread": [
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2024-12-01T11:28:33.648742"
-    },
-    "reverse_summary": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "reverse"
-                    },
-                    "test.featureCounts.tsv.summary:md5,7cfa30ad678b9bc1bc63afbb0281547b"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
-        },
-        "timestamp": "2024-12-01T11:28:27.457841"
+        "timestamp": "2026-02-02T14:44:54.308461465"
     },
     "sarscov2 [bam] - forward - stub": {
         "content": [
@@ -80,7 +61,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
                 ],
                 "counts": [
                     [
@@ -102,16 +87,58 @@
                         "test.featureCounts.tsv.summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
+                "versions_subread": [
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2024-12-01T11:29:21.075114"
+        "timestamp": "2026-02-02T14:44:59.542545235"
+    },
+    "sarscov2 [bam] - unstranded": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "unstranded"
+                    },
+                    "test.featureCounts.tsv:md5,9474f78d2d1d43613cbc16c10ba15047"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "unstranded"
+                    },
+                    "test.featureCounts.tsv.summary:md5,23164b79f9f23f11c82820db61a35560"
+                ]
+            ],
+            {
+                "versions_subread": [
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-02T14:45:15.194324716"
     },
     "sarscov2 [bam] - reverse - stub": {
         "content": [
@@ -137,7 +164,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
                 ],
                 "counts": [
                     [
@@ -159,18 +190,22 @@
                         "test.featureCounts.tsv.summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
+                "versions_subread": [
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2024-12-01T11:29:27.146094"
+        "timestamp": "2026-02-02T14:45:09.979159361"
     },
-    "reverse_counts": {
+    "sarscov2 [bam] - reverse": {
         "content": [
             [
                 [
@@ -181,13 +216,32 @@
                     },
                     "test.featureCounts.tsv:md5,7df6092fdc65ce40b71c64e0c97f95c6"
                 ]
-            ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test.featureCounts.tsv.summary:md5,7cfa30ad678b9bc1bc63afbb0281547b"
+                ]
+            ],
+            {
+                "versions_subread": [
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2024-12-01T11:28:27.448485"
+        "timestamp": "2026-02-02T14:45:04.836250949"
     },
     "sarscov2 [bam] - unstranded - stub": {
         "content": [
@@ -213,7 +267,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
                 ],
                 "counts": [
                     [
@@ -235,89 +293,19 @@
                         "test.featureCounts.tsv.summary:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
+                "versions_subread": [
+                    [
+                        "SUBREAD_FEATURECOUNTS",
+                        "subread",
+                        "2.0.6"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2024-12-01T11:29:33.287109"
-    },
-    "forward_summary": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "forward"
-                    },
-                    "test.featureCounts.tsv.summary:md5,8f602ff9a8ef467af43294e80b367cdf"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
-        },
-        "timestamp": "2024-12-01T11:28:21.006184"
-    },
-    "forward_versions": {
-        "content": [
-            [
-                "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-18T10:19:48.001158764"
-    },
-    "unstranded_summary": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "unstranded"
-                    },
-                    "test.featureCounts.tsv.summary:md5,23164b79f9f23f11c82820db61a35560"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.1"
-        },
-        "timestamp": "2024-12-01T11:28:33.657543"
-    },
-    "reverse_versions": {
-        "content": [
-            [
-                "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-18T10:20:24.551053149"
-    },
-    "unstranded_versions": {
-        "content": [
-            [
-                "versions.yml:md5,956ebb9da6a1747fc47d393fb5931fc2"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-18T10:21:03.25895568"
+        "timestamp": "2026-02-02T14:45:20.368253962"
     }
 }


### PR DESCRIPTION
## Summary

Convert subread/featurecounts from legacy `versions.yml` file emission to `topic: versions` channel emission.

## Changes

- Replace `path "versions.yml", emit: versions` with topic-based eval output
- Remove `cat <<-END_VERSIONS` heredoc blocks from script and stub sections
- Update test assertions to use `process.out.findAll { key, val -> key.startsWith('versions') }`
- Update meta.yml with new output structure

🤖 Generated with [Claude Code](https://claude.ai/code)