### PR TITLE
fix: align GPU CI sharding tags with detection tags

### DIFF
--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           max_shards: 2
           paths: "${{ join(fromJson(steps.list.outputs.components), ' ') }}"
-          tags: "gpu"
+          tags: "gpu,gpu_highmem"
       - name: debug
         run: |
           echo ${{ steps.list.outputs.components }}


### PR DESCRIPTION
## Summary

One-line fix: the GPU CI sharding step uses `tags: "gpu"` but the detection step uses `tags: "gpu,gpu_highmem"`. This means the shard dry-run only counts `gpu`-tagged tests, missing `gpu_highmem`-tagged tests (like parabricks).

## The bug

In `.github/workflows/nf-test-gpu.yml`:
- **Line 67** (detection): `tags: "gpu,gpu_highmem"` - finds test files with either tag
- **Line 84** (sharding): `tags: "gpu"` - only counts `gpu`-tagged tests in its dry run

When only `gpu_highmem`-tagged tests change (e.g. parabricks-only PRs), the sharding step finds 0 tests and `total_shards=0`, which would skip all GPU jobs. This is currently masked because the matrix `include` generates `gpu_highmem` runner entries regardless, but the nf-test execution still runs with `--tag gpu_highmem` and finds the tests. However, a test tagged only `gpu` (not `gpu_highmem`) would pass sharding but silently not execute on the `gpu_highmem` runner.

## Fix

Change line 84 from `tags: "gpu"` to `tags: "gpu,gpu_highmem"` to match line 67.

Discovered while adding GPU tests for ribodetector (see #11177, #11178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)