### PR TITLE
fastq_fastqc_umitools_trimgalore: handle null trim_log in read-count map

### DIFF
--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -36,81 +36,81 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
     min_trimmed_reads // integer: > 0
 
     main:
-    fastqc_html = channel.empty()
-    fastqc_zip = channel.empty()
+    ch_fastqc_html = channel.empty()
+    ch_fastqc_zip = channel.empty()
     if (!skip_fastqc) {
         FASTQC(reads)
-        fastqc_html = FASTQC.out.html
-        fastqc_zip = FASTQC.out.zip
+        ch_fastqc_html = FASTQC.out.html
+        ch_fastqc_zip = FASTQC.out.zip
     }
 
-    trimmer_reads = reads
-    umi_log = channel.empty()
-    umi_reads = channel.empty()
+    ch_trimmer_reads = reads
+    ch_umi_log = channel.empty()
+    ch_umi_reads = channel.empty()
     if (with_umi && !skip_umi_extract) {
         UMITOOLS_EXTRACT(reads)
-        trimmer_reads = UMITOOLS_EXTRACT.out.reads
-        umi_reads = UMITOOLS_EXTRACT.out.reads
-        umi_log = UMITOOLS_EXTRACT.out.log
+        ch_trimmer_reads = UMITOOLS_EXTRACT.out.reads
+        ch_umi_reads = UMITOOLS_EXTRACT.out.reads
+        ch_umi_log = UMITOOLS_EXTRACT.out.log
 
         // Discard R1 / R2 if required
         if (umi_discard_read in [1, 2]) {
             UMITOOLS_EXTRACT.out.reads
-                .map { meta, reads_ ->
-                    meta.single_end ? [meta, reads_] : [meta + ['single_end': true], reads_[umi_discard_read % 2]]
+                .map { meta, reads ->
+                    meta.single_end ? [meta, reads] : [meta + ['single_end': true], reads[umi_discard_read % 2]]
                 }
-                .set { trimmer_reads }
+                .set { ch_trimmer_reads }
         }
     }
 
-    trim_reads = trimmer_reads
-    trim_unpaired = channel.empty()
-    trim_html = channel.empty()
-    trim_zip = channel.empty()
-    trim_log = channel.empty()
-    trim_read_count = channel.empty()
+    ch_trim_reads = ch_trimmer_reads
+    ch_trim_unpaired = channel.empty()
+    ch_trim_html = channel.empty()
+    ch_trim_zip = channel.empty()
+    ch_trim_log = channel.empty()
+    ch_trim_read_count = channel.empty()
     if (!skip_trimming) {
-        TRIMGALORE(trimmer_reads)
-        trim_unpaired = TRIMGALORE.out.unpaired
-        trim_html = TRIMGALORE.out.html
-        trim_zip = TRIMGALORE.out.zip
-        trim_log = TRIMGALORE.out.log
+        TRIMGALORE(ch_trimmer_reads)
+        ch_trim_unpaired = TRIMGALORE.out.unpaired
+        ch_trim_html = TRIMGALORE.out.html
+        ch_trim_zip = TRIMGALORE.out.zip
+        ch_trim_log = TRIMGALORE.out.log
 
         //
         // Filter FastQ files based on minimum trimmed read count after adapter trimming
         //
         TRIMGALORE.out.reads
-            .join(trim_log, remainder: true)
-            .map { meta, reads_, trim_log_ ->
-                if (trim_log_) {
-                    def num_reads = getTrimGaloreReadsAfterFiltering(meta.single_end ? trim_log_ : trim_log_[-1])
-                    [meta, reads_, num_reads]
+            .join(ch_trim_log, remainder: true)
+            .map { meta, reads, trim_log ->
+                if (trim_log) {
+                    def num_reads = getTrimGaloreReadsAfterFiltering(meta.single_end ? trim_log : trim_log[-1])
+                    [meta, reads, num_reads]
                 }
                 else {
-                    [meta, reads_, min_trimmed_reads.toFloat() + 1]
+                    [meta, reads, min_trimmed_reads.toFloat() + 1]
                 }
             }
             .set { ch_num_trimmed_reads }
 
         ch_num_trimmed_reads
             .filter { _meta, _reads, num_reads -> num_reads >= min_trimmed_reads.toFloat() }
-            .map { meta, reads_, _num_reads -> [meta, reads_] }
-            .set { trim_reads }
+            .map { meta, reads, _num_reads -> [meta, reads] }
+            .set { ch_trim_reads }
 
         ch_num_trimmed_reads
             .map { meta, _reads, num_reads -> [meta, num_reads] }
-            .set { trim_read_count }
+            .set { ch_trim_read_count }
     }
 
     emit:
-    reads           = trim_reads // channel: [ val(meta), [ reads ] ]
-    fastqc_html     // channel: [ val(meta), [ html ] ]
-    fastqc_zip      // channel: [ val(meta), [ zip ] ]
-    umi_log         // channel: [ val(meta), [ log ] ]
-    umi_reads       // channel: [ val(meta), [ reads ] ]
-    trim_unpaired   // channel: [ val(meta), [ reads ] ]
-    trim_html       // channel: [ val(meta), [ html ] ]
-    trim_zip        // channel: [ val(meta), [ zip ] ]
-    trim_log        // channel: [ val(meta), [ txt ] ]
-    trim_read_count // channel: [ val(meta), val(count) ]
+    reads           = ch_trim_reads       // channel: [ val(meta), [ reads ] ]
+    fastqc_html     = ch_fastqc_html      // channel: [ val(meta), [ html ] ]
+    fastqc_zip      = ch_fastqc_zip       // channel: [ val(meta), [ zip ] ]
+    umi_log         = ch_umi_log          // channel: [ val(meta), [ log ] ]
+    umi_reads       = ch_umi_reads        // channel: [ val(meta), [ reads ] ]
+    trim_unpaired   = ch_trim_unpaired    // channel: [ val(meta), [ reads ] ]
+    trim_html       = ch_trim_html        // channel: [ val(meta), [ html ] ]
+    trim_zip        = ch_trim_zip         // channel: [ val(meta), [ zip ] ]
+    trim_log        = ch_trim_log         // channel: [ val(meta), [ txt ] ]
+    trim_read_count = ch_trim_read_count  // channel: [ val(meta), val(count) ]
 }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -82,12 +82,12 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
         TRIMGALORE.out.reads
             .join(trim_log, remainder: true)
             .map { meta, reads_, trim_log_ ->
-                if (trim_log) {
+                if (trim_log_) {
                     def num_reads = getTrimGaloreReadsAfterFiltering(meta.single_end ? trim_log_ : trim_log_[-1])
                     [meta, reads_, num_reads]
                 }
                 else {
-                    [meta, reads, min_trimmed_reads.toFloat() + 1]
+                    [meta, reads_, min_trimmed_reads.toFloat() + 1]
                 }
             }
             .set { ch_num_trimmed_reads }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -56,8 +56,8 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
         // Discard R1 / R2 if required
         if (umi_discard_read in [1, 2]) {
             UMITOOLS_EXTRACT.out.reads
-                .map { meta, reads ->
-                    meta.single_end ? [meta, reads] : [meta + ['single_end': true], reads[umi_discard_read % 2]]
+                .map { meta, reads_ ->
+                    meta.single_end ? [meta, reads_] : [meta + ['single_end': true], reads_[umi_discard_read % 2]]
                 }
                 .set { ch_trimmer_reads }
         }
@@ -81,20 +81,20 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
         //
         TRIMGALORE.out.reads
             .join(ch_trim_log, remainder: true)
-            .map { meta, reads, trim_log ->
+            .map { meta, reads_, trim_log ->
                 if (trim_log) {
                     def num_reads = getTrimGaloreReadsAfterFiltering(meta.single_end ? trim_log : trim_log[-1])
-                    [meta, reads, num_reads]
+                    [meta, reads_, num_reads]
                 }
                 else {
-                    [meta, reads, min_trimmed_reads.toFloat() + 1]
+                    [meta, reads_, min_trimmed_reads.toFloat() + 1]
                 }
             }
             .set { ch_num_trimmed_reads }
 
         ch_num_trimmed_reads
             .filter { _meta, _reads, num_reads -> num_reads >= min_trimmed_reads.toFloat() }
-            .map { meta, reads, _num_reads -> [meta, reads] }
+            .map { meta, reads_, _num_reads -> [meta, reads_] }
             .set { ch_trim_reads }
 
         ch_num_trimmed_reads

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
@@ -122,7 +122,7 @@ nextflow_workflow {
         when {
             workflow {
                 """
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
@@ -131,7 +131,7 @@ nextflow_workflow {
                 ])
                 input[1] = true  // skip_fastqc
                 input[2] = false // with_umi
-                input[3] = false // skip_umi_extract
+                input[3] = true  // skip_umi_extract
                 input[4] = false // skip_trimming
                 input[5] = 0     // umi_discard_read
                 input[6] = 1     // min_trimmed_reads
@@ -146,7 +146,7 @@ nextflow_workflow {
                     workflow.out.reads,
                     workflow.out.trim_read_count,
                     workflow.out.trim_unpaired,
-).match() }
+                ).match() }
             )
         }
     }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
@@ -115,6 +115,42 @@ nextflow_workflow {
         }
     }
 
+    test("test paired end read without UMI - hardtrim5 (no trim log)") {
+
+        config './nextflow-hardtrim.config'
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = true  // skip_fastqc
+                input[2] = false // with_umi
+                input[3] = false // skip_umi_extract
+                input[4] = false // skip_trimming
+                input[5] = 0     // umi_discard_read
+                input[6] = 1     // min_trimmed_reads
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.reads,
+                    workflow.out.trim_read_count,
+                    workflow.out.trim_unpaired,
+).match() }
+            )
+        }
+    }
+
     test("test skip all steps") {
 
         when {

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test.snap
@@ -523,5 +523,38 @@
             "nextflow": "25.10.3"
         },
         "timestamp": "2026-02-03T13:21:36.092099503"
+    },
+    "test paired end read without UMI - hardtrim5 (no trim log)": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.8bp_5prime.fq.gz:md5,70f5059c1a54be0cb280ef42ee849122",
+                        "test_2.8bp_5prime.fq.gz:md5,fdec97e9e36ac5f30685f4fa0975dcf7"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    2.0
+                ]
+            ],
+            [
+                
+            ]
+        ],
+        "timestamp": "2026-04-20T10:04:54.300393835",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/nextflow-hardtrim.config
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/nextflow-hardtrim.config
@@ -1,0 +1,11 @@
+process {
+    withName: UMITOOLS_EXTRACT {
+        ext.args = '--bc-pattern="NNNN"'
+    }
+    withName: TRIMGALORE {
+        // --hardtrim5 makes trim_galore skip the adapter / quality pass and not emit a
+        // *_trimming_report.txt, so the trim_log channel join leaves a null element.
+        // Used to exercise the null-log branch of the read-count map.
+        ext.args = '--hardtrim5 8'
+    }
+}


### PR DESCRIPTION
## Summary

Three commits, one behaviour change:

1. **`1c2b050309`** — null-log fix.
2. **`546c722afd`** — `ch_` prefix rename on outer local channels (removes the collision with closure params for `trim_log`). No behaviour change.
3. **`7af199b8ad`** — lint fix: `reads_` keeps its trailing underscore in closures because `reads` is a `take:` parameter and Nextflow lint blocks the shadow.

## The bug

When `ext.args` includes `--hardtrim5` / `--hardtrim3`, trim_galore skips the adapter / quality pass and emits no `*_trimming_report.txt`. The `.join(trim_log, remainder: true)` then carries a `null` log element, and the null guard had two scoping bugs:

```groovy
.map { meta, reads_, trim_log_ ->
    if (trim_log) {                                     // outer channel, always truthy
        def num_reads = getTrimGaloreReadsAfterFiltering(
            meta.single_end ? trim_log_ : trim_log_[-1])
        [meta, reads_, num_reads]
    } else {
        [meta, reads, min_trimmed_reads.toFloat() + 1]  // outer take param, a channel
    }
}
```

- `if (trim_log)` checked the outer channel (always truthy) → `getTrimGaloreReadsAfterFiltering(null)` → `Cannot invoke method eachLine() on null object`.
- Else branch referenced the outer `reads` take parameter instead of the closure element.

Commit 1 fixes both by targeting the `_`-suffixed closure params. Commit 2 renames outer channels to `ch_*` so the `trim_log` closure param can drop its underscore. Commit 3 reinstates `reads_` because Nextflow lint rejects shadowing the `take:` parameter.

## Reproduction

Surfaced triaging [nf-core/rnaseq#1807](https://github.com/nf-core/rnaseq/issues/1807). Running the pipeline with `--extra_trimgalore_args '--hardtrim5 8'` crashes on master at `main.nf:15`.

## Test

New case `test paired end read without UMI - hardtrim5 (no trim log)` sets `ext.args = '--hardtrim5 8'` on TRIMGALORE. Fails on master, passes here. All 9 tests pass.

## Review tip

Most of the line count lives in commit 2 (the rename). The behaviourally-important lines appear **unchanged** in the final master-vs-HEAD diff because the rename flipped which name resolves to what. Self-review pins the real fix inline. Commit-by-commit review recommended.

PR checklist
---
- [x] This comment contains a description of changes (with reason).
- [ ] `CHANGELOG.md` is updated.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Ensure the test suite passes (`nf-core subworkflows test <SUBWORKFLOW> --profile docker`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)