### PR TITLE
feat: add msisensorpro/baseline module; clarify pro -d dual semantics

### DIFF
--- a/modules/nf-core/msisensorpro/baseline/environment.yml
+++ b/modules/nf-core/msisensorpro/baseline/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::msisensor-pro=1.3.0

--- a/modules/nf-core/msisensorpro/baseline/main.nf
+++ b/modules/nf-core/msisensorpro/baseline/main.nf
@@ -1,0 +1,48 @@
+process MSISENSORPRO_BASELINE {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/msisensor-pro%3A1.3.0--hfef96ef_0':
+        'biocontainers/msisensor-pro:1.3.0--hfef96ef_0' }"
+
+    input:
+    tuple val(meta), path(list)
+    tuple val(meta2), path(pro_all_files, stageAs: 'pro_all/*')
+
+    output:
+    tuple val(meta), path("${prefix}.baseline"), emit: baseline
+    tuple val("${task.process}"), val('msisensor-pro'), eval("msisensor-pro --version 2>&1 | sed -nE 's/Version:\\s*//p'") , emit: versions_msisensorpro, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    # Build the configure file consumed by \`msisensor-pro baseline -i\`:
+    #   one row per normal sample, columns: <sample_name>\\t<absolute_path_to_*_all>
+    # Sample names are derived from each file's basename with the "_all" suffix stripped.
+    : > configure.txt
+    for f in pro_all/*_all; do
+        [ -e "\$f" ] || continue
+        name=\$(basename "\$f" _all)
+        printf '%s\\t%s\\n' "\$name" "\$(readlink -f "\$f")" >> configure.txt
+    done
+
+    msisensor-pro \\
+        baseline \\
+        -d $list \\
+        -i configure.txt \\
+        -o ${prefix}.baseline \\
+        $args
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.baseline
+    """
+}

--- a/modules/nf-core/msisensorpro/baseline/main.nf
+++ b/modules/nf-core/msisensorpro/baseline/main.nf
@@ -1,0 +1,48 @@
+process MSISENSORPRO_BASELINE {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/msisensor-pro%3A1.3.0--hfef96ef_0':
+        'quay.io/biocontainers/msisensor-pro:1.3.0--hfef96ef_0' }"
+
+    input:
+    tuple val(meta), path(list)
+    tuple val(meta2), path(pro_all_files, stageAs: 'pro_all/*')
+
+    output:
+    tuple val(meta), path("${prefix}.baseline"), emit: baseline
+    tuple val("${task.process}"), val('msisensor-pro'), eval("msisensor-pro --version 2>&1 | sed -nE 's/Version:\\s*v//p'") , emit: versions_msisensorpro, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    # Build the configure file consumed by `msisensor-pro baseline -i`:
+    #   one row per normal sample, columns: <sample_name>\\t<path_to_*_all>
+    # Sample names are derived from each file's basename with the "_all" suffix stripped.
+    touch configure.txt
+    for f in pro_all/*_all; do
+        [ -e "\$f" ] || continue
+        name=\$(basename "\$f" _all)
+        printf '%s\\t%s\\n' "\$name" "\$f" >> configure.txt
+    done
+
+    msisensor-pro \\
+        baseline \\
+        -d $list \\
+        -i configure.txt \\
+        -o ${prefix}.baseline \\
+        $args
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.baseline
+    """
+}

--- a/modules/nf-core/msisensorpro/baseline/meta.yml
+++ b/modules/nf-core/msisensorpro/baseline/meta.yml
@@ -1,0 +1,85 @@
+name: "msisensorpro_baseline"
+description: MSIsensor-pro/baseline builds a baseline microsatellite file from a
+  panel of normal samples, for use with msisensor-pro/pro tumor-only MSI detection.
+keywords:
+  - msisensor-pro
+  - baseline
+  - micro-satellite
+  - tumor-only
+  - panel-of-normals
+tools:
+  - msisensorpro:
+      description: Microsatellite Instability (MSI) detection using
+        high-throughput sequencing data.
+      homepage: https://github.com/xjtu-omics/msisensor-pro
+      documentation: https://github.com/xjtu-omics/msisensor-pro/wiki
+      tool_dev_url: https://github.com/xjtu-omics/msisensor-pro
+      doi: "10.1016/j.gpb.2020.02.001"
+      licence:
+        - "Custom Licence"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing baseline information
+          e.g. `[ id:'my_baseline' ]`
+    - list:
+        type: file
+        description: |
+          Microsatellite list produced by `msisensorpro/scan` and passed to
+          `msisensor-pro baseline -d`.
+        pattern: "*.{list}"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information for the panel of normals
+    - pro_all_files:
+        type: file
+        description: |
+          One or more `*_all` files produced by running `msisensorpro/pro` on
+          individual normal samples. The configure file consumed by
+          `msisensor-pro baseline -i` is constructed internally; sample names
+          are derived from each file's basename with the `_all` suffix stripped.
+        pattern: "*_all"
+        ontologies: []
+output:
+  baseline:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing baseline information
+            e.g. `[ id:'my_baseline' ]`
+      - ${prefix}.baseline:
+          type: file
+          description: |
+            Trained baseline microsatellite file suitable for passing to
+            `msisensorpro/pro -d` for tumor-only MSI calling.
+          pattern: "*.baseline"
+          ontologies: []
+  versions_msisensorpro:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - msisensor-pro:
+          type: string
+          description: The name of the tool
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*//p':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - msisensor-pro:
+          type: string
+          description: The name of the tool
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*//p':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/msisensorpro/baseline/meta.yml
+++ b/modules/nf-core/msisensorpro/baseline/meta.yml
@@ -1,0 +1,85 @@
+name: "msisensorpro_baseline"
+description: MSIsensor-pro/baseline builds a baseline microsatellite file from a
+  panel of normal samples, for use with msisensor-pro/pro tumor-only MSI detection.
+keywords:
+  - msisensor-pro
+  - baseline
+  - micro-satellite
+  - tumor-only
+  - panel-of-normals
+tools:
+  - msisensorpro:
+      description: Microsatellite Instability (MSI) detection using
+        high-throughput sequencing data.
+      homepage: https://github.com/xjtu-omics/msisensor-pro
+      documentation: https://github.com/xjtu-omics/msisensor-pro/wiki
+      tool_dev_url: https://github.com/xjtu-omics/msisensor-pro
+      doi: "10.1016/j.gpb.2020.02.001"
+      licence:
+        - "Custom Licence"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing baseline information
+          e.g. `[ id:'my_baseline' ]`
+    - list:
+        type: file
+        description: |
+          Microsatellite list produced by `msisensorpro/scan` and passed to
+          `msisensor-pro baseline -d`.
+        pattern: "*.{list}"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information for the panel of normals
+    - pro_all_files:
+        type: file
+        description: |
+          One or more `*_all` files produced by running `msisensorpro/pro` on
+          individual normal samples. The configure file consumed by
+          `msisensor-pro baseline -i` is constructed internally; sample names
+          are derived from each file's basename with the `_all` suffix stripped.
+        pattern: "*_all"
+        ontologies: []
+output:
+  baseline:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing baseline information
+            e.g. `[ id:'my_baseline' ]`
+      - ${prefix}.baseline:
+          type: file
+          description: |
+            Trained baseline microsatellite file suitable for passing to
+            `msisensorpro/pro -d` for tumor-only MSI calling.
+          pattern: "*.baseline"
+          ontologies: []
+  versions_msisensorpro:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - msisensor-pro:
+          type: string
+          description: The name of the tool
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*v//p':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - msisensor-pro:
+          type: string
+          description: The name of the tool
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*v//p':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/msisensorpro/baseline/tests/main.nf.test
+++ b/modules/nf-core/msisensorpro/baseline/tests/main.nf.test
@@ -1,0 +1,110 @@
+nextflow_process {
+
+    name "Test Process MSISENSORPRO_BASELINE"
+    script "../main.nf"
+    process "MSISENSORPRO_BASELINE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "msisensorpro"
+    tag "msisensorpro/baseline"
+    tag "msisensorpro/scan"
+    tag "msisensorpro/pro"
+
+    test("homo_sapiens - chr21 - two normals") {
+        setup {
+            run("MSISENSORPRO_SCAN") {
+                script "../../scan/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+            run("MSISENSORPRO_PRO", alias: "MSISENSORPRO_PRO_A") {
+                script "../../pro/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: 'normal_a' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
+                    ]
+                    input[1] = MSISENSORPRO_SCAN.out.list
+                    input[2] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    ]
+                    input[3] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+            run("MSISENSORPRO_PRO", alias: "MSISENSORPRO_PRO_B") {
+                script "../../pro/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: 'normal_b' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test2.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test2.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
+                    ]
+                    input[1] = MSISENSORPRO_SCAN.out.list
+                    input[2] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    ]
+                    input[3] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+        when {
+            process {
+                """
+                input[0] = MSISENSORPRO_SCAN.out.list.map { meta, list -> [ [ id: 'baseline' ], list ] }
+                input[1] = MSISENSORPRO_PRO_A.out.all_msi
+                    .mix(MSISENSORPRO_PRO_B.out.all_msi)
+                    .map { meta, all -> all }
+                    .collect()
+                    .map { alls -> [ [ id: 'baseline' ], alls ] }
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - chr21 - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'baseline' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = [ [ id: 'baseline' ], [] ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/msisensorpro/baseline/tests/main.nf.test
+++ b/modules/nf-core/msisensorpro/baseline/tests/main.nf.test
@@ -1,0 +1,110 @@
+nextflow_process {
+
+    name "Test Process MSISENSORPRO_BASELINE"
+    script "../main.nf"
+    process "MSISENSORPRO_BASELINE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "msisensorpro"
+    tag "msisensorpro/baseline"
+    tag "msisensorpro/scan"
+    tag "msisensorpro/pro"
+
+    test("homo_sapiens - chr21 - two normals") {
+        setup {
+            run("MSISENSORPRO_SCAN") {
+                script "../../scan/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+            run("MSISENSORPRO_PRO", alias: "MSISENSORPRO_PRO_A") {
+                script "../../pro/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: 'normal_a' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
+                    ]
+                    input[1] = MSISENSORPRO_SCAN.out.list
+                    input[2] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    ]
+                    input[3] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+            run("MSISENSORPRO_PRO", alias: "MSISENSORPRO_PRO_B") {
+                script "../../pro/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: 'normal_b' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test2.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test2.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
+                    ]
+                    input[1] = MSISENSORPRO_SCAN.out.list
+                    input[2] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    ]
+                    input[3] = [
+                        [ id: 'chr21' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+        when {
+            process {
+                """
+                input[0] = MSISENSORPRO_SCAN.out.list.map { meta, list -> [ [ id: 'baseline' ], list ] }
+                input[1] = MSISENSORPRO_PRO_A.out.all_msi
+                    .mix(MSISENSORPRO_PRO_B.out.all_msi)
+                    .map { meta, all -> all }
+                    .collect()
+                    .map { alls -> [ [ id: 'baseline' ], alls ] }
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - chr21 - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'baseline' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = [ [ id: 'baseline' ], [] ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/msisensorpro/baseline/tests/main.nf.test.snap
+++ b/modules/nf-core/msisensorpro/baseline/tests/main.nf.test.snap
@@ -1,0 +1,54 @@
+{
+    "homo_sapiens - chr21 - two normals": {
+        "content": [
+            {
+                "baseline": [
+                    [
+                        {
+                            "id": "baseline"
+                        },
+                        "baseline.baseline:md5,5530bf5cd6cac2b403a1ffee391eb9ce"
+                    ]
+                ],
+                "versions_msisensorpro": [
+                    [
+                        "MSISENSORPRO_BASELINE",
+                        "msisensor-pro",
+                        "1.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-03T00:25:49.325224546",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "homo_sapiens - chr21 - stub": {
+        "content": [
+            {
+                "baseline": [
+                    [
+                        {
+                            "id": "baseline"
+                        },
+                        "baseline.baseline:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_msisensorpro": [
+                    [
+                        "MSISENSORPRO_BASELINE",
+                        "msisensor-pro",
+                        "1.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-03T00:25:54.769329759",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    }
+}

--- a/modules/nf-core/msisensorpro/pro/meta.yml
+++ b/modules/nf-core/msisensorpro/pro/meta.yml
@@ -39,8 +39,19 @@ input:
           e.g. `[ id:'sample1', single_end:false ]`
     - list:
         type: file
-        description: micro-satellite list
-        pattern: "*.{list}"
+        description: |
+          Micro-satellite file passed to `msisensor-pro pro -d`. The tool
+          accepts either of two file types here:
+            1. A raw scan list produced by `msisensorpro/scan`. When used,
+               `msisensor-pro pro` falls back to a hard threshold for MSI
+               calling, set via `-i` (default `0.1`, configurable via
+               `ext.args`).
+            2. A trained baseline produced by `msisensorpro/baseline` from
+               a panel of normals. This enables per-site trained thresholds
+               and is the tumor-only workflow recommended by the
+               msisensor-pro maintainers
+               (https://github.com/xjtu-omics/msisensor-pro/wiki/Best-Practices).
+        pattern: "*.{list,baseline}"
         ontologies: []
   - - meta3:
         type: map


### PR DESCRIPTION
Closes #11188, overlaps with #6007 (and closed #6350).

## What

1. **New module `msisensorpro/baseline`** wrapping `msisensor-pro baseline`. Builds a trained baseline microsatellite file from a panel of normal samples, for use with `msisensor-pro pro -d` in tumor-only MSI calling. The configure file consumed by `baseline -i` is built internally from the staged `*_all` files so callers can feed a collected channel of `msisensorpro/pro` outputs directly (rather than hand-writing a configure file that references Nextflow work paths).
2. **`msisensorpro/pro/meta.yml`**: expand the `-d` input description to document both supported modes (raw scan list with hard threshold via `-i`, vs trained baseline). No behavior change; `pro`'s `main.nf` already accepts either file type and `-i` already flows through `$args`.

## Why

`msisensor-pro pro -d` accepts both a scan list and a baseline file per [`ProUsage()` in `cpp/distribution.cpp` L199-L206](https://github.com/xjtu-omics/msisensor-pro/blob/2063de1588cf65dd310a7b95ba5efc6f64c7515a/cpp/distribution.cpp#L199-L206). The [wiki Best-Practices](https://github.com/xjtu-omics/msisensor-pro/wiki/Best-Practices) documents only the baseline workflow for tumor-only, and the maintainer recommends it in xjtu-omics/msisensor-pro#77. Until now the baseline subcommand had no module, so pipelines couldn't produce a baseline within nf-core/modules and defaulted to the scan-list-with-hard-threshold fallback mode.

## TODOs before ready for review

- [ ] Verify the live test under `-profile docker` against real fixture data. The chr21 test fasta may not contain enough microsatellites for `baseline` to produce a usable output. If so, either locate richer fixtures or drop to stub-only testing and open a follow-up for fixtures.
- [ ] `nf-core modules test msisensorpro/baseline --profile {docker,singularity,conda}`
- [ ] Snapshot (`tests/main.nf.test.snap`) once live test passes
- [ ] Migrate `msisensorpro/pro`'s test to chain through the new baseline module so CI exercises mode 2 (recommended mode)
- [ ] Maintainer input on whether to rename `pro`'s second input from `list` to something like `microsat_file` (would be a breaking doc-only change)

Happy to iterate on any of the above. Specifically wanted to surface the design of the baseline module's input shape (internally-constructed configure file) before doing more work.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests! (live test present but unverified, see TODOs)
- [x] If you've added a new tool - have you followed the module conventions in the contribution docs
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] Broadcast software version numbers to `topic: versions`
- [ ] `nf-core modules test <MODULE> --profile docker`
- [ ] `nf-core modules test <MODULE> --profile singularity`
- [ ] `nf-core modules test <MODULE> --profile conda`
- [x] Remove all TODO statements. (none in module code; TODOs above are PR-level followups)