### PR TITLE
feat: add bam_qc_rnaseq subworkflow

### DIFF
--- a/modules/nf-core/custom/multiqccustombiotype/environment.yml
+++ b/modules/nf-core/custom/multiqccustombiotype/environment.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::python=3.12.2

--- a/modules/nf-core/custom/multiqccustombiotype/main.nf
+++ b/modules/nf-core/custom/multiqccustombiotype/main.nf
@@ -1,0 +1,36 @@
+process CUSTOM_MULTIQCCUSTOMBIOTYPE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.12' :
+        'biocontainers/python:3.12' }"
+
+    input:
+    tuple val(meta), path(count)
+    tuple val(meta2), path(header)
+
+    output:
+    tuple val(meta), path("*biotype_counts_mqc.tsv")     , emit: tsv
+    tuple val(meta), path("*biotype_counts_rrna_mqc.tsv") , emit: rrna
+    path "versions.yml"                                   , emit: versions, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    template 'mqc_features_stat.py'
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.biotype_counts_mqc.tsv
+    touch ${prefix}.biotype_counts_rrna_mqc.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/custom/multiqccustombiotype/meta.yml
+++ b/modules/nf-core/custom/multiqccustombiotype/meta.yml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "custom_multiqccustombiotype"
+description: Generate MultiQC-compatible biotype count summaries from featureCounts output
+keywords:
+  - biotype
+  - featurecounts
+  - multiqc
+  - rnaseq
+  - qc
+tools:
+  - "custom":
+      description: "Summarise featureCounts biotype assignments for MultiQC reporting"
+      tool_dev_url: "https://github.com/nf-core/modules/blob/master/modules/nf-core/custom/multiqccustombiotype/main.nf"
+      licence: ["MIT"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - count:
+        type: file
+        description: featureCounts output count file
+        pattern: "*.featureCounts.txt"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+    - header:
+        type: file
+        description: Header file for the biotype counts MultiQC table
+        pattern: "*.txt"
+        ontologies: []
+output:
+  tsv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+      - "*biotype_counts_mqc.tsv":
+          type: file
+          description: Biotype counts formatted for MultiQC
+          pattern: "*biotype_counts_mqc.tsv"
+          ontologies: []
+  rrna:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+      - "*biotype_counts_rrna_mqc.tsv":
+          type: file
+          description: rRNA percentage for MultiQC general stats
+          pattern: "*biotype_counts_rrna_mqc.tsv"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
+authors:
+  - "@pinin4fjords"
+maintainers:
+  - "@pinin4fjords"

--- a/modules/nf-core/custom/multiqccustombiotype/templates/mqc_features_stat.py
+++ b/modules/nf-core/custom/multiqccustombiotype/templates/mqc_features_stat.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+# Combine featureCounts biotype counts with a header for MultiQC,
+# then calculate feature percentages for the general stats table.
+#
+# Written by Senthilkumar Panneerselvam and released under the MIT license.
+# Adapted for nf-core/modules by Jonathan Manning.
+
+import logging
+import os
+import platform
+
+# Create a logger
+logging.basicConfig(format="%(name)s - %(asctime)s %(levelname)s: %(message)s")
+logger = logging.getLogger(__file__)
+logger.setLevel(logging.INFO)
+
+# Template variables from Nextflow
+count_file = "${count}"
+header_file = "${header}"
+prefix = "${task.ext.prefix}" if "${task.ext.prefix}" != "null" else "${meta.id}"
+sample_name = "${meta.id}"
+
+
+def prepare_biotype_counts(count_file, header_file, prefix):
+    """Cut gene ID and count columns from featureCounts output, prepend header."""
+    outfile = f"{prefix}.biotype_counts_mqc.tsv"
+
+    with open(header_file) as hf:
+        header = hf.read()
+
+    with open(count_file) as cf:
+        lines = cf.readlines()[2:]  # skip featureCounts header lines
+
+    with open(outfile, "w") as of:
+        of.write(header)
+        for line in lines:
+            fields = line.strip().split("\\t")
+            if len(fields) >= 7:
+                of.write(f"{fields[0]}\\t{fields[6]}\\n")
+
+    return outfile
+
+
+mqc_main = """#id: 'biotype-gs'
+#plot_type: 'generalstats'
+#pconfig:"""
+
+mqc_pconf = """#    percent_{ft}:
+#        title: '% {ft}'
+#        namespace: 'Biotype Counts'
+#        description: '% reads overlapping {ft} features'
+#        max: 100
+#        min: 0
+#        scale: 'RdYlGn-rev'"""
+
+
+def mqc_feature_stat(bfile, features, outfile, sname=None):
+    """Calculate features percentage for biotype counts."""
+    if not sname:
+        sname = os.path.splitext(os.path.basename(bfile))[0]
+
+    fcounts = {}
+    try:
+        with open(bfile) as bfl:
+            for ln in bfl:
+                if ln.startswith("#"):
+                    continue
+                parts = ln.strip().split("\\t")
+                if len(parts) == 2:
+                    ft, cn = parts
+                    fcounts[ft] = float(cn)
+    except Exception:
+        logger.error(f"Trouble reading the biocount file {bfile}")
+        return
+
+    total_count = sum(fcounts.values())
+    if total_count == 0:
+        logger.error("No biocounts found, exiting")
+        return
+
+    fpercent = {f: (fcounts[f] / total_count) * 100 if f in fcounts else 0 for f in features}
+    if len(fpercent) == 0:
+        logger.error(f"None of given features '{', '.join(features)}' found in the biocount file {bfile}")
+        return
+
+    out_head, out_value, out_mqc = ("Sample", f"'{sname}'", mqc_main)
+    for ft, pt in fpercent.items():
+        out_head = f"{out_head}\\tpercent_{ft}"
+        out_value = f"{out_value}\\t{pt}"
+        out_mqc = f"{out_mqc}\\n{mqc_pconf.format(ft=ft)}"
+
+    with open(outfile, "w") as ofl:
+        out_final = "\\n".join([out_mqc, out_head, out_value]).strip()
+        ofl.write(out_final + "\\n")
+
+
+if __name__ == "__main__":
+    # Step 1: Prepare biotype counts TSV from featureCounts output
+    biotype_file = prepare_biotype_counts(count_file, header_file, prefix)
+
+    # Step 2: Calculate rRNA percentage for MultiQC general stats
+    mqc_feature_stat(
+        biotype_file,
+        ["rRNA"],
+        f"{prefix}.biotype_counts_rrna_mqc.tsv",
+        sname=sample_name,
+    )
+
+    # Versions
+    with open("versions.yml", "w") as f:
+        f.write('"\\${task.process}":\\n')
+        f.write(f"    python: {platform.python_version()}\\n")

--- a/modules/nf-core/custom/multiqccustombiotype/tests/main.nf.test
+++ b/modules/nf-core/custom/multiqccustombiotype/tests/main.nf.test
@@ -1,0 +1,76 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_MULTIQCCUSTOMBIOTYPE"
+    script "../main.nf"
+    process "CUSTOM_MULTIQCCUSTOMBIOTYPE"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "custom/multiqccustombiotype"
+
+    test("featurecounts biotype counts") {
+
+        when {
+            process {
+                """
+                // Create a minimal featureCounts output file
+                def count_file = file("\${workDir}/test.featureCounts.txt")
+                count_file.text = [
+                    '# Program:featureCounts v2.0.1',
+                    'Geneid\tChr\tStart\tEnd\tStrand\tLength\ttest',
+                    'protein_coding\tchr1\t1\t1000\t+\t1000\t5000',
+                    'rRNA\tchr1\t2000\t3000\t+\t1000\t500',
+                    'lincRNA\tchr1\t4000\t5000\t+\t1000\t200',
+                    'miRNA\tchr1\t6000\t7000\t+\t1000\t100'
+                ].join('\\n') + '\\n'
+
+                // Create a biotypes header file
+                def header_file = file("\${workDir}/biotypes_header.txt")
+                header_file.text = [
+                    "# id: 'biotype_counts'",
+                    "# section_name: 'Biotype Counts'",
+                    "# description: 'shows reads overlapping genomic features of different biotypes'",
+                    "# plot_type: 'bargraph'",
+                    "# anchor: 'featurecounts_biotype'",
+                ].join('\\n') + '\\n'
+
+                input[0] = channel.of([ [ id:'test' ], count_file ])
+                input[1] = channel.of([ [:], header_file ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("featurecounts biotype counts - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                def count_file = file("\${workDir}/test.featureCounts.txt")
+                count_file.text = 'stub'
+                def header_file = file("\${workDir}/biotypes_header.txt")
+                header_file.text = 'stub'
+
+                input[0] = channel.of([ [ id:'test' ], count_file ])
+                input[1] = channel.of([ [:], header_file ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/custom/multiqccustombiotype/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/multiqccustombiotype/tests/main.nf.test.snap
@@ -1,0 +1,100 @@
+{
+    "featurecounts biotype counts - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.biotype_counts_mqc.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.biotype_counts_rrna_mqc.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,5b1127473a5d4657f663101a8fd1f737"
+                ],
+                "rrna": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.biotype_counts_rrna_mqc.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.biotype_counts_mqc.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5b1127473a5d4657f663101a8fd1f737"
+                ]
+            }
+        ],
+        "timestamp": "2026-04-10T12:08:00.66332716",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "featurecounts biotype counts": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.biotype_counts_mqc.tsv:md5,6b122075c66e5565fd82804095dfd68a"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.biotype_counts_rrna_mqc.tsv:md5,ac6ea1053b89872f745a73c4f61b5afe"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,fa9a9f9b8abe32a9411e5fa5c3a65b83"
+                ],
+                "rrna": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.biotype_counts_rrna_mqc.tsv:md5,ac6ea1053b89872f745a73c4f61b5afe"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.biotype_counts_mqc.tsv:md5,6b122075c66e5565fd82804095dfd68a"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,fa9a9f9b8abe32a9411e5fa5c3a65b83"
+                ]
+            }
+        ],
+        "timestamp": "2026-04-10T12:07:55.638491947",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/dupradar/main.nf
+++ b/modules/nf-core/dupradar/main.nf
@@ -19,7 +19,7 @@ process DUPRADAR {
     tuple val(meta), path("*_intercept_slope.txt")  , emit: intercept_slope
     tuple val(meta), path("*_mqc.txt")              , emit: multiqc
     tuple val(meta), path("*.R_sessionInfo.log")    , emit: session_info
-    path "versions.yml"                             , emit: versions
+    path "versions.yml"                             , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/dupradar/meta.yml
+++ b/modules/nf-core/dupradar/meta.yml
@@ -127,6 +127,11 @@ output:
         pattern: "versions.yml"
         ontologies:
           - edam: http://edamontology.org/format_3750 # YAML
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
 authors:
   - "@pinin4fjords"
 maintainers:

--- a/modules/nf-core/dupradar/tests/main.nf.test.snap
+++ b/modules/nf-core/dupradar/tests/main.nf.test.snap
@@ -23,8 +23,8 @@
                         "strandedness": "forward"
                     },
                     [
-                        "test_dup_intercept_mqc.txt:md5,11961f0962ffc70e42aa57a12984e0fc",
-                        "test_duprateExpDensCurve_mqc.txt:md5,f7d3432ef52047336b156446281aa6ac"
+                        "test_dup_intercept_mqc.txt:md5,602a30c09b79533abbbb76efbb168e3e",
+                        "test_duprateExpDensCurve_mqc.txt:md5,b41f82f7d515d5e2b3e7993add90d26b"
                     ]
                 ]
             ],
@@ -34,11 +34,11 @@
                 }
             }
         ],
+        "timestamp": "2026-04-10T13:28:41.184045226",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-08-27T15:55:26.944511"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "versions": {
         "content": [
@@ -48,11 +48,11 @@
                 }
             }
         ],
+        "timestamp": "2026-04-10T13:28:41.1989833",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-08-27T15:44:39.879885"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - bam - single_end - stub": {
         "content": [
@@ -211,11 +211,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-10T13:28:47.435208509",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-08-27T15:44:46.00689"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - bam - paired_end": {
         "content": [
@@ -241,8 +241,8 @@
                         "strandedness": "forward"
                     },
                     [
-                        "test_dup_intercept_mqc.txt:md5,002855b42a71aa0f407ef7fa19df9ac3",
-                        "test_duprateExpDensCurve_mqc.txt:md5,e797d8e256c5b2ab3aad1801360f1a77"
+                        "test_dup_intercept_mqc.txt:md5,4071a87d8db9731e9a74e51f00523056",
+                        "test_duprateExpDensCurve_mqc.txt:md5,af58f18dd239447f04fa4a313124a549"
                     ]
                 ]
             ],
@@ -252,11 +252,11 @@
                 }
             }
         ],
+        "timestamp": "2026-04-10T13:28:56.119446765",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-08-27T15:55:55.958566"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - bam - paired_end - stub": {
         "content": [
@@ -415,10 +415,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-10T13:29:02.570599881",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-08-27T15:45:15.504711"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/subworkflows/nf-core/bam_qc_rnaseq/main.nf
+++ b/subworkflows/nf-core/bam_qc_rnaseq/main.nf
@@ -13,233 +13,140 @@ include { BAM_RSEQC                       } from '../bam_rseqc/main'
 workflow BAM_QC_RNASEQ {
 
     take:
-    ch_bam_bai              // channel: [ val(meta), path(bam), path(bai) ]
-    ch_gtf                  // channel: [ val(meta), path(gtf) ]
-    ch_gene_bed             // channel: path(bed)
-    ch_fasta_fai            // channel: [ val(meta), path(fasta), path(fai) ]
-    ch_biotypes_header      // channel: [ val(meta), path(biotypes_header.txt) ]
-    skip_preseq             // val(bool)
-    skip_biotype_qc         // val(bool)
-    skip_qualimap           // val(bool)
-    skip_dupradar           // val(bool)
-    skip_rseqc              // val(bool)
-    biotype                 // val(string) - e.g. "gene_type" or "gene_biotype"
-    rseqc_modules           // val(list)   - e.g. ['bam_stat', 'infer_experiment', ...]
+    ch_bam_bai         // channel: [ val(meta), path(bam), path(bai) ]
+    ch_gtf             // channel: [ val(meta), path(gtf) ]
+    ch_gene_bed        // channel: path(bed)
+    ch_fasta_fai       // channel: [ val(meta), path(fasta), path(fai) ]
+    ch_biotypes_header // channel: [ val(meta), path(biotypes_header.txt) ]
+    tools   // val(list)   - e.g. ['preseq', 'biotype_qc', 'qualimap', 'dupradar', 'rseqc_bam_stat', 'rseqc_infer_experiment', ...]
+    biotype // val(string) - e.g. "gene_type" or "gene_biotype"
 
     main:
-    ch_multiqc_files       = channel.empty()
-    ch_inferexperiment_txt = channel.empty()
+    def rseqc_modules = tools.findAll { it.startsWith('rseqc_') }.collect { it.replace('rseqc_', '') }
 
     ch_genome_bam = ch_bam_bai.map { meta, bam, _bai -> [ meta, bam ] }
 
-    // Initialise individual output channels (populated conditionally below)
-    ch_preseq_lc_extrap       = channel.empty()
-    ch_preseq_log             = channel.empty()
-    ch_biotype_tsv            = channel.empty()
-    ch_biotype_rrna           = channel.empty()
-    ch_featurecounts_counts   = channel.empty()
-    ch_featurecounts_summary  = channel.empty()
-    ch_qualimap_results       = channel.empty()
-    ch_dupradar_scatter2d     = channel.empty()
-    ch_dupradar_boxplot       = channel.empty()
-    ch_dupradar_hist          = channel.empty()
-    ch_dupradar_dupmatrix     = channel.empty()
-    ch_dupradar_intercept_slope = channel.empty()
-    ch_dupradar_multiqc       = channel.empty()
-    ch_bamstat_txt              = channel.empty()
-    ch_innerdistance_all        = channel.empty()
-    ch_innerdistance_distance   = channel.empty()
-    ch_innerdistance_freq       = channel.empty()
-    ch_innerdistance_mean       = channel.empty()
-    ch_innerdistance_pdf        = channel.empty()
-    ch_innerdistance_rscript    = channel.empty()
-    ch_junctionannotation_all          = channel.empty()
-    ch_junctionannotation_bed          = channel.empty()
-    ch_junctionannotation_interact_bed = channel.empty()
-    ch_junctionannotation_xls          = channel.empty()
-    ch_junctionannotation_pdf          = channel.empty()
-    ch_junctionannotation_events_pdf   = channel.empty()
-    ch_junctionannotation_rscript      = channel.empty()
-    ch_junctionannotation_log          = channel.empty()
-    ch_junctionsaturation_all     = channel.empty()
-    ch_junctionsaturation_pdf     = channel.empty()
-    ch_junctionsaturation_rscript = channel.empty()
-    ch_readdistribution_txt     = channel.empty()
-    ch_readduplication_all      = channel.empty()
-    ch_readduplication_seq_xls  = channel.empty()
-    ch_readduplication_pos_xls  = channel.empty()
-    ch_readduplication_pdf      = channel.empty()
-    ch_readduplication_rscript  = channel.empty()
-    ch_tin_txt                  = channel.empty()
-
     //
-    // MODULE: Run Preseq
+    // MODULE: Preseq library complexity
     //
-    if (!skip_preseq) {
-        PRESEQ_LCEXTRAP (
-            ch_genome_bam
-        )
-        ch_preseq_lc_extrap = PRESEQ_LCEXTRAP.out.lc_extrap
-        ch_preseq_log       = PRESEQ_LCEXTRAP.out.log
-        ch_multiqc_files = ch_multiqc_files.mix(PRESEQ_LCEXTRAP.out.lc_extrap)
-    }
+    PRESEQ_LCEXTRAP (
+        ch_genome_bam.filter { 'preseq' in tools }
+    )
 
     //
     // MODULE: Feature biotype QC using featureCounts
     //
-    if (!skip_biotype_qc && biotype) {
+    SUBREAD_FEATURECOUNTS (
+        ch_genome_bam
+            .combine(ch_gtf.map { _meta, gtf -> gtf })
+            .filter { 'biotype_qc' in tools && biotype }
+    )
 
-        SUBREAD_FEATURECOUNTS (
-            ch_genome_bam
-                .combine(ch_gtf.map { _meta, gtf -> gtf })
-        )
-
-        ch_featurecounts_counts  = SUBREAD_FEATURECOUNTS.out.counts
-        ch_featurecounts_summary = SUBREAD_FEATURECOUNTS.out.summary
-
-        CUSTOM_MULTIQCCUSTOMBIOTYPE (
-            SUBREAD_FEATURECOUNTS.out.counts,
-            ch_biotypes_header
-        )
-        ch_biotype_tsv  = CUSTOM_MULTIQCCUSTOMBIOTYPE.out.tsv
-        ch_biotype_rrna = CUSTOM_MULTIQCCUSTOMBIOTYPE.out.rrna
-        ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_MULTIQCCUSTOMBIOTYPE.out.tsv)
-    }
+    CUSTOM_MULTIQCCUSTOMBIOTYPE (
+        SUBREAD_FEATURECOUNTS.out.counts,
+        ch_biotypes_header
+    )
 
     //
-    // MODULE: Qualimap
+    // MODULE: Qualimap (name-sorted BAM via samtools sort)
+    // Requires ext.args = '-n' to be set by the caller for SAMTOOLS_SORT_QUALIMAP
     //
-    if (!skip_qualimap) {
-        // Sort BAM by name for qualimap
-        // Requires ext.args = '-n' to be set by the caller
-        SAMTOOLS_SORT_QUALIMAP (
-            ch_genome_bam,
-            ch_fasta_fai,
-            ''
-        )
+    SAMTOOLS_SORT_QUALIMAP (
+        ch_genome_bam.filter { 'qualimap' in tools },
+        ch_fasta_fai,
+        ''
+    )
 
-        QUALIMAP_RNASEQ (
-            SAMTOOLS_SORT_QUALIMAP.out.bam,
-            ch_gtf
-        )
-        ch_qualimap_results = QUALIMAP_RNASEQ.out.results
-        ch_multiqc_files = ch_multiqc_files.mix(QUALIMAP_RNASEQ.out.results)
-    }
+    QUALIMAP_RNASEQ (
+        SAMTOOLS_SORT_QUALIMAP.out.bam,
+        ch_gtf
+    )
 
     //
     // MODULE: dupRadar
     //
-    if (!skip_dupradar) {
-        DUPRADAR (
-            ch_genome_bam,
-            ch_gtf
-        )
-        ch_dupradar_scatter2d     = DUPRADAR.out.scatter2d
-        ch_dupradar_boxplot       = DUPRADAR.out.boxplot
-        ch_dupradar_hist          = DUPRADAR.out.hist
-        ch_dupradar_dupmatrix     = DUPRADAR.out.dupmatrix
-        ch_dupradar_intercept_slope = DUPRADAR.out.intercept_slope
-        ch_dupradar_multiqc       = DUPRADAR.out.multiqc
-        ch_multiqc_files = ch_multiqc_files.mix(DUPRADAR.out.multiqc)
-    }
+    DUPRADAR (
+        ch_genome_bam.filter { 'dupradar' in tools },
+        ch_gtf
+    )
 
     //
     // SUBWORKFLOW: RSeQC
     //
-    if (!skip_rseqc && rseqc_modules.size() > 0) {
-        BAM_RSEQC (
-            ch_bam_bai.map { meta, bam, bai -> [ meta, [ bam, bai ] ] },
-            ch_gene_bed,
-            rseqc_modules
-        )
-        ch_bamstat_txt              = BAM_RSEQC.out.bamstat_txt
-        ch_innerdistance_all        = BAM_RSEQC.out.innerdistance_all
-        ch_innerdistance_distance   = BAM_RSEQC.out.innerdistance_distance
-        ch_innerdistance_freq       = BAM_RSEQC.out.innerdistance_freq
-        ch_innerdistance_mean       = BAM_RSEQC.out.innerdistance_mean
-        ch_innerdistance_pdf        = BAM_RSEQC.out.innerdistance_pdf
-        ch_innerdistance_rscript    = BAM_RSEQC.out.innerdistance_rscript
-        ch_inferexperiment_txt      = BAM_RSEQC.out.inferexperiment_txt
-        ch_junctionannotation_all          = BAM_RSEQC.out.junctionannotation_all
-        ch_junctionannotation_bed          = BAM_RSEQC.out.junctionannotation_bed
-        ch_junctionannotation_interact_bed = BAM_RSEQC.out.junctionannotation_interact_bed
-        ch_junctionannotation_xls          = BAM_RSEQC.out.junctionannotation_xls
-        ch_junctionannotation_pdf          = BAM_RSEQC.out.junctionannotation_pdf
-        ch_junctionannotation_events_pdf   = BAM_RSEQC.out.junctionannotation_events_pdf
-        ch_junctionannotation_rscript      = BAM_RSEQC.out.junctionannotation_rscript
-        ch_junctionannotation_log          = BAM_RSEQC.out.junctionannotation_log
-        ch_junctionsaturation_all     = BAM_RSEQC.out.junctionsaturation_all
-        ch_junctionsaturation_pdf     = BAM_RSEQC.out.junctionsaturation_pdf
-        ch_junctionsaturation_rscript = BAM_RSEQC.out.junctionsaturation_rscript
-        ch_readdistribution_txt     = BAM_RSEQC.out.readdistribution_txt
-        ch_readduplication_all      = BAM_RSEQC.out.readduplication_all
-        ch_readduplication_seq_xls  = BAM_RSEQC.out.readduplication_seq_xls
-        ch_readduplication_pos_xls  = BAM_RSEQC.out.readduplication_pos_xls
-        ch_readduplication_pdf      = BAM_RSEQC.out.readduplication_pdf
-        ch_readduplication_rscript  = BAM_RSEQC.out.readduplication_rscript
-        ch_tin_txt                  = BAM_RSEQC.out.tin_txt
+    BAM_RSEQC (
+        ch_bam_bai
+            .map { meta, bam, bai -> [ meta, [ bam, bai ] ] }
+            .filter { rseqc_modules.size() > 0 },
+        ch_gene_bed,
+        rseqc_modules
+    )
 
-        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.bamstat_txt)
-        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.inferexperiment_txt)
-        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.innerdistance_freq)
-        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.junctionannotation_log)
-        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.junctionsaturation_rscript)
-        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.readdistribution_txt)
-        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.readduplication_pos_xls)
-        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.tin_txt)
-    }
+    // Aggregate MultiQC-compatible output files
+    ch_multiqc_files = Channel.empty()
+        .mix(PRESEQ_LCEXTRAP.out.lc_extrap)
+        .mix(CUSTOM_MULTIQCCUSTOMBIOTYPE.out.tsv)
+        .mix(QUALIMAP_RNASEQ.out.results)
+        .mix(DUPRADAR.out.multiqc)
+        .mix(BAM_RSEQC.out.bamstat_txt)
+        .mix(BAM_RSEQC.out.inferexperiment_txt)
+        .mix(BAM_RSEQC.out.innerdistance_freq)
+        .mix(BAM_RSEQC.out.junctionannotation_log)
+        .mix(BAM_RSEQC.out.junctionsaturation_rscript)
+        .mix(BAM_RSEQC.out.readdistribution_txt)
+        .mix(BAM_RSEQC.out.readduplication_pos_xls)
+        .mix(BAM_RSEQC.out.tin_txt)
 
     emit:
     // Aggregated
-    multiqc_files                       = ch_multiqc_files                               // channel: [ val(meta), path(files) ]
+    multiqc_files = ch_multiqc_files // channel: [ val(meta), path(files) ]
 
     // Preseq
-    preseq_lc_extrap                    = ch_preseq_lc_extrap                            // channel: [ val(meta), path(txt) ]
-    preseq_log                          = ch_preseq_log                                  // channel: [ val(meta), path(log) ]
+    preseq_lc_extrap = PRESEQ_LCEXTRAP.out.lc_extrap // channel: [ val(meta), path(txt) ]
+    preseq_log       = PRESEQ_LCEXTRAP.out.log       // channel: [ val(meta), path(log) ]
 
     // Biotype QC
-    featurecounts_counts                = ch_featurecounts_counts                        // channel: [ val(meta), path(txt) ]
-    featurecounts_summary               = ch_featurecounts_summary                       // channel: [ val(meta), path(txt) ]
-    biotype_tsv                         = ch_biotype_tsv                                 // channel: [ val(meta), path(tsv) ]
-    biotype_rrna                        = ch_biotype_rrna                                // channel: [ val(meta), path(tsv) ]
+    featurecounts_counts  = SUBREAD_FEATURECOUNTS.out.counts     // channel: [ val(meta), path(txt) ]
+    featurecounts_summary = SUBREAD_FEATURECOUNTS.out.summary    // channel: [ val(meta), path(txt) ]
+    biotype_tsv           = CUSTOM_MULTIQCCUSTOMBIOTYPE.out.tsv  // channel: [ val(meta), path(tsv) ]
+    biotype_rrna          = CUSTOM_MULTIQCCUSTOMBIOTYPE.out.rrna // channel: [ val(meta), path(tsv) ]
 
     // Qualimap
-    qualimap_results                    = ch_qualimap_results                            // channel: [ val(meta), path(dir) ]
+    qualimap_results = QUALIMAP_RNASEQ.out.results // channel: [ val(meta), path(dir) ]
 
     // dupRadar
-    dupradar_scatter2d                  = ch_dupradar_scatter2d                          // channel: [ val(meta), path(pdf) ]
-    dupradar_boxplot                    = ch_dupradar_boxplot                            // channel: [ val(meta), path(pdf) ]
-    dupradar_hist                       = ch_dupradar_hist                               // channel: [ val(meta), path(pdf) ]
-    dupradar_dupmatrix                  = ch_dupradar_dupmatrix                          // channel: [ val(meta), path(txt) ]
-    dupradar_intercept_slope            = ch_dupradar_intercept_slope                    // channel: [ val(meta), path(txt) ]
-    dupradar_multiqc                    = ch_dupradar_multiqc                            // channel: [ val(meta), path(txt) ]
+    dupradar_scatter2d       = DUPRADAR.out.scatter2d       // channel: [ val(meta), path(pdf) ]
+    dupradar_boxplot         = DUPRADAR.out.boxplot         // channel: [ val(meta), path(pdf) ]
+    dupradar_hist            = DUPRADAR.out.hist            // channel: [ val(meta), path(pdf) ]
+    dupradar_dupmatrix       = DUPRADAR.out.dupmatrix       // channel: [ val(meta), path(txt) ]
+    dupradar_intercept_slope = DUPRADAR.out.intercept_slope // channel: [ val(meta), path(txt) ]
+    dupradar_multiqc         = DUPRADAR.out.multiqc         // channel: [ val(meta), path(txt) ]
 
-    // RSeQC (populated via ch_ variables set inside the conditional block)
-    inferexperiment_txt                 = ch_inferexperiment_txt                          // channel: [ val(meta), path(txt) ]
-    bamstat_txt                         = ch_bamstat_txt                                  // channel: [ val(meta), path(txt) ]
-    innerdistance_all                   = ch_innerdistance_all                            // channel: [ val(meta), path(txt/pdf/r) ]
-    innerdistance_distance              = ch_innerdistance_distance                       // channel: [ val(meta), path(txt) ]
-    innerdistance_freq                  = ch_innerdistance_freq                           // channel: [ val(meta), path(txt) ]
-    innerdistance_mean                  = ch_innerdistance_mean                           // channel: [ val(meta), path(txt) ]
-    innerdistance_pdf                   = ch_innerdistance_pdf                            // channel: [ val(meta), path(pdf) ]
-    innerdistance_rscript               = ch_innerdistance_rscript                        // channel: [ val(meta), path(r) ]
-    junctionannotation_all              = ch_junctionannotation_all                       // channel: [ val(meta), path(bed/xls/pdf/r/log) ]
-    junctionannotation_bed              = ch_junctionannotation_bed                       // channel: [ val(meta), path(bed) ]
-    junctionannotation_interact_bed     = ch_junctionannotation_interact_bed              // channel: [ val(meta), path(bed) ]
-    junctionannotation_xls              = ch_junctionannotation_xls                       // channel: [ val(meta), path(xls) ]
-    junctionannotation_pdf              = ch_junctionannotation_pdf                       // channel: [ val(meta), path(pdf) ]
-    junctionannotation_events_pdf       = ch_junctionannotation_events_pdf                // channel: [ val(meta), path(pdf) ]
-    junctionannotation_rscript          = ch_junctionannotation_rscript                   // channel: [ val(meta), path(r) ]
-    junctionannotation_log              = ch_junctionannotation_log                       // channel: [ val(meta), path(log) ]
-    junctionsaturation_all              = ch_junctionsaturation_all                       // channel: [ val(meta), path(pdf/r) ]
-    junctionsaturation_pdf              = ch_junctionsaturation_pdf                       // channel: [ val(meta), path(pdf) ]
-    junctionsaturation_rscript          = ch_junctionsaturation_rscript                   // channel: [ val(meta), path(r) ]
-    readdistribution_txt                = ch_readdistribution_txt                         // channel: [ val(meta), path(txt) ]
-    readduplication_all                 = ch_readduplication_all                          // channel: [ val(meta), path(xls/pdf/r) ]
-    readduplication_seq_xls             = ch_readduplication_seq_xls                      // channel: [ val(meta), path(xls) ]
-    readduplication_pos_xls             = ch_readduplication_pos_xls                      // channel: [ val(meta), path(xls) ]
-    readduplication_pdf                 = ch_readduplication_pdf                          // channel: [ val(meta), path(pdf) ]
-    readduplication_rscript             = ch_readduplication_rscript                       // channel: [ val(meta), path(r) ]
-    tin_txt                             = ch_tin_txt                                      // channel: [ val(meta), path(txt) ]
+    // RSeQC
+    inferexperiment_txt             = BAM_RSEQC.out.inferexperiment_txt             // channel: [ val(meta), path(txt) ]
+    bamstat_txt                     = BAM_RSEQC.out.bamstat_txt                     // channel: [ val(meta), path(txt) ]
+    innerdistance_all               = BAM_RSEQC.out.innerdistance_all               // channel: [ val(meta), path(txt/pdf/r) ]
+    innerdistance_distance          = BAM_RSEQC.out.innerdistance_distance          // channel: [ val(meta), path(txt) ]
+    innerdistance_freq              = BAM_RSEQC.out.innerdistance_freq              // channel: [ val(meta), path(txt) ]
+    innerdistance_mean              = BAM_RSEQC.out.innerdistance_mean              // channel: [ val(meta), path(txt) ]
+    innerdistance_pdf               = BAM_RSEQC.out.innerdistance_pdf               // channel: [ val(meta), path(pdf) ]
+    innerdistance_rscript           = BAM_RSEQC.out.innerdistance_rscript           // channel: [ val(meta), path(r) ]
+    junctionannotation_all          = BAM_RSEQC.out.junctionannotation_all          // channel: [ val(meta), path(bed/xls/pdf/r/log) ]
+    junctionannotation_bed          = BAM_RSEQC.out.junctionannotation_bed          // channel: [ val(meta), path(bed) ]
+    junctionannotation_interact_bed = BAM_RSEQC.out.junctionannotation_interact_bed // channel: [ val(meta), path(bed) ]
+    junctionannotation_xls          = BAM_RSEQC.out.junctionannotation_xls          // channel: [ val(meta), path(xls) ]
+    junctionannotation_pdf          = BAM_RSEQC.out.junctionannotation_pdf          // channel: [ val(meta), path(pdf) ]
+    junctionannotation_events_pdf   = BAM_RSEQC.out.junctionannotation_events_pdf   // channel: [ val(meta), path(pdf) ]
+    junctionannotation_rscript      = BAM_RSEQC.out.junctionannotation_rscript      // channel: [ val(meta), path(r) ]
+    junctionannotation_log          = BAM_RSEQC.out.junctionannotation_log          // channel: [ val(meta), path(log) ]
+    junctionsaturation_all          = BAM_RSEQC.out.junctionsaturation_all          // channel: [ val(meta), path(pdf/r) ]
+    junctionsaturation_pdf          = BAM_RSEQC.out.junctionsaturation_pdf          // channel: [ val(meta), path(pdf) ]
+    junctionsaturation_rscript      = BAM_RSEQC.out.junctionsaturation_rscript      // channel: [ val(meta), path(r) ]
+    readdistribution_txt            = BAM_RSEQC.out.readdistribution_txt            // channel: [ val(meta), path(txt) ]
+    readduplication_all             = BAM_RSEQC.out.readduplication_all             // channel: [ val(meta), path(xls/pdf/r) ]
+    readduplication_seq_xls         = BAM_RSEQC.out.readduplication_seq_xls         // channel: [ val(meta), path(xls) ]
+    readduplication_pos_xls         = BAM_RSEQC.out.readduplication_pos_xls         // channel: [ val(meta), path(xls) ]
+    readduplication_pdf             = BAM_RSEQC.out.readduplication_pdf             // channel: [ val(meta), path(pdf) ]
+    readduplication_rscript         = BAM_RSEQC.out.readduplication_rscript         // channel: [ val(meta), path(r) ]
+    tin_txt                         = BAM_RSEQC.out.tin_txt                         // channel: [ val(meta), path(txt) ]
 
 }

--- a/subworkflows/nf-core/bam_qc_rnaseq/main.nf
+++ b/subworkflows/nf-core/bam_qc_rnaseq/main.nf
@@ -1,0 +1,245 @@
+//
+// Run post-alignment QC tools on RNA-seq BAM files
+//
+
+include { DUPRADAR                        } from '../../../modules/nf-core/dupradar/main'
+include { PRESEQ_LCEXTRAP                 } from '../../../modules/nf-core/preseq/lcextrap/main'
+include { QUALIMAP_RNASEQ                 } from '../../../modules/nf-core/qualimap/rnaseq/main'
+include { SUBREAD_FEATURECOUNTS           } from '../../../modules/nf-core/subread/featurecounts/main'
+include { CUSTOM_MULTIQCCUSTOMBIOTYPE     } from '../../../modules/nf-core/custom/multiqccustombiotype/main'
+include { SAMTOOLS_SORT as SAMTOOLS_SORT_QUALIMAP } from '../../../modules/nf-core/samtools/sort/main'
+include { BAM_RSEQC                       } from '../bam_rseqc/main'
+
+workflow BAM_QC_RNASEQ {
+
+    take:
+    ch_bam_bai              // channel: [ val(meta), path(bam), path(bai) ]
+    ch_gtf                  // channel: [ val(meta), path(gtf) ]
+    ch_gene_bed             // channel: path(bed)
+    ch_fasta_fai            // channel: [ val(meta), path(fasta), path(fai) ]
+    ch_biotypes_header      // channel: [ val(meta), path(biotypes_header.txt) ]
+    skip_preseq             // val(bool)
+    skip_biotype_qc         // val(bool)
+    skip_qualimap           // val(bool)
+    skip_dupradar           // val(bool)
+    skip_rseqc              // val(bool)
+    biotype                 // val(string) - e.g. "gene_type" or "gene_biotype"
+    rseqc_modules           // val(list)   - e.g. ['bam_stat', 'infer_experiment', ...]
+
+    main:
+    ch_multiqc_files       = channel.empty()
+    ch_inferexperiment_txt = channel.empty()
+
+    ch_genome_bam = ch_bam_bai.map { meta, bam, _bai -> [ meta, bam ] }
+
+    // Initialise individual output channels (populated conditionally below)
+    ch_preseq_lc_extrap       = channel.empty()
+    ch_preseq_log             = channel.empty()
+    ch_biotype_tsv            = channel.empty()
+    ch_biotype_rrna           = channel.empty()
+    ch_featurecounts_counts   = channel.empty()
+    ch_featurecounts_summary  = channel.empty()
+    ch_qualimap_results       = channel.empty()
+    ch_dupradar_scatter2d     = channel.empty()
+    ch_dupradar_boxplot       = channel.empty()
+    ch_dupradar_hist          = channel.empty()
+    ch_dupradar_dupmatrix     = channel.empty()
+    ch_dupradar_intercept_slope = channel.empty()
+    ch_dupradar_multiqc       = channel.empty()
+    ch_bamstat_txt              = channel.empty()
+    ch_innerdistance_all        = channel.empty()
+    ch_innerdistance_distance   = channel.empty()
+    ch_innerdistance_freq       = channel.empty()
+    ch_innerdistance_mean       = channel.empty()
+    ch_innerdistance_pdf        = channel.empty()
+    ch_innerdistance_rscript    = channel.empty()
+    ch_junctionannotation_all          = channel.empty()
+    ch_junctionannotation_bed          = channel.empty()
+    ch_junctionannotation_interact_bed = channel.empty()
+    ch_junctionannotation_xls          = channel.empty()
+    ch_junctionannotation_pdf          = channel.empty()
+    ch_junctionannotation_events_pdf   = channel.empty()
+    ch_junctionannotation_rscript      = channel.empty()
+    ch_junctionannotation_log          = channel.empty()
+    ch_junctionsaturation_all     = channel.empty()
+    ch_junctionsaturation_pdf     = channel.empty()
+    ch_junctionsaturation_rscript = channel.empty()
+    ch_readdistribution_txt     = channel.empty()
+    ch_readduplication_all      = channel.empty()
+    ch_readduplication_seq_xls  = channel.empty()
+    ch_readduplication_pos_xls  = channel.empty()
+    ch_readduplication_pdf      = channel.empty()
+    ch_readduplication_rscript  = channel.empty()
+    ch_tin_txt                  = channel.empty()
+
+    //
+    // MODULE: Run Preseq
+    //
+    if (!skip_preseq) {
+        PRESEQ_LCEXTRAP (
+            ch_genome_bam
+        )
+        ch_preseq_lc_extrap = PRESEQ_LCEXTRAP.out.lc_extrap
+        ch_preseq_log       = PRESEQ_LCEXTRAP.out.log
+        ch_multiqc_files = ch_multiqc_files.mix(PRESEQ_LCEXTRAP.out.lc_extrap)
+    }
+
+    //
+    // MODULE: Feature biotype QC using featureCounts
+    //
+    if (!skip_biotype_qc && biotype) {
+
+        SUBREAD_FEATURECOUNTS (
+            ch_genome_bam
+                .combine(ch_gtf.map { _meta, gtf -> gtf })
+        )
+
+        ch_featurecounts_counts  = SUBREAD_FEATURECOUNTS.out.counts
+        ch_featurecounts_summary = SUBREAD_FEATURECOUNTS.out.summary
+
+        CUSTOM_MULTIQCCUSTOMBIOTYPE (
+            SUBREAD_FEATURECOUNTS.out.counts,
+            ch_biotypes_header
+        )
+        ch_biotype_tsv  = CUSTOM_MULTIQCCUSTOMBIOTYPE.out.tsv
+        ch_biotype_rrna = CUSTOM_MULTIQCCUSTOMBIOTYPE.out.rrna
+        ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_MULTIQCCUSTOMBIOTYPE.out.tsv)
+    }
+
+    //
+    // MODULE: Qualimap
+    //
+    if (!skip_qualimap) {
+        // Sort BAM by name for qualimap
+        // Requires ext.args = '-n' to be set by the caller
+        SAMTOOLS_SORT_QUALIMAP (
+            ch_genome_bam,
+            ch_fasta_fai,
+            ''
+        )
+
+        QUALIMAP_RNASEQ (
+            SAMTOOLS_SORT_QUALIMAP.out.bam,
+            ch_gtf
+        )
+        ch_qualimap_results = QUALIMAP_RNASEQ.out.results
+        ch_multiqc_files = ch_multiqc_files.mix(QUALIMAP_RNASEQ.out.results)
+    }
+
+    //
+    // MODULE: dupRadar
+    //
+    if (!skip_dupradar) {
+        DUPRADAR (
+            ch_genome_bam,
+            ch_gtf
+        )
+        ch_dupradar_scatter2d     = DUPRADAR.out.scatter2d
+        ch_dupradar_boxplot       = DUPRADAR.out.boxplot
+        ch_dupradar_hist          = DUPRADAR.out.hist
+        ch_dupradar_dupmatrix     = DUPRADAR.out.dupmatrix
+        ch_dupradar_intercept_slope = DUPRADAR.out.intercept_slope
+        ch_dupradar_multiqc       = DUPRADAR.out.multiqc
+        ch_multiqc_files = ch_multiqc_files.mix(DUPRADAR.out.multiqc)
+    }
+
+    //
+    // SUBWORKFLOW: RSeQC
+    //
+    if (!skip_rseqc && rseqc_modules.size() > 0) {
+        BAM_RSEQC (
+            ch_bam_bai.map { meta, bam, bai -> [ meta, [ bam, bai ] ] },
+            ch_gene_bed,
+            rseqc_modules
+        )
+        ch_bamstat_txt              = BAM_RSEQC.out.bamstat_txt
+        ch_innerdistance_all        = BAM_RSEQC.out.innerdistance_all
+        ch_innerdistance_distance   = BAM_RSEQC.out.innerdistance_distance
+        ch_innerdistance_freq       = BAM_RSEQC.out.innerdistance_freq
+        ch_innerdistance_mean       = BAM_RSEQC.out.innerdistance_mean
+        ch_innerdistance_pdf        = BAM_RSEQC.out.innerdistance_pdf
+        ch_innerdistance_rscript    = BAM_RSEQC.out.innerdistance_rscript
+        ch_inferexperiment_txt      = BAM_RSEQC.out.inferexperiment_txt
+        ch_junctionannotation_all          = BAM_RSEQC.out.junctionannotation_all
+        ch_junctionannotation_bed          = BAM_RSEQC.out.junctionannotation_bed
+        ch_junctionannotation_interact_bed = BAM_RSEQC.out.junctionannotation_interact_bed
+        ch_junctionannotation_xls          = BAM_RSEQC.out.junctionannotation_xls
+        ch_junctionannotation_pdf          = BAM_RSEQC.out.junctionannotation_pdf
+        ch_junctionannotation_events_pdf   = BAM_RSEQC.out.junctionannotation_events_pdf
+        ch_junctionannotation_rscript      = BAM_RSEQC.out.junctionannotation_rscript
+        ch_junctionannotation_log          = BAM_RSEQC.out.junctionannotation_log
+        ch_junctionsaturation_all     = BAM_RSEQC.out.junctionsaturation_all
+        ch_junctionsaturation_pdf     = BAM_RSEQC.out.junctionsaturation_pdf
+        ch_junctionsaturation_rscript = BAM_RSEQC.out.junctionsaturation_rscript
+        ch_readdistribution_txt     = BAM_RSEQC.out.readdistribution_txt
+        ch_readduplication_all      = BAM_RSEQC.out.readduplication_all
+        ch_readduplication_seq_xls  = BAM_RSEQC.out.readduplication_seq_xls
+        ch_readduplication_pos_xls  = BAM_RSEQC.out.readduplication_pos_xls
+        ch_readduplication_pdf      = BAM_RSEQC.out.readduplication_pdf
+        ch_readduplication_rscript  = BAM_RSEQC.out.readduplication_rscript
+        ch_tin_txt                  = BAM_RSEQC.out.tin_txt
+
+        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.bamstat_txt)
+        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.inferexperiment_txt)
+        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.innerdistance_freq)
+        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.junctionannotation_log)
+        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.junctionsaturation_rscript)
+        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.readdistribution_txt)
+        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.readduplication_pos_xls)
+        ch_multiqc_files = ch_multiqc_files.mix(BAM_RSEQC.out.tin_txt)
+    }
+
+    emit:
+    // Aggregated
+    multiqc_files                       = ch_multiqc_files                               // channel: [ val(meta), path(files) ]
+
+    // Preseq
+    preseq_lc_extrap                    = ch_preseq_lc_extrap                            // channel: [ val(meta), path(txt) ]
+    preseq_log                          = ch_preseq_log                                  // channel: [ val(meta), path(log) ]
+
+    // Biotype QC
+    featurecounts_counts                = ch_featurecounts_counts                        // channel: [ val(meta), path(txt) ]
+    featurecounts_summary               = ch_featurecounts_summary                       // channel: [ val(meta), path(txt) ]
+    biotype_tsv                         = ch_biotype_tsv                                 // channel: [ val(meta), path(tsv) ]
+    biotype_rrna                        = ch_biotype_rrna                                // channel: [ val(meta), path(tsv) ]
+
+    // Qualimap
+    qualimap_results                    = ch_qualimap_results                            // channel: [ val(meta), path(dir) ]
+
+    // dupRadar
+    dupradar_scatter2d                  = ch_dupradar_scatter2d                          // channel: [ val(meta), path(pdf) ]
+    dupradar_boxplot                    = ch_dupradar_boxplot                            // channel: [ val(meta), path(pdf) ]
+    dupradar_hist                       = ch_dupradar_hist                               // channel: [ val(meta), path(pdf) ]
+    dupradar_dupmatrix                  = ch_dupradar_dupmatrix                          // channel: [ val(meta), path(txt) ]
+    dupradar_intercept_slope            = ch_dupradar_intercept_slope                    // channel: [ val(meta), path(txt) ]
+    dupradar_multiqc                    = ch_dupradar_multiqc                            // channel: [ val(meta), path(txt) ]
+
+    // RSeQC (populated via ch_ variables set inside the conditional block)
+    inferexperiment_txt                 = ch_inferexperiment_txt                          // channel: [ val(meta), path(txt) ]
+    bamstat_txt                         = ch_bamstat_txt                                  // channel: [ val(meta), path(txt) ]
+    innerdistance_all                   = ch_innerdistance_all                            // channel: [ val(meta), path(txt/pdf/r) ]
+    innerdistance_distance              = ch_innerdistance_distance                       // channel: [ val(meta), path(txt) ]
+    innerdistance_freq                  = ch_innerdistance_freq                           // channel: [ val(meta), path(txt) ]
+    innerdistance_mean                  = ch_innerdistance_mean                           // channel: [ val(meta), path(txt) ]
+    innerdistance_pdf                   = ch_innerdistance_pdf                            // channel: [ val(meta), path(pdf) ]
+    innerdistance_rscript               = ch_innerdistance_rscript                        // channel: [ val(meta), path(r) ]
+    junctionannotation_all              = ch_junctionannotation_all                       // channel: [ val(meta), path(bed/xls/pdf/r/log) ]
+    junctionannotation_bed              = ch_junctionannotation_bed                       // channel: [ val(meta), path(bed) ]
+    junctionannotation_interact_bed     = ch_junctionannotation_interact_bed              // channel: [ val(meta), path(bed) ]
+    junctionannotation_xls              = ch_junctionannotation_xls                       // channel: [ val(meta), path(xls) ]
+    junctionannotation_pdf              = ch_junctionannotation_pdf                       // channel: [ val(meta), path(pdf) ]
+    junctionannotation_events_pdf       = ch_junctionannotation_events_pdf                // channel: [ val(meta), path(pdf) ]
+    junctionannotation_rscript          = ch_junctionannotation_rscript                   // channel: [ val(meta), path(r) ]
+    junctionannotation_log              = ch_junctionannotation_log                       // channel: [ val(meta), path(log) ]
+    junctionsaturation_all              = ch_junctionsaturation_all                       // channel: [ val(meta), path(pdf/r) ]
+    junctionsaturation_pdf              = ch_junctionsaturation_pdf                       // channel: [ val(meta), path(pdf) ]
+    junctionsaturation_rscript          = ch_junctionsaturation_rscript                   // channel: [ val(meta), path(r) ]
+    readdistribution_txt                = ch_readdistribution_txt                         // channel: [ val(meta), path(txt) ]
+    readduplication_all                 = ch_readduplication_all                          // channel: [ val(meta), path(xls/pdf/r) ]
+    readduplication_seq_xls             = ch_readduplication_seq_xls                      // channel: [ val(meta), path(xls) ]
+    readduplication_pos_xls             = ch_readduplication_pos_xls                      // channel: [ val(meta), path(xls) ]
+    readduplication_pdf                 = ch_readduplication_pdf                          // channel: [ val(meta), path(pdf) ]
+    readduplication_rscript             = ch_readduplication_rscript                       // channel: [ val(meta), path(r) ]
+    tin_txt                             = ch_tin_txt                                      // channel: [ val(meta), path(txt) ]
+
+}

--- a/subworkflows/nf-core/bam_qc_rnaseq/meta.yml
+++ b/subworkflows/nf-core/bam_qc_rnaseq/meta.yml
@@ -54,32 +54,19 @@ input:
       type: file
       description: Header file for biotype counts MultiQC section
       pattern: "*.{txt}"
-  - skip_preseq:
-      type: boolean
-      description: Skip Preseq library complexity estimation
-  - skip_biotype_qc:
-      type: boolean
-      description: Skip biotype QC with featureCounts
-  - skip_qualimap:
-      type: boolean
-      description: Skip Qualimap RNA-seq QC
-  - skip_dupradar:
-      type: boolean
-      description: Skip dupRadar duplicate rate analysis
-  - skip_rseqc:
-      type: boolean
-      description: Skip RSeQC analysis
+  - tools:
+      type: list
+      description: |
+        List of QC tools to run. Top-level tools: 'preseq', 'biotype_qc', 'qualimap',
+        'dupradar'. RSeQC modules use an 'rseqc_' prefix: 'rseqc_bam_stat',
+        'rseqc_inner_distance', 'rseqc_infer_experiment', 'rseqc_junction_annotation',
+        'rseqc_junction_saturation', 'rseqc_read_distribution', 'rseqc_read_duplication',
+        'rseqc_tin'. Pass an empty list to skip all.
   - biotype:
       type: string
       description: |
         GTF attribute for biotype grouping (e.g. "gene_type" or "gene_biotype").
-        Set to empty string to skip biotype QC.
-  - rseqc_modules:
-      type: list
-      description: |
-        List of RSeQC modules to run
-        e.g. [ 'bam_stat', 'infer_experiment', 'inner_distance', 'junction_annotation',
-               'junction_saturation', 'read_distribution', 'read_duplication', 'tin' ]
+        Only used when 'biotype_qc' is in tools. Set to empty string to skip biotype QC.
 output:
   - multiqc_files:
       type: file

--- a/subworkflows/nf-core/bam_qc_rnaseq/meta.yml
+++ b/subworkflows/nf-core/bam_qc_rnaseq/meta.yml
@@ -1,0 +1,137 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: bam_qc_rnaseq
+description: |
+  Run post-alignment QC tools on RNA-seq BAM files including library complexity
+  estimation (Preseq), biotype QC (featureCounts), RNA-seq-specific QC metrics
+  (Qualimap), duplicate rate analysis (dupRadar), and comprehensive RSeQC analysis.
+keywords:
+  - rnaseq
+  - bam
+  - qc
+  - quality_control
+  - preseq
+  - qualimap
+  - dupradar
+  - rseqc
+  - featurecounts
+  - biotype
+components:
+  - preseq/lcextrap
+  - qualimap/rnaseq
+  - dupradar
+  - subread/featurecounts
+  - custom/multiqccustombiotype
+  - samtools/sort
+  - bam_rseqc
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false, strandedness:'reverse' ]
+  - bam:
+      type: file
+      description: Coordinate-sorted BAM file aligned to the genome
+      pattern: "*.{bam}"
+  - bai:
+      type: file
+      description: Index for the genome-aligned BAM file
+      pattern: "*.{bai}"
+  - gtf:
+      type: file
+      description: GTF annotation file
+      pattern: "*.{gtf}"
+  - gene_bed:
+      type: file
+      description: BED12 file for the reference gene model
+      pattern: "*.{bed}"
+  - fasta_fai:
+      type: file
+      description: |
+        Tuple of FASTA and FAI files for samtools sort
+        [ val(meta), path(fasta), path(fai) ]
+  - biotypes_header:
+      type: file
+      description: Header file for biotype counts MultiQC section
+      pattern: "*.{txt}"
+  - skip_preseq:
+      type: boolean
+      description: Skip Preseq library complexity estimation
+  - skip_biotype_qc:
+      type: boolean
+      description: Skip biotype QC with featureCounts
+  - skip_qualimap:
+      type: boolean
+      description: Skip Qualimap RNA-seq QC
+  - skip_dupradar:
+      type: boolean
+      description: Skip dupRadar duplicate rate analysis
+  - skip_rseqc:
+      type: boolean
+      description: Skip RSeQC analysis
+  - biotype:
+      type: string
+      description: |
+        GTF attribute for biotype grouping (e.g. "gene_type" or "gene_biotype").
+        Set to empty string to skip biotype QC.
+  - rseqc_modules:
+      type: list
+      description: |
+        List of RSeQC modules to run
+        e.g. [ 'bam_stat', 'infer_experiment', 'inner_distance', 'junction_annotation',
+               'junction_saturation', 'read_distribution', 'read_duplication', 'tin' ]
+output:
+  - multiqc_files:
+      type: file
+      description: Collected MultiQC-compatible output files from all enabled tools
+  - preseq_lc_extrap:
+      type: file
+      description: Preseq library complexity extrapolation curve
+      pattern: "*.lc_extrap.txt"
+  - preseq_log:
+      type: file
+      description: Preseq log file
+      pattern: "*.log"
+  - featurecounts_counts:
+      type: file
+      description: featureCounts count matrix
+      pattern: "*.featureCounts.txt"
+  - featurecounts_summary:
+      type: file
+      description: featureCounts summary statistics
+      pattern: "*.featureCounts.txt.summary"
+  - biotype_tsv:
+      type: file
+      description: Biotype counts formatted for MultiQC bargraph
+      pattern: "*biotype_counts_mqc.tsv"
+  - biotype_rrna:
+      type: file
+      description: rRNA percentage for MultiQC general stats
+      pattern: "*biotype_counts_rrna_mqc.tsv"
+  - qualimap_results:
+      type: directory
+      description: Qualimap RNA-seq QC results directory
+  - dupradar_multiqc:
+      type: file
+      description: dupRadar MultiQC-compatible output
+      pattern: "*_mqc.txt"
+  - inferexperiment_txt:
+      type: file
+      description: RSeQC infer_experiment results (for strandedness detection)
+      pattern: "*.infer_experiment.txt"
+  - bamstat_txt:
+      type: file
+      description: RSeQC bam_stat report
+      pattern: "*.bam_stat.txt"
+  - readdistribution_txt:
+      type: file
+      description: RSeQC read_distribution report
+      pattern: "*.read_distribution.txt"
+  - tin_txt:
+      type: file
+      description: RSeQC TIN results summary
+      pattern: "*.txt"
+authors:
+  - "@pinin4fjords"
+maintainers:
+  - "@pinin4fjords"

--- a/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test
@@ -48,13 +48,8 @@ nextflow_workflow {
                     file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa.fai', checkIfExists: true)
                 ])
                 input[4] = channel.of([ [:], biotypes_header ])
-                input[5] = false  // skip_preseq
-                input[6] = false  // skip_biotype_qc
-                input[7] = false  // skip_qualimap
-                input[8] = false  // skip_dupradar
-                input[9] = false  // skip_rseqc
-                input[10] = 'gene_biotype' // biotype
-                input[11] = ['bam_stat', 'inner_distance', 'infer_experiment', 'junction_annotation', 'junction_saturation', 'read_distribution', 'read_duplication', 'tin']
+                input[5] = ['preseq', 'biotype_qc', 'qualimap', 'dupradar', 'rseqc_bam_stat', 'rseqc_inner_distance', 'rseqc_infer_experiment', 'rseqc_junction_annotation', 'rseqc_junction_saturation', 'rseqc_read_distribution', 'rseqc_read_duplication', 'rseqc_tin']
+                input[6] = 'gene_biotype'
                 """
             }
         }
@@ -117,13 +112,8 @@ nextflow_workflow {
                     file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa.fai', checkIfExists: true)
                 ])
                 input[4] = channel.of([ [:], biotypes_header ])
-                input[5] = false  // skip_preseq
-                input[6] = false  // skip_biotype_qc
-                input[7] = false  // skip_qualimap
-                input[8] = false  // skip_dupradar
-                input[9] = false  // skip_rseqc
-                input[10] = 'gene_biotype' // biotype
-                input[11] = ['bam_stat', 'infer_experiment', 'junction_annotation', 'junction_saturation', 'read_distribution', 'read_duplication', 'tin']
+                input[5] = ['preseq', 'biotype_qc', 'qualimap', 'dupradar', 'rseqc_bam_stat', 'rseqc_infer_experiment', 'rseqc_junction_annotation', 'rseqc_junction_saturation', 'rseqc_read_distribution', 'rseqc_read_duplication', 'rseqc_tin']
+                input[6] = 'gene_biotype'
                 """
             }
         }
@@ -152,7 +142,7 @@ nextflow_workflow {
         }
     }
 
-    test("saccharomyces_cerevisiae paired-end [bam] - skip all optional") {
+    test("saccharomyces_cerevisiae paired-end [bam] - no tools enabled") {
 
         when {
             workflow {
@@ -178,13 +168,8 @@ nextflow_workflow {
                     file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa.fai', checkIfExists: true)
                 ])
                 input[4] = channel.of([ [:], biotypes_header ])
-                input[5] = true   // skip_preseq
-                input[6] = true   // skip_biotype_qc
-                input[7] = true   // skip_qualimap
-                input[8] = true   // skip_dupradar
-                input[9] = true   // skip_rseqc
-                input[10] = ''    // biotype
-                input[11] = []    // rseqc_modules
+                input[5] = [] // tools - none enabled
+                input[6] = '' // biotype
                 """
             }
         }
