### PR TITLE
fix(purge_dups): log is empty

### DIFF
--- a/modules/nf-core/purgedups/purgedups/main.nf
+++ b/modules/nf-core/purgedups/purgedups/main.nf
@@ -27,9 +27,8 @@ process PURGEDUPS_PURGEDUPS {
         ${args} \\
         -T ${cutoff} \\
         -c ${basecov} \\
-        ${paf} | gzip \\
-        > ${prefix}.dups.bed.gz \\
-        2>| >(tee ${prefix}.purge_dups.log >&2)
+        ${paf} 2> >(tee test.purge_dups.log >&2) | gzip \
+        > test.dups.bed.gz
     """
 
     stub:


### PR DESCRIPTION
Log file in purgedups/purgedups was empty... test snapshot doesn't need to be updated as the log file is unstable, so hashing is skipped.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
