### PR TITLE
feat(subworkflows): add per_sample_mqc_bundle emit to fastq_qc / bam_qc_rnaseq / bam_markduplicates_picard / bam_dedup_umi

### DIFF
--- a/subworkflows/nf-core/bam_dedup_umi/main.nf
+++ b/subworkflows/nf-core/bam_dedup_umi/main.nf
@@ -120,6 +120,14 @@ workflow BAM_DEDUP_UMI {
         .mix(UMI_DEDUP_GENOME.out.idxstats)
         .transpose()
 
+    // Genome-side only; transcriptome stats excluded (MultiQC can't
+    // disambiguate them from genome stats without extra work).
+    ch_per_sample_mqc_bundle = ch_genomic_dedup_log
+        .join(UMI_DEDUP_GENOME.out.stats,    remainder: true)
+        .join(UMI_DEDUP_GENOME.out.flagstat, remainder: true)
+        .join(UMI_DEDUP_GENOME.out.idxstats, remainder: true)
+        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> e instanceof List ? e : [e] }] }
+
     emit:
     bam                            = UMI_DEDUP_GENOME.out.bam // channel: [ val(meta), path(bam) ]
     index                          = UMI_DEDUP_GENOME.out.index // channel: [ val(meta), path(bai) ]
@@ -129,6 +137,9 @@ workflow BAM_DEDUP_UMI {
     stats                          = UMI_DEDUP_GENOME.out.stats.mix(UMI_DEDUP_TRANSCRIPTOME.out.stats) // channel: [ val(meta), path(stats)]
     flagstat                       = UMI_DEDUP_GENOME.out.flagstat.mix(UMI_DEDUP_TRANSCRIPTOME.out.flagstat) // channel: [ val(meta), path(flagstat)]
     idxstats                       = UMI_DEDUP_GENOME.out.idxstats.mix(UMI_DEDUP_TRANSCRIPTOME.out.idxstats) // channel: [ val(meta), path(idxstats)]
+    genome_stats                   = UMI_DEDUP_GENOME.out.stats // channel: [ val(meta), path(stats) ]
+    genome_flagstat                = UMI_DEDUP_GENOME.out.flagstat // channel: [ val(meta), path(flagstat) ]
+    genome_idxstats                = UMI_DEDUP_GENOME.out.idxstats // channel: [ val(meta), path(idxstats) ]
     tsv_edit_distance              = ch_tsv_edit_distance // channel: [ val(meta), path(tsv) ]
     tsv_per_umi                    = ch_tsv_per_umi // channel: [ val(meta), path(tsv) ]
     tsv_umi_per_position           = ch_tsv_umi_per_position // channel: [ val(meta), path(tsv) ]
@@ -138,4 +149,5 @@ workflow BAM_DEDUP_UMI {
     transcriptome_sorted_bam       = SAMTOOLS_SORT.out.bam // channel: [ val(meta), path(bam) ] - name-sorted
     transcriptome_sorted_bam_index = UMI_DEDUP_TRANSCRIPTOME.out.index // channel: [ val(meta), path(index) ] - coordinate-sorted dedup index
     transcriptome_filtered_bam     = UMITOOLS_PREPAREFORRSEM.out.bam // channel: [ val(meta), path(bam) ] - paired-end filtered
+    per_sample_mqc_bundle          = ch_per_sample_mqc_bundle // channel: [ val(meta), list(files) ]
 }

--- a/subworkflows/nf-core/bam_dedup_umi/main.nf
+++ b/subworkflows/nf-core/bam_dedup_umi/main.nf
@@ -126,7 +126,7 @@ workflow BAM_DEDUP_UMI {
         .join(UMI_DEDUP_GENOME.out.stats,    remainder: true)
         .join(UMI_DEDUP_GENOME.out.flagstat, remainder: true)
         .join(UMI_DEDUP_GENOME.out.idxstats, remainder: true)
-        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> e instanceof List ? e : [e] }] }
+        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> (e instanceof List) ? e : [e] }] }
 
     emit:
     bam                            = UMI_DEDUP_GENOME.out.bam // channel: [ val(meta), path(bam) ]

