### PR TITLE
Add gcta/fastgwa module

### DIFF
--- a/modules/nf-core/gcta/fastgwa/environment.yml
+++ b/modules/nf-core/gcta/fastgwa/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::gcta=1.94.1

--- a/modules/nf-core/gcta/fastgwa/main.nf
+++ b/modules/nf-core/gcta/fastgwa/main.nf
@@ -28,13 +28,12 @@ process GCTA_FASTGWA {
     def genotype_suffix = bed_pgen.name.tokenize('.').last()
     def genotype_flag = genotype_suffix == 'pgen' ? '--pfile' : '--bfile'
     def genotype_prefix = bed_pgen.baseName
-    def grm_arg = sparse_grm_files ? "--grm-sparse ${meta5.id}" : ''
     def qcovar_arg = quant_covariates_file ? "--qcovar ${quant_covariates_file}" : ''
     def covar_arg = cat_covariates_file ? "--covar ${cat_covariates_file}" : ''
     """
     gcta \\
         ${genotype_flag} ${genotype_prefix} \\
-        ${grm_arg} \\
+        --grm-sparse ${meta5.id} \\
         --fastGWA-mlm \\
         --pheno ${phenotype_file} \\
         ${qcovar_arg} \\

--- a/modules/nf-core/gcta/fastgwa/main.nf
+++ b/modules/nf-core/gcta/fastgwa/main.nf
@@ -1,0 +1,54 @@
+process GCTA_FASTGWA {
+    tag "${meta.id}"
+    label 'process_medium'
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/46b0d05f0daa47561d87d2a9cac5e51edc2c78e26f1bbab439c688386241a274/data'
+        : 'community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9'}"
+
+    input:
+    tuple val(meta), path(bed_pgen), path(bim_pvar), path(fam_psam)
+    tuple val(meta2), path(phenotype_file)
+    tuple val(meta3), path(quant_covariates_file)
+    tuple val(meta4), path(cat_covariates_file)
+    tuple val(meta5), path(sparse_grm_files)
+
+    output:
+    tuple val(meta), path("*.fastGWA"), emit: results
+    tuple val(meta), path("*.log"), emit: log
+    tuple val("${task.process}"), val("gcta"), eval("gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'"), emit: versions_gcta, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def out = prefix
+    def genotype_suffix = bed_pgen.name.tokenize('.').last()
+    def genotype_flag = genotype_suffix == 'pgen' ? '--pfile' : '--bfile'
+    def genotype_prefix = bed_pgen.baseName
+    def grm_arg = sparse_grm_files ? "--grm-sparse ${meta5.id}" : ''
+    def qcovar_arg = quant_covariates_file ? "--qcovar ${quant_covariates_file}" : ''
+    def covar_arg = cat_covariates_file ? "--covar ${cat_covariates_file}" : ''
+    """
+    gcta \\
+        ${genotype_flag} ${genotype_prefix} \\
+        ${grm_arg} \\
+        --fastGWA-mlm \\
+        --pheno ${phenotype_file} \\
+        ${qcovar_arg} \\
+        ${covar_arg} \\
+        --thread-num ${task.cpus} \\
+        --out ${out} \\
+        ${args}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def out = prefix
+    """
+    touch ${out}.fastGWA
+    touch ${out}.log
+    """
+}

--- a/modules/nf-core/gcta/fastgwa/meta.yml
+++ b/modules/nf-core/gcta/fastgwa/meta.yml
@@ -78,10 +78,10 @@ input:
         description: |
           Groovy map containing sparse GRM metadata
           e.g. `[ id:'plink_simulated_sp' ]`
-          Used when sparse GRM files are supplied
+          Used as the sparse GRM basename for `--grm-sparse` when sparse GRM files are supplied
     - sparse_grm_files:
         type: file
-        description: Sparse GRM sidecar files, pass `[]` when absent
+        description: Sparse GRM sidecar files
         pattern: "*.grm.{id,sp}"
         ontologies: []
 output:

