### PR TITLE
Fix: use find instead of ls for reference list generation

### DIFF
--- a/modules/nf-core/centrifuger/build/main.nf
+++ b/modules/nf-core/centrifuger/build/main.nf
@@ -31,7 +31,7 @@ process CENTRIFUGER_BUILD {
 
    """
     #Create reference file from staged input file(s)
-    ls -1 genomes/* > reference_list.txt
+    find -L genomes/ -type f > reference_list.txt
 
     mkdir -p ${prefix}
 


### PR DESCRIPTION
<!--
Replace `ls` with `find` for generating the reference list file.
Using `ls genomes/*` can fail when:
- the number of files is large (`Argument list too long`)

## Changes
- Replace:
  ls -1 genomes/*
- With:
find -L genomes/ -type f > reference_list.txt
-->
## PR checklist
- [x] This comment contains a description of changes (with reason).
- [x] Bug fix applied (ls → find)