### PR TITLE
GZI index in samtools

### DIFF
--- a/modules/nf-core/samtools/faidx/main.nf
+++ b/modules/nf-core/samtools/faidx/main.nf
@@ -8,7 +8,7 @@ process SAMTOOLS_FAIDX {
         : 'community.wave.seqera.io/library/htslib_samtools:1.23.1--5b6bb4ede7e612e5'}"
 
     input:
-    tuple val(meta), path(fasta), path(fai)
+    tuple val(meta), path(fasta), path(fai), path(gzi)
     val get_sizes
 
     output:

--- a/modules/nf-core/samtools/faidx/meta.yml
+++ b/modules/nf-core/samtools/faidx/meta.yml
@@ -27,12 +27,17 @@ input:
     - fasta:
         type: file
         description: FASTA file
-        pattern: "*.{fa,fasta}"
+        pattern: "*.{fa,fasta}[.gz]"
         ontologies: []
     - fai:
         type: file
         description: FASTA index file
         pattern: "*.{fai}"
+        ontologies: []
+    - gzi:
+        type: file
+        description: Index file fot bgzip-ed FASTA
+        pattern: "*.{gzi}"
         ontologies: []
   - get_sizes:
       type: boolean

--- a/modules/nf-core/samtools/faidx/tests/main.nf.test
+++ b/modules/nf-core/samtools/faidx/tests/main.nf.test
@@ -21,6 +21,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    [],
                     []
                 ]
                 input[1] = false
@@ -47,6 +48,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
+                    [],
                     []
                 ]
                 input[1] = false
@@ -73,7 +75,35 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                    []
+                ]
+                input[1] = false
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert  snapshot(sanitizeOutput(process.out)).match()}
+            )
+        }
+    }
+
+    test("test_samtools_faidx_bgzip_index") {
+
+        when {
+            params {
+                module_args = 'MT192765.1 -o extract.fa'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz.gzi', checkIfExists: true),
                 ]
                 input[1] = false
                 """
@@ -100,7 +130,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ]
                 input[1] = false
                 """
@@ -127,6 +158,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    [],
                     []
                 ]
                 input[1] = false
@@ -153,6 +185,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    [],
                     []
                 ]
                 input[1] = true
@@ -179,6 +212,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
+                    [],
                     []
                 ]
                 input[1] = true
@@ -207,6 +241,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    [],
                     []
                 ]
                 input[1] = true
@@ -235,6 +270,7 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
+                    [],
                     []
                 ]
                 input[1] = true

--- a/modules/nf-core/samtools/faidx/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/faidx/tests/main.nf.test.snap
@@ -1,4 +1,44 @@
 {
+    "test_samtools_faidx_bgzip_index": {
+        "content": [
+            {
+                "fa": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "extract.fa:md5,6a0774a0ad937ba0bfd2ac7457d90f36"
+                    ]
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "genome.fasta.gz.fai:md5,9da2a56e2853dc8c0b86a9e7229c9fe5"
+                    ]
+                ],
+                "gzi": [
+                    
+                ],
+                "sizes": [
+                    
+                ],
+                "versions_samtools": [
+                    [
+                        "SAMTOOLS_FAIDX",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-14T08:25:00.948467574"
+    },
     "test_samtools_faidx": {
         "content": [
             {

--- a/modules/nf-core/samtools/sort/main.nf
+++ b/modules/nf-core/samtools/sort/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_SORT {
 
     input:
     tuple val(meta), path(bam)
-    tuple val(meta2), path(fasta), path(fai)
+    tuple val(meta2), path(fasta), path(fai), path(gzi)
     val index_format
 
     output:

--- a/modules/nf-core/samtools/sort/meta.yml
+++ b/modules/nf-core/samtools/sort/meta.yml
@@ -35,13 +35,19 @@ input:
     - fasta:
         type: file
         description: Reference genome FASTA file
-        pattern: "*.{fa,fasta,fna}"
+        pattern: "*.{fa,fasta,fna}[.gz]"
         optional: true
         ontologies: []
     - fai:
         type: file
         description: Reference genome FASTA index file
         pattern: "*.{fai}"
+        optional: true
+        ontologies: []
+    - gzi:
+        type: file
+        description: Index file fot bgzip-ed FASTA
+        pattern: "*.{gzi}"
         optional: true
         ontologies: []
   - index_format:

--- a/modules/nf-core/samtools/sort/tests/main.nf.test
+++ b/modules/nf-core/samtools/sort/tests/main.nf.test
@@ -22,7 +22,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = ''
                 """
@@ -55,7 +56,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = 'bai'
                 """
@@ -88,7 +90,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = 'csi'
                 """
@@ -124,7 +127,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = ''
                 """
@@ -160,7 +164,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = 'bai'
                 """
@@ -196,7 +201,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = 'csi'
                 """
@@ -229,7 +235,42 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
+                ])
+                input[2] = ''
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(
+                    process.out.cram.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.index.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match()}
+            )
+        }
+    }
+
+    test("cram_gz") {
+
+        config "./nextflow_cram.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true)
+                ])
+                input[1] = Channel.of([
+                    [ id:'fasta' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz.gzi', checkIfExists: true)
                 ])
                 input[2] = ''
                 """
@@ -263,7 +304,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = ''
                 """
@@ -295,7 +337,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = ''
                 """
@@ -325,7 +368,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = ''
                 """
@@ -354,7 +398,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = ''
                 """
@@ -389,7 +434,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'fasta' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 input[2] = ''
                 """

--- a/modules/nf-core/samtools/sort/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/sort/tests/main.nf.test.snap
@@ -340,5 +340,41 @@
             "nextflow": "25.10.4"
         },
         "timestamp": "2026-03-19T09:04:09.147615"
