### PR TITLE
Remove task.ext.stringency

### DIFF
--- a/modules/nf-core/picard/fixmateinformation/main.nf
+++ b/modules/nf-core/picard/fixmateinformation/main.nf
@@ -20,7 +20,6 @@ process PICARD_FIXMATEINFORMATION {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def STRINGENCY = task.ext.stringency ?: "STRICT"
     def avail_mem = 3072
     if (!task.memory) {
         log.info('[Picard FixMateInformation] Available memory not known - defaulting to 3GB. Specify process memory requirements to change this.')
@@ -38,7 +37,6 @@ process PICARD_FIXMATEINFORMATION {
         FixMateInformation \\
         --INPUT ${bam} \\
         --OUTPUT ${prefix}.bam \\
-        --VALIDATION_STRINGENCY ${STRINGENCY} \\
         ${args}
     """
 


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Part of #8716 <!-- If this PR fixes an issue, please link it here! -->

This PR removes the optional ext field for stringency which can be added through `ext.args`

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
