### PR TITLE
feat: add topic version emission to quant-related modules

### DIFF
--- a/modules/nf-core/custom/tx2gene/main.nf
+++ b/modules/nf-core/custom/tx2gene/main.nf
@@ -16,7 +16,7 @@ process CUSTOM_TX2GENE {
 
     output:
     tuple val(meta), path("*tx2gene.tsv"), emit: tx2gene
-    path "versions.yml"                  , emit: versions
+    path "versions.yml"                  , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/custom/tx2gene/meta.yml
+++ b/modules/nf-core/custom/tx2gene/meta.yml
@@ -61,10 +61,14 @@ output:
   versions:
     - versions.yml:
         type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+        description: YAML file containing versions of tools used in the module
         ontologies:
           - edam: http://edamontology.org/format_3750 # YAML
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
 authors:
   - "@pinin4fjords"
 maintainers:

--- a/modules/nf-core/summarizedexperiment/summarizedexperiment/main.nf
+++ b/modules/nf-core/summarizedexperiment/summarizedexperiment/main.nf
@@ -15,7 +15,7 @@ process SUMMARIZEDEXPERIMENT_SUMMARIZEDEXPERIMENT {
     output:
     tuple val(meta), path("*.rds")              , emit: rds
     tuple val(meta), path("*.R_sessionInfo.log"), emit: log
-    path "versions.yml"                         , emit: versions
+    path "versions.yml"                         , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/summarizedexperiment/summarizedexperiment/meta.yml
+++ b/modules/nf-core/summarizedexperiment/summarizedexperiment/meta.yml
@@ -87,10 +87,14 @@ output:
   versions:
     - versions.yml:
         type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+        description: YAML file containing versions of tools used in the module
         ontologies:
           - edam: http://edamontology.org/format_3750 # YAML
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
 authors:
   - "@pinin4fjords"
 maintainers:

--- a/modules/nf-core/tximeta/tximport/main.nf
+++ b/modules/nf-core/tximeta/tximport/main.nf
@@ -21,7 +21,7 @@ process TXIMETA_TXIMPORT {
     tuple val(meta), path("*transcript_tpm.tsv")           , emit: tpm_transcript
     tuple val(meta), path("*transcript_counts.tsv")        , emit: counts_transcript
     tuple val(meta), path("*transcript_lengths.tsv")       , emit: lengths_transcript
-    path "versions.yml"                                    , emit: versions
+    path "versions.yml"                                    , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/tximeta/tximport/meta.yml
+++ b/modules/nf-core/tximeta/tximport/meta.yml
@@ -162,10 +162,14 @@ output:
   versions:
     - versions.yml:
         type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+        description: YAML file containing versions of tools used in the module
         ontologies:
           - edam: http://edamontology.org/format_3750 # YAML
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
 authors:
   - "@pinin4fjords"
 maintainers:


### PR DESCRIPTION
## Summary

- Convert `custom/tx2gene`, `tximeta/tximport`, and `summarizedexperiment/summarizedexperiment` to emit versions via `topic: versions` channels
- Update meta.yml files with `topics` section and updated version output descriptions

This enables downstream subworkflows (e.g. `quant_tximport_summarizedexperiment`) to collect versions automatically via topic channels instead of manual `ch_versions.mix()`, which is needed for conditional execution paths like #10928.

Follows the pattern I observed in #10873 for templated modules.

## Test plan
- [ ] Existing module tests pass (snapshot update expected for versions format)
- [ ] `process.out.versions` still works in tests (emit is preserved alongside topic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)