### PR TITLE
fix: split GPU CI into separate jobs per tag to fix silent test skipping

### DIFF
--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -101,13 +101,6 @@ jobs:
           paths: "${{ join(fromJson(steps.list-gpu-highmem.outputs.components), ' ') }}"
           tags: "gpu_highmem"
 
-      - name: debug
-        run: |
-          echo "gpu paths: ${{ steps.list-gpu.outputs.components }}"
-          echo "gpu shards: ${{ steps.shards-gpu.outputs.shard }} / ${{ steps.shards-gpu.outputs.total_shards }}"
-          echo "gpu_highmem paths: ${{ steps.list-gpu-highmem.outputs.components }}"
-          echo "gpu_highmem shards: ${{ steps.shards-gpu-highmem.outputs.shard }} / ${{ steps.shards-gpu-highmem.outputs.total_shards }}"
-
   # Standard GPU tests (g4dn.xlarge - 4 vCPU, 16 GB RAM, T4 GPU)
   # Runs tests tagged "gpu" (20+ modules: parabricks, amulety, cellpose, etc.)
   nf-test-gpu:

--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -40,14 +40,16 @@ jobs:
       - runner=4cpu-linux-x64
       - image=ubuntu22-full-x64
     outputs:
-      # Expose detected tags as 'modules' and 'workflows' output variables
-      paths: ${{ steps.list.outputs.components }}
-      modules: ${{ steps.outputs.outputs.modules }}
-      subworkflows: ${{ steps.outputs.outputs.subworkflows}}
-      shard: ${{ steps.set-shards.outputs.shard }}
-      total_shards: ${{ steps.set-shards.outputs.total_shards }}
+      # gpu tag outputs
+      gpu_paths: ${{ steps.list-gpu.outputs.components }}
+      gpu_shard: ${{ steps.shards-gpu.outputs.shard }}
+      gpu_total_shards: ${{ steps.shards-gpu.outputs.total_shards }}
+      # gpu_highmem tag outputs
+      gpu_highmem_paths: ${{ steps.list-gpu-highmem.outputs.components }}
+      gpu_highmem_shard: ${{ steps.shards-gpu-highmem.outputs.shard }}
+      gpu_highmem_total_shards: ${{ steps.shards-gpu-highmem.outputs.total_shards }}
     steps:
