### PR TITLE
add syntax comment to dockerfile

### DIFF
--- a/modules/nf-core/wittyer/Dockerfile
+++ b/modules/nf-core/wittyer/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1-labs
 FROM mcr.microsoft.com/dotnet/sdk:9.0@sha256:7d24e90a392e88eb56093e4eb325ff883ad609382a55d42f17fd557b997022ca as builder
 
 ADD https://github.com/Illumina/witty.er.git#v0.5.2 /src


### PR DESCRIPTION
Using `ADD` with a github repo was not supported on the codespace docker. Adding this comment fixes it