### PR TITLE
fix(custom/multiqccustombiotype): fix unicode escape error in versions output

### DIFF
--- a/modules/nf-core/custom/multiqccustombiotype/templates/mqc_features_stat.py
+++ b/modules/nf-core/custom/multiqccustombiotype/templates/mqc_features_stat.py
@@ -109,5 +109,5 @@ if __name__ == "__main__":
 
     # Versions
     with open("versions.yml", "w") as f:
-        f.write('"\\${task.process}":\\n')
+        f.write('"${task.process}":\\n')
         f.write(f"    python: {platform.python_version()}\\n")

--- a/modules/nf-core/custom/multiqccustombiotype/templates/mqc_features_stat.py
+++ b/modules/nf-core/custom/multiqccustombiotype/templates/mqc_features_stat.py
@@ -109,5 +109,5 @@ if __name__ == "__main__":
 
     # Versions
     with open("versions.yml", "w") as f:
-        f.write('"\\${task.process}":\\n')
-        f.write(f"    python: {platform.python_version()}\\n")
+        f.write('"${task.process}":\n')
+        f.write(f"    python: {platform.python_version()}\n")


### PR DESCRIPTION
## Summary
- Fix Python `SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes` when writing versions.yml

The template had `'\\${task.process}'` which Nextflow resolved to `'\NFCORE_...'`. Python then interpreted `\N` as a unicode escape and failed. Removed the backslash escape so Nextflow resolves `${task.process}` directly, matching the pattern used by other nf-core Python templates (`tx2gene`, `catadditionalfasta`, `gtffilter`).

Found while integrating `bam_qc_rnaseq` into nf-core/rnaseq (nf-core/rnaseq#1785).

## Test plan
- [ ] CI green
- [ ] Confirmed fix works in nf-core/rnaseq integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)