### PR TITLE
Remove ext.batch_size to comply with nf-core guidelines

### DIFF
--- a/modules/nf-core/vcfpgloader/load/main.nf
+++ b/modules/nf-core/vcfpgloader/load/main.nf
@@ -34,8 +34,9 @@ process VCFPGLOADER_LOAD {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    // NOTE: batch_size exposed via task.ext for pipeline-level tuning of memory/performance tradeoffs
-    def batch_size = task.ext.batch_size ?: '10000'
+    if (!args.contains('--batch ')) {
+        args += " --batch 10000"
+    }
     """
     vcf-pg-loader load \\
         --host ${db_host} \\
@@ -43,7 +44,6 @@ process VCFPGLOADER_LOAD {
         --database ${db_name} \\
         --user ${db_user} \\
         --schema ${db_schema} \\
-        --batch ${batch_size} \\
         --workers ${task.cpus} \\
         --sample-id ${meta.id} \\
         --report ${prefix}.load_report.json \\


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Part of #8716 <!-- If this PR fixes an issue, please link it here! -->

Removes `ext.batch_size` and supports the flag via `ext.args`

--- 

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
