### PR TITLE
Migrate annosine to topic channels

### DIFF
--- a/modules/nf-core/annosine/main.nf
+++ b/modules/nf-core/annosine/main.nf
@@ -2,7 +2,6 @@ process ANNOSINE {
     tag "$meta.id"
     label 'process_medium'
 
-    // WARN: Manually update when changing Bioconda assets
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/annosine2:2.0.8--pyh7e72e81_0':
@@ -15,7 +14,7 @@ process ANNOSINE {
     output:
     tuple val(meta), path("${prefix}.log"), emit: log
     tuple val(meta), path("${prefix}.fa") , emit: fa, optional: true
-    tuple val("${task.process}"), val('annosine'), eval('pip show annosine2 | sed -n "s/Version: //p"'), emit: versions_annosine, topic: versions
+    tuple val("${task.process}"), val('annosine'), eval("pip show annosine2 | sed -n 's/Version: //p'"), emit: versions_annosine, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/annosine/meta.yml
+++ b/modules/nf-core/annosine/meta.yml
@@ -65,7 +65,7 @@ output:
       - "annosine":
           type: string
           description: The name of the tool
-      - 'pip show annosine2 | grep "^Version" | sed "s/Version: //"':
+      - "pip show annosine2 | sed -n 's/Version: //p'":
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -76,7 +76,7 @@ topics:
       - "annosine":
           type: string
           description: The name of the tool
-      - 'pip show annosine2 | grep "^Version" | sed "s/Version: //"':
+      - "pip show annosine2 | sed -n 's/Version: //p'":
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/annosine/tests/main.nf.test
+++ b/modules/nf-core/annosine/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/eukaryotes/actinidia_chinensis/genome/chr1/genome.fasta.gz', checkIfExists: true)
                 ]
                 input[1] = 3
@@ -31,8 +31,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.fa,
                     process.out.findAll { key, val -> key.startsWith('versions') },
-                    ).match()
-                }
+                ).match()}
             )
         }
 
@@ -46,7 +45,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/eukaryotes/actinidia_chinensis/genome/chr1/genome.fasta.gz', checkIfExists: true)
                 ]
                 input[1] = 3
@@ -57,7 +56,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/annosine/tests/main.nf.test.snap
+++ b/modules/nf-core/annosine/tests/main.nf.test.snap
@@ -4,8 +4,7 @@
             [
                 [
                     {
-                        "id": "test",
-                        "single_end": false
+                        "id": "test"
                     },
                     "test_annosine.fa:md5,fc3bd39555133a1b50623bccc7d4cf9b"
                 ]
@@ -20,45 +19,19 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-13T09:45:27.322794252",
+        "timestamp": "2026-04-06T17:07:55.829032275",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.03.1"
         }
     },
     "actinidia_chinensis - fasta - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_annosine.log:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_annosine.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        "ANNOSINE",
-                        "annosine",
-                        "2.0.8"
-                    ]
-                ],
                 "fa": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
                         "test_annosine.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
@@ -66,8 +39,7 @@
                 "log": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
                         "test_annosine.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
@@ -81,10 +53,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-13T09:46:04.662034254",
+        "timestamp": "2026-04-06T17:08:03.950796341",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.03.1"
         }
     }
 }


### PR DESCRIPTION
Closes nf-core/modules#10182

Migrated annosine module from versions.yml to topic channels following the [migration guide](https://nf-co.re/docs/tutorials/migrate_to_topics/update_modules).