### PR TITLE
Update whatshap module to single input tuple and topics channels

### DIFF
--- a/modules/nf-core/whatshap/haplotag/tests/main.nf.test
+++ b/modules/nf-core/whatshap/haplotag/tests/main.nf.test
@@ -33,15 +33,11 @@ nextflow_process {
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/vcf/NA03697B2_new.pbmm2.repeats.vcf.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/vcf/NA03697B2_new.pbmm2.repeats.vcf.gz.csi', checkIfExists: true),
-                ]
-
-                input[1] = [
-                    [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/bam/NA03697B2_downsampled.pbmm2.repeats.bam', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/bam/NA03697B2_downsampled.pbmm2.repeats.bam.bai', checkIfExists: true),
                 ]
 
-                input[2] = Channel.of([
+                input[1] = Channel.of([
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome3.fasta', checkIfExists: true)
                 ]).join(SAMTOOLS_FAIDX.out.fai)

--- a/modules/nf-core/whatshap/phase/main.nf
+++ b/modules/nf-core/whatshap/phase/main.nf
@@ -8,9 +8,8 @@ process WHATSHAP_PHASE {
         : 'community.wave.seqera.io/library/whatshap:2.8--7fe530bc624a3e5a' }"
 
     input:
-    tuple val(meta), path(vcf), path(tbi)
-    tuple val(meta2), path(bam), path(bai)
-    tuple val(meta3), path(fasta), path(fai)
+    tuple val(meta),  path(vcf),   path(tbi), path(bam), path(bai)
+    tuple val(meta2), path(fasta), path(fai)
 
     output:
     tuple val(meta), path("*.vcf.gz"),     emit: vcf

--- a/modules/nf-core/whatshap/phase/meta.yml
+++ b/modules/nf-core/whatshap/phase/meta.yml
@@ -33,11 +33,6 @@ input:
         type: file
         description: VCF index file (optional but recommended)
         pattern: "*.{tbi,csi}"
-  - - meta2:
-        type: map
-        description: |
-          Groovy Map containing bam information
-          e.g. [ id:'test', single_end:false ]
     - bam:
         type: file
         description: BAM file with aligned reads
@@ -46,7 +41,7 @@ input:
         type: file
         description: BAM index file (optional but recommended)
         pattern: "*.bai"
-  - - meta3:
+  - - meta2:
         type: map
         description: |
           Groovy Map containing reference information

--- a/modules/nf-core/whatshap/phase/tests/main.nf.test
+++ b/modules/nf-core/whatshap/phase/tests/main.nf.test
@@ -35,16 +35,11 @@ nextflow_process {
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/vcf/NA03697B2_new.pbmm2.repeats.vcf.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/vcf/NA03697B2_new.pbmm2.repeats.vcf.gz.csi', checkIfExists: true),
-
-                ]
-
-                input[1] = [
-                    [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/bam/NA03697B2_downsampled.pbmm2.repeats.bam', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/bam/NA03697B2_downsampled.pbmm2.repeats.bam.bai', checkIfExists: true),
                 ]
 
-                input[2] = Channel.of([
+                input[1] = Channel.of([
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome3.fasta', checkIfExists: true)
                 ]).join(SAMTOOLS_FAIDX.out.fai)
@@ -76,16 +71,11 @@ nextflow_process {
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/vcf/NA03697B2_new.pbmm2.repeats.vcf.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/vcf/NA03697B2_new.pbmm2.repeats.vcf.gz.csi', checkIfExists: true),
-
-                ]
-
-                input[1] = [
-                    [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/bam/NA03697B2_downsampled.pbmm2.repeats.bam', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/pacbio/bam/NA03697B2_downsampled.pbmm2.repeats.bam.bai', checkIfExists: true),
                 ]
 
-                input[2] = Channel.of([
+                input[1] = Channel.of([
                     [ id:'test' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome3.fasta', checkIfExists: true)
                 ]).join(SAMTOOLS_FAIDX.out.fai)


### PR DESCRIPTION
1. Change input structure to single tuple
1. Removes leftover version.yaml and retains only topics.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