-      - name: Clean Workspace # Purge the workspace in case it's running on a self-hosted runner
+      - name: Clean Workspace
         run: |
           ls -la ./
           rm -rf ./* || true
@@ -57,57 +59,70 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: List nf-test files
-        id: list
+      # Detect gpu and gpu_highmem tests separately
+      - name: List gpu test files
+        id: list-gpu
         uses: adamrtalbot/detect-nf-test-changes@de3c3c8e113031b4f15a3c1104b5f135e8346997 # v0.0.6
         with:
           head: ${{ github.sha }}
           base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/master' }}
           n_parents: 0
-          tags: "gpu,gpu_highmem"
+          tags: "gpu"
 
-      - name: Separate modules and subworkflows
-        id: outputs
-        run: |
-          echo modules=$(echo '${{ steps.list.outputs.components }}' | jq -c '. | map(select(contains("modules"))) | map(gsub("modules/nf-core/"; ""))') >> $GITHUB_OUTPUT
-          echo subworkflows=$(echo '${{ steps.list.outputs.components }}' | jq '. | map(select(contains("subworkflows"))) | map(gsub("subworkflows/nf-core/"; ""))') >> $GITHUB_OUTPUT
+      - name: List gpu_highmem test files
+        id: list-gpu-highmem
+        uses: adamrtalbot/detect-nf-test-changes@de3c3c8e113031b4f15a3c1104b5f135e8346997 # v0.0.6
+        with:
+          head: ${{ github.sha }}
+          base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/master' }}
+          n_parents: 0
+          tags: "gpu_highmem"
 
-      - name: get number of shards
-        id: set-shards
-        if: ${{ steps.list.outputs.components != '[]' }}
+      # Shard each tag independently
+      - name: Get gpu shards
+        id: shards-gpu
+        if: ${{ steps.list-gpu.outputs.components != '[]' }}
         uses: ./.github/actions/get-shards
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
           max_shards: 2
-          paths: "${{ join(fromJson(steps.list.outputs.components), ' ') }}"
-          tags: "gpu,gpu_highmem"
+          paths: "${{ join(fromJson(steps.list-gpu.outputs.components), ' ') }}"
+          tags: "gpu"
+
+      - name: Get gpu_highmem shards
+        id: shards-gpu-highmem
+        if: ${{ steps.list-gpu-highmem.outputs.components != '[]' }}
+        uses: ./.github/actions/get-shards
+        env:
+          NFT_VER: ${{ env.NFT_VER }}
+        with:
+          max_shards: 2
+          paths: "${{ join(fromJson(steps.list-gpu-highmem.outputs.components), ' ') }}"
+          tags: "gpu_highmem"
+
       - name: debug
         run: |
-          echo ${{ steps.list.outputs.components }}
-          echo ${{ steps.outputs.outputs.modules }}
-          echo ${{ steps.outputs.outputs.subworkflows }}
-          echo ${{ steps.set-shards.outputs.shard }}
-          echo ${{ steps.set-shards.outputs.total_shards }}
+          echo "gpu paths: ${{ steps.list-gpu.outputs.components }}"
+          echo "gpu shards: ${{ steps.shards-gpu.outputs.shard }} / ${{ steps.shards-gpu.outputs.total_shards }}"
+          echo "gpu_highmem paths: ${{ steps.list-gpu-highmem.outputs.components }}"
+          echo "gpu_highmem shards: ${{ steps.shards-gpu-highmem.outputs.shard }} / ${{ steps.shards-gpu-highmem.outputs.total_shards }}"
 
+  # Standard GPU tests (g4dn.xlarge - 4 vCPU, 16 GB RAM, T4 GPU)
+  # Runs tests tagged "gpu" (20+ modules: parabricks, amulety, cellpose, etc.)
   nf-test-gpu:
-    runs-on: "runs-on=${{ github.run_id }}/family=${{ matrix.runner }}/image=ubuntu24-gpu-x64"
-    name: "GPU Test | ${{ matrix.runner }} | ${{ matrix.profile }} | ${{ matrix.shard }}"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.xlarge/image=ubuntu24-gpu-x64"
+    name: "GPU Test | g4dn.xlarge | ${{ matrix.profile }} | ${{ matrix.shard }}"
     needs: [nf-test-changes]
-    if: ${{ needs.nf-test-changes.outputs.total_shards != '0' }}
+    if: ${{ needs.nf-test-changes.outputs.gpu_total_shards != '0' && needs.nf-test-changes.outputs.gpu_total_shards != '' }}
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
+        shard: ${{ fromJson(needs.nf-test-changes.outputs.gpu_shard) }}
         profile: [docker, singularity]
-        include:
-          - runner: g4dn.xlarge
-            tag: gpu
-          - runner: g4dn.2xlarge
-            tag: gpu_highmem
     env:
       NXF_ANSI_LOG: false
-      TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
+      TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.gpu_total_shards }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -127,15 +142,53 @@ jobs:
           profile: ${{ matrix.profile }},gpu
           shard: ${{ matrix.shard }}
           total_shards: ${{ env.TOTAL_SHARDS }}
-          paths: "${{ join(fromJson(needs.nf-test-changes.outputs.paths), ' ') }}"
-          tags: ${{ matrix.tag }}
+          paths: "${{ join(fromJson(needs.nf-test-changes.outputs.gpu_paths), ' ') }}"
+          tags: gpu
+
+  # High-memory GPU tests (g4dn.2xlarge - 8 vCPU, 32 GB RAM, T4 GPU)
+  # Runs tests tagged "gpu_highmem" (currently only parabricks/rnafq2bam,
+  # which requires >16 GB system RAM)
+  nf-test-gpu-highmem:
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64"
+    name: "GPU Test | g4dn.2xlarge | ${{ matrix.profile }} | ${{ matrix.shard }}"
+    needs: [nf-test-changes]
+    if: ${{ needs.nf-test-changes.outputs.gpu_highmem_total_shards != '0' && needs.nf-test-changes.outputs.gpu_highmem_total_shards != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJson(needs.nf-test-changes.outputs.gpu_highmem_shard) }}
+        profile: [docker, singularity]
+    env:
+      NXF_ANSI_LOG: false
+      TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.gpu_highmem_total_shards }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: test cuda
+        run: |
+          nvidia-smi -L
+      - name: Run nf-test Action
+        uses: ./.github/actions/nf-test-action
+        env:
+          SENTIEON_ENCRYPTION_KEY: ${{ secrets.SENTIEON_ENCRYPTION_KEY }}
+          SENTIEON_LICENSE_MESSAGE: ${{ secrets.SENTIEON_LICENSE_MESSAGE }}
+          SENTIEON_LICSRVR_IP: ${{ secrets.SENTIEON_LICSRVR_IP }}
+          SENTIEON_AUTH_MECH: "GitHub Actions - token"
+        with:
+          profile: ${{ matrix.profile }},gpu
+          shard: ${{ matrix.shard }}
+          total_shards: ${{ env.TOTAL_SHARDS }}
+          paths: "${{ join(fromJson(needs.nf-test-changes.outputs.gpu_highmem_paths), ' ') }}"
+          tags: gpu_highmem
 
   confirm-pass-gpu:
     runs-on:
       - runs-on=${{ github.run_id }}-confirm-pass-gpu
       - runner=2cpu-linux-x64
       - image=ubuntu22-full-x64
-    needs: [nf-test-gpu]
+    needs: [nf-test-gpu, nf-test-gpu-highmem]
     if: always()
     steps:
       - name: One or more tests failed
@@ -147,7 +200,7 @@ jobs:
         run: exit 1
 
       - name: All tests ok
-        if: ${{ contains(needs.*.result, 'success') }}
+        if: ${{ contains(needs.*.result, 'success') || (needs.nf-test-gpu.result == 'skipped' && needs.nf-test-gpu-highmem.result == 'skipped') }}
         run: exit 0
 
       - name: debug-print


### PR DESCRIPTION
## Problem

GPU tests tagged `gpu` (20 modules) never run. The matrix `include` in [`1f96a6d`](https://github.com/nf-core/modules/commit/1f96a6d8f85a7fad77dbf82024ba13f4dc3021aa) added `runner`/`tag` as new keys without a matching matrix dimension, so the last entry (`gpu_highmem`) wins for all jobs. [#11179](https://github.com/nf-core/modules/pull/11179) fixed detection but not execution.

### Why not just add `tag` as a matrix dimension?

Adding `tag: [gpu, gpu_highmem]` to the matrix fixes the matching, but doubles every shard. Only 1 of 21 GPU modules is `gpu_highmem`, so most PRs would spin up g4dn.2xlarge instances that find zero tests and exit.

## Fix

Split into two independent test jobs:

- **`nf-test-gpu`**: g4dn.xlarge, `--tag gpu` (20+ modules)
- **`nf-test-gpu-highmem`**: g4dn.2xlarge, `--tag gpu_highmem` (parabricks/rnafq2bam, needs >16GB RAM)

Each has its own detection, sharding, and `if` gate. A PR touching only `gpu` modules spins up zero `gpu_highmem` runners (and vice versa).

Validated on [#11197](https://github.com/nf-core/modules/pull/11197): all 4 `gpu` jobs passed on g4dn.xlarge (docker + singularity), `gpu_highmem` correctly skipped, `confirm-pass-gpu` green.