### PR TITLE
Add YAML schemas to workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "nextflow.formatting.harshilAlignment": true
+    "nextflow.formatting.harshilAlignment": true,
+    "yaml.schemas": {
+        "./modules/meta-schema.json": ["modules/nf-core/**/meta.yml"],
+        "./modules/environment-schema.json": ["modules/nf-core/**/environment.yml"],
+        "./subworkflows/yaml-schema.json": ["subworkflows/nf-core/**/meta.yml"]
+    }
 }


### PR DESCRIPTION
This PR sets the YAML schema paths for validation within the VSCode `redhat.vscode-yaml` plugin. This will make the editor aware of the schemas to apply to which files, even when the `# yaml-language-server: $schema=...` line is absent.
