### PR TITLE
bot init attempt for fairy/coverage - testing

### DIFF
--- a/modules/nf-core/fairy/coverage/environment.yml
+++ b/modules/nf-core/fairy/coverage/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::fairy=0.5.8"

--- a/modules/nf-core/fairy/coverage/main.nf
+++ b/modules/nf-core/fairy/coverage/main.nf
@@ -1,0 +1,40 @@
+process FAIRY_COVERAGE {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/fairy:0.5.8--hc1c3326_0':
+        'biocontainers/fairy:0.5.8--hc1c3326_0' }"
+
+    input:
+    tuple val(meta), path(sketches), path(contigs)
+
+    output:
+    tuple val(meta), path("${prefix}.tsv"), emit: coverage
+    tuple val("${task.process}"), val('fairy'), eval("fairy --version 2>&1 | sed 's/fairy //'"), topic: versions, emit: versions_fairy
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    fairy coverage \\
+        ${sketches} \\
+        ${contigs} \\
+        -t ${task.cpus} \\
+        -o ${prefix}.tsv \\
+        ${args}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo ${args}
+
+    touch ${prefix}.tsv
+    """
+}

--- a/modules/nf-core/fairy/coverage/main.nf
+++ b/modules/nf-core/fairy/coverage/main.nf
@@ -33,7 +33,7 @@ process FAIRY_COVERAGE {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo ${args}
+    echo "$args"
 
     touch ${prefix}.tsv
     """

--- a/modules/nf-core/fairy/coverage/meta.yml
+++ b/modules/nf-core/fairy/coverage/meta.yml
@@ -1,0 +1,86 @@
+name: fairy_coverage
+description: |
+  Computes coverage depth statistics for assembled contigs from one or more
+  fairy sketch files, producing a MetaBAT2-compatible TSV with per-contig
+  mean depth and variance columns.
+keywords:
+  - metagenomics
+  - coverage
+  - binning
+  - alignment-free
+  - contig
+tools:
+  - fairy:
+      description: |
+        fairy is a fast, alignment-free, k-mer-based tool for computing
+        coverage depth statistics for metagenomic samples. It is orders of
+        magnitude faster than alignment-based approaches and produces output
+        directly compatible with MetaBAT2.
+      homepage: https://github.com/bluenote10/fairy
+      documentation: https://github.com/bluenote10/fairy
+      tool_dev_url: https://github.com/bluenote10/fairy
+      licence:
+        - "MIT"
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - sketches:
+        type: file
+        description: One or more fairy sketch files (.bcsp) produced by `fairy sketch`
+        pattern: "*.bcsp"
+        ontologies: []
+    - contigs:
+        type: file
+        description: Assembled contigs in FASTA format
+        pattern: "*.{fa,fasta,fna,fa.gz,fasta.gz,fna.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
+
+output:
+  coverage:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - ${prefix}.tsv:
+          type: file
+          description: |
+            MetaBAT2-compatible TSV file with per-contig coverage statistics.
+            Columns: contigName, contigLen, totalAvgDepth, and per-sample
+            mean depth and variance.
+          pattern: "*.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  versions_fairy:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - fairy:
+          type: string
+          description: The name of the tool
+      - fairy --version 2>&1 | sed 's/fairy //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - fairy:
+          type: string
+          description: The name of the tool
+      - fairy --version 2>&1 | sed 's/fairy //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@vagkaratzas"
+maintainers:
+  - "@vagkaratzas"

--- a/modules/nf-core/fairy/coverage/meta.yml
+++ b/modules/nf-core/fairy/coverage/meta.yml
@@ -16,9 +16,9 @@ tools:
         coverage depth statistics for metagenomic samples. It is orders of
         magnitude faster than alignment-based approaches and produces output
         directly compatible with MetaBAT2.
-      homepage: https://github.com/bluenote10/fairy
-      documentation: https://github.com/bluenote10/fairy
-      tool_dev_url: https://github.com/bluenote10/fairy
+      homepage: https://github.com/bluenote-1577/fairy
+      documentation: https://github.com/bluenote-1577/fairy
+      tool_dev_url: https://github.com/bluenote-1577/fairy
       licence:
         - "MIT"
       identifier: ""

--- a/modules/nf-core/fairy/coverage/tests/main.nf.test
+++ b/modules/nf-core/fairy/coverage/tests/main.nf.test
@@ -1,0 +1,119 @@
+nextflow_process {
+
+    name "Test Process FAIRY_COVERAGE"
+    script "../main.nf"
+    process "FAIRY_COVERAGE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "fairy"
+    tag "fairy/coverage"
+    tag "fairy/sketch"
+
+    test("sarscov2 - illumina paired-end [fastq_gz] + contigs [fasta] - tsv coverage") {
+
+        setup {
+            run("FAIRY_SKETCH") {
+                script "../../sketch/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test', single_end:false ],
+                        [
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                        ]
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = FAIRY_SKETCH.out.sketch.map { meta, sketches ->
+                    [
+                        meta,
+                        sketches,
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true)
+                    ]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - illumina single-end [fastq_gz] + contigs [fasta] - tsv coverage") {
+
+        setup {
+            run("FAIRY_SKETCH") {
+                script "../../sketch/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test', single_end:true ],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = FAIRY_SKETCH.out.sketch.map { meta, sketches ->
+                    [
+                        meta,
+                        sketches,
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true)
+                    ]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - illumina paired-end [fastq_gz] + contigs [fasta] - tsv coverage - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/fairy/coverage/tests/main.nf.test.snap
+++ b/modules/nf-core/fairy/coverage/tests/main.nf.test.snap
@@ -1,0 +1,83 @@
+{
+    "sarscov2 - illumina single-end [fastq_gz] + contigs [fasta] - tsv coverage": {
+        "content": [
+            {
+                "coverage": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.tsv:md5,08208bef24f2edb7a57846c9f330dfe8"
+                    ]
+                ],
+                "versions_fairy": [
+                    [
+                        "FAIRY_COVERAGE",
+                        "fairy",
+                        "0.5.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-17T22:46:36.637796281"
+    },
+    "sarscov2 - illumina paired-end [fastq_gz] + contigs [fasta] - tsv coverage": {
+        "content": [
+            {
+                "coverage": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,57810071bf0459a4756b017b0bc34e93"
+                    ]
+                ],
+                "versions_fairy": [
+                    [
+                        "FAIRY_COVERAGE",
+                        "fairy",
+                        "0.5.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-17T22:46:26.455200249"
+    },
+    "sarscov2 - illumina paired-end [fastq_gz] + contigs [fasta] - tsv coverage - stub": {
+        "content": [
+            {
+                "coverage": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_fairy": [
+                    [
+                        "FAIRY_COVERAGE",
+                        "fairy",
+                        "0.5.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-17T22:46:46.957397773"
+    }
+}


### PR DESCRIPTION
Adding `fairy/coverage`, downstream module from `fairy/sketch`;
contig coverage computation for metagenomic binning

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
