### PR TITLE
fq/lint: constrain reads input to arity 1..2

### DIFF
--- a/modules/nf-core/fq/lint/main.nf
+++ b/modules/nf-core/fq/lint/main.nf
@@ -8,7 +8,7 @@ process FQ_LINT {
         'biocontainers/fq:0.12.0--h9ee0642_0' }"
 
     input:
-    tuple val(meta), path(fastq)
+    tuple val(meta), path(fastq, arity: '1..2')
 
     output:
     tuple val(meta), path("*.fq_lint.txt"), emit: lint

--- a/modules/nf-core/fq/lint/tests/main.nf.test
+++ b/modules/nf-core/fq/lint/tests/main.nf.test
@@ -36,6 +36,32 @@ nextflow_process {
 
     }
 
+    test("test_fq_lint_rejects_more_than_two_fastqs") {
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                def fq1 = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                def fq2 = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                def fq3 = file("\${workDir}/test_3.fastq.gz")
+                fq3.bytes = fq1.bytes
+                input[0] = [ [ id:'test', single_end:false ],
+                             [ fq1, fq2, fq3 ]
+                           ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert !process.success }
+            )
+        }
+
+    }
+
     test("test_fq_lint_fail") {
         when {
             params {


### PR DESCRIPTION
## Summary

`fq lint` only accepts `<R1>` or `<R1> <R2>`. Downstream pipelines that accidentally forward more than two FASTQs into this module currently fail inside the container with a cryptic message like:

```
error: unexpected argument 'sample_val_2.fq.gz' found
Usage: fq lint [OPTIONS] <R1_SRC> [R2_SRC]
```

Declaring `arity: '1..2'` on the input surfaces the cardinality mismatch as a clear Nextflow-level error at channel bind:

```
Incorrect number of input files for process `FQ_LINT (1)` -- expected 1..2, found 3
```

Makes accidental over-forwarding (e.g. a `path(...)` glob that picks up more files than the user realised) fail fast and obvious, rather than requiring someone to read the container stderr.

Reported by @edmundmiller in [nf-core/rnaseq#1807](https://github.com/nf-core/rnaseq/issues/1807).

## Changes

- `modules/nf-core/fq/lint/main.nf`: add `arity: '1..2'` to the `fastq` input.
- `modules/nf-core/fq/lint/tests/main.nf.test`: add `test_fq_lint_rejects_more_than_two_fastqs` to lock the constraint in place.

## Test

```
$ nf-test test modules/nf-core/fq/lint/tests/main.nf.test --profile docker
Test Process FQ_LINT
  Test [d1f52092] 'test_fq_lint_success'                        PASSED (5.708s)
  Test [b262fadb] 'test_fq_lint_rejects_more_than_two_fastqs'   PASSED (4.359s)
  Test [ad922e58] 'test_fq_lint_fail'                           PASSED (6.033s)

SUCCESS: Executed 3 tests in 16.106s
```

PR checklist
---
- [x] This comment contains a description of changes (with reason).
- [ ] `CHANGELOG.md` is updated.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Ensure the test suite passes (`nf-core modules test <MODULE> --profile docker`).
- [x] Include any new arguments/options with a sensible default.
- [x] Ensure `meta.yml` is up to date (no changes needed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)