--- a/subworkflows/nf-core/bam_dedup_umi/meta.yml
+++ b/subworkflows/nf-core/bam_dedup_umi/meta.yml
@@ -168,6 +168,48 @@ output:
             type: file
             description: Idxstats file
             pattern: "*.idxstats"
+  - genome_stats:
+      description: Channel containing BAM statistics for the genome-aligned BAM only (transcriptome excluded)
+      structure:
+        - meta:
+            type: map
+            description: Metadata map
+        - stats:
+            type: file
+            description: BAM statistics file
+            pattern: "*.stats"
+  - genome_flagstat:
+      description: Channel containing flagstat for the genome-aligned BAM only
+      structure:
+        - meta:
+            type: map
+            description: Metadata map
+        - flagstat:
+            type: file
+            description: Flagstat file
+            pattern: "*.flagstat"
+  - genome_idxstats:
+      description: Channel containing idxstats for the genome-aligned BAM only
+      structure:
+        - meta:
+            type: map
+            description: Metadata map
+        - idxstats:
+            type: file
+            description: Idxstats file
+            pattern: "*.idxstats"
+  - per_sample_mqc_bundle:
+      description: |
+        Per-sample MultiQC-feeding outputs (genome-side only: genomic dedup log,
+        genome stats, flagstat, idxstats) joined on meta. Transcriptome stats
+        excluded (MultiQC can't disambiguate them from genome stats).
+      structure:
+        - meta:
+            type: map
+            description: Metadata map
+        - files:
+            type: file
+            description: List of MultiQC-relevant files for the sample
   - multiqc_files:
       description: Channel containing files for MultiQC
       structure:

--- a/subworkflows/nf-core/bam_dedup_umi/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_umi/tests/main.nf.test
@@ -55,7 +55,13 @@ nextflow_workflow {
                     workflow.out.flagstat,
                     workflow.out.idxstats
                 ).match() },
-                { assert path(workflow.out.index.get(0).get(1)).exists() }
+                { assert path(workflow.out.index.get(0).get(1)).exists() },
+                { assert workflow.out.genome_stats.size() == 1 },
+                { assert workflow.out.genome_flagstat.size() == 1 },
+                { assert workflow.out.genome_idxstats.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle[0][0] == [ id:'test' ] },
+                { assert workflow.out.per_sample_mqc_bundle[0][1].size() == 4 }
             )
         }
 
@@ -94,7 +100,13 @@ nextflow_workflow {
                     workflow.out.flagstat,
                     workflow.out.idxstats
                 ).match() },
-                { assert path(workflow.out.index.get(0).get(1)).exists() }
+                { assert path(workflow.out.index.get(0).get(1)).exists() },
+                { assert workflow.out.genome_stats.size() == 1 },
+                { assert workflow.out.genome_flagstat.size() == 1 },
+                { assert workflow.out.genome_idxstats.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle[0][0] == [ id:'test' ] },
+                { assert workflow.out.per_sample_mqc_bundle[0][1].size() == 4 }
             )
         }
     }

--- a/subworkflows/nf-core/bam_markduplicates_picard/main.nf
+++ b/subworkflows/nf-core/bam_markduplicates_picard/main.nf
@@ -22,12 +22,19 @@ workflow BAM_MARKDUPLICATES_PICARD {
 
     BAM_STATS_SAMTOOLS(ch_reads_index, ch_fasta_fai)
 
+    ch_per_sample_mqc_bundle = BAM_STATS_SAMTOOLS.out.stats
+        .join(BAM_STATS_SAMTOOLS.out.flagstat,   remainder: true)
+        .join(BAM_STATS_SAMTOOLS.out.idxstats,   remainder: true)
+        .join(PICARD_MARKDUPLICATES.out.metrics, remainder: true)
+        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> e instanceof List ? e : [e] }] }
+
     emit:
