### PR TITLE
Updating bigslice

### DIFF
--- a/modules/nf-core/bigslice/main.nf
+++ b/modules/nf-core/bigslice/main.nf
@@ -15,7 +15,7 @@ process BIGSLICE {
     output:
     tuple val(meta), path("${prefix}/result/data.db")    , emit: db
     tuple val(meta), path("${prefix}/result/tmp/**/*.fa"), emit: fa
-    tuple val("${task.process}"), val('bigslice'), eval("echo 2.0.2"), topic: versions
+    tuple val("${task.process}"), val('bigslice'), eval("echo 2.0.2"), topic: versions, emit: versions_bigslice
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/bigslice/tests/main.nf.test
+++ b/modules/nf-core/bigslice/tests/main.nf.test
@@ -77,7 +77,7 @@ nextflow_process {
                 { assert snapshot(
                     file(process.out.db[0][1]).name,
                     process.out.fa[0][1].size(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions")}
                 ).match() }
             )
         }
@@ -107,7 +107,7 @@ nextflow_process {
             assertAll(
                 { assert snapshot(
                     process.out,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions")}
                 ).match() }
             )
         }

--- a/modules/nf-core/bigslice/tests/main.nf.test.snap
+++ b/modules/nf-core/bigslice/tests/main.nf.test.snap
@@ -40,26 +40,49 @@
                         },
                         "test.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
+                ],
+                "versions_bigslice": [
+                    [
+                        "BIGSLICE",
+                        "bigslice",
+                        "2.0.2"
+                    ]
                 ]
             },
-            null
+            {
+                "versions_bigslice": [
+                    [
+                        "BIGSLICE",
+                        "bigslice",
+                        "2.0.2"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
         },
-        "timestamp": "2026-03-04T00:23:22.776974908"
+        "timestamp": "2026-03-04T09:47:43.387153103"
     },
     "streptomyces_coelicolor - bigslice - gbk": {
         "content": [
             "data.db",
             40,
-            null
+            {
+                "versions_bigslice": [
+                    [
+                        "BIGSLICE",
+                        "bigslice",
+                        "2.0.2"
+                    ]
+                ]
+            }
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
         },
-        "timestamp": "2026-03-04T00:23:10.410022744"
+        "timestamp": "2026-03-04T09:47:30.918713387"
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] Updated BiG-SLiCE module to work correctly as part of the nf-core/funcscan pipeline.

    Changes:
    
    Added stageAs: 'bgc_files/*' to input to allow receiving a list of individual GBK files
    Added preparation of the folder structure required by BiG-SLiCE (datasets.tsv, dataset/sample subfolders, taxonomy/) directly in the process script
    Changed the issuance of versions from the topic: versions in the versions.yml file for compatibility with the funcscan pipeline
    Updated tests to reflect the new input and output structure
    Reason: BiG-SLiCE requires a specific folder structure at input (-i), not just a list of files. Without these changes, the module cannot be functionally integrated into a pipeline.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
