### PR TITLE
Remove non-standard ext keys to comply with nf-core guidelines

### DIFF
--- a/modules/nf-core/plink2/vcf2bgen/main.nf
+++ b/modules/nf-core/plink2/vcf2bgen/main.nf
@@ -29,8 +29,6 @@ process PLINK2_VCF2BGEN {
         --memory ${task.memory.toMega()} \
         --vcf ${vcf} 'dosage=${dosage_field}' \
         --export bgen-1.2 ${reffirst}\
-        --max-alleles 2 \
-        --vcf-half-call r \
         --${sample_name_mode} \
         --out ${prefix} \
         ${args}

--- a/modules/nf-core/plink2/vcf2bgen/tests/main.nf.test
+++ b/modules/nf-core/plink2/vcf2bgen/tests/main.nf.test
@@ -13,6 +13,9 @@ nextflow_process {
         config "./nextflow.config"
 
         when {
+            params {
+                plink2_vcf2bgen_args = "--max-alleles 2 --vcf-half-call r"
+            }
             process {
                 """
                 input[0] = [
@@ -43,6 +46,9 @@ nextflow_process {
         config "./nextflow.config"
 
         when {
+            params {
+                plink2_vcf2bgen_args = "--max-alleles 2 --vcf-half-call r"
+            }
             process {
                 """
                 input[0] = [
@@ -73,6 +79,9 @@ nextflow_process {
         config "./nextflow.config"
 
         when {
+            params {
+                plink2_vcf2bgen_args = "--max-alleles 2 --vcf-half-call r"
+            }
             process {
                 """
                 input[0] = [
@@ -104,6 +113,9 @@ nextflow_process {
         options "-stub"
 
         when {
+            params {
+                plink2_vcf2bgen_args = "--max-alleles 2 --vcf-half-call r"
+            }
             process {
                 """
                 input[0] = [

--- a/modules/nf-core/plink2/vcf2bgen/tests/nextflow.config
+++ b/modules/nf-core/plink2/vcf2bgen/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'PLINK2_VCF2BGEN' {
+        ext.args = params.plink2_vcf2bgen_args
+    }
+}


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Part of #8716  <!-- If this PR fixes an issue, please link it here! -->
- Removes non-standard ext keys. Since they are already inputs, values can be taken directly from there.
- Moves hard-coded cli options to ext.args.

I can't see where this module is used. 

---

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
