### PR TITLE
fix: Centralize tximport subworkflow config defaults, remove dead entries

### DIFF
--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/nextflow.config
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/nextflow.config
@@ -1,4 +1,12 @@
 process {
+    withName: '.*:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:CUSTOM_TX2GENE' {
+        ext.prefix = { "${quant_type}.merged" }
+    }
+
+    withName: '.*:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:TXIMETA_TXIMPORT' {
+        ext.prefix = { "${quant_type}.merged" }
+    }
+
     withName: '.*:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:SE_GENE_UNIFIED' {
         ext.prefix = { "${meta.id}_gene" }
         ext.args = '--assay_names counts,counts_length_scaled,counts_scaled,lengths,tpm'

--- a/subworkflows/nf-core/quantify_pseudo_alignment/nextflow.config
+++ b/subworkflows/nf-core/quantify_pseudo_alignment/nextflow.config
@@ -8,22 +8,4 @@ process {
     withName: '.*:QUANTIFY_PSEUDO_ALIGNMENT:KALLISTO_QUANT' {
         ext.args = params.extra_kallisto_quant_args ?: ''
     }
-
-    withName: '.*:QUANTIFY_PSEUDO_ALIGNMENT:CUSTOM_TX2GENE' {
-        ext.prefix = { "${quant_type}.merged" }
-    }
-
-    withName: '.*:QUANTIFY_PSEUDO_ALIGNMENT:TXIMETA_TXIMPORT' {
-        ext.prefix = { "${quant_type}.merged" }
-    }
-
-    withName: '.*:QUANTIFY_PSEUDO_ALIGNMENT:SE_GENE_UNIFIED' {
-        ext.prefix = { "${meta.id}_gene" }
-        ext.args = '--assay_names counts,counts_length_scaled,counts_scaled,lengths,tpm'
-    }
-
-    withName: '.*:QUANTIFY_PSEUDO_ALIGNMENT:SE_TRANSCRIPT_UNIFIED' {
-        ext.prefix = { "${meta.id}_transcript" }
-        ext.args = '--assay_names counts,lengths,tpm'
-    }
 }

--- a/subworkflows/nf-core/quantify_rsem/nextflow.config
+++ b/subworkflows/nf-core/quantify_rsem/nextflow.config
@@ -5,21 +5,7 @@ process {
         ext.args   = '--estimate-rspd --seed 1'
     }
 
-    withName: '.*:QUANTIFY_RSEM:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:CUSTOM_TX2GENE' {
+    withName: '.*:QUANTIFY_RSEM:CUSTOM_RSEMMERGECOUNTS' {
         ext.prefix = { "rsem.merged" }
-    }
-
-    withName: '.*:QUANTIFY_RSEM:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:TXIMETA_TXIMPORT' {
-        ext.prefix = { "rsem.merged" }
-    }
-
-    withName: '.*:QUANTIFY_RSEM:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:SE_GENE_UNIFIED' {
-        ext.prefix = { "${meta.id}_gene" }
-        ext.args = '--assay_names counts,counts_length_scaled,counts_scaled,lengths,tpm'
-    }
-
-    withName: '.*:QUANTIFY_RSEM:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:SE_TRANSCRIPT_UNIFIED' {
-        ext.prefix = { "${meta.id}_transcript" }
-        ext.args = '--assay_names counts,lengths,tpm'
     }
 }


### PR DESCRIPTION
## Summary

Fixes config issues introduced in #9995 where the refactoring that nested tximport processes inside `QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT` left some `withName` patterns targeting the wrong nesting depth.

### Changes

**`quant_tximport_summarizedexperiment/nextflow.config`** - Add default `ext.prefix` for `CUSTOM_TX2GENE` and `TXIMETA_TXIMPORT` using `${quant_type}.merged`. This ensures all callers (RSEM, pseudo-alignment, BAM Salmon) get correctly prefixed tx2gene and tximport output files without needing per-caller overrides.

**`quantify_pseudo_alignment/nextflow.config`** - Remove dead config entries for `CUSTOM_TX2GENE`, `TXIMETA_TXIMPORT`, `SE_GENE_UNIFIED`, and `SE_TRANSCRIPT_UNIFIED`. These patterns (e.g. `QUANTIFY_PSEUDO_ALIGNMENT:CUSTOM_TX2GENE`) never matched after #9995 because the processes are now nested one level deeper (`QUANTIFY_PSEUDO_ALIGNMENT:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:CUSTOM_TX2GENE`). The shared subworkflow config now provides these defaults.

**`quantify_rsem/nextflow.config`** - Remove entries for `CUSTOM_TX2GENE`, `TXIMETA_TXIMPORT`, `SE_GENE_UNIFIED`, and `SE_TRANSCRIPT_UNIFIED` that are now redundant with the shared subworkflow defaults. Retain only the RSEM-specific entries (`RSEM_CALCULATEEXPRESSION` ext.args and `CUSTOM_RSEMMERGECOUNTS` ext.prefix).

### Why the old patterns were broken

After #9995, tximport processes are nested inside `QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT`:
```
# Old process path (matched)
QUANTIFY_PSEUDO_ALIGNMENT:CUSTOM_TX2GENE

# New process path (old pattern doesn't match)
QUANTIFY_PSEUDO_ALIGNMENT:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:CUSTOM_TX2GENE
```

The shared config uses `.*:QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT:CUSTOM_TX2GENE` which correctly matches regardless of the calling workflow.

### Test configs are unaffected

All three subworkflow test configs (`tests/nextflow.config`) have their own explicit overrides with correct nested paths, so they continue to work as before.

## Test plan

- [ ] `nf-test test subworkflows/nf-core/quant_tximport_summarizedexperiment/tests/main.nf.test` passes
- [ ] `nf-test test subworkflows/nf-core/quantify_pseudo_alignment/tests/main.nf.test` passes
- [ ] `nf-test test subworkflows/nf-core/quantify_rsem/tests/main.nf.test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)