### PR TITLE
Decouple Parabricks GPU count from accelerator directive

### DIFF
--- a/modules/nf-core/parabricks/applybqsr/main.nf
+++ b/modules/nf-core/parabricks/applybqsr/main.nf
@@ -30,7 +30,7 @@ process PARABRICKS_APPLYBQSR {
     def args             = task.ext.args    ?: ''
     def prefix           = task.ext.prefix  ?: "${meta.id}"
     def interval_command = intervals        ? intervals.collect { interval -> "--interval-file ${interval}" }.join(' ') : ""
-    def num_gpus         = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus         = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     pbrun \\
         applybqsr \\

--- a/modules/nf-core/parabricks/dbsnp/main.nf
+++ b/modules/nf-core/parabricks/dbsnp/main.nf
@@ -25,7 +25,7 @@ process PARABRICKS_DBSNP {
     }
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     pbrun \\
         dbsnp \\

--- a/modules/nf-core/parabricks/deepvariant/main.nf
+++ b/modules/nf-core/parabricks/deepvariant/main.nf
@@ -29,7 +29,7 @@ process PARABRICKS_DEEPVARIANT {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def output_file = args.contains("--gvcf") ? "${prefix}.g.vcf.gz" : "${prefix}.vcf.gz"
     def interval_command = intervals        ? intervals.collect { interval -> "--interval-file ${interval}" }.join(' ') : ""
-    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     pbrun \\
         deepvariant \\

--- a/modules/nf-core/parabricks/fq2bam/main.nf
+++ b/modules/nf-core/parabricks/fq2bam/main.nf
@@ -44,7 +44,7 @@ process PARABRICKS_FQ2BAM {
     def known_sites_output_cmd = known_sites ? "--out-recal-file ${prefix}.table" : ""
     def intervals_command = intervals ? (intervals instanceof List ? intervals.collect { interval -> "--interval-file ${interval}" }.join(' ') : "--interval-file ${intervals}") : ""
 
-    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
     cp ${fasta} \$INDEX

--- a/modules/nf-core/parabricks/fq2bammeth/main.nf
+++ b/modules/nf-core/parabricks/fq2bammeth/main.nf
@@ -34,7 +34,7 @@ process PARABRICKS_FQ2BAMMETH {
     def in_fq_command       = meta.single_end ? "--in-se-fq ${reads}" : "--in-fq ${reads}"
     def known_sites_command = known_sites ? known_sites.collect { knownSite ->  "--knownSites ${knownSite}" }.join(' ') : ""
     def known_sites_output  = known_sites ? "--out-recal-file ${prefix}.table" : ""
-    def num_gpus            = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus            = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     if [ -L ${fasta} ]; then
         ln -sf \$(readlink ${fasta}) ${index}/${fasta}

--- a/modules/nf-core/parabricks/haplotypecaller/main.nf
+++ b/modules/nf-core/parabricks/haplotypecaller/main.nf
@@ -31,7 +31,7 @@ process PARABRICKS_HAPLOTYPECALLER {
     def output_file           = args.contains("--gvcf") ? "${prefix}.g.vcf.gz" : "${prefix}.vcf"
     def intervals_command     = intervals     ? (intervals instanceof List ? intervals.collect { interval -> "--interval-file ${interval}" }.join(' ') : "--interval-file ${intervals}") : ""
 
-    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     pbrun \\
         haplotypecaller \\

--- a/modules/nf-core/parabricks/indexgvcf/main.nf
+++ b/modules/nf-core/parabricks/indexgvcf/main.nf
@@ -24,7 +24,7 @@ process PARABRICKS_INDEXGVCF {
         error("Parabricks module does not support Conda. Please use Docker / Singularity / Podman instead.")
     }
     def args = task.ext.args ?: ''
-    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     pbrun \\
         indexgvcf \\

--- a/modules/nf-core/parabricks/minimap2/main.nf
+++ b/modules/nf-core/parabricks/minimap2/main.nf
@@ -53,7 +53,7 @@ process PARABRICKS_MINIMAP2 {
     def known_sites_output_cmd = known_sites ? "--out-recal-file ${prefix}.table" : ""
     def intervals_command  = intervals     ? (intervals instanceof List ? intervals.collect { interval -> "--interval-file ${interval}" }.join(' ') : "--interval-file ${intervals}") : ""
 
-    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     pbrun \\
         minimap2 \\

--- a/modules/nf-core/parabricks/mutectcaller/main.nf
+++ b/modules/nf-core/parabricks/mutectcaller/main.nf
@@ -35,7 +35,7 @@ process PARABRICKS_MUTECTCALLER {
     def prepon_command = panel_of_normals ? "cp -L ${panel_of_normals_index} `readlink -f ${panel_of_normals}`.tbi && pbrun prepon --in-pon-file ${panel_of_normals}" : ""
     def postpon_command = panel_of_normals ? "pbrun postpon --in-vcf ${prefix}.vcf.gz --in-pon-file ${panel_of_normals} --out-vcf ${prefix}_annotated.vcf.gz" : ""
 
-    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ""
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     # if panel of normals specified, run prepon
     ${prepon_command}

--- a/modules/nf-core/parabricks/rnafq2bam/main.nf
+++ b/modules/nf-core/parabricks/rnafq2bam/main.nf
@@ -48,7 +48,7 @@ process PARABRICKS_RNAFQ2BAM {
     prefix = task.ext.prefix ?: "${meta.id}"
 
     def in_fq_command = meta.single_end ? "--in-se-fq ${reads}" : "--in-fq ${reads}"
-    def num_gpus = task.accelerator ? "--num-gpus ${task.accelerator.request}" : ''
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
 
     def qc_metrics_command = qc_metrics ? "--out-qc-metrics-dir ${prefix}_qc_metrics" : ""
     def duplicate_metrics_command = mark_duplicates ? "--out-duplicate-metrics ${prefix}.duplicate-metrics.txt" : "--no-markdups"

--- a/modules/nf-core/parabricks/starfusion/main.nf
+++ b/modules/nf-core/parabricks/starfusion/main.nf
@@ -27,7 +27,7 @@ process PARABRICKS_STARFUSION {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
-    def num_gpus = task.accelerator ? "--num-gpus $task.accelerator.request" : ''
+    def num_gpus = task.ext.num_gpus ? "--num-gpus ${task.ext.num_gpus}" : ''
     """
     pbrun \\
         starfusion \\


### PR DESCRIPTION
(not sure if this is right yet, for discussion only until we have agreement in https://nfcore.slack.com/archives/CQY2U5QU9/p1771579583230519)

## Summary

- Replace `task.accelerator.request` with `task.ext.num_gpus` for the `--num-gpus` flag across all 11 Parabricks modules

All Parabricks modules currently read `task.accelerator.request` to set `--num-gpus` for pbrun. This couples two separate concerns:

1. **Executor GPU scheduling** (`accelerator`) - tells cloud executors (AWS Batch, Google Batch, K8s) to provision GPU instances
2. **Tool GPU count** (`--num-gpus`) - tells pbrun how many GPUs to use

This coupling prevents pipelines from making `accelerator` executor-conditional (as some nf-core pipelines do, e.g. Sarek), because omitting `accelerator` on local/SLURM also drops `--num-gpus` from the tool command.

Using `task.ext.num_gpus` instead lets pipeline configs set them independently:

```groovy
withLabel: process_gpu {
    ext.num_gpus = 1
    accelerator  = { task.executor in ['awsbatch','google-batch','k8s'] ? 1 : null }
}
```

Context: nf-core/rnaseq#1710, nf-core/rnaseq#1711

## Affected modules

- `parabricks/applybqsr`
- `parabricks/dbsnp`
- `parabricks/deepvariant`
- `parabricks/fq2bam`
- `parabricks/fq2bammeth`
- `parabricks/haplotypecaller`
- `parabricks/indexgvcf`
- `parabricks/minimap2`
- `parabricks/mutectcaller`
- `parabricks/rnafq2bam`
- `parabricks/starfusion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)