### PR TITLE
feat(sylphtax/taxprof): Convert to topic-based version emission

### DIFF
--- a/modules/nf-core/sylphtax/taxprof/main.nf
+++ b/modules/nf-core/sylphtax/taxprof/main.nf
@@ -14,7 +14,7 @@ process SYLPHTAX_TAXPROF {
 
     output:
     tuple val(meta), path("*.sylphmpa"), emit: taxprof_output
-    path "versions.yml"                , emit: versions
+    tuple val("${task.process}"), val('sylph-tax'), eval("sylph-tax --version 2>&1 | tail -1"), emit: versions_sylphtax, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,22 +32,11 @@ process SYLPHTAX_TAXPROF {
         -t $taxonomy
 
     mv *.sylphmpa ${prefix}.sylphmpa
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sylph-tax: \$(sylph-tax --version)
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    export SYLPH_TAXONOMY_CONFIG="/tmp/config.json"
     touch ${prefix}.sylphmpa
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sylph-tax: \$(sylph-tax --version)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sylphtax/taxprof/meta.yml
+++ b/modules/nf-core/sylphtax/taxprof/meta.yml
@@ -44,13 +44,29 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
           pattern: "*{.sylphmpa}"
+  versions_sylphtax:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - sylph-tax:
+          type: string
+          description: The name of the tool
+      - "sylph-tax --version 2>&1 | tail -1":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - sylph-tax:
+          type: string
+          description: The name of the tool
+      - "sylph-tax --version 2>&1 | tail -1":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@sofstam"
 maintainers:

--- a/modules/nf-core/sylphtax/taxprof/tests/main.nf.test
+++ b/modules/nf-core/sylphtax/taxprof/tests/main.nf.test
@@ -41,7 +41,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith('versions') },
                     process.out.taxprof_output
                 ).match() }
             )
@@ -81,7 +81,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith('versions') },
                     process.out.taxprof_output
                 ).match() }
             )

--- a/modules/nf-core/sylphtax/taxprof/tests/main.nf.test.snap
+++ b/modules/nf-core/sylphtax/taxprof/tests/main.nf.test.snap
@@ -1,9 +1,15 @@
 {
     "stub sarscov2 illumina single-end [fastq_gz]": {
         "content": [
-            [
-                "versions.yml:md5,bdbbd22b3e721ba2027d3e6cb1dc4bb4"
-            ],
+            {
+                "versions_sylphtax": [
+                    [
+                        "SYLPHTAX_TAXPROF",
+                        "sylph-tax",
+                        "1.2.0"
+                    ]
+                ]
+            },
             [
                 [
                     {
@@ -14,16 +20,22 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2025-04-07T15:28:04.026470884"
+        "timestamp": "2026-02-02T14:48:37.167778561"
     },
     "sarscov2 illumina single-end [fastq_gz]": {
         "content": [
-            [
-                "versions.yml:md5,bdbbd22b3e721ba2027d3e6cb1dc4bb4"
-            ],
+            {
+                "versions_sylphtax": [
+                    [
+                        "SYLPHTAX_TAXPROF",
+                        "sylph-tax",
+                        "1.2.0"
+                    ]
+                ]
+            },
             [
                 [
                     {
@@ -35,9 +47,9 @@
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2025-11-12T08:38:09.643877438"
+        "timestamp": "2026-02-02T14:48:30.003068972"
     }
 }


### PR DESCRIPTION
## Summary

Convert sylphtax/taxprof from legacy `versions.yml` file emission to `topic: versions` channel emission.

## Changes

- Replace `path "versions.yml", emit: versions` with topic-based eval output
- Remove `cat <<-END_VERSIONS` heredoc blocks from script and stub sections
- Update test assertions to use `process.out.findAll { key, val -> key.startsWith('versions') }`
- Update meta.yml with new output structure

🤖 Generated with [Claude Code](https://claude.ai/code)