### PR TITLE
Remove ext regions_prefix to conform to nf-core guidelines

### DIFF
--- a/modules/nf-core/icountmini/segment/main.nf
+++ b/modules/nf-core/icountmini/segment/main.nf
@@ -20,15 +20,16 @@ process ICOUNTMINI_SEGMENT {
     task.ext.when == null || task.ext.when
 
     script:
-    def prefix = task.ext.prefix ?: "${gtf.simpleName}_seg"
-    def regions_prefix = task.ext.regions_prefix ?: "${gtf.simpleName}"
+    def args   = task.ext.args ?: ""
+    def prefix = task.ext.prefix ?: "${gtf.simpleName}"
     """
     iCount-Mini segment \\
+        $args \\
         $gtf \\
-        ${prefix}.gtf \\
+        ${prefix}_seg.gtf \\
         $fai
 
-    mv regions.gtf.gz ${regions_prefix}_regions.gtf.gz
+    mv regions.gtf.gz ${prefix}_regions.gtf.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -37,11 +38,10 @@ process ICOUNTMINI_SEGMENT {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${gtf.simpleName}_seg"
-    def regions_prefix = task.ext.regions_prefix ?: "${gtf.simpleName}"
+    def prefix = task.ext.prefix ?: "${gtf.simpleName}"
     """
-    touch ${prefix}.gtf
-    echo | gzip > ${regions_prefix}_regions.gtf.gz
+    touch ${prefix}_seg.gtf
+    echo | gzip > ${prefix}_regions.gtf.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Part of #8716 <!-- If this PR fixes an issue, please link it here! -->

  - Removes `ext.regions_prefix` and simply uses `prefix`.
  - Fixes case where changing `prefix` leading to output not being found.
  - Adds `ext.args` to allow supplying cli options.
---

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