-    bam      = PICARD_MARKDUPLICATES.out.bam // channel: [ val(meta), path(bam) ]
-    cram     = PICARD_MARKDUPLICATES.out.cram // channel: [ val(meta), path(cram) ]
-    metrics  = PICARD_MARKDUPLICATES.out.metrics // channel: [ val(meta), path(metrics) ]
-    index    = SAMTOOLS_INDEX.out.index // channel: [ val(meta), path(index) ]
-    stats    = BAM_STATS_SAMTOOLS.out.stats // channel: [ val(meta), path(stats) ]
-    flagstat = BAM_STATS_SAMTOOLS.out.flagstat // channel: [ val(meta), path(flagstat) ]
-    idxstats = BAM_STATS_SAMTOOLS.out.idxstats // channel: [ val(meta), path(idxstats) ]
+    bam                   = PICARD_MARKDUPLICATES.out.bam // channel: [ val(meta), path(bam) ]
+    cram                  = PICARD_MARKDUPLICATES.out.cram // channel: [ val(meta), path(cram) ]
+    metrics               = PICARD_MARKDUPLICATES.out.metrics // channel: [ val(meta), path(metrics) ]
+    index                 = SAMTOOLS_INDEX.out.index // channel: [ val(meta), path(index) ]
+    stats                 = BAM_STATS_SAMTOOLS.out.stats // channel: [ val(meta), path(stats) ]
+    flagstat              = BAM_STATS_SAMTOOLS.out.flagstat // channel: [ val(meta), path(flagstat) ]
+    idxstats              = BAM_STATS_SAMTOOLS.out.idxstats // channel: [ val(meta), path(idxstats) ]
+    per_sample_mqc_bundle = ch_per_sample_mqc_bundle // channel: [ val(meta), list(files) ]
 }

--- a/subworkflows/nf-core/bam_markduplicates_picard/main.nf
+++ b/subworkflows/nf-core/bam_markduplicates_picard/main.nf
@@ -26,7 +26,7 @@ workflow BAM_MARKDUPLICATES_PICARD {
         .join(BAM_STATS_SAMTOOLS.out.flagstat,   remainder: true)
         .join(BAM_STATS_SAMTOOLS.out.idxstats,   remainder: true)
         .join(PICARD_MARKDUPLICATES.out.metrics, remainder: true)
-        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> e instanceof List ? e : [e] }] }
+        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> (e instanceof List) ? e : [e] }] }
 
     emit:
     bam                   = PICARD_MARKDUPLICATES.out.bam // channel: [ val(meta), path(bam) ]

--- a/subworkflows/nf-core/bam_markduplicates_picard/meta.yml
+++ b/subworkflows/nf-core/bam_markduplicates_picard/meta.yml
@@ -55,6 +55,10 @@ output:
       description: |
         File containing samtools idxstats output
         Structure: [ val(meta), path(idxstats) ]
+  - per_sample_mqc_bundle:
+      description: |
+        Per-sample MultiQC-feeding outputs (stats, flagstat, idxstats, metrics) joined on meta.
+        Structure: [ val(meta), list(files) ]
   - versions:
       description: |
         Files containing software versions

--- a/subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test
@@ -41,6 +41,9 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success},
                 { assert path(workflow.out.metrics.get(0).get(1)).getText().contains("97") },
