### PR TITLE
Remove ext.report_title to conform to nf-core guidelines

### DIFF
--- a/modules/nf-core/fastplong/main.nf
+++ b/modules/nf-core/fastplong/main.nf
@@ -30,7 +30,9 @@ process FASTPLONG {
     def adapter_list = adapter_fasta ? "--adapter_fasta ${adapter_fasta}" : ""
     def fail_fastq  = save_trimmed_fail ? "--failed_out ${prefix}.fail.fastq.gz" : ''
     def output_file = discard_trimmed_pass ? '' : "--out ${prefix}.fastplong.fastq.gz"
-    def report_title = task.ext.report_title ?: "${prefix}_fastplong_report"
+    if (!args.contains("--report_title ")) {
+        args += " --report_title ${prefix}_fastplong_report"
+    }
     """
     fastplong \\
         --in ${reads} \\
@@ -40,7 +42,6 @@ process FASTPLONG {
         $adapter_list \\
         $fail_fastq \\
         --thread $task.cpus \\
-        --report_title $report_title\\
         $args \\
         2> >(tee ${prefix}.fastplong.log >&2)
     """


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Part of #8716 <!-- If this PR fixes an issue, please link it here! -->

Removes `ext.report_title`, adding `--report-title` to `ext.args` where it can be overridden.

---

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
