### PR TITLE
feat(hisat2/align): Convert to topic-based version emission

### DIFF
--- a/modules/nf-core/hisat2/align/main.nf
+++ b/modules/nf-core/hisat2/align/main.nf
@@ -16,7 +16,8 @@ process HISAT2_ALIGN {
     tuple val(meta), path("*.bam")                   , emit: bam
     tuple val(meta), path("*.log")                   , emit: summary
     tuple val(meta), path("*fastq.gz"), optional:true, emit: fastq
-    path  "versions.yml"                             , emit: versions
+    tuple val("${task.process}"), val('hisat2'), eval("hisat2 --version | sed -n '1s/.*version //p'"), emit: versions_hisat2, topic: versions
+    tuple val("${task.process}"), val('samtools'), eval("samtools --version | sed -n '1s/samtools //p'"), emit: versions_samtools, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -48,12 +49,6 @@ process HISAT2_ALIGN {
             $unaligned \\
             $args \\
             | samtools view -bS -F 4 -F 256 - > ${prefix}.bam
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            hisat2: \$(hisat2 --version | grep -o 'version [^ ]*' | cut -d ' ' -f 2)
-            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-        END_VERSIONS
         """
     } else {
         def unaligned = params.save_unaligned ? "--un-conc-gz ${prefix}.unmapped.fastq.gz" : ''
@@ -80,12 +75,6 @@ process HISAT2_ALIGN {
         if [ -f ${prefix}.unmapped.fastq.2.gz ]; then
             mv ${prefix}.unmapped.fastq.2.gz ${prefix}.unmapped_2.fastq.gz
         fi
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            hisat2: \$(hisat2 --version | grep -o 'version [^ ]*' | cut -d ' ' -f 2)
-            samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-        END_VERSIONS
         """
     }
 
@@ -97,12 +86,6 @@ process HISAT2_ALIGN {
 
     touch ${prefix}.hisat2.summary.log
     touch ${prefix}.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        hisat2: \$(hisat2 --version | grep -o 'version [^ ]*' | cut -d ' ' -f 2)
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
     """
 
 

--- a/modules/nf-core/hisat2/align/meta.yml
+++ b/modules/nf-core/hisat2/align/meta.yml
@@ -82,13 +82,48 @@ output:
           pattern: "*fastq.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
+  versions_hisat2:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - hisat2:
+          type: string
+          description: The name of the tool
+      - "hisat2 --version | sed -n '1s/.*version //p'":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - "samtools --version | sed -n '1s/samtools //p'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - hisat2:
+          type: string
+          description: The name of the tool
+      - "hisat2 --version | sed -n '1s/.*version //p'":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - "samtools --version | sed -n '1s/samtools //p'":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@ntoda03"
   - "@ramprasadn"

--- a/modules/nf-core/hisat2/align/tests/main.nf.test
+++ b/modules/nf-core/hisat2/align/tests/main.nf.test
@@ -63,7 +63,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(process.out.summary).match("se_summary") },
                 { assert snapshot(process.out.fastq).match("se_fastq") },
-                { assert snapshot(process.out.versions).match("se_versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("se_versions") }
             )
         }
     }
@@ -179,7 +179,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(process.out.summary).match("pe_summary") },
                 { assert snapshot(process.out.fastq).match("pe_fastq") },
-                { assert snapshot(process.out.versions).match("pe_versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("pe_versions") }
             )
         }
     }
@@ -281,7 +281,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(process.out.summary).match("se_no_ss_summary") },
                 { assert snapshot(process.out.fastq).match("se_no_ss_fastq") },
-                { assert snapshot(process.out.versions).match("se_no_ss_versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("se_no_ss_versions") }
             )
         }
     }
@@ -369,7 +369,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(process.out.summary).match("pe_no_ss_summary") },
                 { assert snapshot(process.out.fastq).match("pe_no_ss_fastq") },
-                { assert snapshot(process.out.versions).match("pe_no_ss_versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("pe_no_ss_versions") }
             )
         }
     }

--- a/modules/nf-core/hisat2/align/tests/main.nf.test.snap
+++ b/modules/nf-core/hisat2/align/tests/main.nf.test.snap
@@ -1,15 +1,28 @@
 {
     "se_versions": {
         "content": [
-            [
-                "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
-            ]
+            {
+                "versions_hisat2": [
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:34:25.408496"
+        "timestamp": "2026-02-02T23:39:56.867139"
     },
     "Paired-End - stub": {
         "content": [
@@ -36,7 +49,18 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "4": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
                 ],
                 "bam": [
                     [
@@ -59,16 +83,27 @@
                         "test.hisat2.summary.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
+                "versions_hisat2": [
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:35:07.399682"
+        "timestamp": "2026-02-02T23:40:56.902461"
     },
     "Single-End - stub": {
         "content": [
@@ -95,7 +130,18 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "4": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
                 ],
                 "bam": [
                     [
@@ -118,28 +164,52 @@
                         "test.hisat2.summary.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
+                "versions_hisat2": [
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:34:39.530376"
+        "timestamp": "2026-02-02T23:40:17.08214"
     },
     "pe_no_ss_versions": {
         "content": [
-            [
-                "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
-            ]
+            {
+                "versions_hisat2": [
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:35:42.179425"
+        "timestamp": "2026-02-02T23:41:41.765628"
     },
     "Paired-End No Splice Sites - stub": {
         "content": [
@@ -166,7 +236,18 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "4": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
                 ],
                 "bam": [
                     [
@@ -189,16 +270,27 @@
                         "test.hisat2.summary.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
+                "versions_hisat2": [
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:35:54.361279"
+        "timestamp": "2026-02-02T23:41:53.108448"
     },
     "pe_no_ss_summary": {
         "content": [
@@ -310,15 +402,28 @@
     },
     "se_no_ss_versions": {
         "content": [
-            [
-                "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
-            ]
+            {
+                "versions_hisat2": [
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:35:18.850585"
+        "timestamp": "2026-02-02T23:41:17.495998"
     },
     "se_no_ss_fastq": {
         "content": [
@@ -357,7 +462,18 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "4": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
                 ],
                 "bam": [
                     [
@@ -380,27 +496,51 @@
                         "test.hisat2.summary.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
+                "versions_hisat2": [
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:35:30.451275"
+        "timestamp": "2026-02-02T23:41:27.847461"
     },
     "pe_versions": {
         "content": [
-            [
-                "versions.yml:md5,1a38a5d8b9ea523ccfa7c9f9802fa7ec"
-            ]
+            {
+                "versions_hisat2": [
+                    [
+                        "HISAT2_ALIGN",
+                        "hisat2",
+                        "2.2.1"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_ALIGN",
+                        "samtools",
+                        "1.20"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:34:53.518239"
+        "timestamp": "2026-02-02T23:40:40.784947"
     }
 }

--- a/subworkflows/nf-core/fastq_align_hisat2/main.nf
+++ b/subworkflows/nf-core/fastq_align_hisat2/main.nf
@@ -18,7 +18,6 @@ workflow FASTQ_ALIGN_HISAT2 {
     // Map reads with HISAT2
     //
     HISAT2_ALIGN ( reads, index, splicesites )
-    ch_versions = ch_versions.mix(HISAT2_ALIGN.out.versions.first())
 
     //
     // Sort, index BAM file and run samtools stats, flagstat and idxstats

--- a/subworkflows/nf-core/fastq_align_hisat2/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_hisat2/tests/main.nf.test.snap
@@ -48,15 +48,14 @@
             ],
             [
                 "versions.yml:md5,18dfb578b63a4c06df9029d214d26b21",
-                "versions.yml:md5,e0481c30dd24b96ee2ace998a360ea29",
                 "versions.yml:md5,ec6468a88403ffc733629109b26e2484"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-29T11:01:58.187559944"
+        "timestamp": "2026-02-02T23:45:06.622869"
     },
     "sarscov2 - bam - single_end - stub": {
         "content": [
@@ -132,7 +131,6 @@
                 ],
                 "9": [
                     "versions.yml:md5,18dfb578b63a4c06df9029d214d26b21",
-                    "versions.yml:md5,e0481c30dd24b96ee2ace998a360ea29",
                     "versions.yml:md5,ec6468a88403ffc733629109b26e2484"
                 ],
                 "bai": [
@@ -206,16 +204,15 @@
                 ],
                 "versions": [
                     "versions.yml:md5,18dfb578b63a4c06df9029d214d26b21",
-                    "versions.yml:md5,e0481c30dd24b96ee2ace998a360ea29",
                     "versions.yml:md5,ec6468a88403ffc733629109b26e2484"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-29T11:02:16.827277066"
+        "timestamp": "2026-02-02T23:46:05.18776"
     },
     "sarscov2 - bam - paired_end": {
         "content": [
@@ -266,15 +263,14 @@
             ],
             [
                 "versions.yml:md5,18dfb578b63a4c06df9029d214d26b21",
-                "versions.yml:md5,e0481c30dd24b96ee2ace998a360ea29",
                 "versions.yml:md5,ec6468a88403ffc733629109b26e2484"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-29T11:02:07.498528175"
+        "timestamp": "2026-02-02T23:45:40.919891"
     },
     "sarscov2 - bam - paired_end - stub": {
         "content": [
@@ -350,7 +346,6 @@
                 ],
                 "9": [
                     "versions.yml:md5,18dfb578b63a4c06df9029d214d26b21",
-                    "versions.yml:md5,e0481c30dd24b96ee2ace998a360ea29",
                     "versions.yml:md5,ec6468a88403ffc733629109b26e2484"
                 ],
                 "bai": [
@@ -424,15 +419,14 @@
                 ],
                 "versions": [
                     "versions.yml:md5,18dfb578b63a4c06df9029d214d26b21",
-                    "versions.yml:md5,e0481c30dd24b96ee2ace998a360ea29",
                     "versions.yml:md5,ec6468a88403ffc733629109b26e2484"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-01-29T11:02:26.100701853"
+        "timestamp": "2026-02-02T23:46:33.575796"
     }
 }


### PR DESCRIPTION
## Summary
- Replace versions.yml file emission with `topic: versions` channel
- Emit hisat2 and samtools versions as structured tuples
- Update test assertions to use findAll pattern for versions
- Remove explicit version collection from fastq_align_hisat2 subworkflow

## Test plan
- [x] Module tests pass with updated snapshots
- [x] Subworkflow tests pass
- [x] nf-core lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)