### PR TITLE
feat: Add RSEM support to tximeta/tximport and custom/tx2gene

### DIFF
--- a/modules/nf-core/custom/tx2gene/meta.yml
+++ b/modules/nf-core/custom/tx2gene/meta.yml
@@ -6,6 +6,7 @@ keywords:
   - gene
   - gtf
   - pseudoalignment
+  - rsem
   - transcript
 tools:
   - "custom":
@@ -37,7 +38,7 @@ input:
         description: quants file
   - quant_type:
       type: string
-      description: Quantification type, 'kallisto' or 'salmon'
+      description: Quantification type, 'kallisto', 'salmon', or 'rsem'
   - id:
       type: string
       description: Gene ID attribute in the GTF file (default= gene_id)

--- a/modules/nf-core/custom/tx2gene/tests/main.nf.test
+++ b/modules/nf-core/custom/tx2gene/tests/main.nf.test
@@ -88,6 +88,54 @@ nextflow_process {
         }
     }
 
+    test("saccharomyces_cerevisiae - rsem - gtf") {
+
+        setup {
+            run("UNTAR") {
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of([
+                        [ id:'test'], // meta map
+                        // TODO: revert to params.modules_testdata_base_path once nf-core/test-datasets#1864 is merged
+                        file('https://raw.githubusercontent.com/pinin4fjords/test-datasets/rsem-test-data/data/genomics/eukaryotes/saccharomyces_cerevisiae/rsem_results.tar.gz', checkIfExists: true)
+                    ])
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test'], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.gtf', checkIfExists: true)
+                ])
+                input[1] = UNTAR.out.untar.flatMap { meta, dir ->
+                    def entries = []
+                    dir.toFile().eachDir { d ->
+                        d.eachFileMatch(~/.*\\.isoforms\\.results/) { f ->
+                            entries << [ meta, f.toPath() ]
+                        }
+                    }
+                    [ [ meta, entries.collect { it[1] } ] ]
+                }
+                input[2] = 'rsem'
+                input[3] = 'gene_id'
+                input[4] = 'gene_name'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
     test("saccharomyces_cerevisiae - gtf - stub") {
 
         options "-stub"

--- a/modules/nf-core/tximeta/tximport/meta.yml
+++ b/modules/nf-core/tximeta/tximport/meta.yml
@@ -7,6 +7,7 @@ keywords:
   - gene
   - kallisto
   - pseudoalignment
+  - rsem
   - salmon
   - transcript
 tools:
@@ -44,7 +45,7 @@ input:
           - edam: http://edamontology.org/format_3475 # TSV
   - quant_type:
       type: string
-      description: Quantification type, `kallisto` or `salmon`
+      description: Quantification type, `kallisto`, `salmon`, or `rsem`
 output:
   tpm_gene:
     - - meta:

--- a/modules/nf-core/tximeta/tximport/tests/main.nf.test
+++ b/modules/nf-core/tximeta/tximport/tests/main.nf.test
@@ -265,6 +265,106 @@ nextflow_process {
         }
     }
 
+    test("saccharomyces_cerevisiae - rsem - gtf") {
+
+        setup {
+            run("UNTAR") {
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of([
+                        [ id:'test'], // meta map
+                        // TODO: revert to params.modules_testdata_base_path once nf-core/test-datasets#1864 is merged
+                        file('https://raw.githubusercontent.com/pinin4fjords/test-datasets/rsem-test-data/data/genomics/eukaryotes/saccharomyces_cerevisiae/rsem_results.tar.gz', checkIfExists: true)
+                    ])
+                    """
+                }
+            }
+            run("CUSTOM_TX2GENE") {
+                script "../../../custom/tx2gene/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of([
+                        [ id:'test'], // meta map
+                        file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.gtf', checkIfExists: true)
+                    ])
+                    input[1] = UNTAR.out.untar.flatMap { meta, dir ->
+                        def entries = []
+                        dir.toFile().eachDir { d ->
+                            d.eachFileMatch(~/.*\\.isoforms\\.results/) { f ->
+                                entries << [ meta, f.toPath() ]
+                            }
+                        }
+                        [ [ meta, entries.collect { it[1] } ] ]
+                    }
+                    input[2] = 'rsem'
+                    input[3] = 'gene_id'
+                    input[4] = 'gene_name'
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = UNTAR.out.untar.flatMap { meta, dir ->
+                    def entries = []
+                    dir.toFile().eachDir { d ->
+                        d.eachFileMatch(~/.*\\.isoforms\\.results/) { f ->
+                            entries << [ meta, f.toPath() ]
+                        }
+                    }
+                    [ [ meta, entries.collect { it[1] } ] ]
+                }
+                input[1] = CUSTOM_TX2GENE.out.tx2gene
+                input[2] = 'rsem'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.counts_gene,
+                    process.out.counts_gene_length_scaled,
+                    process.out.counts_gene_scaled,
+                    process.out.counts_transcript,
+                    process.out.lengths_gene,
+                    process.out.lengths_transcript,
+                    process.out.tpm_gene,
+                    process.out.tpm_transcript,
+                    process.out.versions).match()
+                }
+            )
+        }
+    }
+
+    test("saccharomyces_cerevisiae - rsem - gtf - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([ [], [] ])
+                input[1] = Channel.of([ [], [] ])
+                input[2] = 'rsem'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match()
+                }
+            )
+        }
+
+    }
+
     test("saccharomyces_cerevisiae - kallisto - gtf - custom_column_names") {
 
         config "./nextflow.config"


### PR DESCRIPTION
## Summary

- Add RSEM as a supported quantification type alongside Salmon and Kallisto for `tximeta/tximport` and `custom/tx2gene` modules
- `tximeta/tximport`: adds RSEM branch handling flat directory layout (`.isoforms.results` files) with double-escaped regex for Nextflow template parsing, using `tximport(type='rsem', txIn=TRUE, txOut=TRUE)`
- `custom/tx2gene`: `read_top_transcripts()` now tries flat directory layout when subdirectory layout finds no matches; file pattern selection expanded to explicitly handle salmon (`quant.sf`), kallisto (`abundance.tsv`), and rsem (`*.isoforms.results`)
- Both `meta.yml` files updated with `rsem` keyword and `quant_type` description
- RSEM test cases added for both modules

## Dependencies

- **nf-core/test-datasets#1864**: RSEM test data (`rsem_results.tar.gz`) is not yet in the nf-core S3 bucket. Tests currently reference the data via the raw GitHub URL from the `pinin4fjords/test-datasets:rsem-test-data` fork branch. Once that PR is merged and the data is synced to S3, the test data URLs should be reverted to use `params.modules_testdata_base_path` (marked with TODO comments in the test files).
- Related pipeline PR: nf-core/rnaseq#1697

## Test plan

- [ ] Existing Salmon/Kallisto tests should pass unchanged (backward-compatible)
- [ ] New RSEM test for `custom/tx2gene` should pass once test-datasets PR is merged
- [ ] New RSEM test for `tximeta/tximport` should pass once test-datasets PR is merged
- [ ] Stub tests should pass immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)