### PR TITLE
Add gcta/makegrmpart module

### DIFF
--- a/modules/nf-core/gcta/makegrmpart/environment.yml
+++ b/modules/nf-core/gcta/makegrmpart/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::gcta=1.94.1

--- a/modules/nf-core/gcta/makegrmpart/main.nf
+++ b/modules/nf-core/gcta/makegrmpart/main.nf
@@ -1,0 +1,49 @@
+process GCTA_MAKEGRMPART {
+    tag "part ${meta.part_gcta_job} of ${meta.nparts_gcta} (${meta.id})"
+    label 'process_medium'
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'docker://community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9' :
+        'community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9' }"
+
+    input:
+    tuple val(meta), path(mfile), path(bed_pgen), path(bim_pvar), path(fam_psam)
+    tuple val(meta2), path(snp_group_file)
+
+    output:
+    tuple val(meta), path("*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.id"), path("*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.bin"), path("*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.N.bin"), emit: grm_files
+    tuple val("${task.process}"), val("gcta"), eval("gcta --version 2>&1 | grep 'version v' | tr -s ' ' | cut -d' ' -f3 | sed 's/^v//'"), emit: versions_gcta, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def part_gcta_job = meta.part_gcta_job
+    def nparts_gcta = meta.nparts_gcta
+    def extract_cmd = snp_group_file ? "--extract ${snp_group_file}" : ''
+    def extra_args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def genotype_files = bed_pgen instanceof List ? bed_pgen : [bed_pgen]
+    def genotype_extension = genotype_files[0].name.tokenize('.').last()
+    def multi_file_flag = genotype_extension == 'pgen' ? '--mpfile' : '--mbfile'
+
+    """
+    set -euo pipefail
+
+    gcta \\
+        ${multi_file_flag} ${mfile} \\
+        --make-grm-part ${nparts_gcta} ${part_gcta_job} \\
+        ${extract_cmd} \\
+        --maf 0.01 \\
+        --thread-num ${task.cpus} \\
+        --out ${prefix} ${extra_args}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.id
+    touch ${prefix}.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.bin
+    touch ${prefix}.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.N.bin
+    """
+}

--- a/modules/nf-core/gcta/makegrmpart/main.nf
+++ b/modules/nf-core/gcta/makegrmpart/main.nf
@@ -1,25 +1,25 @@
 process GCTA_MAKEGRMPART {
-    tag "part ${meta.part_gcta_job} of ${meta.nparts_gcta} (${meta.id})"
+    tag "part ${part_gcta_job ?: 1} of ${nparts_gcta ?: 1} (${meta.id})"
     label 'process_medium'
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9' :
-        'community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9' }"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'docker://community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9'
+        : 'community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9'}"
 
     input:
-    tuple val(meta), path(mfile), path(bed_pgen), path(bim_pvar), path(fam_psam)
+    tuple val(meta), val(nparts_gcta), val(part_gcta_job), path(mfile), path(bed_pgen), path(bim_pvar), path(fam_psam)
     tuple val(meta2), path(snp_group_file)
 
     output:
