### PR TITLE
[WIP] Add cpu and allow bigger resource label

### DIFF
--- a/modules/nf-core/agat/spkeeplongestisoform/main.nf
+++ b/modules/nf-core/agat/spkeeplongestisoform/main.nf
@@ -1,6 +1,6 @@
 process AGAT_SPKEEPLONGESTISOFORM {
     tag "$meta.id"
-    label 'process_single'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -26,6 +26,7 @@ process AGAT_SPKEEPLONGESTISOFORM {
     """
     agat_sp_keep_longest_isoform.pl \\
         --gff ${gxf} \\
+        --cpu ${task.cpus} \\
         ${config_param} \\
         --out ${output} \\
         ${args}


### PR DESCRIPTION
## PR checklist

Closes #10968 

I added the cpu flag and gave more resources to this module, as I think this will speed it up

But before we merge this, I want to test it, hence WIP. Maybe splitting up with cpu could make it slower, if IPC::Shareable in this perl script is causing the stalling, when /dev/shm gets full



- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!

- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`