### PR TITLE
used proper repo path variable, changed iterator to it instead of f

### DIFF
--- a/modules/nf-core/bigslice/tests/main.nf.test
+++ b/modules/nf-core/bigslice/tests/main.nf.test
@@ -39,7 +39,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test_gbk' ],
-                    'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/' + 'genomics/prokaryotes/streptomyces_coelicolor/fixtures_bigslice_gbk.tar.gz' // https URL
+                    params.modules_testdata_base_path + 'genomics/prokaryotes/streptomyces_coelicolor/fixtures_bigslice_gbk.tar.gz' // https URL
                 ]
                 """
             }
@@ -61,7 +61,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR_GBK.out.untar
-                input[1] = UNTAR_HMMDB.out.untar.map{ f -> f[1] }
+                input[1] = UNTAR_HMMDB.out.untar.map{ it -> it[1] }
                 """
             }
         }
@@ -87,7 +87,7 @@ nextflow_process {
             process {
                 """
                 input[0] = UNTAR_GBK.out.untar
-                input[1] = UNTAR_HMMDB.out.untar.map{ f -> f[1] }
+                input[1] = UNTAR_HMMDB.out.untar.map{ it -> it[1] }
                 """
             }
         }


### PR DESCRIPTION
## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