--- a/modules/nf-core/gcta/fastgwa/meta.yml
+++ b/modules/nf-core/gcta/fastgwa/meta.yml
@@ -1,0 +1,136 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "gcta_fastgwa"
+description: Run GCTA fastGWA mixed linear model association analysis with PLINK genotype inputs
+keywords:
+  - gcta
+  - genome-wide complex trait analysis
+  - fastgwa
+  - fast genome-wide association
+  - gwas
+  - genome-wide association study
+  - genetics
+tools:
+  - "gcta":
+      description: "Genome-wide Complex Trait Analysis (GCTA) estimates genetic relationships, variance components, and association statistics from genome-wide data."
+      homepage: "https://yanglab.westlake.edu.cn/software/gcta/"
+      documentation: "https://yanglab.westlake.edu.cn/software/gcta/static/gcta_doc_latest.pdf"
+      tool_dev_url: "https://yanglab.westlake.edu.cn/software/gcta/"
+      licence: ["GPL-3.0-only"]
+      identifier: "biotools:gcta"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy map containing PLINK genotype metadata
+          e.g. `[ id:'plink_simulated' ]`
+    - bed_pgen:
+        type: file
+        description: PLINK primary genotype file, either `.bed` or `.pgen`
+        pattern: "*.{bed,pgen}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - bim_pvar:
+        type: file
+        description: PLINK variant sidecar file, either `.bim` or `.pvar`
+        pattern: "*.{bim,pvar}"
+        ontologies: []
+    - fam_psam:
+        type: file
+        description: PLINK sample sidecar file, either `.fam` or `.psam`
+        pattern: "*.{fam,psam}"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy map containing genotype/sample information associated with the phenotype input
+          Keep only the shared genotype/sample identifier in this map
+          e.g. `[ id:'plink_simulated' ]`
+    - phenotype_file:
+        type: file
+        description: Phenotype file
+        pattern: "*.{phe,pheno,txt,tsv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+  - - meta3:
+        type: map
+        description: |
+          Groovy map containing genotype/sample information associated with the quantitative covariate input
+          e.g. `[ id:'plink_simulated' ]`
+    - quant_covariates_file:
+        type: file
+        description: Quantitative covariates file, pass `[]` when absent
+        pattern: "*.{covar,cov,txt,tsv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+  - - meta4:
+        type: map
+        description: |
+          Groovy map containing genotype/sample information associated with the categorical covariate input
+          e.g. `[ id:'plink_simulated' ]`
+    - cat_covariates_file:
+        type: file
+        description: Categorical covariates file, pass `[]` when absent
+        pattern: "*.{covar,cov,txt,tsv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+  - - meta5:
+        type: map
+        description: |
+          Groovy map containing sparse GRM metadata
+          e.g. `[ id:'plink_simulated_sp' ]`
+          Used when sparse GRM files are supplied
+    - sparse_grm_files:
+        type: file
+        description: Sparse GRM sidecar files, pass `[]` when absent
+        pattern: "*.grm.{id,sp}"
+        ontologies: []
+output:
+  results:
+    - - meta:
+          type: map
+          description: |
+            Groovy map containing PLINK genotype metadata
+            e.g. `[ id:'plink_simulated' ]`
+      - "*.fastGWA":
+          type: file
+          description: FastGWA association results
+          pattern: "*.fastGWA"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330"
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy map containing PLINK genotype metadata
+            e.g. `[ id:'plink_simulated' ]`
+      - "*.log":
+          type: file
+          description: GCTA fastGWA log file
+          pattern: "*.log"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330"
+  versions_gcta:
+    - - "${task.process}":
+          type: string
+          description: The process the version was collected from
+      - "gcta":
+          type: string
+          description: The tool name
+      - "gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'":
+          type: eval
+          description: The command used to retrieve the GCTA version
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the version was collected from
+      - gcta:
+          type: string
+          description: The tool name
+      - "gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'":
+          type: eval
+          description: The command used to retrieve the GCTA version
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/gcta/fastgwa/tests/main.nf.test
+++ b/modules/nf-core/gcta/fastgwa/tests/main.nf.test
@@ -1,0 +1,373 @@
+nextflow_process {
+
+    name "Test Process GCTA_FASTGWA"
+    script "../main.nf"
+    process "GCTA_FASTGWA"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gcta"
+    tag "gcta/fastgwa"
+    tag "gcta/makegrm"
+    tag "gcta/makebksparse"
+    tag "gawk"
+
+    setup {
+        run("GAWK", alias: "GAWK_QUANTITATIVE_PHENO") {
+            script "../../../gawk/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'QuantitativeTrait' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ]
+                input[1] = Channel.of('FNR == 1 { next } { print \$1, \$2, \$3 }').collectFile(name:'quantitative_phenotype.awk')
+                input[2] = false
+                """
+            }
+        }
+
+        run("GAWK", alias: "GAWK_MULTI_PHENO") {
+            script "../../../gawk/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'QuantitativeTraits' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ]
+                input[1] = Channel.of('FNR == 1 { next } { print \$1, \$2, \$3, (\$3 * 1.7) + ((NR % 5) / 10.0) }').collectFile(name:'multi_phenotype.awk')
+                input[2] = false
+                """
+            }
+        }
+
+        run("GAWK", alias: "GAWK_QUANTITATIVE_COVARIATES") {
+            script "../../../gawk/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'covariates_quant' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ]
+                input[1] = Channel.of('FNR == 1 { next } { print \$1, \$2, \$4, \$5, \$6 }').collectFile(name:'quantitative_covariates.awk')
+                input[2] = false
+                """
+            }
+        }
+
+        run("GAWK", alias: "GAWK_CATEGORICAL_COVARIATES") {
+            script "../../../gawk/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'covariates_cat' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ]
+                input[1] = Channel.of('FNR == 1 { next } { print \$1, \$2, \$3 }').collectFile(name:'categorical_covariates.awk')
+                input[2] = false
+                """
+            }
+        }
+
+        run("GCTA_MAKEGRM", alias: "GCTA_MAKEGRM_DENSE") {
+            script "../../makegrm/main.nf"
+            process {
+                """
+                file('plink_simulated.mbfile').text = 'plink_simulated\\n'
+
+                input[0] = [
+                    [ id:'plink_simulated_dense' ],
+                    file('plink_simulated.mbfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        run("GCTA_MAKEBKSPARSE", alias: "GCTA_MAKEBKSPARSE_DENSE") {
+            script "../../makebksparse/main.nf"
+            process {
+                """
+                input[0] = GCTA_MAKEGRM_DENSE.out.grm_files
+                input[1] = Channel.value(0.05)
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens popgen - plink1 with sparse GRM and quantitative phenotype") {
+        config "./mpheno.config"
+
+        when {
+            params {
+                module_args = '--mpheno 1'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:"plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                input[1] = GAWK_QUANTITATIVE_PHENO.out.output.map { generated_meta, phenotype_file ->
+                    [[ id:"plink_simulated" ], phenotype_file]
+                }
+                input[2] = GAWK_QUANTITATIVE_COVARIATES.out.output.map { generated_meta, covariates_file ->
+                    [[ id:"plink_simulated" ], covariates_file]
+                }
+                input[3] = GAWK_CATEGORICAL_COVARIATES.out.output.map { generated_meta, covariates_file ->
+                    [[ id:"plink_simulated" ], covariates_file]
+                }
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.results.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                { assert process.out.results.get(0).get(0).id == "plink_simulated" },
+                { assert path(process.out.results.get(0).get(1)).fileName.toString() == "plink_simulated.fastGWA" },
+                { assert path(process.out.log.get(0).get(1)).fileName.toString() == "plink_simulated.log" },
+                { assert path(process.out.results.get(0).get(1)).readLines().get(0).contains("BETA") },
+                { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--fastGWA-mlm") },
+                { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--grm-sparse plink_simulated_dense_sp") },
+                { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--mpheno 1") },
+                {
+                    assert snapshot(
+                        process.out.results,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink1 with sparse GRM and quantitative phenotype mpheno selection") {
+        config "./mpheno.config"
+
+        when {
+            params {
+                module_args = '--mpheno 2'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:"plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                input[1] = GAWK_MULTI_PHENO.out.output.map { generated_meta, phenotype_file ->
+                    [[ id:"plink_simulated" ], phenotype_file]
+                }
+                input[2] = GAWK_QUANTITATIVE_COVARIATES.out.output.map { generated_meta, covariates_file ->
+                    [[ id:"plink_simulated" ], covariates_file]
+                }
+                input[3] = GAWK_CATEGORICAL_COVARIATES.out.output.map { generated_meta, covariates_file ->
+                    [[ id:"plink_simulated" ], covariates_file]
+                }
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.results.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                { assert process.out.results.get(0).get(0).id == "plink_simulated" },
+                { assert path(process.out.results.get(0).get(1)).fileName.toString() == "plink_simulated.fastGWA" },
+                { assert path(process.out.log.get(0).get(1)).fileName.toString() == "plink_simulated.log" },
+                { assert path(process.out.results.get(0).get(1)).readLines().get(0).contains("BETA") },
+                { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--mpheno 2") },
+                {
+                    assert snapshot(
+                        process.out.results,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink1 with sparse GRM and default phenotype selection") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:"plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                input[1] = GAWK_QUANTITATIVE_PHENO.out.output.map { generated_meta, phenotype_file ->
+                    [[ id:"plink_simulated" ], phenotype_file]
+                }
+                input[2] = GAWK_QUANTITATIVE_COVARIATES.out.output.map { generated_meta, covariates_file ->
+                    [[ id:"plink_simulated" ], covariates_file]
+                }
+                input[3] = GAWK_CATEGORICAL_COVARIATES.out.output.map { generated_meta, covariates_file ->
+                    [[ id:"plink_simulated" ], covariates_file]
+                }
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files.map { meta, sparse_grm_files ->
+                    [meta, sparse_grm_files]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.results.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                { assert process.out.results.get(0).get(0).id == "plink_simulated" },
+                { assert path(process.out.results.get(0).get(1)).fileName.toString() == "plink_simulated.fastGWA" },
+                { assert path(process.out.log.get(0).get(1)).fileName.toString() == "plink_simulated.log" },
+                { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--fastGWA-mlm") },
+                { assert !file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--mpheno") },
+                { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--grm-sparse plink_simulated_dense_sp") },
+                {
+                    assert snapshot(
+                        process.out.results,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink2 with sparse GRM and quantitative phenotype") {
+        config "./mpheno.config"
+
+        when {
+            params {
+                module_args = '--mpheno 1'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:"plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.pgen", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.pvar", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.psam", checkIfExists: true)
+                ]
+                input[1] = GAWK_QUANTITATIVE_PHENO.out.output.map { generated_meta, phenotype_file ->
+                    [[ id:"plink_simulated" ], phenotype_file]
+                }
+                input[2] = [[ id:"plink_simulated" ], []]
+                input[3] = [[ id:"plink_simulated" ], []]
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.results.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                { assert process.out.results.get(0).get(0).id == "plink_simulated" },
+                { assert path(process.out.results.get(0).get(1)).fileName.toString() == "plink_simulated.fastGWA" },
+                { assert path(process.out.log.get(0).get(1)).fileName.toString() == "plink_simulated.log" },
+                { assert path(process.out.results.get(0).get(1)).readLines().get(0).contains("BETA") },
+                { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--grm-sparse plink_simulated_dense_sp") },
+                {
+                    assert snapshot(
+                        process.out.results,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - non-binary fails when sparse GRM prefix mismatches files") {
+        when {
+            process {
+                """
+                sparse_grm_bad_prefix = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files.map { meta, sparse_grm_files ->
+                    [[ id:'incorrect_sparse_prefix' ], sparse_grm_files]
+                }
+
+                input[0] = [
+                    [ id:"plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                input[1] = GAWK_QUANTITATIVE_PHENO.out.output.map { generated_meta, phenotype_file ->
+                    [[ id:"plink_simulated" ], phenotype_file]
+                }
+                input[2] = [[ id:"plink_simulated" ], []]
+                input[3] = [[ id:"plink_simulated" ], []]
+                input[4] = sparse_grm_bad_prefix
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.exitStatus != 0 },
+                { assert process.stdout.toString().contains("incorrect_sparse_prefix") },
+                { assert process.stdout.toString().contains("incorrect_sparse_prefix.grm.id") }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink2 with sparse GRM - stub") {
+        options "-stub"
+        config "./mpheno.config"
+
+        when {
+            params {
+                module_args = '--mpheno 1'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:"plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.pgen", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.pvar", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.psam", checkIfExists: true)
+                ]
+                input[1] = GAWK_QUANTITATIVE_PHENO.out.output.map { generated_meta, phenotype_file ->
+                    [[ id:"plink_simulated" ], phenotype_file]
+                }
+                input[2] = [[ id:"plink_simulated" ], []]
+                input[3] = [[ id:"plink_simulated" ], []]
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.results.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                { assert process.out.results.get(0).get(0).id == "plink_simulated" },
+                {
+                    assert snapshot(
+                        process.out.results,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+}

--- a/modules/nf-core/gcta/fastgwa/tests/main.nf.test
+++ b/modules/nf-core/gcta/fastgwa/tests/main.nf.test
@@ -127,7 +127,10 @@ nextflow_process {
                 input[3] = GAWK_CATEGORICAL_COVARIATES.out.output.map { generated_meta, covariates_file ->
                     [[ id:"plink_simulated" ], covariates_file]
                 }
-                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files.map { meta, sparse_grm_files ->
+                    sparse_grm_id = sparse_grm_files.find { sparse_grm_file -> sparse_grm_file.name.endsWith('.grm.id') }
+                    [[ id:sparse_grm_id.name - '.grm.id' ], sparse_grm_files]
+                }
                 """
             }
         }
@@ -175,7 +178,10 @@ nextflow_process {
                 input[3] = GAWK_CATEGORICAL_COVARIATES.out.output.map { generated_meta, covariates_file ->
                     [[ id:"plink_simulated" ], covariates_file]
                 }
-                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files.map { meta, sparse_grm_files ->
+                    sparse_grm_id = sparse_grm_files.find { sparse_grm_file -> sparse_grm_file.name.endsWith('.grm.id') }
+                    [[ id:sparse_grm_id.name - '.grm.id' ], sparse_grm_files]
+                }
                 """
             }
         }
@@ -217,7 +223,8 @@ nextflow_process {
                     [[ id:"plink_simulated" ], covariates_file]
                 }
                 input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files.map { meta, sparse_grm_files ->
-                    [meta, sparse_grm_files]
+                    sparse_grm_id = sparse_grm_files.find { sparse_grm_file -> sparse_grm_file.name.endsWith('.grm.id') }
+                    [[ id:sparse_grm_id.name - '.grm.id' ], sparse_grm_files]
                 }
                 """
             }
@@ -261,7 +268,10 @@ nextflow_process {
                 }
                 input[2] = [[ id:"plink_simulated" ], []]
                 input[3] = [[ id:"plink_simulated" ], []]
-                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files.map { meta, sparse_grm_files ->
+                    sparse_grm_id = sparse_grm_files.find { sparse_grm_file -> sparse_grm_file.name.endsWith('.grm.id') }
+                    [[ id:sparse_grm_id.name - '.grm.id' ], sparse_grm_files]
+                }
                 """
             }
         }
@@ -338,7 +348,10 @@ nextflow_process {
                 }
                 input[2] = [[ id:"plink_simulated" ], []]
                 input[3] = [[ id:"plink_simulated" ], []]
-                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files
+                input[4] = GCTA_MAKEBKSPARSE_DENSE.out.sparse_grm_files.map { meta, sparse_grm_files ->
+                    sparse_grm_id = sparse_grm_files.find { sparse_grm_file -> sparse_grm_file.name.endsWith('.grm.id') }
+                    [[ id:sparse_grm_id.name - '.grm.id' ], sparse_grm_files]
+                }
                 """
             }
         }

--- a/modules/nf-core/gcta/fastgwa/tests/main.nf.test
+++ b/modules/nf-core/gcta/fastgwa/tests/main.nf.test
@@ -145,10 +145,7 @@ nextflow_process {
                 { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--grm-sparse plink_simulated_dense_sp") },
                 { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--mpheno 1") },
                 {
-                    assert snapshot(
-                        process.out.results,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
+                    assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match()
                 }
             )
         }
@@ -194,10 +191,7 @@ nextflow_process {
                 { assert path(process.out.results.get(0).get(1)).readLines().get(0).contains("BETA") },
                 { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--mpheno 2") },
                 {
-                    assert snapshot(
-                        process.out.results,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
+                    assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match()
                 }
             )
         }
@@ -241,10 +235,7 @@ nextflow_process {
                 { assert !file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--mpheno") },
                 { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--grm-sparse plink_simulated_dense_sp") },
                 {
-                    assert snapshot(
-                        process.out.results,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
+                    assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match()
                 }
             )
         }
@@ -286,10 +277,7 @@ nextflow_process {
                 { assert path(process.out.results.get(0).get(1)).readLines().get(0).contains("BETA") },
                 { assert file(path(process.out.results.get(0).get(1)).parent.toString() + "/.command.sh").text.contains("--grm-sparse plink_simulated_dense_sp") },
                 {
-                    assert snapshot(
-                        process.out.results,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
+                    assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match()
                 }
             )
         }
@@ -362,10 +350,7 @@ nextflow_process {
                 { assert process.out.log.size() == 1 },
                 { assert process.out.results.get(0).get(0).id == "plink_simulated" },
                 {
-                    assert snapshot(
-                        process.out.results,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
+                    assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match()
                 }
             )
         }

--- a/modules/nf-core/gcta/fastgwa/tests/main.nf.test
+++ b/modules/nf-core/gcta/fastgwa/tests/main.nf.test
@@ -1,6 +1,7 @@
 nextflow_process {
 
     name "Test Process GCTA_FASTGWA"
+    config "./nextflow.config"
     script "../main.nf"
     process "GCTA_FASTGWA"
 
@@ -104,8 +105,6 @@ nextflow_process {
     }
 
     test("homo_sapiens popgen - plink1 with sparse GRM and quantitative phenotype") {
-        config "./mpheno.config"
-
         when {
             params {
                 module_args = '--mpheno 1'
@@ -155,8 +154,6 @@ nextflow_process {
     }
 
     test("homo_sapiens popgen - plink1 with sparse GRM and quantitative phenotype mpheno selection") {
-        config "./mpheno.config"
-
         when {
             params {
                 module_args = '--mpheno 2'
@@ -249,8 +246,6 @@ nextflow_process {
     }
 
     test("homo_sapiens popgen - plink2 with sparse GRM and quantitative phenotype") {
-        config "./mpheno.config"
-
         when {
             params {
                 module_args = '--mpheno 1'
@@ -329,7 +324,6 @@ nextflow_process {
 
     test("homo_sapiens popgen - plink2 with sparse GRM - stub") {
         options "-stub"
-        config "./mpheno.config"
 
         when {
             params {

--- a/modules/nf-core/gcta/fastgwa/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/fastgwa/tests/main.nf.test.snap
@@ -1,0 +1,132 @@
+{
+    "homo_sapiens popgen - plink2 with sparse GRM - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated.fastGWA:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_FASTGWA",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-20T01:47:16.233806578"
+    },
+    "homo_sapiens popgen - plink1 with sparse GRM and quantitative phenotype": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated.fastGWA:md5,d9190e07273a3de2a15a6e7053aed487"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_FASTGWA",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-20T01:45:45.465829105"
+    },
+    "homo_sapiens popgen - plink1 with sparse GRM and quantitative phenotype mpheno selection": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated.fastGWA:md5,d10da1dac8dccf55a9000c4813d4f625"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_FASTGWA",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-20T01:46:07.506996953"
+    },
+    "homo_sapiens popgen - plink2 with sparse GRM and quantitative phenotype": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated.fastGWA:md5,6742a23a7e4280161c104027b1cac012"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_FASTGWA",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-20T01:46:44.663884707"
+    },
+    "homo_sapiens popgen - plink1 with sparse GRM and default phenotype selection": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated.fastGWA:md5,d9190e07273a3de2a15a6e7053aed487"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_FASTGWA",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-20T01:48:39.602548614"
+    }
+}

--- a/modules/nf-core/gcta/fastgwa/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/fastgwa/tests/main.nf.test.snap
@@ -1,15 +1,23 @@
 {
     "homo_sapiens popgen - plink2 with sparse GRM - stub": {
         "content": [
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated.fastGWA:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ],
             {
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.fastGWA:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
                 "versions_gcta": [
                     [
                         "GCTA_FASTGWA",
@@ -23,19 +31,27 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-20T01:47:16.233806578"
+        "timestamp": "2026-05-26T21:52:28.104060693"
     },
     "homo_sapiens popgen - plink1 with sparse GRM and quantitative phenotype": {
         "content": [
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated.fastGWA:md5,d9190e07273a3de2a15a6e7053aed487"
-                ]
-            ],
             {
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.fastGWA:md5,d9190e07273a3de2a15a6e7053aed487"
+                    ]
+                ],
                 "versions_gcta": [
                     [
                         "GCTA_FASTGWA",
@@ -49,19 +65,27 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-20T01:45:45.465829105"
+        "timestamp": "2026-05-26T21:51:19.966260988"
     },
     "homo_sapiens popgen - plink1 with sparse GRM and quantitative phenotype mpheno selection": {
         "content": [
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated.fastGWA:md5,d10da1dac8dccf55a9000c4813d4f625"
-                ]
-            ],
             {
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.fastGWA:md5,d10da1dac8dccf55a9000c4813d4f625"
+                    ]
+                ],
                 "versions_gcta": [
                     [
                         "GCTA_FASTGWA",
@@ -75,19 +99,27 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-20T01:46:07.506996953"
+        "timestamp": "2026-05-26T21:51:33.306218448"
     },
     "homo_sapiens popgen - plink2 with sparse GRM and quantitative phenotype": {
         "content": [
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated.fastGWA:md5,6742a23a7e4280161c104027b1cac012"
-                ]
-            ],
             {
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.fastGWA:md5,6742a23a7e4280161c104027b1cac012"
+                    ]
+                ],
                 "versions_gcta": [
                     [
                         "GCTA_FASTGWA",
@@ -101,19 +133,27 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-20T01:46:44.663884707"
+        "timestamp": "2026-05-26T21:51:58.932411426"
     },
     "homo_sapiens popgen - plink1 with sparse GRM and default phenotype selection": {
         "content": [
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated.fastGWA:md5,d9190e07273a3de2a15a6e7053aed487"
-                ]
-            ],
             {
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.fastGWA:md5,d9190e07273a3de2a15a6e7053aed487"
+                    ]
+                ],
                 "versions_gcta": [
                     [
                         "GCTA_FASTGWA",
@@ -127,6 +167,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-20T01:48:39.602548614"
+        "timestamp": "2026-05-26T21:51:45.611830254"
     }
 }

--- a/modules/nf-core/gcta/fastgwa/tests/mpheno.config
+++ b/modules/nf-core/gcta/fastgwa/tests/mpheno.config
@@ -1,0 +1,5 @@
+process {
+    withName: "GCTA_FASTGWA" {
+        ext.args = { params.module_args ?: "" }
+    }
+}

--- a/modules/nf-core/gcta/fastgwa/tests/nextflow.config
+++ b/modules/nf-core/gcta/fastgwa/tests/nextflow.config
@@ -1,3 +1,7 @@
+params {
+    module_args = ""
+}
+
 process {
     withName: "GCTA_FASTGWA" {
         ext.args = { params.module_args ?: "" }


### PR DESCRIPTION
This PR adds the `gcta/fastgwa` module, which runs GCTA fastGWA for quantitative and binary phenotypes from PLINK genotype inputs and sparse GRM inputs.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] `nf-core modules test gcta/fastgwa --profile docker`
- [x] `nf-core modules test gcta/fastgwa --profile singularity`
- [x] `nf-core modules test gcta/fastgwa --profile conda`

