### PR TITLE
feat(telomerehunter): add cytoband input to fix hg38 IndexError

### DIFF
--- a/modules/nf-core/telomerehunter/main.nf
+++ b/modules/nf-core/telomerehunter/main.nf
@@ -9,7 +9,7 @@ process TELOMEREHUNTER {
 
     input:
     tuple val(meta), path(tumor_bam), path(tumor_bai), path(control_bam), path(control_bai)
-    tuple val(meta2), path(fasta), path(fai)
+    tuple val(meta2), path(fasta), path(fai), path(cytoband)
 
     output:
     tuple val(meta), path("${prefix}/${prefix}_summary.tsv")        , emit: summary
@@ -24,6 +24,7 @@ process TELOMEREHUNTER {
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
+    def cytoband_arg = cytoband ? "-b ${cytoband}" : ""
     // telomerehunter doesn't support CRAM (pysam opened in BAM-only mode)
     def tumor_is_cram = tumor_bam.name.endsWith(".cram")
     def control_is_cram = control_bam ? control_bam.name.endsWith(".cram") : false
@@ -38,6 +39,7 @@ process TELOMEREHUNTER {
     telomerehunter \\
         -ibt ${tumor} \\
         ${control ? "-ibc ${control}" : ""} \\
+        ${cytoband_arg} \\
         -o . \\
         -p ${prefix} \\
         ${args}

--- a/modules/nf-core/telomerehunter/meta.yml
+++ b/modules/nf-core/telomerehunter/meta.yml
@@ -62,6 +62,15 @@ input:
         description: Reference FASTA index
         pattern: "*.fai"
         ontologies: []
+    - cytoband:
+        type: file
+        description: |
+          Optional cytoband file for the reference genome.
+          When not provided ([]), telomerehunter uses its bundled hg19 cytoband.
+          Must be supplied for hg38 data to avoid an IndexError caused by
+          chromosomes that are longer in hg38 than hg19.
+        pattern: "*.txt"
+        ontologies: []
 output:
   summary:
     - - meta:

--- a/modules/nf-core/telomerehunter/tests/main.nf.test
+++ b/modules/nf-core/telomerehunter/tests/main.nf.test
@@ -22,7 +22,8 @@ nextflow_process {
                 input[1] = [
                     [],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ]
                 """
             }
@@ -52,7 +53,8 @@ nextflow_process {
                 input[1] = [
                     [],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ]
                 """
             }
@@ -83,7 +85,8 @@ nextflow_process {
                 input[1] = [
                     [],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ]
                 """
             }
@@ -95,6 +98,45 @@ nextflow_process {
                 { assert snapshot(
                     process.out.summary,
                     process.out.control,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - bam - tumor only with cytoband") {
+        when {
+            process {
+                """
+                // Create a minimal cytoband file matching the test genome (chr22-only)
+                def cytoband_file = new File("${workDir}/hg38_cytoBand.txt")
+                cytoband_file.text = [
+                    "chr22\t0\t12200000\tp13\tacen",
+                    "chr22\t12200000\t17900000\tp12\tstalk",
+                    "chr22\t17900000\t50818468\tq11.1\tgneg"
+                ].join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id:'test_cytoband' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    [], []
+                ]
+                input[1] = [
+                    [],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    file(cytoband_file.toString())
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.summary,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -117,7 +159,8 @@ nextflow_process {
                 input[1] = [
                     [],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ]
                 """
             }

--- a/modules/nf-core/telomerehunter/tests/main.nf.test
+++ b/modules/nf-core/telomerehunter/tests/main.nf.test
@@ -108,14 +108,6 @@ nextflow_process {
         when {
             process {
                 """
-                // Create a minimal cytoband file matching the test genome (chr22-only)
-                def cytoband_file = new File("${workDir}/hg38_cytoBand.txt")
-                cytoband_file.text = [
-                    "chr22\t0\t12200000\tp13\tacen",
-                    "chr22\t12200000\t17900000\tp12\tstalk",
-                    "chr22\t17900000\t50818468\tq11.1\tgneg"
-                ].join("\\n") + "\\n"
-
                 input[0] = [
                     [ id:'test_cytoband' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
@@ -126,7 +118,7 @@ nextflow_process {
                     [],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
-                    file(cytoband_file.toString())
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/cytoBand_hg38.txt', checkIfExists: true)
                 ]
                 """
             }

--- a/modules/nf-core/telomerehunter/tests/main.nf.test.snap
+++ b/modules/nf-core/telomerehunter/tests/main.nf.test.snap
@@ -26,11 +26,44 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-08T16:02:18.219355833",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-08T16:02:18.219355833"
+    },
+    "homo_sapiens - bam - tumor only with cytoband": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test_cytoband"
+                    },
+                    "test_cytoband_summary.tsv:md5,6d7dd67102af1b04433dba9f1b41aef5"
+                ]
+            ],
+            {
+                "versions_samtools": [
+                    [
+                        "TELOMEREHUNTER",
+                        "samtools",
+                        "1.10"
+                    ]
+                ],
+                "versions_telomerehunter": [
+                    [
+                        "TELOMEREHUNTER",
+                        "telomerehunter",
+                        "1.1.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-10T15:02:21.238482"
     },
     "homo_sapiens - bam - tumor and control": {
         "content": [
@@ -117,11 +150,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-08T16:02:39.097579299",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-08T16:02:39.097579299"
     },
     "homo_sapiens - bam - stub": {
         "content": [
@@ -163,11 +196,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-08T16:02:44.963119665",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-08T16:02:44.963119665"
     },
     "homo_sapiens - bam - tumor only": {
         "content": [
@@ -196,10 +229,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-08T16:02:03.257435025",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-08T16:02:03.257435025"
     }
 }

--- a/subworkflows/nf-core/bam_telomere_estimation/main.nf
+++ b/subworkflows/nf-core/bam_telomere_estimation/main.nf
@@ -17,6 +17,7 @@ workflow BAM_TELOMERE_ESTIMATION {
                         //   data_type: 'short' or 'long'; bed: optional exome BED for telseq ([] if not needed)
     ch_control          // channel: [ val(meta), path(control_bam), path(control_bai) ]
     ch_fasta            // channel: [ val(meta2), path(fasta), path(fai) ]
+    ch_cytoband         // channel: [ path(cytoband) ] - optional cytoband file for telomerehunter
     run_telomerehunter  // val(boolean): enable telomerehunter content profiling
     length_estimator    // val(string):  'short'|'long'|null - global override
 
@@ -78,7 +79,13 @@ workflow BAM_TELOMERE_ESTIMATION {
         }
         .filter { _meta, _bam, _bai, _cbam, _cbai -> run_telomerehunter as boolean }
 
-    TELOMEREHUNTER(ch_th_input, ch_fasta)
+    // Append optional cytoband to fasta tuple for telomerehunter
+    // Callers pass Channel.value([cytoband_path]) or Channel.value([[]])
+    def ch_fasta_cytoband = ch_fasta
+        .combine(ch_cytoband)
+        .map { meta, fasta, fai, cytoband -> [ meta, fasta, fai, cytoband ] }
+
+    TELOMEREHUNTER(ch_th_input, ch_fasta_cytoband)
 
     ch_content_tsv          = TELOMEREHUNTER.out.summary
     ch_telomerehunter_tumor = TELOMEREHUNTER.out.tumor

--- a/subworkflows/nf-core/bam_telomere_estimation/meta.yml
+++ b/subworkflows/nf-core/bam_telomere_estimation/meta.yml
@@ -33,6 +33,14 @@ input:
       description: |
         Reference genome FASTA with index.
         Structure: [ val(meta2), path(fasta), path(fai) ]
+  - ch_cytoband:
+      type: file
+      description: |
+        Optional cytoband file for telomerehunter.
+        Structure: [ path(cytoband) ]
+        When not provided ([[]] / empty), telomerehunter uses its bundled hg19 cytoband.
+        Must be supplied for hg38 data to avoid an IndexError caused by
+        chromosomes that are longer in hg38 than hg19.
   - run_telomerehunter:
       type: boolean
       description: Enable telomerehunter content profiling

--- a/subworkflows/nf-core/bam_telomere_estimation/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_telomere_estimation/tests/main.nf.test
@@ -32,8 +32,9 @@ nextflow_workflow {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
                 ])
-                input[3] =false
-                input[4] =null
+                input[3] = Channel.value([[]])
+                input[4] =false
+                input[5] =null
                 """
             }
         }
@@ -70,8 +71,9 @@ nextflow_workflow {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
                 ])
-                input[3] =true
-                input[4] =null
+                input[3] = Channel.value([[]])
+                input[4] =true
+                input[5] =null
                 """
             }
         }
@@ -108,8 +110,9 @@ nextflow_workflow {
                 ])
                 input[1] = Channel.empty()
                 input[2] = Channel.value([ [id:'genome'], [], [] ])
-                input[3] =true
-                input[4] =null
+                input[3] = Channel.value([[]])
+                input[4] =true
+                input[5] =null
                 """
             }
         }
@@ -148,8 +151,9 @@ nextflow_workflow {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
                 ])
-                input[3] =false
-                input[4] ='short'
+                input[3] = Channel.value([[]])
+                input[4] =false
+                input[5] ='short'
                 """
             }
         }
@@ -185,8 +189,9 @@ nextflow_workflow {
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
                 ])
-                input[3] =false
-                input[4] =null
+                input[3] = Channel.value([[]])
+                input[4] =false
+                input[5] =null
                 """
             }
         }