-    tuple val(meta), path("*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.id"), path("*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.bin"), path("*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.N.bin"), emit: grm_files
-    tuple val("${task.process}"), val("gcta"), eval("gcta --version 2>&1 | grep 'version v' | tr -s ' ' | cut -d' ' -f3 | sed 's/^v//'"), emit: versions_gcta, topic: versions
+    tuple val(meta), path("*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.id"), path("*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.bin"), path("*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.N.bin"), val(nparts_gcta), val(part_gcta_job), emit: grm_files
+    tuple val("${task.process}"), val("gcta"), eval("gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'"), emit: versions_gcta, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def part_gcta_job = meta.part_gcta_job
-    def nparts_gcta = meta.nparts_gcta
+    def nparts = nparts_gcta ?: 1
+    def part = part_gcta_job ?: 1
     def extract_cmd = snp_group_file ? "--extract ${snp_group_file}" : ''
     def extra_args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -32,7 +32,7 @@ process GCTA_MAKEGRMPART {
 
     gcta \\
         ${multi_file_flag} ${mfile} \\
-        --make-grm-part ${nparts_gcta} ${part_gcta_job} \\
+        --make-grm-part ${nparts} ${part} \\
         ${extract_cmd} \\
         --maf 0.01 \\
         --thread-num ${task.cpus} \\
@@ -40,10 +40,12 @@ process GCTA_MAKEGRMPART {
     """
 
     stub:
+    def nparts = nparts_gcta ?: 1
+    def part = part_gcta_job ?: 1
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.id
-    touch ${prefix}.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.bin
-    touch ${prefix}.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.N.bin
+    touch ${prefix}.part_${nparts}_${part}.grm.id
+    touch ${prefix}.part_${nparts}_${part}.grm.bin
+    touch ${prefix}.part_${nparts}_${part}.grm.N.bin
     """
 }

--- a/modules/nf-core/gcta/makegrmpart/main.nf
+++ b/modules/nf-core/gcta/makegrmpart/main.nf
@@ -11,7 +11,7 @@ process GCTA_MAKEGRMPART {
     tuple val(meta2), path(snp_group_file)
 
     output:
-    tuple val(meta), path("*.part_${nparts}_${part}.grm.id"), path("*.part_${nparts}_${part}.grm.bin"), path("*.part_${nparts}_${part}.grm.N.bin"), val(nparts_gcta), val(part_gcta_job), emit: grm_files
+    tuple val(meta), path("*.part_${nparts}_${part}.grm.*"), val(nparts_gcta), val(part_gcta_job), emit: grm_files
     tuple val("${task.process}"), val("gcta"), eval("gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'"), emit: versions_gcta, topic: versions
 
     when:

--- a/modules/nf-core/gcta/makegrmpart/main.nf
+++ b/modules/nf-core/gcta/makegrmpart/main.nf
@@ -11,15 +11,15 @@ process GCTA_MAKEGRMPART {
     tuple val(meta2), path(snp_group_file)
 
     output:
-    tuple val(meta), path("*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.id"), path("*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.bin"), path("*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.N.bin"), val(nparts_gcta), val(part_gcta_job), emit: grm_files
+    tuple val(meta), path("*.part_${nparts}_${part}.grm.id"), path("*.part_${nparts}_${part}.grm.bin"), path("*.part_${nparts}_${part}.grm.N.bin"), val(nparts_gcta), val(part_gcta_job), emit: grm_files
     tuple val("${task.process}"), val("gcta"), eval("gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'"), emit: versions_gcta, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def nparts = nparts_gcta ?: 1
-    def part = part_gcta_job ?: 1
+    nparts = nparts_gcta ?: 1
+    part = part_gcta_job ?: 1
     def extract_cmd = snp_group_file ? "--extract ${snp_group_file}" : ''
     def extra_args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -40,8 +40,8 @@ process GCTA_MAKEGRMPART {
     """
 
     stub:
-    def nparts = nparts_gcta ?: 1
-    def part = part_gcta_job ?: 1
+    nparts = nparts_gcta ?: 1
+    part = part_gcta_job ?: 1
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.part_${nparts}_${part}.grm.id

--- a/modules/nf-core/gcta/makegrmpart/main.nf
+++ b/modules/nf-core/gcta/makegrmpart/main.nf
@@ -1,9 +1,9 @@
 process GCTA_MAKEGRMPART {
-    tag "${meta.id}: part ${part_gcta_job ?: 1} of ${nparts_gcta ?: 1}"
+    tag "${meta.id}: part ${part_gcta_job} of ${nparts_gcta}"
     label 'process_medium'
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'docker://community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9'
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/46b0d05f0daa47561d87d2a9cac5e51edc2c78e26f1bbab439c688386241a274/data'
         : 'community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9'}"
 
     input:

--- a/modules/nf-core/gcta/makegrmpart/main.nf
+++ b/modules/nf-core/gcta/makegrmpart/main.nf
@@ -1,5 +1,5 @@
 process GCTA_MAKEGRMPART {
-    tag "part ${part_gcta_job ?: 1} of ${nparts_gcta ?: 1} (${meta.id})"
+    tag "${meta.id}: part ${part_gcta_job ?: 1} of ${nparts_gcta ?: 1}"
     label 'process_medium'
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container

--- a/modules/nf-core/gcta/makegrmpart/main.nf
+++ b/modules/nf-core/gcta/makegrmpart/main.nf
@@ -28,13 +28,10 @@ process GCTA_MAKEGRMPART {
     def multi_file_flag = genotype_extension == 'pgen' ? '--mpfile' : '--mbfile'
 
     """
-    set -euo pipefail
-
     gcta \\
         ${multi_file_flag} ${mfile} \\
         --make-grm-part ${nparts} ${part} \\
         ${extract_cmd} \\
-        --maf 0.01 \\
         --thread-num ${task.cpus} \\
         --out ${prefix} ${extra_args}
     """

--- a/modules/nf-core/gcta/makegrmpart/meta.yml
+++ b/modules/nf-core/gcta/makegrmpart/meta.yml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "gcta_makegrmpart"
+description: Compute one partition of a GCTA genetic relationship matrix
+keywords:
+  - gcta
+  - grm
+  - genetics
+tools:
+  - "gcta":
+      description: "GCTA is a tool for genome-wide complex trait analysis."
+      homepage: "https://yanglab.westlake.edu.cn/software/gcta/"
+      documentation: "https://yanglab.westlake.edu.cn/software/gcta/static/gcta_doc_latest.pdf"
+      tool_dev_url: "https://github.com/jianyangqt/gcta"
+      licence: ["GPL-3.0-only"]
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing GRM-partition job metadata
+          e.g. `[ id:'gcta_grm', part_gcta_job:1, nparts_gcta:2 ]`
+    - mfile:
+        type: file
+        description: GCTA multi-input manifest consumed by `--mbfile` or `--mpfile`
+        pattern: "*.{mbfile,mpfile,txt}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2330"
+    - bed_pgen:
+        type: file
+        description: Collection of PLINK primary genotype files referenced by the multi-input manifest
+        pattern: "*.{bed,pgen}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - bim_pvar:
+        type: file
+        description: Collection of PLINK variant metadata files referenced by the multi-input manifest
+        pattern: "*.{bim,pvar}"
+        ontologies: []
+    - fam_psam:
+        type: file
+        description: Collection of PLINK sample metadata files referenced by the multi-input manifest
+        pattern: "*.{fam,psam}"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing SNP-selection metadata
+          e.g. `[ id:'snp_group1', snp_group:1 ]`
+    - snp_group_file:
+        type: file
+        description: Optional SNP extraction file passed to `--extract`; provide `[]` when absent
+        pattern: "*.{txt,list}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2330"
+output:
+  grm_files:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing GRM-partition job metadata
+            e.g. `[ id:'gcta_grm', part_gcta_job:1, nparts_gcta:2 ]`
+      - "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.id":
+          type: file
+          description: Partitioned GRM ID file
+          pattern: "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.id"
+          ontologies: []
+      - "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.bin":
+          type: file
+          description: Partitioned GRM binary matrix file
+          pattern: "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.bin"
+          ontologies: []
+      - "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.N.bin":
+          type: file
+          description: Partitioned GRM sample-count matrix file
+          pattern: "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.N.bin"
+          ontologies: []
+  versions_gcta:
+    - - "${task.process}":
+          type: string
+          description: The process the versions were collected from
+      - "gcta":
+          type: string
+          description: The tool name
+      - "gcta --version 2>&1 | grep 'version v' | tr -s ' ' | cut -d' ' -f3 | sed 's/^v//'":
+          type: eval
+          description: The command used to generate the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gcta:
+          type: string
+          description: The tool name
+      - gcta --version 2>&1 | grep 'version v' | tr -s ' ' | cut -d' ' -f3 | sed 's/^v//':
+          type: eval
+          description: The command used to generate the version of the tool
+authors:
+  - "@andongni"
+maintainers:
+  - "@andongni"

--- a/modules/nf-core/gcta/makegrmpart/meta.yml
+++ b/modules/nf-core/gcta/makegrmpart/meta.yml
@@ -122,6 +122,6 @@ topics:
           type: eval
           description: The command used to generate the version of the tool
 authors:
-  - "@andongni"
+  - "@lyh970817"
 maintainers:
-  - "@andongni"
+  - "@lyh970817"

--- a/modules/nf-core/gcta/makegrmpart/meta.yml
+++ b/modules/nf-core/gcta/makegrmpart/meta.yml
@@ -11,43 +11,60 @@ tools:
       homepage: "https://yanglab.westlake.edu.cn/software/gcta/"
       documentation: "https://yanglab.westlake.edu.cn/software/gcta/static/gcta_doc_latest.pdf"
       tool_dev_url: "https://github.com/jianyangqt/gcta"
-      licence: ["GPL-3.0-only"]
+      licence:
+        - "GPL-3.0-only"
+      identifier: biotools:gcta
 input:
   - - meta:
         type: map
         description: |
-          Groovy Map containing GRM-partition job metadata
-          e.g. `[ id:'gcta_grm', part_gcta_job:1, nparts_gcta:2 ]`
+          Groovy Map containing GRM-partition sample metadata
+          e.g. `[ id:'gcta_grm' ]`
+    - nparts_gcta:
+        type: integer
+        description: Total number of GRM partitions requested via
+          `--make-grm-part`; defaults to `1` when `null`
+        default: 1
+    - part_gcta_job:
+        type: integer
+        description: One-based index of the GRM partition to compute via
+          `--make-grm-part`; defaults to `1` when `null`
+        default: 1
     - mfile:
         type: file
-        description: GCTA multi-input manifest consumed by `--mbfile` or `--mpfile`
+        description: GCTA multi-input manifest consumed by `--mbfile` or
+          `--mpfile`
         pattern: "*.{mbfile,mpfile,txt}"
         ontologies:
           - edam: "http://edamontology.org/format_2330"
     - bed_pgen:
         type: file
-        description: Collection of PLINK primary genotype files referenced by the multi-input manifest
+        description: Collection of PLINK primary genotype files referenced by the
+          multi-input manifest
         pattern: "*.{bed,pgen}"
         ontologies:
           - edam: "http://edamontology.org/format_3003"
     - bim_pvar:
         type: file
-        description: Collection of PLINK variant metadata files referenced by the multi-input manifest
+        description: Collection of PLINK variant metadata files referenced by the
+          multi-input manifest
         pattern: "*.{bim,pvar}"
         ontologies: []
     - fam_psam:
         type: file
-        description: Collection of PLINK sample metadata files referenced by the multi-input manifest
+        description: Collection of PLINK sample metadata files referenced by the
+          multi-input manifest
         pattern: "*.{fam,psam}"
         ontologies: []
   - - meta2:
         type: map
         description: |
           Groovy Map containing SNP-selection metadata
-          e.g. `[ id:'snp_group1', snp_group:1 ]`
+          e.g. `[ id:'snp_group1' ]`
     - snp_group_file:
         type: file
-        description: Optional SNP extraction file passed to `--extract`; provide `[]` when absent
+        description: Optional SNP extraction file passed to `--extract`; provide
+          `[]` when absent
         pattern: "*.{txt,list}"
         ontologies:
           - edam: "http://edamontology.org/format_2330"
@@ -56,31 +73,39 @@ output:
     - - meta:
           type: map
           description: |
-            Groovy Map containing GRM-partition job metadata
-            e.g. `[ id:'gcta_grm', part_gcta_job:1, nparts_gcta:2 ]`
-      - "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.id":
+            Groovy Map containing GRM-partition sample metadata
+            e.g. `[ id:'gcta_grm' ]`
+      - "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.id":
           type: file
           description: Partitioned GRM ID file
-          pattern: "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.id"
+          pattern: "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.id"
           ontologies: []
-      - "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.bin":
+      - "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.bin":
           type: file
           description: Partitioned GRM binary matrix file
-          pattern: "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.bin"
+          pattern: "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.bin"
           ontologies: []
-      - "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.N.bin":
+      - "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.N.bin":
           type: file
           description: Partitioned GRM sample-count matrix file
-          pattern: "*.part_${meta.nparts_gcta}_${meta.part_gcta_job}.grm.N.bin"
+          pattern: "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.N.bin"
           ontologies: []
+      - nparts_gcta:
+          type: integer
+          description: Total number of GRM partitions requested via
+            `--make-grm-part`
+      - part_gcta_job:
+          type: integer
+          description: One-based index of the GRM partition computed via
+            `--make-grm-part`
   versions_gcta:
-    - - "${task.process}":
+    - - ${task.process}:
           type: string
           description: The process the versions were collected from
-      - "gcta":
+      - gcta:
           type: string
           description: The tool name
-      - "gcta --version 2>&1 | grep 'version v' | tr -s ' ' | cut -d' ' -f3 | sed 's/^v//'":
+      - "gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'":
           type: eval
           description: The command used to generate the version of the tool
 topics:
@@ -91,7 +116,7 @@ topics:
       - gcta:
           type: string
           description: The tool name
-      - gcta --version 2>&1 | grep 'version v' | tr -s ' ' | cut -d' ' -f3 | sed 's/^v//':
+      - "gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'":
           type: eval
           description: The command used to generate the version of the tool
 authors:

--- a/modules/nf-core/gcta/makegrmpart/meta.yml
+++ b/modules/nf-core/gcta/makegrmpart/meta.yml
@@ -3,7 +3,9 @@ name: "gcta_makegrmpart"
 description: Compute one partition of a GCTA genetic relationship matrix
 keywords:
   - gcta
+  - genome-wide complex trait analysis
   - grm
+  - genetic relationship matrix
   - genetics
 tools:
   - "gcta":
@@ -75,20 +77,20 @@ output:
           description: |
             Groovy Map containing GRM-partition sample metadata
             e.g. `[ id:'gcta_grm' ]`
-      - "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.id":
+      - "*.part_${nparts}_${part}.grm.id":
           type: file
           description: Partitioned GRM ID file
-          pattern: "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.id"
+          pattern: "*.part_${nparts}_${part}.grm.id"
           ontologies: []
-      - "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.bin":
+      - "*.part_${nparts}_${part}.grm.bin":
           type: file
           description: Partitioned GRM binary matrix file
-          pattern: "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.bin"
+          pattern: "*.part_${nparts}_${part}.grm.bin"
           ontologies: []
-      - "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.N.bin":
+      - "*.part_${nparts}_${part}.grm.N.bin":
           type: file
           description: Partitioned GRM sample-count matrix file
-          pattern: "*.part_${nparts_gcta ?: 1}_${part_gcta_job ?: 1}.grm.N.bin"
+          pattern: "*.part_${nparts}_${part}.grm.N.bin"
           ontologies: []
       - nparts_gcta:
           type: integer

--- a/modules/nf-core/gcta/makegrmpart/meta.yml
+++ b/modules/nf-core/gcta/makegrmpart/meta.yml
@@ -77,20 +77,11 @@ output:
           description: |
             Groovy Map containing GRM-partition sample metadata
             e.g. `[ id:'gcta_grm' ]`
-      - "*.part_${nparts}_${part}.grm.id":
+      - "*.part_${nparts}_${part}.grm.*":
           type: file
-          description: Partitioned GRM ID file
-          pattern: "*.part_${nparts}_${part}.grm.id"
-          ontologies: []
-      - "*.part_${nparts}_${part}.grm.bin":
-          type: file
-          description: Partitioned GRM binary matrix file
-          pattern: "*.part_${nparts}_${part}.grm.bin"
-          ontologies: []
-      - "*.part_${nparts}_${part}.grm.N.bin":
-          type: file
-          description: Partitioned GRM sample-count matrix file
-          pattern: "*.part_${nparts}_${part}.grm.N.bin"
+          description: Partitioned GRM output files, including ID, binary matrix,
+            and sample-count matrix files
+          pattern: "*.part_${nparts}_${part}.grm.*"
           ontologies: []
       - nparts_gcta:
           type: integer

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
@@ -1,0 +1,87 @@
+nextflow_process {
+
+    name "Test Process GCTA_MAKEGRMPART"
+    script "../main.nf"
+    process "GCTA_MAKEGRMPART"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gcta"
+    tag "gcta/makegrmpart"
+
+    test("homo_sapiens popgen - plink2") {
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                file('gcta_grm.mpfile').text = 'plink_simulated plink_simulated.pgen plink_simulated.psam plink_simulated.pvar\\n'
+
+                input[0] = [
+                    [ id:'gcta_grm', part_gcta_job:1, nparts_gcta:2 ],
+                    file('gcta_grm.mpfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                    ]
+                ]
+                input[1] = [[ id:'snp_group0' ], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.grm_files.size() == 1 },
+                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm' },
+                {
+                    assert snapshot(
+                        process.out.grm_files,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink1 - stub") {
+        options "-stub"
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                file('gcta_grm.mbfile').text = 'plink_simulated\\n'
+
+                input[0] = [
+                    [ id:'gcta_grm_bed', part_gcta_job:1, nparts_gcta:2 ],
+                    file('gcta_grm.mbfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                ]
+                input[1] = [[ id:'snp_group0' ], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
@@ -50,6 +50,95 @@ nextflow_process {
         }
     }
 
+    test("homo_sapiens popgen - plink1") {
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                file('gcta_grm.mbfile').text = 'plink_simulated\\n'
+
+                input[0] = [
+                    [ id:'gcta_grm_bed', part_gcta_job:1, nparts_gcta:2 ],
+                    file('gcta_grm.mbfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                ]
+                input[1] = [[ id:'snp_group0' ], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.grm_files.size() == 1 },
+                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed' },
+                {
+                    assert snapshot(
+                        process.out.grm_files,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink1 - extract snp group") {
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                file('gcta_grm_extract.mbfile').text = 'plink_simulated\\n'
+
+                def bimFile = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true)
+                def extractSnps = bimFile.readLines()
+                    .take(10)
+                    .collect { row -> row.trim().split(/\\s+/)[1] }
+                    .join('\\n') + '\\n'
+                file('snp_group_extract.txt').text = extractSnps
+
+                input[0] = [
+                    [ id:'gcta_grm_bed_extract', part_gcta_job:1, nparts_gcta:2 ],
+                    file('gcta_grm_extract.mbfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
+                    ],
+                    [
+                        bimFile
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                ]
+                input[1] = [[ id:'snp_group_extract', snp_group:1 ], file('snp_group_extract.txt')]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.grm_files.size() == 1 },
+                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed_extract' },
+                {
+                    assert snapshot(
+                        process.out.grm_files,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
     test("homo_sapiens popgen - plink1 - stub") {
         options "-stub"
         config "./nextflow.config"

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
@@ -10,8 +10,6 @@ nextflow_process {
     tag "gcta/makegrmpart"
 
     test("homo_sapiens popgen - plink2") {
-        config "./nextflow.config"
-
         when {
             process {
                 """
@@ -56,8 +54,6 @@ nextflow_process {
     }
 
     test("homo_sapiens popgen - plink1") {
-        config "./nextflow.config"
-
         when {
             process {
                 """
@@ -102,8 +98,6 @@ nextflow_process {
     }
 
     test("homo_sapiens popgen - plink1 - extract snp group") {
-        config "./nextflow.config"
-
         when {
             process {
                 """
@@ -155,8 +149,6 @@ nextflow_process {
     }
 
     test("homo_sapiens popgen - plink1 - default partition values") {
-        config "./nextflow.config"
-
         when {
             process {
                 """
@@ -204,7 +196,6 @@ nextflow_process {
 
     test("homo_sapiens popgen - plink1 - stub") {
         options "-stub"
-        config "./nextflow.config"
 
         when {
             process {

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
@@ -18,7 +18,9 @@ nextflow_process {
                 file('gcta_grm.mpfile').text = 'plink_simulated plink_simulated.pgen plink_simulated.psam plink_simulated.pvar\\n'
 
                 input[0] = [
-                    [ id:'gcta_grm', part_gcta_job:1, nparts_gcta:2 ],
+                    [ id:'gcta_grm' ],
+                    2,
+                    1,
                     file('gcta_grm.mpfile'),
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true)
@@ -40,6 +42,9 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.grm_files.size() == 1 },
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm' },
+                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
+                { assert process.out.grm_files.get(0).get(4) == 2 },
+                { assert process.out.grm_files.get(0).get(5) == 1 },
                 {
                     assert snapshot(
                         process.out.grm_files,
@@ -59,7 +64,9 @@ nextflow_process {
                 file('gcta_grm.mbfile').text = 'plink_simulated\\n'
 
                 input[0] = [
-                    [ id:'gcta_grm_bed', part_gcta_job:1, nparts_gcta:2 ],
+                    [ id:'gcta_grm_bed' ],
+                    2,
+                    1,
                     file('gcta_grm.mbfile'),
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
@@ -81,6 +88,9 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.grm_files.size() == 1 },
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed' },
+                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
+                { assert process.out.grm_files.get(0).get(4) == 2 },
+                { assert process.out.grm_files.get(0).get(5) == 1 },
                 {
                     assert snapshot(
                         process.out.grm_files,
@@ -107,7 +117,9 @@ nextflow_process {
                 file('snp_group_extract.txt').text = extractSnps
 
                 input[0] = [
-                    [ id:'gcta_grm_bed_extract', part_gcta_job:1, nparts_gcta:2 ],
+                    [ id:'gcta_grm_bed_extract' ],
+                    2,
+                    1,
                     file('gcta_grm_extract.mbfile'),
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
@@ -119,7 +131,7 @@ nextflow_process {
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
                     ]
                 ]
-                input[1] = [[ id:'snp_group_extract', snp_group:1 ], file('snp_group_extract.txt')]
+                input[1] = [[ id:'snp_group_extract' ], file('snp_group_extract.txt')]
                 """
             }
         }
@@ -129,9 +141,60 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.grm_files.size() == 1 },
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed_extract' },
+                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
+                { assert process.out.grm_files.get(0).get(4) == 2 },
+                { assert process.out.grm_files.get(0).get(5) == 1 },
                 {
                     assert snapshot(
                         process.out.grm_files,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink1 - default partition values") {
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                file('gcta_grm_default.mbfile').text = 'plink_simulated\\n'
+
+                input[0] = [
+                    [ id:'gcta_grm_bed_default' ],
+                    null,
+                    null,
+                    file('gcta_grm_default.mbfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                ]
+                input[1] = [[ id:'snp_group0' ], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.grm_files.size() == 1 },
+                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed_default' },
+                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
+                { assert process.out.grm_files.get(0).get(1).contains('gcta_grm_bed_default.part_1_1.grm.id') },
+                { assert process.out.grm_files.get(0).get(2).contains('gcta_grm_bed_default.part_1_1.grm.bin') },
+                { assert process.out.grm_files.get(0).get(3).contains('gcta_grm_bed_default.part_1_1.grm.N.bin') },
+                { assert process.out.grm_files.get(0).get(4) == null },
+                { assert process.out.grm_files.get(0).get(5) == null },
+                {
+                    assert snapshot(
                         process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 }
@@ -149,7 +212,9 @@ nextflow_process {
                 file('gcta_grm.mbfile').text = 'plink_simulated\\n'
 
                 input[0] = [
-                    [ id:'gcta_grm_bed', part_gcta_job:1, nparts_gcta:2 ],
+                    [ id:'gcta_grm_bed' ],
+                    2,
+                    1,
                     file('gcta_grm.mbfile'),
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
@@ -41,8 +41,9 @@ nextflow_process {
                 { assert process.out.grm_files.size() == 1 },
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm' },
                 { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(4) == 2 },
-                { assert process.out.grm_files.get(0).get(5) == 1 },
+                { assert process.out.grm_files.get(0).get(1).size() == 3 },
+                { assert process.out.grm_files.get(0).get(2) == 2 },
+                { assert process.out.grm_files.get(0).get(3) == 1 },
                 {
                     assert snapshot(
                         process.out.grm_files,
@@ -85,8 +86,9 @@ nextflow_process {
                 { assert process.out.grm_files.size() == 1 },
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed' },
                 { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(4) == 2 },
-                { assert process.out.grm_files.get(0).get(5) == 1 },
+                { assert process.out.grm_files.get(0).get(1).size() == 3 },
+                { assert process.out.grm_files.get(0).get(2) == 2 },
+                { assert process.out.grm_files.get(0).get(3) == 1 },
                 {
                     assert snapshot(
                         process.out.grm_files,
@@ -136,8 +138,9 @@ nextflow_process {
                 { assert process.out.grm_files.size() == 1 },
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed_extract' },
                 { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(4) == 2 },
-                { assert process.out.grm_files.get(0).get(5) == 1 },
+                { assert process.out.grm_files.get(0).get(1).size() == 3 },
+                { assert process.out.grm_files.get(0).get(2) == 2 },
+                { assert process.out.grm_files.get(0).get(3) == 1 },
                 {
                     assert snapshot(
                         process.out.grm_files,
@@ -180,11 +183,16 @@ nextflow_process {
                 { assert process.out.grm_files.size() == 1 },
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed_default' },
                 { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(1).contains('gcta_grm_bed_default.part_1_1.grm.id') },
-                { assert process.out.grm_files.get(0).get(2).contains('gcta_grm_bed_default.part_1_1.grm.bin') },
-                { assert process.out.grm_files.get(0).get(3).contains('gcta_grm_bed_default.part_1_1.grm.N.bin') },
-                { assert process.out.grm_files.get(0).get(4) == null },
-                { assert process.out.grm_files.get(0).get(5) == null },
+                { assert process.out.grm_files.get(0).get(1).size() == 3 },
+                {
+                    assert process.out.grm_files.get(0).get(1).collect { it.toString().tokenize('/').last() }.toSet() == [
+                        'gcta_grm_bed_default.part_1_1.grm.id',
+                        'gcta_grm_bed_default.part_1_1.grm.bin',
+                        'gcta_grm_bed_default.part_1_1.grm.N.bin'
+                    ] as Set
+                },
+                { assert process.out.grm_files.get(0).get(2) == null },
+                { assert process.out.grm_files.get(0).get(3) == null },
                 {
                     assert snapshot(
                         process.out.findAll { key, val -> key.startsWith('versions') }

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
@@ -29,6 +29,66 @@
         },
         "timestamp": "2026-03-13T13:29:12.139953008"
     },
+    "homo_sapiens popgen - plink1": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "gcta_grm_bed",
+                        "part_gcta_job": 1,
+                        "nparts_gcta": 2
+                    },
+                    "gcta_grm_bed.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
+                    "gcta_grm_bed.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
+                    "gcta_grm_bed.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRMPART",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-03-21T00:29:46.089561787"
+    },
+    "homo_sapiens popgen - plink1 - extract snp group": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "gcta_grm_bed_extract",
+                        "part_gcta_job": 1,
+                        "nparts_gcta": 2
+                    },
+                    "gcta_grm_bed_extract.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
+                    "gcta_grm_bed_extract.part_2_1.grm.bin:md5,9ec73c76840e9dce7ffe30d66d6d427d",
+                    "gcta_grm_bed_extract.part_2_1.grm.N.bin:md5,6b38fd68fa01357c900ba502c1d17f24"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRMPART",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-03-21T00:29:53.31782213"
+    },
     "homo_sapiens popgen - plink1 - stub": {
         "content": [
             {

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
@@ -1,0 +1,81 @@
+{
+    "homo_sapiens popgen - plink2": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "gcta_grm",
+                        "part_gcta_job": 1,
+                        "nparts_gcta": 2
+                    },
+                    "gcta_grm.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
+                    "gcta_grm.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
+                    "gcta_grm.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRMPART",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-03-13T13:29:12.139953008"
+    },
+    "homo_sapiens popgen - plink1 - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "gcta_grm_bed",
+                            "part_gcta_job": 1,
+                            "nparts_gcta": 2
+                        },
+                        "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "GCTA_MAKEGRMPART",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ],
+                "grm_files": [
+                    [
+                        {
+                            "id": "gcta_grm_bed",
+                            "part_gcta_job": 1,
+                            "nparts_gcta": 2
+                        },
+                        "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRMPART",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-03-13T13:29:17.993546066"
+    }
+}

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
@@ -6,9 +6,11 @@
                     {
                         "id": "gcta_grm"
                     },
-                    "gcta_grm.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
-                    "gcta_grm.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
-                    "gcta_grm.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
+                    [
+                        "gcta_grm.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
+                        "gcta_grm.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
+                        "gcta_grm.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
+                    ],
                     2,
                     1
                 ]
@@ -27,7 +29,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-10T16:52:27.160067981"
+        "timestamp": "2026-05-14T14:40:46.422832109"
     },
     "homo_sapiens popgen - plink1": {
         "content": [
@@ -36,9 +38,11 @@
                     {
                         "id": "gcta_grm_bed"
                     },
-                    "gcta_grm_bed.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
-                    "gcta_grm_bed.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
-                    "gcta_grm_bed.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
+                    [
+                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
+                        "gcta_grm_bed.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
+                        "gcta_grm_bed.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
+                    ],
                     2,
                     1
                 ]
@@ -57,7 +61,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-10T16:52:39.590709167"
+        "timestamp": "2026-05-14T14:41:32.425143203"
     },
     "homo_sapiens popgen - plink1 - extract snp group": {
         "content": [
@@ -66,9 +70,11 @@
                     {
                         "id": "gcta_grm_bed_extract"
                     },
-                    "gcta_grm_bed_extract.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
-                    "gcta_grm_bed_extract.part_2_1.grm.bin:md5,9ec73c76840e9dce7ffe30d66d6d427d",
-                    "gcta_grm_bed_extract.part_2_1.grm.N.bin:md5,6b38fd68fa01357c900ba502c1d17f24",
+                    [
+                        "gcta_grm_bed_extract.part_2_1.grm.N.bin:md5,6b38fd68fa01357c900ba502c1d17f24",
+                        "gcta_grm_bed_extract.part_2_1.grm.bin:md5,9ec73c76840e9dce7ffe30d66d6d427d",
+                        "gcta_grm_bed_extract.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
+                    ],
                     2,
                     1
                 ]
@@ -87,7 +93,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-10T16:52:53.520350436"
+        "timestamp": "2026-05-14T14:42:17.337260978"
     },
     "homo_sapiens popgen - plink1 - stub": {
         "content": [
@@ -97,9 +103,11 @@
                         {
                             "id": "gcta_grm_bed"
                         },
-                        "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        [
+                            "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ],
                         2,
                         1
                     ]
@@ -116,9 +124,11 @@
                         {
                             "id": "gcta_grm_bed"
                         },
-                        "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        [
+                            "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ],
                         2,
                         1
                     ]
@@ -136,7 +146,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-10T16:53:17.014474342"
+        "timestamp": "2026-05-14T14:43:49.194574681"
     },
     "homo_sapiens popgen - plink1 - default partition values": {
         "content": [

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
@@ -4,13 +4,13 @@
             [
                 [
                     {
-                        "id": "gcta_grm",
-                        "part_gcta_job": 1,
-                        "nparts_gcta": 2
+                        "id": "gcta_grm"
                     },
                     "gcta_grm.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
                     "gcta_grm.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
-                    "gcta_grm.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66"
+                    "gcta_grm.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
+                    2,
+                    1
                 ]
             ],
             {
@@ -27,20 +27,20 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-03-13T13:29:12.139953008"
+        "timestamp": "2026-05-10T16:52:27.160067981"
     },
     "homo_sapiens popgen - plink1": {
         "content": [
             [
                 [
                     {
-                        "id": "gcta_grm_bed",
-                        "part_gcta_job": 1,
-                        "nparts_gcta": 2
+                        "id": "gcta_grm_bed"
                     },
                     "gcta_grm_bed.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
                     "gcta_grm_bed.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
-                    "gcta_grm_bed.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66"
+                    "gcta_grm_bed.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
+                    2,
+                    1
                 ]
             ],
             {
@@ -57,20 +57,20 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-03-21T00:29:46.089561787"
+        "timestamp": "2026-05-10T16:52:39.590709167"
     },
     "homo_sapiens popgen - plink1 - extract snp group": {
         "content": [
             [
                 [
                     {
-                        "id": "gcta_grm_bed_extract",
-                        "part_gcta_job": 1,
-                        "nparts_gcta": 2
+                        "id": "gcta_grm_bed_extract"
                     },
                     "gcta_grm_bed_extract.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718",
                     "gcta_grm_bed_extract.part_2_1.grm.bin:md5,9ec73c76840e9dce7ffe30d66d6d427d",
-                    "gcta_grm_bed_extract.part_2_1.grm.N.bin:md5,6b38fd68fa01357c900ba502c1d17f24"
+                    "gcta_grm_bed_extract.part_2_1.grm.N.bin:md5,6b38fd68fa01357c900ba502c1d17f24",
+                    2,
+                    1
                 ]
             ],
             {
@@ -87,7 +87,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-03-21T00:29:53.31782213"
+        "timestamp": "2026-05-10T16:52:53.520350436"
     },
     "homo_sapiens popgen - plink1 - stub": {
         "content": [
@@ -95,13 +95,13 @@
                 "0": [
                     [
                         {
-                            "id": "gcta_grm_bed",
-                            "part_gcta_job": 1,
-                            "nparts_gcta": 2
+                            "id": "gcta_grm_bed"
                         },
                         "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
                         "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        2,
+                        1
                     ]
                 ],
                 "1": [
@@ -114,13 +114,13 @@
                 "grm_files": [
                     [
                         {
-                            "id": "gcta_grm_bed",
-                            "part_gcta_job": 1,
-                            "nparts_gcta": 2
+                            "id": "gcta_grm_bed"
                         },
                         "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
                         "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        2,
+                        1
                     ]
                 ],
                 "versions_gcta": [
@@ -136,6 +136,24 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-03-13T13:29:17.993546066"
+        "timestamp": "2026-05-10T16:53:17.014474342"
+    },
+    "homo_sapiens popgen - plink1 - default partition values": {
+        "content": [
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRMPART",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-15T20:37:03.862317452"
     }
 }

--- a/modules/nf-core/gcta/makegrmpart/tests/nextflow.config
+++ b/modules/nf-core/gcta/makegrmpart/tests/nextflow.config
@@ -1,3 +1,0 @@
-params {
-    modules_testdata_base_path = System.getenv('NF_MODULES_TESTDATA_BASE_PATH') ?: 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
-}

--- a/modules/nf-core/gcta/makegrmpart/tests/nextflow.config
+++ b/modules/nf-core/gcta/makegrmpart/tests/nextflow.config
@@ -1,0 +1,3 @@
+params {
+    modules_testdata_base_path = System.getenv('NF_MODULES_TESTDATA_BASE_PATH') ?: 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
+}


### PR DESCRIPTION
This PR adds the `gcta/makegrmpart` module, which computes one partition of a GCTA genetic relationship matrix from PLINK inputs.

Merge dependencies: none. This PR is self-contained and does not require any other split GCTA PR to merge first.


## PR checklist


- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] `nf-core modules test gcta/makegrmpart --profile docker`
- [x] `nf-core modules test gcta/makegrmpart --profile singularity`
- [x] `nf-core modules test gcta/makegrmpart --profile conda`



