### PR TITLE
Update KAIJU/MKFMI to also emit the downstream required nodes file

### DIFF
--- a/modules/nf-core/kaiju/mkfmi/main.nf
+++ b/modules/nf-core/kaiju/mkfmi/main.nf
@@ -9,10 +9,11 @@ process KAIJU_MKFMI {
 
     input:
     tuple val(meta), path(fasta)
+    path nodes_dmp, stageAs: "nodes.dmp"
     val keep_intermediate
 
     output:
-    tuple val(meta), path("*.fmi"), emit: fmi
+    tuple val(meta), path("*.{fmi,dmp}", includeInputs: true), emit: fmi
     tuple val(meta), path("*.bwt"), optional: true, emit: bwt
     tuple val(meta), path("*.sa"), optional: true, emit: sa
     path "versions.yml", emit: versions

--- a/modules/nf-core/kaiju/mkfmi/meta.yml
+++ b/modules/nf-core/kaiju/mkfmi/meta.yml
@@ -26,7 +26,14 @@ input:
         type: file
         description: Uncompressed Protein FASTA file (mandatory)
         pattern: "*.{fa,faa,fasta}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
+  - nodes_dmp:
+      type: file
+      description: NCBI nodes.dmp file (mandatory)
+      pattern: "nodes.dmp"
+      ontologies:
+        - edam: http://edamontology.org/format_3751 # DSV
   - keep_intermediate:
       type: boolean
       description: "Keep intermediate files"
@@ -38,10 +45,10 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'test', single_end:false ]`
-      - "*.fmi":
+      - "*.{fmi,dmp}":
           type: file
-          description: Kaiju FM-index file
-          pattern: "*.{fmi}"
+          description: Kaiju FM-index file and nodes.dmp file required for Kaiju classification
+          pattern: "*.{fmi,dmp}"
           ontologies: []
   bwt:
     - - meta:

--- a/modules/nf-core/kaiju/mkfmi/tests/main.nf.test
+++ b/modules/nf-core/kaiju/mkfmi/tests/main.nf.test
@@ -18,7 +18,8 @@ nextflow_process {
                         [ id:'test', single_end:true ],
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta', checkIfExists: true)
                         ]
-                input[1] = false
+                input[1] = file(params.modules_testdata_base_path + 'delete_me/kaiju/nodes.dmp', checkIfExists: true)
+                input[2] = false
                 """
             }
         }
@@ -41,7 +42,8 @@ nextflow_process {
                         [ id:'test', single_end:true ],
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta', checkIfExists: true)
                         ]
-                input[1] = true
+                input[1] = file(params.modules_testdata_base_path + 'delete_me/kaiju/nodes.dmp', checkIfExists: true)
+                input[2] = true
                 """
             }
         }
@@ -66,7 +68,8 @@ nextflow_process {
                         [ id:'test', single_end:true ],
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta', checkIfExists: true)
                         ]
-                input[1] = true
+                input[1] = file(params.modules_testdata_base_path + 'delete_me/kaiju/nodes.dmp', checkIfExists: true)
+                input[2] = true
                 """
             }
         }
@@ -74,7 +77,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(file(process.out.fmi[0][1]).name).match() }
+                { assert snapshot(process.out).match() }
             )
         }
 

--- a/modules/nf-core/kaiju/mkfmi/tests/main.nf.test.snap
+++ b/modules/nf-core/kaiju/mkfmi/tests/main.nf.test.snap
@@ -1,13 +1,80 @@
 {
     "sarscov2 - fasta - stub": {
         "content": [
-            "test.fmi"
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        [
+                            "nodes.dmp:md5,cf7b63f1194c1eb7baa5d3e1b745a69b",
+                            "test.fmi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.bwt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.sa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,3cbd427d0187ffee188347830d33dc12"
+                ],
+                "bwt": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.bwt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fmi": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        [
+                            "nodes.dmp:md5,cf7b63f1194c1eb7baa5d3e1b745a69b",
+                            "test.fmi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "sa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.sa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,3cbd427d0187ffee188347830d33dc12"
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2024-01-20T16:27:00.670884904"
+        "timestamp": "2026-04-14T06:08:06.043028519"
     },
     "sarscov2 - proteome - fasta": {
         "content": [
@@ -18,7 +85,10 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.fmi:md5,54fd89f5e4eab61af30175e8aa389598"
+                        [
+                            "nodes.dmp:md5,cf7b63f1194c1eb7baa5d3e1b745a69b",
+                            "test.fmi:md5,54fd89f5e4eab61af30175e8aa389598"
+                        ]
                     ]
                 ],
                 "1": [
@@ -39,7 +109,10 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.fmi:md5,54fd89f5e4eab61af30175e8aa389598"
+                        [
+                            "nodes.dmp:md5,cf7b63f1194c1eb7baa5d3e1b745a69b",
+                            "test.fmi:md5,54fd89f5e4eab61af30175e8aa389598"
+                        ]
                     ]
                 ],
                 "sa": [
@@ -51,10 +124,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-01-16T09:29:43.118144301"
+        "timestamp": "2026-04-14T06:03:37.757184272"
     },
     "sarscov2 - proteome - keep intermediates": {
         "content": [
@@ -65,7 +138,10 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.fmi:md5,54fd89f5e4eab61af30175e8aa389598"
+                        [
+                            "nodes.dmp:md5,cf7b63f1194c1eb7baa5d3e1b745a69b",
+                            "test.fmi:md5,54fd89f5e4eab61af30175e8aa389598"
+                        ]
                     ]
                 ],
                 "1": [
@@ -104,7 +180,10 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.fmi:md5,54fd89f5e4eab61af30175e8aa389598"
+                        [
+                            "nodes.dmp:md5,cf7b63f1194c1eb7baa5d3e1b745a69b",
+                            "test.fmi:md5,54fd89f5e4eab61af30175e8aa389598"
+                        ]
                     ]
                 ],
                 "sa": [
@@ -122,9 +201,9 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-01-16T09:29:47.890853152"
+        "timestamp": "2026-04-14T06:00:45.06420002"
     }
 }


### PR DESCRIPTION
Even though the subcommand does not REQUIRE the nodes.dmp file itself, when the `.fmi` file is used with the kaiju classification module itself, the `nodes.dmp` is mandatory - i.e. you always need both files.

This update streamlines the use of the two modules.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