@@ -228,13 +213,8 @@ nextflow_workflow {
                     file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa.fai', checkIfExists: true)
                 ])
                 input[4] = channel.of([ [:], biotypes_header ])
-                input[5] = false  // skip_preseq
-                input[6] = false  // skip_biotype_qc
-                input[7] = false  // skip_qualimap
-                input[8] = false  // skip_dupradar
-                input[9] = false  // skip_rseqc
-                input[10] = 'gene_biotype' // biotype
-                input[11] = ['bam_stat', 'inner_distance', 'infer_experiment', 'junction_annotation', 'junction_saturation', 'read_distribution', 'read_duplication', 'tin']
+                input[5] = ['preseq', 'biotype_qc', 'qualimap', 'dupradar', 'rseqc_bam_stat', 'rseqc_inner_distance', 'rseqc_infer_experiment', 'rseqc_junction_annotation', 'rseqc_junction_saturation', 'rseqc_read_distribution', 'rseqc_read_duplication', 'rseqc_tin']
+                input[6] = 'gene_biotype'
                 """
             }
         }

--- a/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test
@@ -1,0 +1,255 @@
+nextflow_workflow {
+
+    name "Test Workflow BAM_QC_RNASEQ"
+    script "../main.nf"
+    workflow "BAM_QC_RNASEQ"
+    config "./nextflow.config"
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/bam_qc_rnaseq"
+    tag "bam_qc_rnaseq"
+    tag "preseq/lcextrap"
+    tag "qualimap/rnaseq"
+    tag "dupradar"
+    tag "subread/featurecounts"
+    tag "custom/multiqccustombiotype"
+    tag "samtools/sort"
+    tag "subworkflows/bam_rseqc"
+
+    test("saccharomyces_cerevisiae paired-end [bam] - all modules") {
+
+        when {
+            workflow {
+                """
+                def biotypes_header = file("\${workDir}/biotypes_header.txt")
+                biotypes_header.text = [
+                    "# id: 'biotype_counts'",
+                    "# section_name: 'Biotype Counts'",
+                    "# description: 'shows reads overlapping genomic features of different biotypes'",
+                    "# plot_type: 'bargraph'",
+                    "# anchor: 'featurecounts_biotype'",
+                ].join('\\n') + '\\n'
+
+                input[0] = channel.of([
+                    [ id:'test', single_end:false, strandedness:'reverse' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ])
+                input[1] = channel.of([
+                    [ id:'saccharomyces_cerevisiae' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.gtf', checkIfExists: true)
+                ])
+                input[2] = channel.of(
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.bed12', checkIfExists: true)
+                )
+                input[3] = channel.of([
+                    [ id:'saccharomyces_cerevisiae' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa.fai', checkIfExists: true)
+                ])
+                input[4] = channel.of([ [:], biotypes_header ])
+                input[5] = false  // skip_preseq
+                input[6] = false  // skip_biotype_qc
+                input[7] = false  // skip_qualimap
+                input[8] = false  // skip_dupradar
+                input[9] = false  // skip_rseqc
+                input[10] = 'gene_biotype' // biotype
+                input[11] = ['bam_stat', 'inner_distance', 'infer_experiment', 'junction_annotation', 'junction_saturation', 'read_distribution', 'read_duplication', 'tin']
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.qualimap_results.size() == 1 },
+                { assert workflow.out.dupradar_multiqc.size() == 1 },
+                { assert workflow.out.biotype_tsv.size() == 1 },
+                { assert workflow.out.biotype_rrna.size() == 1 },
+                { assert workflow.out.featurecounts_counts.size() == 1 },
+                { assert workflow.out.bamstat_txt.size() == 1 },
+                { assert workflow.out.inferexperiment_txt.size() == 1 },
+                { assert workflow.out.readdistribution_txt.size() == 1 },
+                { assert workflow.out.multiqc_files.size() > 0 },
+                { assert snapshot(
+                    workflow.out.dupradar_dupmatrix,
+                    workflow.out.dupradar_intercept_slope,
+                    workflow.out.dupradar_multiqc,
+                    workflow.out.bamstat_txt,
+                    workflow.out.inferexperiment_txt,
+                    workflow.out.readdistribution_txt,
+                    workflow.out.readduplication_all.findAll { it[1].endsWith('.pdf') == false },
+                    workflow.out.tin_txt
+                ).match() }
+            )
+        }
+    }
+
+    test("saccharomyces_cerevisiae single-end [bam] - all modules") {
+
+        when {
+            workflow {
+                """
+                def biotypes_header = file("\${workDir}/biotypes_header.txt")
+                biotypes_header.text = [
+                    "# id: 'biotype_counts'",
+                    "# section_name: 'Biotype Counts'",
+                    "# description: 'shows reads overlapping genomic features of different biotypes'",
+                    "# plot_type: 'bargraph'",
+                    "# anchor: 'featurecounts_biotype'",
+                ].join('\\n') + '\\n'
+
+                input[0] = channel.of([
+                    [ id:'test', single_end:true, strandedness:'reverse' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/illumina/bam/test.single_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/illumina/bam/test.single_end.sorted.bam.bai', checkIfExists: true)
+                ])
+                input[1] = channel.of([
+                    [ id:'saccharomyces_cerevisiae' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.gtf', checkIfExists: true)
+                ])
+                input[2] = channel.of(
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.bed12', checkIfExists: true)
+                )
+                input[3] = channel.of([
+                    [ id:'saccharomyces_cerevisiae' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa.fai', checkIfExists: true)
+                ])
+                input[4] = channel.of([ [:], biotypes_header ])
+                input[5] = false  // skip_preseq
+                input[6] = false  // skip_biotype_qc
+                input[7] = false  // skip_qualimap
+                input[8] = false  // skip_dupradar
+                input[9] = false  // skip_rseqc
+                input[10] = 'gene_biotype' // biotype
+                input[11] = ['bam_stat', 'infer_experiment', 'junction_annotation', 'junction_saturation', 'read_distribution', 'read_duplication', 'tin']
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.qualimap_results.size() == 1 },
+                { assert workflow.out.dupradar_multiqc.size() == 1 },
+                { assert workflow.out.biotype_tsv.size() == 1 },
+                { assert workflow.out.bamstat_txt.size() == 1 },
+                { assert workflow.out.inferexperiment_txt.size() == 1 },
+                { assert workflow.out.readdistribution_txt.size() == 1 },
+                { assert workflow.out.multiqc_files.size() > 0 },
+                { assert snapshot(
+                    workflow.out.dupradar_dupmatrix,
+                    workflow.out.dupradar_intercept_slope,
+                    workflow.out.dupradar_multiqc,
+                    workflow.out.bamstat_txt,
+                    workflow.out.inferexperiment_txt,
+                    workflow.out.readdistribution_txt,
+                    workflow.out.readduplication_all.findAll { it[1].endsWith('.pdf') == false },
+                    workflow.out.tin_txt
+                ).match() }
+            )
+        }
+    }
+
+    test("saccharomyces_cerevisiae paired-end [bam] - skip all optional") {
+
+        when {
+            workflow {
+                """
+                def biotypes_header = file("\${workDir}/biotypes_header.txt")
+                biotypes_header.text = '# stub'
+
+                input[0] = channel.of([
+                    [ id:'test', single_end:false, strandedness:'reverse' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ])
+                input[1] = channel.of([
+                    [ id:'saccharomyces_cerevisiae' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.gtf', checkIfExists: true)
+                ])
+                input[2] = channel.of(
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.bed12', checkIfExists: true)
+                )
+                input[3] = channel.of([
+                    [ id:'saccharomyces_cerevisiae' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa.fai', checkIfExists: true)
+                ])
+                input[4] = channel.of([ [:], biotypes_header ])
+                input[5] = true   // skip_preseq
+                input[6] = true   // skip_biotype_qc
+                input[7] = true   // skip_qualimap
+                input[8] = true   // skip_dupradar
+                input[9] = true   // skip_rseqc
+                input[10] = ''    // biotype
+                input[11] = []    // rseqc_modules
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.qualimap_results.size() == 0 },
+                { assert workflow.out.dupradar_multiqc.size() == 0 },
+                { assert workflow.out.bamstat_txt.size() == 0 },
+                { assert workflow.out.multiqc_files.size() == 0 }
+            )
+        }
+    }
+
+    test("saccharomyces_cerevisiae paired-end [bam] - all modules - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                def biotypes_header = file("\${workDir}/biotypes_header.txt")
+                biotypes_header.text = '# stub'
+
+                input[0] = channel.of([
+                    [ id:'test', single_end:false, strandedness:'reverse' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ])
+                input[1] = channel.of([
+                    [ id:'saccharomyces_cerevisiae' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.gtf', checkIfExists: true)
+                ])
+                input[2] = channel.of(
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.bed12', checkIfExists: true)
+                )
+                input[3] = channel.of([
+                    [ id:'saccharomyces_cerevisiae' ],
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome/genome.fa.fai', checkIfExists: true)
+                ])
+                input[4] = channel.of([ [:], biotypes_header ])
+                input[5] = false  // skip_preseq
+                input[6] = false  // skip_biotype_qc
+                input[7] = false  // skip_qualimap
+                input[8] = false  // skip_dupradar
+                input[9] = false  // skip_rseqc
+                input[10] = 'gene_biotype' // biotype
+                input[11] = ['bam_stat', 'inner_distance', 'infer_experiment', 'junction_annotation', 'junction_saturation', 'read_distribution', 'read_duplication', 'tin']
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { def getNames = { ch -> ch.collect { it[1] instanceof List ? it[1].collect { file(it).name } : file(it[1]).name }.flatten().sort() }
+                  def channels = ['preseq_lc_extrap', 'qualimap_results', 'dupradar_multiqc',
+                      'featurecounts_counts', 'biotype_tsv', 'bamstat_txt', 'inferexperiment_txt',
+                      'readdistribution_txt', 'tin_txt', 'multiqc_files']
+                  assert snapshot(
+                    channels.collectEntries { [it, getNames(workflow.out[it])] }.sort()
+                ).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test.snap
@@ -1,0 +1,272 @@
+{
+    "saccharomyces_cerevisiae paired-end [bam] - all modules - stub": {
+        "content": [
+            {
+                "bamstat_txt": [
+                    "test.bam_stat.txt"
+                ],
+                "biotype_tsv": [
+                    "test.biotype_counts_mqc.tsv"
+                ],
+                "dupradar_multiqc": [
+                    "test_dup_intercept_mqc.txt",
+                    "test_duprateExpDensCurve_mqc.txt"
+                ],
+                "featurecounts_counts": [
+                    "test.featureCounts.tsv"
+                ],
+                "inferexperiment_txt": [
+                    "test.infer_experiment.txt"
+                ],
+                "multiqc_files": [
+                    "test",
+                    "test.bam_stat.txt",
+                    "test.biotype_counts_mqc.tsv",
+                    "test.infer_experiment.txt",
+                    "test.inner_distance_freq.txt",
+                    "test.junctionSaturation_plot.r",
+                    "test.junction_annotation.log",
+                    "test.lc_extrap.txt",
+                    "test.pos.DupRate.xls",
+                    "test.read_distribution.txt",
+                    "test.summary.txt",
+                    "test_dup_intercept_mqc.txt",
+                    "test_duprateExpDensCurve_mqc.txt"
+                ],
+                "preseq_lc_extrap": [
+                    "test.lc_extrap.txt"
+                ],
+                "qualimap_results": [
+                    "test"
+                ],
+                "readdistribution_txt": [
+                    "test.read_distribution.txt"
+                ],
+                "tin_txt": [
+                    "test.summary.txt"
+                ]
+            }
+        ],
+        "timestamp": "2026-04-10T14:55:15.57192368",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "saccharomyces_cerevisiae paired-end [bam] - all modules": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test_dupMatrix.txt:md5,4cd083a8144215f9d80c34d3841bde36"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test_intercept_slope.txt:md5,dc393f346ae9f43bd5704d9c8affe351"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    [
+                        "test_dup_intercept_mqc.txt:md5,64da8d99554272a1a7501a1b52eed667",
+                        "test_duprateExpDensCurve_mqc.txt:md5,5441cfe6cf13ebd0ac26c1adae8fe131"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test.bam_stat.txt:md5,bedd1069cd80ba60e4c2582f0b272dc0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test.infer_experiment.txt:md5,a042a3c5dea0327933454c22d3db7b9e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test.read_distribution.txt:md5,b21eced1f3cb1c26b4e748160275ab04"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test.DupRate_plot.r:md5,cf6de4497dc1480dba295aea4949d6ab"
+                ],
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test.pos.DupRate.xls:md5,ae658848e182671218e14a79941ecf67"
+                ],
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test.seq.DupRate.xls:md5,97fc0d868448adf5f8799da0644c2df7"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "reverse"
+                    },
+                    "test.summary.txt:md5,0588ec890e99b20299edb759527741ca"
+                ]
+            ]
+        ],
+        "timestamp": "2026-04-10T14:54:48.143695956",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "saccharomyces_cerevisiae single-end [bam] - all modules": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test_dupMatrix.txt:md5,0b4aafa812ef154a2409b3e0acfebada"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test_intercept_slope.txt:md5,0dc5b562ff54376cc1a1a7d92f218c58"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    [
+                        "test_dup_intercept_mqc.txt:md5,ef0821176e262ea24cafbd989f6550a7",
+                        "test_duprateExpDensCurve_mqc.txt:md5,3743208006d3389428b1faa741378c30"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test.bam_stat.txt:md5,203794185a965ac4098d400abe79f123"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test.infer_experiment.txt:md5,763e0b4dc06ebcd736e4ba54f57f700d"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test.read_distribution.txt:md5,520f3ff160bd671582926040bcdbae54"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test.DupRate_plot.r:md5,deee1e49cfb1c7eb679a9e049af78b9c"
+                ],
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test.pos.DupRate.xls:md5,290cb109fa1ff4524ec5bda36ecd222e"
+                ],
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test.seq.DupRate.xls:md5,a0abd41eae5a0db12b3206ba39c2ac6f"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "reverse"
+                    },
+                    "test.summary.txt:md5,c1d6833aaa82d4288884a56ae2328590"
+                ]
+            ]
+        ],
+        "timestamp": "2026-04-10T14:54:59.745465997",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/subworkflows/nf-core/bam_qc_rnaseq/tests/nextflow.config
+++ b/subworkflows/nf-core/bam_qc_rnaseq/tests/nextflow.config
@@ -1,0 +1,26 @@
+process {
+
+    // Preseq may fail on BAMs without sufficient positional duplicates.
+    // The yeast RNA-seq test BAM has enough reads but few duplicates.
+    withName: PRESEQ_LCEXTRAP {
+        errorStrategy = 'ignore'
+    }
+
+    // Configure featureCounts for the yeast GTF which uses 'exon' features
+    // and gene_biotype grouping
+    withName: SUBREAD_FEATURECOUNTS {
+        ext.args = '-g gene_biotype -t exon'
+    }
+
+    // Name-sort BAM for qualimap
+    withName: SAMTOOLS_SORT_QUALIMAP {
+        ext.args = '-n'
+        ext.prefix = { "${meta.id}.namesorted" }
+    }
+
+    // Tell qualimap input is name-sorted
+    withName: QUALIMAP_RNASEQ {
+        ext.args = '--sorted'
+    }
+
+}