+    },
+    "cram_gz": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.sorted.cram"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.sorted.cram.crai"
+                ]
+            ],
+            {
+                "versions_samtools": [
+                    [
+                        "SAMTOOLS_SORT",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-14T09:03:49.540847928"
     }
 }

--- a/modules/nf-core/samtools/stats/main.nf
+++ b/modules/nf-core/samtools/stats/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_STATS {
 
     input:
     tuple val(meta), path(input), path(input_index)
-    tuple val(meta2), path(fasta), path(fai)
+    tuple val(meta2), path(fasta), path(fai), path(gzi)
 
     output:
     tuple val(meta), path("*.stats"), emit: stats

--- a/modules/nf-core/samtools/stats/meta.yml
+++ b/modules/nf-core/samtools/stats/meta.yml
@@ -41,12 +41,17 @@ input:
     - fasta:
         type: file
         description: Reference file the CRAM was created with (optional)
-        pattern: "*.{fasta,fa,fna}"
+        pattern: "*.{fasta,fa,fna}[.gz]"
         ontologies: []
     - fai:
         type: file
         description: FASTA ref index file
-        pattern: "*.{fasta,fa,fna}.fai"
+        pattern: "*.{fasta,fa,fna}[.gz].fai"
+        ontologies: []
+    - gzi:
+        type: file
+        description: Index file fot bgzip-ed FASTA
+        pattern: "*.{fasta,fa,fna}.gz.gzi"
         ontologies: []
 output:
   stats:

--- a/modules/nf-core/samtools/stats/tests/main.nf.test
+++ b/modules/nf-core/samtools/stats/tests/main.nf.test
@@ -19,7 +19,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
                 ])
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 """
             }
         }
@@ -45,7 +45,36 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'genome' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true),
+                    []
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                {assert process.success},
+                {assert snapshot(process.out).match()}
+            )
+        }
+    }
+
+    test("cram_gz") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true),
+                ])
+                input[1] = Channel.of([
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz.gzi', checkIfExists: true)
                 ])
                 """
             }
@@ -71,7 +100,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
                 ])
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 """
             }
         }
@@ -99,7 +128,8 @@ nextflow_process {
                 input[1] = Channel.of([
                     [ id:'genome' ], // meta map
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true),
+                    []
                 ])
                 """
             }

--- a/modules/nf-core/samtools/stats/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/stats/tests/main.nf.test.snap
@@ -128,6 +128,49 @@
         },
         "timestamp": "2026-03-19T09:05:56.38373"
     },
