### PR TITLE
fix(bam_telomere_estimation): remove def for Nextflow 24.10.5 compat

### DIFF
--- a/subworkflows/nf-core/bam_telomere_estimation/main.nf
+++ b/subworkflows/nf-core/bam_telomere_estimation/main.nf
@@ -81,7 +81,7 @@ workflow BAM_TELOMERE_ESTIMATION {
 
     // Append optional cytoband to fasta tuple for telomerehunter
     // Callers pass Channel.value([cytoband_path]) or Channel.value([[]])
-    def ch_fasta_cytoband = ch_fasta
+    ch_fasta_cytoband = ch_fasta
         .combine(ch_cytoband)
         .map { meta, fasta, fai, cytoband -> [ meta, fasta, fai, cytoband ] }
 


### PR DESCRIPTION
## Summary

One-line fix: remove `def` from `ch_fasta_cytoband = ch_fasta.combine(...)` in the bam_telomere_estimation subworkflow.

## Problem

Nextflow 24.10.5 rejects `def` on a channel variable when the RHS references a `take:` input:

```
Variable `ch_fasta` already defined in the process scope @ line 84, column 29.
def ch_fasta_cytoband = ch_fasta
                        ^
```

This was introduced in #11152. Nextflow 25.x is more lenient and accepts it.

## Fix

Drop `def` - the assignment works identically without it and is compatible with both NF 24.10.5 and 25.x.