### PR TITLE
Add missing samplename from `generateReadgroupBCLCONVERT` metadata

### DIFF
--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -123,7 +123,6 @@ def generateReadgroupBCLCONVERT(ch_fastq_list_csv, ch_fastq) {
                         samplename: row.RGSM,
                         readgroup: rg,
                         single_end: !fastq2,
-                        lane: row.Lane,
                     ]
 
                     meta_fastq << [new_meta, fastq2 ? [fastq1, fastq2] : [fastq1]]

--- a/subworkflows/nf-core/bcl_demultiplex/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bcl_demultiplex/tests/main.nf.test.snap
@@ -14,6 +14,7 @@
                                 "PU": "HMTFYDRXX.1",
                                 "SM": "SampleZ"
                             },
+                            "samplename": "SampleZ",
                             "single_end": true
                         },
                         [
@@ -26,6 +27,7 @@
                         {
                             "id": "Sample1_S1_L001",
                             "lane": 1,
+                            "samplename": "Sample1",
                             "readgroup": {
                                 "ID": "GAACTGAGCG.TCGTGGAGCG.1",
                                 "PU": "HMTFYDRXX.1",
@@ -43,6 +45,7 @@
                         {
                             "id": "Sample23_S3_L001",
                             "lane": 1,
+                            "samplename": "Sample23",
                             "readgroup": {
                                 "ID": "CGTCTCATAT.TATAGTAGCT.1",
                                 "PU": "HMTFYDRXX.1",
@@ -60,6 +63,7 @@
                         {
                             "id": "SampleA_S2_L001",
                             "lane": 1,
+                            "samplename": "SampleA",
                             "readgroup": {
                                 "ID": "AGGTCAGATA.CTACAAGATA.1",
                                 "PU": "HMTFYDRXX.1",
@@ -77,6 +81,7 @@
                         {
                             "id": "sampletest_S4_L001",
                             "lane": 1,
+                            "samplename": "sampletest",
                             "readgroup": {
                                 "ID": "ATTCCATAAG.TGCCTGGTGG.1",
                                 "PU": "HMTFYDRXX.1",
@@ -175,9 +180,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nextflow": "25.04.8"
         },
-        "timestamp": "2026-03-04T19:55:51.054792"
+        "timestamp": "2026-03-09T19:52:12.815342731"
     },
     "bcl2fastq": {
         "content": [


### PR DESCRIPTION
Recent changes removed the `samplename` from being produced by the `generateReadgroupBCLCONVERT` function in the `BCL_DEMULTIPLEX` workflow. This was breaking things downstream, as the samplename is required to make the FASTQ samplesheets in the `nf-core/demultiplex` pipeline. I added this piece of metadata back in. 

## PR checklist

Closes #10373.

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
