### PR TITLE
fix(bam_stringtie_merge): collect per-sample GTFs before merge

### DIFF
--- a/subworkflows/nf-core/bam_stringtie_merge/main.nf
+++ b/subworkflows/nf-core/bam_stringtie_merge/main.nf
@@ -16,7 +16,7 @@ workflow BAM_STRINGTIE_MERGE {
 
     STRINGTIE_STRINGTIE.out.transcript_gtf
         .map { _meta, gtf -> gtf }
-        .collect()
+        .toSortedList { a, b -> a.name <=> b.name }
         .map { gtfs -> [ [id: 'stringtie_merge'], gtfs ] }
         .set { collected_gtfs }
 

--- a/subworkflows/nf-core/bam_stringtie_merge/main.nf
+++ b/subworkflows/nf-core/bam_stringtie_merge/main.nf
@@ -8,21 +8,23 @@ workflow BAM_STRINGTIE_MERGE {
     ch_chrgtf // channel: [ meta, gtf ]
 
     main:
-    ch_stringtie_gtfs = channel.empty()
 
     STRINGTIE_STRINGTIE(
         bam_sorted,
         ch_chrgtf.map { _meta, gtf -> [gtf] },
     )
 
-    STRINGTIE_STRINGTIE.out.transcript_gtf.set { stringtie_gtfs }
+    STRINGTIE_STRINGTIE.out.transcript_gtf
+        .map { _meta, gtf -> gtf }
+        .collect()
+        .map { gtfs -> [ [id: 'stringtie_merge'], gtfs ] }
+        .set { collected_gtfs }
 
     STRINGTIE_MERGE(
-        stringtie_gtfs,
+        collected_gtfs,
         ch_chrgtf
     )
-    ch_stringtie_gtfs = STRINGTIE_MERGE.out.merged_gtf
 
     emit:
-    stringtie_gtf = ch_stringtie_gtfs // channel: [ meta, gtf ]
+    stringtie_gtf = STRINGTIE_MERGE.out.merged_gtf // channel: [ meta, gtf ]
 }

--- a/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test
@@ -10,17 +10,23 @@ nextflow_workflow {
     tag "stringtie/merge"
     tag "subworkflows/bam_stringtie_merge"
 
-    test("Should run stringtie subworkflow") {
+    test("Should merge transcripts across multiple samples") {
 
         when {
             workflow {
                 """
-                input[0] = Channel.of([
-                        [ id:'test', strandedness:'reverse' ], // meta map
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true)
-                ])
-                input[1] = Channel.of([
-                    [ id:'test' ], // meta map
+                input[0] = Channel.of(
+                    [
+                        [ id:'sample1', strandedness:'reverse' ],
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true)
+                    ],
+                    [
+                        [ id:'sample2', strandedness:'reverse' ],
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam", checkIfExists: true)
+                    ]
+                )
+                input[1] = Channel.value([
+                    [ id:'annotation' ],
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/genome.gtf", checkIfExists: true)
                 ])
                 """
@@ -30,6 +36,7 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                { assert workflow.out.stringtie_gtf.size() == 1 },
                 { assert snapshot(
                     sanitizeOutput(workflow.out)
                     ).match() },

--- a/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "stringtie_merge"
                         },
-                        "stringtie_merge.gtf:md5,9cb06076fb1833ae93494dea5a0aa263"
+                        "stringtie_merge.gtf:md5,3d11d4f54395709b4fdca53ea31cea7e"
                     ]
                 ]
             }

--- a/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test.snap
@@ -1,22 +1,21 @@
 {
-    "Should run stringtie subworkflow": {
+    "Should merge transcripts across multiple samples": {
         "content": [
             {
                 "stringtie_gtf": [
                     [
                         {
-                            "id": "test",
-                            "strandedness": "reverse"
+                            "id": "stringtie_merge"
                         },
-                        "test.gtf:md5,40780dc05eff7cf2c77705f857768441"
+                        "stringtie_merge.gtf:md5,9cb06076fb1833ae93494dea5a0aa263"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-08T13:03:23.975567558",
         "meta": {
-            "nf-test": "0.9.5",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-14T13:36:54.066473"
     }
 }


### PR DESCRIPTION
## Summary

- The `bam_stringtie_merge` subworkflow's [meta.yml](https://github.com/nf-core/modules/blob/master/subworkflows/nf-core/bam_stringtie_merge/meta.yml) describes its purpose as merging "per-sample transcript GTFs into a unified annotation", but the implementation passed per-sample GTFs directly to `STRINGTIE_MERGE` without collecting them first
- This caused `STRINGTIE_MERGE` to run **once per sample** (each with a single GTF) instead of **once across all samples**, defeating the purpose of the merge step
- Fixed by adding `.collect()` between `STRINGTIE_STRINGTIE` output and `STRINGTIE_MERGE` input
- Test updated to use two samples and assert that exactly one merged GTF is produced (`workflow.out.stringtie_gtf.size() == 1`)

### Before (broken)

With 3 samples, `STRINGTIE_MERGE` ran 3 times, each receiving 1 GTF:

```
MOCK_ASSEMBLY (sample1) | 3 of 3 ✔
MOCK_MERGE    (sample1) | 3 of 3 ✔
MERGE OUTPUT: sample3 -> sample3.merged.gtf
MERGE OUTPUT: sample2 -> sample2.merged.gtf
MERGE OUTPUT: sample1 -> sample1.merged.gtf
```

### After (fixed)

`STRINGTIE_MERGE` runs once, receiving all 3 GTFs:

```
MOCK_ASSEMBLY      (sample2) | 3 of 3 ✔
MOCK_MERGE (stringtie_merge) | 1 of 1 ✔
MERGE OUTPUT: stringtie_merge -> stringtie_merge.merged.gtf
```

Verified with the mock merge confirming it received all input files:
```
GTF files received: 3
sample1.transcripts.gtf
sample2.transcripts.gtf
sample3.transcripts.gtf
```

## Context

Discovered while reviewing nf-core/rnaseq#1755, which adds `stringtie --merge` support for de novo assembly workflows.

## Test plan

- [ ] Snapshot needs regenerating (deleted stale snapshot from old single-sample test)
- [ ] CI should confirm `STRINGTIE_MERGE` produces one merged output from two input samples
- [ ] `workflow.out.stringtie_gtf.size() == 1` assertion guards against regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)