### PR TITLE
Add gcta/keep module

### DIFF
--- a/modules/nf-core/gcta/keep/environment.yml
+++ b/modules/nf-core/gcta/keep/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::gcta=1.94.1

--- a/modules/nf-core/gcta/keep/main.nf
+++ b/modules/nf-core/gcta/keep/main.nf
@@ -1,0 +1,40 @@
+process GCTA_KEEP {
+    tag "${meta.id}"
+    label 'process_medium'
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/46b0d05f0daa47561d87d2a9cac5e51edc2c78e26f1bbab439c688386241a274/data'
+        : 'community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9'}"
+
+    input:
+    tuple val(meta), path(grm_files)
+    tuple val(meta2), path(keep_file)
+
+    output:
+    tuple val(meta), path("${prefix}.grm.*"), emit: filtered_grm
+    tuple val("${task.process}"), val("gcta"), eval("gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'"), emit: versions_gcta, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}_keep"
+    """
+    gcta \\
+        --grm ${meta.id} \\
+        --keep ${keep_file} \\
+        --make-grm \\
+        --out ${prefix} \\
+        --thread-num ${task.cpus} \\
+        ${args}
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}_keep"
+    """
+    touch ${prefix}.grm.id
+    touch ${prefix}.grm.bin
+    touch ${prefix}.grm.N.bin
+    """
+}

--- a/modules/nf-core/gcta/keep/meta.yml
+++ b/modules/nf-core/gcta/keep/meta.yml
@@ -1,0 +1,83 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "gcta_keep"
+description: Apply a keep file to a dense GRM using `gcta --keep`
+keywords:
+  - gcta
+  - genome-wide complex trait analysis
+  - grm
+  - genetic relationship matrix
+  - genetics
+tools:
+  - "gcta":
+      description: "Genome-wide Complex Trait Analysis (GCTA) estimates genetic relationships, variance components, and association statistics from genome-wide data."
+      homepage: "https://yanglab.westlake.edu.cn/software/gcta/"
+      documentation: "https://yanglab.westlake.edu.cn/software/gcta/static/gcta_doc_latest.pdf"
+      tool_dev_url: "https://yanglab.westlake.edu.cn/software/gcta/"
+      licence: ["GPL-3.0-only"]
+      identifier: "biotools:gcta"
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy map containing dense GRM metadata
+          e.g. `[ id:'plink_simulated' ]`
+          `meta.id` is required and is the dense GRM basename contract used by `gcta --grm`.
+          Input files must therefore be staged as `<meta.id>.grm.id`, `<meta.id>.grm.bin`, and `<meta.id>.grm.N.bin`.
+    - grm_files:
+        type: file
+        description: Dense GRM file bundle
+        pattern: "*.grm.*"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy map containing keep-file metadata
+          e.g. `[ id:'plink_simulated_keep' ]`
+    - keep_file:
+        type: file
+        description: Keep file listing the individuals to retain
+        pattern: "*.{keep,txt,id}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2330"
+
+output:
+  filtered_grm:
+    - - meta:
+          type: map
+          description: |
+            Groovy map containing dense GRM metadata
+            e.g. `[ id:'plink_simulated' ]`
+            `meta.id` is preserved from the input dense GRM basename contract.
+      - "${prefix}.grm.*":
+          type: file
+          description: Filtered GRM file bundle
+          pattern: "${prefix}.grm.*"
+          ontologies: []
+  versions_gcta:
+    - - "${task.process}":
+          type: string
+          description: The process the version was collected from
+      - "gcta":
+          type: string
+          description: The tool name
+      - "gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'":
+          type: eval
+          description: The command used to retrieve the GCTA version
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the version was collected from
+      - gcta:
+          type: string
+          description: The tool name
+      - "gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'":
+          type: eval
+          description: The command used to retrieve the GCTA version
+
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/gcta/keep/tests/main.nf.test
+++ b/modules/nf-core/gcta/keep/tests/main.nf.test
@@ -1,0 +1,131 @@
+nextflow_process {
+
+    name "Test Process GCTA_KEEP"
+    script "../main.nf"
+    process "GCTA_KEEP"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gcta"
+    tag "gcta/keep"
+    tag "gcta/makegrm"
+    tag "gcta/grmcutoff"
+
+    setup {
+        run("GCTA_MAKEGRM", alias: "GCTA_MAKEGRM_DENSE") {
+            script "../../makegrm/main.nf"
+            process {
+                """
+                file('plink_simulated.mpfile').text = 'plink_simulated plink_simulated.pgen plink_simulated.psam plink_simulated.pvar\\n'
+
+                input[0] = [
+                    [ id:'plink_simulated_dense' ],
+                    file('plink_simulated.mpfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        run("GCTA_GRMCUTOFF", alias: "GCTA_GRMCUTOFF_KEEP") {
+            script "../../grmcutoff/main.nf"
+            process {
+                """
+                dense_grm = GCTA_MAKEGRM_DENSE.out.grm_files
+                    .map { meta, grm_files -> [[ id:meta.id ], grm_files] }
+
+                input[0] = dense_grm
+                input[1] = 0.05
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens popgen - filter dense GRM with keep file") {
+        when {
+            process {
+                """
+                input[0] = GCTA_MAKEGRM_DENSE.out.grm_files.map { meta, grm_files -> [[ id:meta.id ], grm_files] }
+                input[1] = GCTA_GRMCUTOFF_KEEP.out.keep_file
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.filtered_grm.size() == 1 },
+                { assert process.out.filtered_grm.get(0).get(0).id == "plink_simulated_dense" },
+                {
+                    def row = process.out.filtered_grm.get(0)
+                    assert row.get(1).every { file(it).exists() }
+                    assert row.get(1).collect { file(it).name }.sort() == [
+                        "plink_simulated_dense_keep.grm.N.bin",
+                        "plink_simulated_dense_keep.grm.bin",
+                        "plink_simulated_dense_keep.grm.id"
+                    ]
+                },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - fail when meta id does not match dense GRM basename") {
+        when {
+            process {
+                """
+                input[0] = GCTA_MAKEGRM_DENSE.out.grm_files.map { meta, grm_files ->
+                    [[ id:'contract_dense_mismatch' ], grm_files]
+                }
+                input[1] = GCTA_GRMCUTOFF_KEEP.out.keep_file
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.exitStatus != 0 }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - filter dense GRM with keep file - stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = GCTA_MAKEGRM_DENSE.out.grm_files.map { meta, grm_files -> [[ id:meta.id ], grm_files] }
+                input[1] = GCTA_GRMCUTOFF_KEEP.out.keep_file
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.filtered_grm.size() == 1 },
+                { assert process.out.filtered_grm.get(0).get(0).id == "plink_simulated_dense" },
+                {
+                    def row = process.out.filtered_grm.get(0)
+                    assert row.get(1).every { file(it).exists() }
+                    assert row.get(1).collect { file(it).name }.sort() == [
+                        "plink_simulated_dense_keep.grm.N.bin",
+                        "plink_simulated_dense_keep.grm.bin",
+                        "plink_simulated_dense_keep.grm.id"
+                    ]
+                },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/gcta/keep/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/keep/tests/main.nf.test.snap
@@ -1,0 +1,62 @@
+{
+    "homo_sapiens popgen - filter dense GRM with keep file": {
+        "content": [
+            {
+                "filtered_grm": [
+                    [
+                        {
+                            "id": "plink_simulated_dense"
+                        },
+                        [
+                            "plink_simulated_dense_keep.grm.N.bin:md5,06b73ea8bae8f1e5f5d4de33dbd2c75e",
+                            "plink_simulated_dense_keep.grm.bin:md5,b1f124463eecbae86840a6651eec372d",
+                            "plink_simulated_dense_keep.grm.id:md5,ca8c0bded6951fdd3bf0dddc97b6df6b"
+                        ]
+                    ]
+                ],
+                "versions_gcta": [
+                    [
+                        "GCTA_KEEP",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-08T19:58:38.77796418"
+    },
+    "homo_sapiens popgen - filter dense GRM with keep file - stub": {
+        "content": [
+            {
+                "filtered_grm": [
+                    [
+                        {
+                            "id": "plink_simulated_dense"
+                        },
+                        [
+                            "plink_simulated_dense_keep.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "plink_simulated_dense_keep.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "plink_simulated_dense_keep.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions_gcta": [
+                    [
+                        "GCTA_KEEP",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-08T19:58:59.304925724"
+    }
+}


### PR DESCRIPTION
This PR adds the `gcta/keep` module, which applies a keep file to a dense GRM with `gcta --keep`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] `nf-core modules test gcta/keep --profile docker`
- [x] `nf-core modules test gcta/keep --profile singularity`
- [x] `nf-core modules test gcta/keep --profile conda`

