### PR TITLE
fix(telogator2): correct DOI in meta.yml

### DIFF
--- a/modules/nf-core/telogator2/meta.yml
+++ b/modules/nf-core/telogator2/meta.yml
@@ -14,7 +14,7 @@ tools:
       homepage: "https://github.com/zstephens/telogator2"
       documentation: "https://github.com/zstephens/telogator2"
       tool_dev_url: "https://github.com/zstephens/telogator2"
-      doi: "10.1093/bioinformatics/btae078"
+      doi: "10.1186/s12859-024-05807-5"
       licence:
         - "MIT"
       args_id: "$args"


### PR DESCRIPTION
## Summary

The telogator2 module's `meta.yml` has the wrong DOI.

- **Current**: `10.1093/bioinformatics/btae078` (an unrelated paper: "mBARq" by Sintsova et al.)
- **Correct**: `10.1186/s12859-024-05807-5` (Stephens & Kocher, 2024, BMC Bioinformatics: "Characterization of telomere variant repeats using long reads enables allele-specific telomere length estimation")

One-line fix, no functional changes.