### PR DESCRIPTION
## Summary
- Adds `bam_qc_rnaseq` subworkflow: drop-in replacement for the nf-core/rnaseq local `BAM_POST_ALIGNMENT_QC` subworkflow, now as a reusable nf-core/modules component
- Adds `custom/multiqccustombiotype` module: generates MultiQC-compatible biotype count summaries from featureCounts output
- Migrates `dupradar` to topic-based version reporting

## Subworkflow: `bam_qc_rnaseq`

Orchestrates post-alignment RNA-seq QC with conditional execution via skip flags:

| Tool | Purpose |
|------|---------|
| preseq/lcextrap | Library complexity estimation |
| subread/featurecounts + custom/multiqccustombiotype | Biotype QC (gene_biotype counts for MultiQC) |
| samtools/sort + qualimap/rnaseq | RNA-seq alignment QC (name-sorted BAM) |
| dupradar | Duplicate rate analysis |
| bam_rseqc (subworkflow) | Comprehensive RSeQC analysis (8 modules) |

All tool outputs are emitted individually for maximum flexibility, plus an aggregated `multiqc_files` channel. Callers configure tool-specific behaviour (e.g. featureCounts grouping attribute, samtools name-sort) via `ext.args` in their pipeline config.

## Module: `custom/multiqccustombiotype`

Combines featureCounts biotype counts with a MultiQC header file, then calculates rRNA percentage for the MultiQC general stats table. Uses a Python template.

## Test plan
- [x] Subworkflow: paired-end, all modules enabled
- [x] Subworkflow: single-end, all modules enabled
- [x] Subworkflow: all modules skipped (verifies skip flags)
- [x] Subworkflow: all modules stub
- [x] Custom module: real run + stub
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)