@@ -215,8 +220,9 @@ nextflow_workflow {
                 ])
                 input[1] = Channel.empty()
                 input[2] = Channel.value([ [id:'genome'], [], [] ])
-                input[3] =false
-                input[4] =null
+                input[3] = Channel.value([[]])
+                input[4] =false
+                input[5] =null
                 """
             }
         }
@@ -247,8 +253,9 @@ nextflow_workflow {
                 ])
                 input[1] = Channel.empty()
                 input[2] = Channel.value([ [id:'genome'], [], [] ])
-                input[3] =false
-                input[4] =null
+                input[3] = Channel.value([[]])
+                input[4] =false
+                input[5] =null
                 """
             }
         }

--- a/subworkflows/nf-core/bam_telomere_estimation/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_telomere_estimation/tests/main.nf.test.snap
@@ -11,11 +11,11 @@
                 "test_sr_th_telomere_summary.tsv"
             ]
         ],
+        "timestamp": "2026-03-25T17:45:42.824224",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-03-25T17:45:42.824224"
+        }
     },
     "long-read - telogator2 with telomerehunter": {
         "content": [
@@ -29,11 +29,11 @@
                 "test_lr_th_telomere_summary.tsv"
             ]
         ],
+        "timestamp": "2026-04-10T14:48:10.056126677",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-03-25T17:47:18.702192"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "long-read - telogator2 routing": {
         "content": [
@@ -44,11 +44,11 @@
                 "test_lr_telomere_summary.tsv"
             ]
         ],
