### PR TITLE
fix(telomerehunter): change label from process_medium to process_single

### DIFF
--- a/modules/nf-core/telomerehunter/main.nf
+++ b/modules/nf-core/telomerehunter/main.nf
@@ -1,6 +1,6 @@
 process TELOMEREHUNTER {
     tag "${meta.id}"
-    label 'process_medium'
+    label 'process_single'
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container


### PR DESCRIPTION
## Summary

- Change TelomereHunter process label from `process_medium` to `process_single`

`process_medium` allocates 6 CPUs and 36 GB RAM, but TelomereHunter is strictly single-threaded (no parallelism options) and uses minimal memory. This wastes 5 CPUs and ~35 GB RAM per task.

## Benchmarking evidence

Benchmarked on two GIAB HG002 whole-genome BAMs using Nextflow's `trace` report:

| Dataset | BAM size | Peak RSS | CPU usage | Runtime |
|---------|----------|----------|-----------|---------|
| Illumina 60x | 126 GB | 124 MB | 101% | 1.1 h |
| ONT SUP | 172 GB | 193 MB | 100% | 2.3 h |

Key observations:
- **CPU**: 100-101% usage confirms single-threaded execution (1 core). Additional CPUs from `process_medium` go entirely unused.
- **Memory**: Peak RSS of 124-193 MB is well within the 6 GB that `process_single` provides, and far below the 36 GB from `process_medium`.
- **Runtime**: 1.1-2.3 hours suggests the tool is I/O-bound (reading large BAMs), not CPU-bound.

`process_single` (1 CPU, 6 GB RAM) is the appropriate label for this tool's resource profile.