+                { assert workflow.out.per_sample_mqc_bundle.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle[0][0] == [ id:'test', single_end: false ] },
+                { assert workflow.out.per_sample_mqc_bundle[0][1].size() == 4 },
                 { assert snapshot(
                     path(workflow.out.bam[0][1]),
                     path(workflow.out.index[0][1]),
@@ -74,6 +77,9 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success},
                 { assert path(workflow.out.metrics.get(0).get(1)).getText().contains("0.999986") },
+                { assert workflow.out.per_sample_mqc_bundle.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle[0][0] == [ id:'test' ] },
+                { assert workflow.out.per_sample_mqc_bundle[0][1].size() == 4 },
                 { assert snapshot(
                     file(workflow.out.cram[0][1]).name,
                     path(workflow.out.index[0][1]),

--- a/subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test.snap
@@ -73,6 +73,20 @@
                         "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "7": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.flagstat:md5,67394650dbae96d1a4fcc70484822159",
+                            "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.md.metrics.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
                 "bam": [
                     [
                         {
@@ -121,6 +135,20 @@
                         "test.md.metrics.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "per_sample_mqc_bundle": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.flagstat:md5,67394650dbae96d1a4fcc70484822159",
+                            "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.md.metrics.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
                 "stats": [
                     [
                         {
@@ -133,10 +161,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-02-19T19:00:56.802484512"
+        "timestamp": "2026-04-20T10:50:34.652754"
     },
     "homo_sapiens - cram - stub": {
         "content": [
@@ -192,6 +220,19 @@
                         "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "7": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.flagstat:md5,67394650dbae96d1a4fcc70484822159",
+                            "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.md.metrics.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
                 "bam": [
                     
                 ],
@@ -235,6 +276,19 @@
                         "test.md.metrics.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "per_sample_mqc_bundle": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.flagstat:md5,67394650dbae96d1a4fcc70484822159",
+                            "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.md.metrics.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
                 "stats": [
                     [
                         {
@@ -246,10 +300,10 @@
             }
         ],
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-02-19T19:01:05.884074864"
+        "timestamp": "2026-04-20T10:51:10.962305"
     },
     "sarscov2 - bam": {
         "content": [

--- a/subworkflows/nf-core/bam_qc_rnaseq/main.nf
+++ b/subworkflows/nf-core/bam_qc_rnaseq/main.nf
@@ -96,6 +96,22 @@ workflow BAM_QC_RNASEQ {
         .mix(BAM_RSEQC.out.readduplication_pos_xls)
         .mix(BAM_RSEQC.out.tin_txt)
 
+    // `remainder: true` needed because every contributor is gated behind
+    // `tools` / `rseqc_modules`.
+    ch_per_sample_mqc_bundle = PRESEQ_LCEXTRAP.out.lc_extrap
+        .join(CUSTOM_MULTIQCCUSTOMBIOTYPE.out.tsv,         remainder: true)
+        .join(QUALIMAP_RNASEQ.out.results,                 remainder: true)
+        .join(DUPRADAR.out.multiqc,                        remainder: true)
+        .join(BAM_RSEQC.out.bamstat_txt,                   remainder: true)
+        .join(BAM_RSEQC.out.inferexperiment_txt,           remainder: true)
+        .join(BAM_RSEQC.out.innerdistance_freq,            remainder: true)
+        .join(BAM_RSEQC.out.junctionannotation_log,        remainder: true)
+        .join(BAM_RSEQC.out.junctionsaturation_rscript,    remainder: true)
+        .join(BAM_RSEQC.out.readdistribution_txt,          remainder: true)
+        .join(BAM_RSEQC.out.readduplication_pos_xls,       remainder: true)
+        .join(BAM_RSEQC.out.tin_txt,                       remainder: true)
+        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> e instanceof List ? e : [e] }] }
+
     emit:
     // Aggregated
     multiqc_files = ch_multiqc_files // channel: [ val(meta), path(files) ]
@@ -148,5 +164,6 @@ workflow BAM_QC_RNASEQ {
     readduplication_pdf             = BAM_RSEQC.out.readduplication_pdf             // channel: [ val(meta), path(pdf) ]
     readduplication_rscript         = BAM_RSEQC.out.readduplication_rscript         // channel: [ val(meta), path(r) ]
     tin_txt                         = BAM_RSEQC.out.tin_txt                         // channel: [ val(meta), path(txt) ]
+    per_sample_mqc_bundle           = ch_per_sample_mqc_bundle                      // channel: [ val(meta), list(files) ]
 
 }

--- a/subworkflows/nf-core/bam_qc_rnaseq/main.nf
+++ b/subworkflows/nf-core/bam_qc_rnaseq/main.nf
@@ -110,7 +110,7 @@ workflow BAM_QC_RNASEQ {
         .join(BAM_RSEQC.out.readdistribution_txt,          remainder: true)
         .join(BAM_RSEQC.out.readduplication_pos_xls,       remainder: true)
         .join(BAM_RSEQC.out.tin_txt,                       remainder: true)
-        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> e instanceof List ? e : [e] }] }
+        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> (e instanceof List) ? e : [e] }] }
 
     emit:
     // Aggregated

--- a/subworkflows/nf-core/bam_qc_rnaseq/meta.yml
+++ b/subworkflows/nf-core/bam_qc_rnaseq/meta.yml
@@ -118,6 +118,14 @@ output:
       type: file
       description: RSeQC TIN results summary
       pattern: "*.txt"
+  - per_sample_mqc_bundle:
+      type: tuple
+      description: |
+        Per-sample MultiQC-feeding outputs (Preseq, biotype TSV, Qualimap,
+        dupRadar, and RSeQC bamstat/inferexperiment/innerdistance_freq/
+        junctionannotation_log/junctionsaturation_rscript/readdistribution/
+        readduplication_pos/tin) joined on meta.
+        Structure: [ val(meta), list(files) ]
 authors:
   - "@pinin4fjords"
 maintainers:

--- a/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test
@@ -66,6 +66,9 @@ nextflow_workflow {
                 { assert workflow.out.inferexperiment_txt.size() == 1 },
                 { assert workflow.out.readdistribution_txt.size() == 1 },
                 { assert workflow.out.multiqc_files.size() > 0 },
+                { assert workflow.out.per_sample_mqc_bundle.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle[0][0] == [ id:'test', single_end:false, strandedness:'reverse' ] },
+                { assert workflow.out.per_sample_mqc_bundle[0][1].size() >= 12 },
                 { assert snapshot(
                     workflow.out.dupradar_dupmatrix,
                     workflow.out.dupradar_intercept_slope,
@@ -128,6 +131,10 @@ nextflow_workflow {
                 { assert workflow.out.inferexperiment_txt.size() == 1 },
                 { assert workflow.out.readdistribution_txt.size() == 1 },
                 { assert workflow.out.multiqc_files.size() > 0 },
+                { assert workflow.out.per_sample_mqc_bundle.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle[0][0] == [ id:'test', single_end:true, strandedness:'reverse' ] },
+                // single-end drops rseqc_inner_distance
+                { assert workflow.out.per_sample_mqc_bundle[0][1].size() >= 11 },
                 { assert snapshot(
                     workflow.out.dupradar_dupmatrix,
                     workflow.out.dupradar_intercept_slope,
@@ -180,7 +187,8 @@ nextflow_workflow {
                 { assert workflow.out.qualimap_results.size() == 0 },
                 { assert workflow.out.dupradar_multiqc.size() == 0 },
                 { assert workflow.out.bamstat_txt.size() == 0 },
-                { assert workflow.out.multiqc_files.size() == 0 }
+                { assert workflow.out.multiqc_files.size() == 0 },
+                { assert workflow.out.per_sample_mqc_bundle.size() == 0 }
             )
         }
     }
@@ -225,7 +233,7 @@ nextflow_workflow {
                 { def getNames = { ch -> ch.collect { it[1] instanceof List ? it[1].collect { file(it).name } : file(it[1]).name }.flatten().sort() }
                   def channels = ['preseq_lc_extrap', 'qualimap_results', 'dupradar_multiqc',
                       'featurecounts_counts', 'biotype_tsv', 'bamstat_txt', 'inferexperiment_txt',
-                      'readdistribution_txt', 'tin_txt', 'multiqc_files']
+                      'readdistribution_txt', 'tin_txt', 'multiqc_files', 'per_sample_mqc_bundle']
                   assert snapshot(
                     channels.collectEntries { [it, getNames(workflow.out[it])] }.sort()
                 ).match() }

--- a/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_qc_rnaseq/tests/main.nf.test.snap
@@ -33,6 +33,21 @@
                     "test_dup_intercept_mqc.txt",
                     "test_duprateExpDensCurve_mqc.txt"
                 ],
+                "per_sample_mqc_bundle": [
+                    "test",
+                    "test.bam_stat.txt",
+                    "test.biotype_counts_mqc.tsv",
+                    "test.infer_experiment.txt",
+                    "test.inner_distance_freq.txt",
+                    "test.junctionSaturation_plot.r",
+                    "test.junction_annotation.log",
+                    "test.lc_extrap.txt",
+                    "test.pos.DupRate.xls",
+                    "test.read_distribution.txt",
+                    "test.summary.txt",
+                    "test_dup_intercept_mqc.txt",
+                    "test_duprateExpDensCurve_mqc.txt"
+                ],
                 "preseq_lc_extrap": [
                     "test.lc_extrap.txt"
                 ],

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -423,7 +423,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         .join(ch_seqkit_stats,         remainder: true)
         .join(ch_bowtie2_log,          remainder: true)
         .join(ch_fastqc_filtered_zip,  remainder: true)
-        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> e instanceof List ? e : [e] }] }
+        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> (e instanceof List) ? e : [e] }] }
 
     emit:
     reads            = ch_strand_inferred_fastq

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -410,6 +410,21 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         .mix(ch_strand_fastq.known_strand)
         .set { ch_strand_inferred_fastq }
 
+    // `remainder: true` needed because every contributor is gated behind
+    // a `skip_*` / `filter_*` option.
+    ch_per_sample_mqc_bundle = ch_fastqc_raw_zip
+        .join(ch_fastqc_trim_zip,      remainder: true)
+        .join(ch_trim_log,             remainder: true)
+        .join(ch_trim_json,            remainder: true)
+        .join(ch_umi_log,              remainder: true)
+        .join(ch_bbsplit_stats,        remainder: true)
+        .join(ch_sortmerna_log,        remainder: true)
+        .join(ch_ribodetector_log,     remainder: true)
+        .join(ch_seqkit_stats,         remainder: true)
+        .join(ch_bowtie2_log,          remainder: true)
+        .join(ch_fastqc_filtered_zip,  remainder: true)
+        .map { row -> [row[0], row.drop(1).findAll { it != null }.collectMany { e -> e instanceof List ? e : [e] }] }
+
     emit:
     reads            = ch_strand_inferred_fastq
     trim_read_count  = ch_trim_read_count
@@ -441,4 +456,5 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     fastqc_filtered_zip  = ch_fastqc_filtered_zip
     seqkit_prefixed  = ch_seqkit_prefixed
     seqkit_converted = ch_seqkit_converted
+    per_sample_mqc_bundle = ch_per_sample_mqc_bundle // channel: [ val(meta), list(files) ]
 }

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
@@ -223,6 +223,18 @@ output:
             type: file
             description: FastQC report ZIP file
             pattern: "*.zip"
+  - per_sample_mqc_bundle:
+      description: |
+        Per-sample MultiQC-feeding outputs (FastQC raw/trim/filtered zips,
+        trim log/JSON, UMI log, BBSplit stats, SortMeRNA log, RiboDetector
+        log, SeqKit stats, Bowtie2 log) joined on meta.
+      structure:
+        - meta:
+            type: map
+            description: Groovy Map containing sample information
+        - files:
+            type: file
+            description: List of MultiQC-relevant files for the sample
 
 authors:
   - "@pinin4fjords"

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
@@ -306,6 +306,8 @@ nextflow_workflow {
                 { assert pelines2.size() == 16636 },
                 { assert workflow.out.trim_read_count[0][1] == 4169.0 },
                 { assert sortmernaRrnaCount == 20 },  // 10 pairs = 20 individual reads (100% detection)
+                { assert workflow.out.per_sample_mqc_bundle.size() == 1 },
+                { assert workflow.out.per_sample_mqc_bundle[0][1].size() > 0 },
                 { assert snapshot(
                     pelines1.join('\n').md5(),
                     pelines2.join('\n').md5(),


### PR DESCRIPTION
## Summary

Adds a \`per_sample_mqc_bundle\` emit to four RNA-seq subworkflows so consumer pipelines that drive per-sample MultiQC can collapse each call site from an N-way \`.join(..., remainder: true)\` chain to a single consume. Motivation: nf-core/rnaseq PR [#1803](https://github.com/nf-core/rnaseq/pull/1803), where per-sample MultiQC under \`--skip_quantification_merge\` currently rebuilds a chained join at every contributor site inside \`workflows/rnaseq/main.nf\`.

Each subworkflow now emits a single \`[val(meta), list(files)]\` channel, assembled internally by joining every MultiQC-feeding output on \`meta\` with \`remainder: true\` at each step (progressive closure preserved). A small closure strips null holes and flattens list-shaped entries.

### Subworkflows touched

- \`fastq_qc_trim_filter_setstrandedness\` — 11 MQC contributors (fastqc raw/trim/filtered zips, trim log/json, umi log, bbsplit, sortmerna, ribodetector, seqkit, bowtie2)
- \`bam_qc_rnaseq\` — 12 contributors (preseq, biotype tsv, qualimap, dupradar, plus 8 RSeQC outputs)
- \`bam_markduplicates_picard\` — 4 contributors (stats, flagstat, idxstats, metrics)
- \`bam_dedup_umi\` — 4 contributors (genomic dedup log + genome stats/flagstat/idxstats). Transcriptome stats are excluded because MultiQC can't disambiguate them from genome stats without extra processing.

### Incidental change in \`bam_dedup_umi\`

Adds \`genome_stats\` / \`genome_flagstat\` / \`genome_idxstats\` as new discrete emits (the genome-side split from the existing combined \`stats\` / \`flagstat\` / \`idxstats\`). Needed so the bundle can include them cleanly; also useful on its own for consumers that only care about genome-side stats.

### Backward compatibility

All existing discrete emits are unchanged — this PR is purely additive. Pipelines that don't drive per-sample MultiQC can ignore the new channel.

## Test plan

- [x] \`bam_markduplicates_picard\`: 4/4 local tests pass. Stub snapshots regenerated to include the new emit key; existing keys unchanged.
- [x] \`bam_dedup_umi\`: 2/2 local tests pass. No snapshot changes.
- [x] \`bam_qc_rnaseq\`: 3/4 local tests pass. Stub snapshot patched to add the new key. The one non-stub failure is a pre-existing dupRadar md5 flake on my machine — verified by rerunning the same test against baseline (without my changes) and observing the same md5 mismatch.
- [x] \`fastq_qc_trim_filter_setstrandedness\`: 4/6 local tests pass. The two failures are SORTMERNA_INDEX SIGSEGV inside its container — a platform issue on Apple Silicon Docker emulation, unrelated to this change (confirmed: the bundle emit only appears after every process completes, and the failures happen in the rRNA-index step before any bundle logic runs).
- [ ] End-to-end rnaseq run under \`--skip_quantification_merge\` on a Linux host — in progress, will report back.

Relies on CI (Linux) for the two local-only platform flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)