+        "timestamp": "2026-04-10T14:48:53.782837788",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-03-25T17:49:37.194809"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "short-read - telseq routing": {
         "content": [
@@ -59,11 +59,11 @@
                 "test_sr_telomere_summary.tsv"
             ]
         ],
+        "timestamp": "2026-03-25T17:44:37.506259",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-03-25T17:44:37.506259"
+        }
     },
     "short-read - global length_estimator override": {
         "content": [
@@ -74,11 +74,11 @@
                 "test_global_telomere_summary.tsv"
             ]
         ],
+        "timestamp": "2026-03-25T17:47:30.109299",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-03-25T17:47:30.109299"
+        }
     },
     "long-read - telogator2 routing -- stub": {
         "content": [
@@ -86,11 +86,11 @@
                 "test_lr_stub_telomere_summary.tsv"
             ]
         ],
+        "timestamp": "2026-03-25T17:48:00.64229",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-03-25T17:48:00.64229"
+        }
     },
     "short-read - telseq routing -- stub": {
         "content": [
@@ -98,10 +98,10 @@
                 "test_sr_stub_telomere_summary.tsv"
             ]
         ],
+        "timestamp": "2026-03-25T17:47:42.371683",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-03-25T17:47:42.371683"
+        }
     }
 }

--- a/subworkflows/nf-core/bam_telomere_estimation/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_telomere_estimation/tests/main.nf.test.snap
@@ -20,35 +20,35 @@
     "long-read - telogator2 with telomerehunter": {
         "content": [
             [
-                
+                "tlens_by_allele.tsv"
             ],
             [
                 "test_lr_th_summary.tsv"
             ],
             [
-                
+                "test_lr_th_telomere_summary.tsv"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-04-10T15:05:50.799663"
+        "timestamp": "2026-03-25T17:47:18.702192"
     },
     "long-read - telogator2 routing": {
         "content": [
             [
-                
+                "tlens_by_allele.tsv"
             ],
             [
-                
+                "test_lr_telomere_summary.tsv"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2026-04-10T15:07:43.787235"
+        "timestamp": "2026-03-25T17:49:37.194809"
     },
     "short-read - telseq routing": {
         "content": [

--- a/subworkflows/nf-core/bam_telomere_estimation/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_telomere_estimation/tests/main.nf.test.snap
@@ -20,35 +20,35 @@
     "long-read - telogator2 with telomerehunter": {
         "content": [
             [
-                "tlens_by_allele.tsv"
+                
             ],
             [
                 "test_lr_th_summary.tsv"
             ],
             [
-                "test_lr_th_telomere_summary.tsv"
+                
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-03-25T17:47:18.702192"
+        "timestamp": "2026-04-10T15:05:50.799663"
     },
     "long-read - telogator2 routing": {
         "content": [
             [
-                "tlens_by_allele.tsv"
+                
             ],
             [
-                "test_lr_telomere_summary.tsv"
+                
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-03-25T17:49:37.194809"
+        "timestamp": "2026-04-10T15:07:43.787235"
     },
     "short-read - telseq routing": {
         "content": [


### PR DESCRIPTION
## Summary

TelomereHunter defaults to a bundled hg19 cytoband file when no `-b` flag is given. On hg38-aligned BAMs, reads mapping beyond the hg19 cytoband boundaries trigger an `IndexError` (8 chromosomes are longer in hg38 than hg19, most notably chr17 and chr18 which differ by ~2 Mb).

This PR adds an optional `cytoband` input so pipelines can pass the correct banding file for the reference assembly being used.

### Module changes

`path(cytoband)` added as the fourth element in the fasta input tuple:

```groovy
tuple val(meta2), path(fasta), path(fai), path(cytoband)
```

- Pass `[]` to use TelomereHunter's built-in default (hg19)
- Pass a cytoband file (e.g. UCSC `cytoBand.txt.gz`) for hg38 or other assemblies

When provided, it is passed via `-b <cytoband>` to the telomerehunter command.

### Subworkflow changes

`bam_telomere_estimation` gains a `ch_cytoband` take input, combined with `ch_fasta` before calling TELOMEREHUNTER. Existing callers need to add this channel (pass `Channel.value([[]])` for the default behavior).

### Tests

- Module: existing tests pass `[]` (no cytoband, tests default behavior). New test passes `cytoBand_hg38.txt` from nf-core/test-datasets (nf-core/test-datasets#1981).
- Subworkflow: all 7 tests updated and passing.

## Test plan

- [x] Module tests: 5/5 passing (including new cytoband test)
- [x] Subworkflow tests: 7/7 passing