### PR TITLE
Phenoimager2mc move/deprecation

### DIFF
--- a/.github/skip_nf_test.json
+++ b/.github/skip_nf_test.json
@@ -71,7 +71,6 @@
         "modules/nf-core/islandpath",
         "modules/nf-core/mcquant",
         "modules/nf-core/mcstaging/macsima2mc",
-        "modules/nf-core/mcstaging/phenoimager2mc",
         "modules/nf-core/merquryfk/katcomp",
         "modules/nf-core/merquryfk/katgc",
         "modules/nf-core/merquryfk/merquryfk",

--- a/modules/nf-core/mcstaging/phenoimager2mc/main.nf
+++ b/modules/nf-core/mcstaging/phenoimager2mc/main.nf
@@ -15,14 +15,19 @@ process MCSTAGING_PHENOIMAGER2MC {
     task.ext.when == null || task.ext.when
 
     script:
+    def deprecation_message = """
+WARNING: This module has been deprecated. Please use nf-core/modules/phenoimager2mc
 
+Reason:
+Renamed module to match the tool/subtool convention
+"""
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
         error "Phenoimager2mc module in conda does not exist. Please use Docker / Singularity / Podman instead."
     }
     def args   = task.ext.args   ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-
+    assert false: deprecation_message
     """
     python /phenoimager2mc/scripts/phenoimager2mc.py \
         -i ${tiles} \
@@ -33,11 +38,18 @@ process MCSTAGING_PHENOIMAGER2MC {
     """
 
     stub:
+    def deprecation_message = """
+WARNING: This module has been deprecated. Please use nf-core/modules/phenoimager2mc
+
+Reason:
+Renamed module to match the tool/subtool convention
+"""
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
         error "Phenoimager2mc module in conda does not exist. Please use Docker / Singularity / Podman instead."
     }
     def prefix = task.ext.prefix ?: "${meta.id}"
+    assert false: deprecation_message
     """
     touch input
     touch "${prefix}.tif"

--- a/modules/nf-core/mcstaging/phenoimager2mc/tests/main.nf.test
+++ b/modules/nf-core/mcstaging/phenoimager2mc/tests/main.nf.test
@@ -33,9 +33,9 @@ nextflow_process {
             }
         }
         then {
-            assertAll (
-                { assert process.success },
-                { assert snapshot(process.out).match() }
+            assertAll(
+                { assert process.failed },
+                { assert process.errorReport.contains("WARNING: This module has been deprecated.")}
             )
         }
     }
@@ -66,9 +66,9 @@ test("phenoimager2mc - tif - stub") {
             }
         }
         then {
-            assertAll (
-                { assert process.success },
-                { assert snapshot(process.out).match() }
+            assertAll(
+                { assert process.failed },
+                { assert process.errorReport.contains("WARNING: This module has been deprecated.")}
             )
         }
     }

--- a/modules/nf-core/phenoimager2mc/environment.yml
+++ b/modules/nf-core/phenoimager2mc/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - python=3.10.20
   - pip=25.3
   - pip:
-    - phenoimager2mc==0.3.2
+      - phenoimager2mc==0.3.2

--- a/modules/nf-core/phenoimager2mc/environment.yml
+++ b/modules/nf-core/phenoimager2mc/environment.yml
@@ -4,8 +4,8 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.10.20
   - ome-types=0.6.3
+  - python=3.10.20
   - pip=25.3
   - pip:
     - phenoimager2mc==0.3.2

--- a/modules/nf-core/phenoimager2mc/environment.yml
+++ b/modules/nf-core/phenoimager2mc/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python=3.10.20
+  - ome-types=0.6.3
   - pip=25.3
   - pip:
-    - ome_types==0.6.3
     - phenoimager2mc==0.3.2

--- a/modules/nf-core/phenoimager2mc/environment.yml
+++ b/modules/nf-core/phenoimager2mc/environment.yml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.10.20
+  - pip=25.3
+  - pip:
+    - ome_types==0.6.3
+    - phenoimager2mc==0.3.2

--- a/modules/nf-core/phenoimager2mc/main.nf
+++ b/modules/nf-core/phenoimager2mc/main.nf
@@ -1,33 +1,33 @@
 process PHENOIMAGER2MC {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
     container "ghcr.io/schapirolabor/phenoimager2mc:v0.3.2"
 
     input:
-    tuple val(meta) , path(tiles, stageAs: "tiles/*")
+    tuple val(meta), path(tiles, stageAs: "tiles/*")
 
     output:
     tuple val(meta), path("*.tif"), emit: tif
     tuple val("${task.process}"), val('phenoimager2mc'), eval("phenoimager2mc --version"), topic: versions, emit: versions_phenoimager2mc
     tuple val("${task.process}"), val('python'), eval('python --version | sed -e "s/Python //g"'), topic: versions, emit: versions_python
     tuple val("${task.process}"), val('ome_types'), eval('python -m pip show ome_types | sed -n "s/Version: //p"'), topic: versions, emit: versions_ome_types
+
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args   = task.ext.args   ?: ''
+    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     phenoimager2mc \
         -i ${tiles} \
         -o "${prefix}.tif" \
-        $args
+        ${args}
 
     sed -i -E \
         -e 's/UUID="urn:uuid:[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"/                                                    /g' \
-        -e 's/python version- [0-9]+\\.[0-9]+\\.[0-9]+//g' \
         ${prefix}.tif
     """
 
