### PR TITLE
fix(subworkflows): Remove vestigial empty versions channels

### DIFF
--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -126,7 +126,6 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
 
     main:
 
-    ch_versions = channel.empty()
     ch_filtered_reads = channel.empty()
     ch_trim_read_count = channel.empty()
     ch_multiqc_files = channel.empty()
@@ -335,7 +334,6 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         ch_seqkit_prefixed  = FASTQ_REMOVE_RRNA.out.seqkit_prefixed
         ch_seqkit_converted = FASTQ_REMOVE_RRNA.out.seqkit_converted
         ch_multiqc_files = ch_multiqc_files.mix(FASTQ_REMOVE_RRNA.out.multiqc_files)
-        ch_versions = ch_versions.mix(FASTQ_REMOVE_RRNA.out.versions)
 
         if (!skip_linting) {
             FQ_LINT_AFTER_RIBO_REMOVAL(
@@ -375,7 +373,6 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         ch_salmon_index,
         make_salmon_index,
     )
-    ch_versions = ch_versions.mix(FASTQ_SUBSAMPLE_FQ_SALMON.out.versions)
 
     FASTQ_SUBSAMPLE_FQ_SALMON.out.lib_format_counts
         .join(ch_strand_fastq.auto_strand)
@@ -419,6 +416,4 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     bowtie2_index    = ch_bowtie2_index
     seqkit_prefixed  = ch_seqkit_prefixed
     seqkit_converted = ch_seqkit_converted
-
-    versions         = ch_versions // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
@@ -192,13 +192,6 @@ output:
         - count:
             type: integer
             description: Number of reads after trimming
-  - versions:
-      description: File containing software versions
-      structure:
-        - versions:
-            type: file
-            description: File containing software versions
-            pattern: "versions.yml"
   - lint_log:
       description: Log files from FastQ linting
       structure:

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
@@ -486,8 +486,7 @@ nextflow_workflow {
                 { assert bowtie2RrnaCount == 10 },   // 10 reads aligned to rRNA reference
                 { assert snapshot(
                     selines.join('\n').md5(),
-                    processed_ribo_removal_lint_report.md5(),
-                    workflow.out.versions
+                    processed_ribo_removal_lint_report.md5()
                 ).match() }
             )
         }

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test.snap
@@ -50,10 +50,7 @@
     "homo_sapiens single-end [fastq] fastp bowtie2": {
         "content": [
             "b423f619ae31c22b2bf99bdcb89bf852",
-            "5c1e74518dd70e4f1506b4f64da7b5f3",
-            [
-                
-            ]
+            "5c1e74518dd70e4f1506b4f64da7b5f3"
         ],
         "meta": {
             "nf-test": "0.9.3",

--- a/subworkflows/nf-core/fastq_remove_rrna/main.nf
+++ b/subworkflows/nf-core/fastq_remove_rrna/main.nf
@@ -45,7 +45,6 @@ workflow FASTQ_REMOVE_RRNA {
 
     main:
 
-    ch_versions = channel.empty()
     ch_multiqc_files = channel.empty()
     ch_filtered_reads = ch_reads
 
@@ -216,5 +215,4 @@ workflow FASTQ_REMOVE_RRNA {
     bowtie2_index    = ch_bowtie2_index_out // channel: [ val(meta), [ index ] ]
     seqkit_prefixed  = ch_seqkit_prefixed  // channel: [ val(meta), [ fasta ] ]
     seqkit_converted = ch_seqkit_converted // channel: [ val(meta), [ fasta ] ]
-    versions         = ch_versions         // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-core/fastq_remove_rrna/meta.yml
+++ b/subworkflows/nf-core/fastq_remove_rrna/meta.yml
@@ -98,15 +98,6 @@ output:
             type: file
             description: Tool-specific log files
             pattern: "*.log"
-  - versions:
-      type: file
-      description: |
-        File containing software versions
-      structure:
-        - versions:
-            type: file
-            description: File containing software versions
-            pattern: "versions.yml"
 authors:
   - "@pinin4fjords"
 maintainers:

--- a/subworkflows/nf-core/fastq_remove_rrna/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_remove_rrna/tests/main.nf.test
@@ -78,7 +78,6 @@ nextflow_workflow {
                 { assert pelines2.size() == 16636 },
                 { assert sortmernaRrnaCount == 20 },  // 10 pairs = 20 individual reads (100% detection)
                 { assert snapshot(
-                    workflow.out.versions,
                     pelines1.join('\n').md5(),
                     pelines2.join('\n').md5()
                 ).match() }
@@ -127,7 +126,6 @@ nextflow_workflow {
                 { assert pelines2.size() == 16648 },
                 { assert ribodetectorRrnaCount == 7 },  // 7 pairs detected (70% - ML model misses some)
                 { assert snapshot(
-                    workflow.out.versions,
                     sortedLines1.join('\n').md5(),
                     sortedLines2.join('\n').md5()
                 ).match() }
@@ -173,7 +171,6 @@ nextflow_workflow {
                 { assert pelines2.size() == 16636 },
                 { assert bowtie2RrnaCount == 17 },  // 17 mates aligned to rRNA reference
                 { assert snapshot(
-                    workflow.out.versions,
                     pelines1.join('\n').md5(),
                     pelines2.join('\n').md5()
                 ).match() }
@@ -236,7 +233,6 @@ nextflow_workflow {
                 { assert selines.size() == 16636 },  // 4159 reads × 4 lines/read
                 { assert bowtie2RrnaCount == 10 },   // 10 reads aligned to rRNA reference
                 { assert snapshot(
-                    workflow.out.versions,
                     selines.join('\n').md5()
                 ).match() }
             )
@@ -294,7 +290,6 @@ nextflow_workflow {
                 { assert selines.size() == 16636 },  // 4159 reads × 4 lines/read
                 { assert sortmernaRrnaCount == 10 },  // 10 reads detected (100% detection)
                 { assert snapshot(
-                    workflow.out.versions,
                     selines.join('\n').md5()
                 ).match() }
             )
@@ -338,7 +333,6 @@ nextflow_workflow {
             // even when the same rRNA databases are provided multiple times
             assertAll(
                 { assert workflow.success },
-                { assert snapshot(workflow.out.versions).match() },
                 { assert pelines1.size() >= 0 },  // Should have some reads
                 { assert pelines2.size() >= 0 },  // Should have some reads
                 { assert !workflow.stderr.contains("Duplicate entry") },  // No duplicate header errors in stderr

--- a/subworkflows/nf-core/fastq_remove_rrna/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_remove_rrna/tests/main.nf.test.snap
@@ -1,9 +1,6 @@
 {
     "homo_sapiens single-end [fastq] bowtie2": {
         "content": [
-            [
-                
-            ],
             "bdea4e3bbdbb7c301ff578b9d8976fb6"
         ],
         "meta": {
@@ -14,9 +11,6 @@
     },
     "homo_sapiens single-end [fastq] sortmerna": {
         "content": [
-            [
-                
-            ],
             "bdea4e3bbdbb7c301ff578b9d8976fb6"
         ],
         "meta": {
@@ -25,23 +19,8 @@
         },
         "timestamp": "2026-01-19T15:59:26.891896799"
     },
-    "homo_sapiens paired-end [fastq] bowtie2 with duplicate rrna databases": {
-        "content": [
-            [
-                
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-03T16:43:04.529744492"
-    },
     "homo_sapiens paired-end [fastq] sortmerna": {
         "content": [
-            [
-                
-            ],
             "bdea4e3bbdbb7c301ff578b9d8976fb6",
             "1b83618177abebeb38c29d2258efdd4f"
         ],
@@ -53,9 +32,6 @@
     },
     "homo_sapiens paired-end [fastq] ribodetector": {
         "content": [
-            [
-                
-            ],
             "ec0260bcdeef6af8a9b6d470eafb5603",
             "a0ef8564218df5741dee81f03db13600"
         ],
@@ -67,9 +43,6 @@
     },
     "homo_sapiens paired-end [fastq] bowtie2": {
         "content": [
-            [
-                
-            ],
             "4ef4e259208497288aaefaa88770975d",
             "63198a2af4a4a8fb949b01a8b2c4cb7c"
         ],

--- a/subworkflows/nf-core/fastq_subsample_fq_salmon/main.nf
+++ b/subworkflows/nf-core/fastq_subsample_fq_salmon/main.nf
@@ -18,8 +18,6 @@ workflow FASTQ_SUBSAMPLE_FQ_SALMON {
 
     main:
 
-    ch_versions = channel.empty()
-
     //
     // Create Salmon index if required
     //
@@ -47,6 +45,4 @@ workflow FASTQ_SUBSAMPLE_FQ_SALMON {
     results           = SALMON_QUANT.out.results           // channel: [ val(meta), results_dir ]
     json_info         = SALMON_QUANT.out.json_info         // channel: [ val(meta), json_info
     lib_format_counts = SALMON_QUANT.out.lib_format_counts // channel: [ val(meta), json_info
-
-    versions          = ch_versions                        // channel: [ versions.yml ]
 }

--- a/subworkflows/nf-core/fastq_subsample_fq_salmon/meta.yml
+++ b/subworkflows/nf-core/fastq_subsample_fq_salmon/meta.yml
@@ -58,10 +58,6 @@ output:
         File containing meta information from Salmon quant
         Which could be used to infer strandedness among other things
       pattern: "*info.json"
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
 authors:
   - "@robsyme"
   - "@drpatelh"

--- a/subworkflows/nf-core/fastq_subsample_fq_salmon/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_subsample_fq_salmon/tests/main.nf.test
@@ -58,8 +58,7 @@ nextflow_workflow {
                     readlines1.size(),
                     readlines2[0..5],
                     readlines2.size(),
-                    workflow.out.lib_format_counts,
-                    workflow.out.versions).match() }
+                    workflow.out.lib_format_counts).match() }
             )
         }
     }

--- a/subworkflows/nf-core/fastq_subsample_fq_salmon/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_subsample_fq_salmon/tests/main.nf.test.snap
@@ -27,9 +27,6 @@
                     },
                     "test_lib_format_counts.json:md5,0b0e2dc090e5ad88f9a9d6dbe9c3e4a0"
                 ]
-            ],
-            [
-                
             ]
         ],
         "meta": {
@@ -101,9 +98,6 @@
                         "test_lib_format_counts.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "5": [
-                    
-                ],
                 "index": [
                     [
                         "complete_ref_lens.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
@@ -160,12 +154,9 @@
                             "single_end": false
                         },
                         [
-                            
+
                         ]
                     ]
-                ],
-                "versions": [
-                    
                 ]
             }
         ],


### PR DESCRIPTION
## Summary
- Remove unused `ch_versions` channels and `versions` emit statements from `fastq_remove_rrna`, `fastq_subsample_fq_salmon`, and `fastq_qc_trim_filter_setstrandedness` subworkflows
- These channels were never populated as all component modules now use topic-based version reporting
- Update tests and snapshots to remove references to `workflow.out.versions`

## Test plan
- [ ] nf-test passes for all three subworkflows
- [ ] Verify no references to `.out.versions` remain in consuming pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)