### PR TITLE
Fix misleading error message in ribocode/ribocode

### DIFF
--- a/modules/nf-core/ribocode/ribocode/main.nf
+++ b/modules/nf-core/ribocode/ribocode/main.nf
@@ -38,7 +38,7 @@ process RIBOCODE_RIBOCODE {
     if grep -qiE "^Error|Error:" ribocode_output.log; then
         echo "ERROR: RiboCode failed. Check the output above for details." >&2
         echo "Common causes:" >&2
-        echo "  - Invalid config file from metaplots (lower cutoffs in the RIBOCODE_METAPLOTS step, e.g., '-f0_percent 0.5')" >&2
+        echo "  - Invalid config file from metaplots (try lower cutoffs in the RIBOCODE_METAPLOTS step, e.g., '-f0_percent 0.5', though note that this lowers confidence in resulting annotation)" >&2
         echo "  - Insufficient data from Ribo-Seq alignment" >&2
         exit 1
     fi


### PR DESCRIPTION
## Summary

- Clarify that `-f0_percent` cutoff belongs to the `RIBOCODE_METAPLOTS` step, not `RIBOCODE_RIBOCODE`
- The previous wording ("try lowering cutoff via ext.args") led a user to pass `-f0_percent` to the RiboCode ORF detection command, which doesn't accept it (`RiboCode: error: unrecognized arguments: -f0_percent 0.3`)
- New wording: "lower cutoffs in the RIBOCODE_METAPLOTS step"

## Context

Reported by a user in [nf-core/riboseq Slack](https://nfcore.slack.com/). The error fires when the metaplots config file has no valid entries (empty after header), and the suggested fix needs to be applied to the metaplots process, not the ribocode process.

## Test plan

- [ ] Existing ribocode/ribocode tests still pass (no functional change, error message text only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)