@@ -35,7 +35,7 @@ process PHENOIMAGER2MC {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo $args
+    echo ${args}
     
     touch ${prefix}.tif
     """

--- a/modules/nf-core/phenoimager2mc/main.nf
+++ b/modules/nf-core/phenoimager2mc/main.nf
@@ -36,7 +36,7 @@ process PHENOIMAGER2MC {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     echo ${args}
-    
+
     touch ${prefix}.tif
     """
 }

--- a/modules/nf-core/phenoimager2mc/main.nf
+++ b/modules/nf-core/phenoimager2mc/main.nf
@@ -1,0 +1,42 @@
+process PHENOIMAGER2MC {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "ghcr.io/schapirolabor/phenoimager2mc:v0.3.2"
+
+    input:
+    tuple val(meta) , path(tiles, stageAs: "tiles/*")
+
+    output:
+    tuple val(meta), path("*.tif"), emit: tif
+    tuple val("${task.process}"), val('phenoimager2mc'), eval("phenoimager2mc --version"), topic: versions, emit: versions_phenoimager2mc
+    tuple val("${task.process}"), val('python'), eval('python --version | sed -e "s/Python //g"'), topic: versions, emit: versions_python
+    tuple val("${task.process}"), val('ome_types'), eval('python -m pip show ome_types | sed -n "s/Version: //p"'), topic: versions, emit: versions_ome_types
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    phenoimager2mc \
+        -i ${tiles} \
+        -o "${prefix}.tif" \
+        $args
+
+    sed -i -E \
+        -e 's/UUID="urn:uuid:[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"/                                                    /g' \
+        -e 's/python version- [0-9]+\\.[0-9]+\\.[0-9]+//g' \
+        ${prefix}.tif
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo $args
+    
+    touch ${prefix}.tif
+    """
+}

--- a/modules/nf-core/phenoimager2mc/meta.yml
+++ b/modules/nf-core/phenoimager2mc/meta.yml
@@ -1,0 +1,106 @@
+name: "phenoimager2mc"
+description: Formatting PhenoImager TIFF output files into stacked and
+  normalized OME-TIFF files per cycle, compatible as ASHLAR and MCMICRO input.
+keywords:
+  - imaging
+  - registration
+  - ome-tif
+  - Staging
+  - MCMICRO
+tools:
+  - "phenoimager2mc":
+      description: "PhenoImager output conversion into a stacked and normalized OME-TIFF
+        file per cycle."
+      homepage: "https://github.com/SchapiroLabor/phenoimager2mc"
+      documentation: "https://github.com/SchapiroLabor/phenoimager2mc/README.md"
+      tool_dev_url: "https://github.com/SchapiroLabor/phenoimager2mc"
+      licence:
+        - "GPL-2.0 license"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - tiles:
+        type: list
+        description: Folder or list with TIFF files of one cycle from PhenoImager
+output:
+  tif:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.tif":
+          type: file
+          description: One output .tif file containing concatenated tiles of the
+            cycle.
+          pattern: "*.{tif,tiff}"
+          ontologies:
+            - edam: http://edamontology.org/format_3591 # TIFF
+  versions_phenoimager2mc:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - phenoimager2mc:
+          type: string
+          description: The name of the tool
+      - phenoimager2mc --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_python:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - python:
+          type: string
+          description: The name of the tool
+      - python --version | sed -e "s/Python //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_ome_types:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ome_types:
+          type: string
+          description: The name of the tool
+      - 'python -m pip show ome_types | sed -n "s/Version: //p"':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - phenoimager2mc:
+          type: string
+          description: The name of the tool
+      - phenoimager2mc --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - python:
+          type: string
+          description: The name of the tool
+      - python --version | sed -e "s/Python //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ome_types:
+          type: string
+          description: The name of the tool
+      - 'python -m pip show ome_types | sed -n "s/Version: //p"':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@chiarasch"
+  - "@kbestak"
+maintainers:
+  - "@chiarasch"

--- a/modules/nf-core/phenoimager2mc/tests/main.nf.test
+++ b/modules/nf-core/phenoimager2mc/tests/main.nf.test
@@ -1,0 +1,81 @@
+nextflow_process {
+
+    name "Test Process PHENOIMAGER2MC"
+    script "../main.nf"
+    process "PHENOIMAGER2MC"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "phenoimager2mc"
+
+    test("phenoimager2mc - tif") {
+        when {
+            params {
+                module_args = "-m 6 -n 99th"
+            }
+            process {
+                """
+                // stage input tif files in a folder
+                tmpdir = file("tmpdir", type: 'dir')
+                tmpdir.mkdir()
+                tif_file_1 = file(params.modules_testdata_base_path + 'imaging/staging/phenoimager/tile1.tif', checkIfExists: true)
+                tif_file_2 = file(params.modules_testdata_base_path + 'imaging/staging/phenoimager/tile2.tif', checkIfExists: true)
+                tif_file_1.copyTo(tmpdir)
+                tif_file_2.copyTo(tmpdir)
+
+                // define inputs of the process here. Example:
+                input[0] = [
+                    [ id:'test' ],
+                    [
+                        file(tmpdir, type:'dir', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+
+test("phenoimager2mc - tif - stub") {
+
+    options "-stub"
+        when {
+            params {
+                module_args = "-m 6 -n 99th"
+            }
+            process {
+                """
+                // stage input tif files in a folder
+                tmpdir = file("tmpdir", type: 'dir')
+                tmpdir.mkdir()
+                tif_file_1 = file(params.modules_testdata_base_path + 'imaging/staging/phenoimager/tile1.tif', checkIfExists: true)
+                tif_file_2 = file(params.modules_testdata_base_path + 'imaging/staging/phenoimager/tile2.tif', checkIfExists: true)
+                tif_file_1.copyTo(tmpdir)
+                tif_file_2.copyTo(tmpdir)
+
+                // define inputs of the process here. Example:
+                input[0] = [
+                    [ id:'test' ],
+                    [
+                        file(tmpdir, type:'dir', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/phenoimager2mc/tests/main.nf.test.snap
+++ b/modules/nf-core/phenoimager2mc/tests/main.nf.test.snap
@@ -1,0 +1,140 @@
+{
+    "phenoimager2mc - tif - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tif:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "phenoimager2mc",
+                        "v0.3.2"
+                    ]
+                ],
+                "2": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "python",
+                        "3.10.20"
+                    ]
+                ],
+                "3": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "ome_types",
+                        "0.6.3"
+                    ]
+                ],
+                "tif": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tif:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ome_types": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "ome_types",
+                        "0.6.3"
+                    ]
+                ],
+                "versions_phenoimager2mc": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "phenoimager2mc",
+                        "v0.3.2"
+                    ]
+                ],
+                "versions_python": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "python",
+                        "3.10.20"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-16T11:56:16.187363161",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    },
+    "phenoimager2mc - tif": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tif:md5,2b50d4c566699de08bb891427d2afbc0"
+                    ]
+                ],
+                "1": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "phenoimager2mc",
+                        "v0.3.2"
+                    ]
+                ],
+                "2": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "python",
+                        "3.10.20"
+                    ]
+                ],
+                "3": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "ome_types",
+                        "0.6.3"
+                    ]
+                ],
+                "tif": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tif:md5,2b50d4c566699de08bb891427d2afbc0"
+                    ]
+                ],
+                "versions_ome_types": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "ome_types",
+                        "0.6.3"
+                    ]
+                ],
+                "versions_phenoimager2mc": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "phenoimager2mc",
+                        "v0.3.2"
+                    ]
+                ],
+                "versions_python": [
+                    [
+                        "PHENOIMAGER2MC",
+                        "python",
+                        "3.10.20"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-16T11:55:47.056058651",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/phenoimager2mc/tests/main.nf.test.snap
+++ b/modules/nf-core/phenoimager2mc/tests/main.nf.test.snap
@@ -76,7 +76,7 @@
                         {
                             "id": "test"
                         },
-                        "test.tif:md5,2b50d4c566699de08bb891427d2afbc0"
+                        "test.tif:md5,02fbba425ec0761780433c5ba43ae274"
                     ]
                 ],
                 "1": [
@@ -105,7 +105,7 @@
                         {
                             "id": "test"
                         },
-                        "test.tif:md5,2b50d4c566699de08bb891427d2afbc0"
+                        "test.tif:md5,02fbba425ec0761780433c5ba43ae274"
                     ]
                 ],
                 "versions_ome_types": [
@@ -131,7 +131,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-16T11:55:47.056058651",
+        "timestamp": "2026-04-16T16:47:49.030508235",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"

--- a/modules/nf-core/phenoimager2mc/tests/nextflow.config
+++ b/modules/nf-core/phenoimager2mc/tests/nextflow.config
@@ -1,5 +1,5 @@
 process {
-  withName: 'PHENOIMAGER2MC' {
-    ext.args = params.module_args
-  }
+    withName: PHENOIMAGER2MC {
+        ext.args = params.module_args
+    }
 }

--- a/modules/nf-core/phenoimager2mc/tests/nextflow.config
+++ b/modules/nf-core/phenoimager2mc/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+  withName: 'PHENOIMAGER2MC' {
+    ext.args = params.module_args
+  }
+}


### PR DESCRIPTION
Continuing the discussion regarding mismatched tool/command modules --> https://github.com/nf-core/modules/issues/11073

* MCSTAGING/PHENOIMAGER2MC has been deprecated, as the toolname is phenoimager2mc. Final MCSTAGING module (macsima2mc) will follow after we update how it's packaged
* new module PHENOIMAGER2MC has been added
* phenoimager2mc has been published as a python package so the module does not link to a specific script inside the container anymore
* conda support was added for the module
* ext.args are now provided within the main.nf.test
* added Python and ome_types versions as topic output as these are written by default to the metadata


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