+    "cram_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,d6906a7639aac6d3f5162fe528c0094c"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMTOOLS_STATS",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,d6906a7639aac6d3f5162fe528c0094c"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "SAMTOOLS_STATS",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-14T09:36:16.903501456"
+    },
     "bam": {
         "content": [
             {

--- a/modules/nf-core/samtools/view/main.nf
+++ b/modules/nf-core/samtools/view/main.nf
@@ -9,7 +9,7 @@ process SAMTOOLS_VIEW {
 
     input:
     tuple val(meta), path(input), path(index)
-    tuple val(meta2), path(fasta), path(fai)
+    tuple val(meta2), path(fasta), path(fai), path(gzi)
     tuple val(meta3), path(qname)
     tuple val(meta4), path(bed)
     val index_format

--- a/modules/nf-core/samtools/view/meta.yml
+++ b/modules/nf-core/samtools/view/meta.yml
@@ -40,7 +40,7 @@ input:
     - fasta:
         type: file
         description: Fasta reference file
-        pattern: "*.{fasta,fa}"
+        pattern: "*.{fasta,fa}[.gz]"
         ontologies:
           - edam: http://edamontology.org/format_1929 # FASTA
     - fai:
@@ -49,6 +49,12 @@ input:
         pattern: "*.{fai}"
         ontologies:
           - edam: http://edamontology.org/format_3326 # Index
+    - gzi:
+        type: file
+        description: Index file fot bgzip-ed FASTA
+        pattern: "*.{gzi}"
+        optional: true
+        ontologies: []
   - - meta3:
         type: map
         description: |

--- a/modules/nf-core/samtools/view/tests/main.nf.test
+++ b/modules/nf-core/samtools/view/tests/main.nf.test
@@ -22,7 +22,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = [[], []]
                 input[3] = [[], []]
                 input[4] = []
@@ -50,7 +50,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = [[], []]
                 input[3] = [[], []]
                 input[4] = 'csi'
@@ -78,7 +78,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = [[], []]
                 input[3] = [[], []]
                 input[4] = 'bai'
@@ -106,7 +106,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = Channel.of('testN:1')
                     .collectFile(name: 'selected_reads.txt')
                     .map { file -> [[:], file] }
@@ -136,7 +136,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = Channel.of('testN:1')
                     .collectFile(name: 'selected_reads.txt')
                     .map { file -> [[:], file] }
@@ -169,7 +169,41 @@ nextflow_process {
                 input[1] = [
                     [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
+                ]
+                input[2] = [[], []]
+                input[3] = [[], []]
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["cram"])).match()}
+            )
+        }
+    }
+
+    test("cram_gz") {
+        when {
+            params {
+                samtools_args = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz.fai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz.gzi', checkIfExists: true)
                 ]
                 input[2] = [[], []]
                 input[3] = [[], []]
@@ -201,7 +235,8 @@ nextflow_process {
                 input[1] = [
                     [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ]
                 input[2] = [[], []]
                 input[3] = [[], []]
@@ -233,7 +268,8 @@ nextflow_process {
                 input[1] = [
                     [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ]
                 input[2] = [[], []]
                 input[3] = [[], []]
@@ -265,7 +301,8 @@ nextflow_process {
                 input[1] = [
                     [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
+                    []
                 ]
                 input[2] = Channel.of("testN:2817", "testN:2814")
                     .collectFile(name: "readnames.list", newLine: true)
@@ -296,7 +333,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = [[], []]
                 input[3] = [
                     [:],
@@ -330,7 +367,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = [[], []]
                 input[3] = [[], []]
                 input[4] = []
@@ -361,7 +398,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = [[], []]
                 input[3] = [[], []]
                 input[4] = 'csi'
@@ -392,7 +429,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = [[], []]
                 input[3] = [[], []]
                 input[4] = 'bai'
@@ -423,7 +460,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = Channel.of('testN:1')
                     .collectFile(name: 'selected_reads.txt')
                     .map { file -> [[:], file] }
@@ -456,7 +493,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     []
                 ]
-                input[1] = [[],[],[]]
+                input[1] = [[],[],[],[]]
                 input[2] = Channel.of('testN:1')
                     .collectFile(name: 'selected_reads.txt')
                     .map { file -> [[:], file] }

--- a/modules/nf-core/samtools/view/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/view/tests/main.nf.test.snap
@@ -45,11 +45,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:44.475595",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:44.475595"
     },
     "bam_csi_index - stub": {
         "content": [
@@ -138,11 +138,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:07:04.977559",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:07:04.977559"
     },
     "bam_csi_index": {
         "content": [
@@ -190,11 +190,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:07.203393",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:07.203393"
     },
     "cram_to_bam_index_qname": {
         "content": [
@@ -252,11 +252,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:52.242422",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:52.242422"
     },
     "bam_bai_index_unselected": {
         "content": [
@@ -314,11 +314,58 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:18.267421",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:18.267421"
+    },
+    "cram_gz": {
+        "content": [
+            {
+                "bai": [
+                    
+                ],
+                "bam": [
+                    
+                ],
+                "crai": [
+                    
+                ],
+                "cram": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.cram"
+                    ]
+                ],
+                "csi": [
+                    
+                ],
+                "sam": [
+                    
+                ],
+                "unselected": [
+                    
+                ],
+                "unselected_index": [
+                    
+                ],
+                "versions_samtools": [
+                    [
+                        "SAMTOOLS_VIEW",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-04-14T09:52:04.879010554"
     },
     "cram_crai_index_unselected - stub": {
         "content": [
@@ -427,11 +474,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:07:27.864649",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:07:27.864649"
     },
     "bam": {
         "content": [
@@ -474,11 +521,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:01.906355",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:01.906355"
     },
     "bam_bai_index": {
         "content": [
@@ -526,11 +573,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:12.483533",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:12.483533"
     },
     "cram_to_bam": {
         "content": [
@@ -573,11 +620,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:37.592685",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:37.592685"
     },
     "bam_bai_index - stub": {
         "content": [
@@ -666,11 +713,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:07:12.214174",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:07:12.214174"
     },
     "cram": {
         "content": [
@@ -713,11 +760,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:29.867409",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:29.867409"
     },
     "bam_bai_index_uselected - stub": {
         "content": [
@@ -826,11 +873,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:07:21.14353",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:07:21.14353"
     },
     "bam_with_bed": {
         "content": [
@@ -873,11 +920,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-25T12:13:59.0656",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-25T12:13:59.0656"
     },
     "cram_crai_index_unselected": {
         "content": [
@@ -935,11 +982,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:23.90307",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:23.90307"
     },
     "bam_stub": {
         "content": [
@@ -987,10 +1034,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-19T09:06:58.641723",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-19T09:06:58.641723"
     }
 }


### PR DESCRIPTION
samtools commands need a `.gzi` index (_and_ the `.fai` index) when the input Fasta is compressed with `bgzip`.

Although samtools can recreate missing indices on the fly, the intent of the samtools modules is to be able to provide pre-existing ones. Typically there's only room for the `.fai` though.
Here, I add some space for the gzi in the input channel of several samtools commands.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
