### PR TITLE
Make raw_unitigs output optional in hifiasm

### DIFF
--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -9,9 +9,9 @@ process HIFIASM {
 
     input:
     tuple val(meta) , path(long_reads)        , path(ul_reads)
-    tuple val(meta1), path(paternal_kmer_dump), path(maternal_kmer_dump)
-    tuple val(meta2), path(hic_read1)         , path(hic_read2)
-    tuple val(meta3), path(bin_files)
+    tuple val(meta2), path(paternal_kmer_dump), path(maternal_kmer_dump)
+    tuple val(meta3), path(hic_read1)         , path(hic_read2)
+    tuple val(meta4), path(bin_files)
 
     output:
     tuple val(meta), path("*.r_utg.gfa")                             , emit: raw_unitigs      , optional: true

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -14,7 +14,7 @@ process HIFIASM {
     tuple val(meta3), path(bin_files)
 
     output:
-    tuple val(meta), path("*.r_utg.gfa")                             , emit: raw_unitigs
+    tuple val(meta), path("*.r_utg.gfa")                             , emit: raw_unitigs      , optional: true
     tuple val(meta), path("*.bin")                                   , emit: bin_files        , optional: true
     tuple val(meta), path("*.p_utg.gfa")                             , emit: processed_unitigs, optional: true
     tuple val(meta), path("${prefix}.{p_ctg,bp.p_ctg,hic.p_ctg}.gfa"), emit: primary_contigs  , optional: true

--- a/modules/nf-core/hifiasm/meta.yml
+++ b/modules/nf-core/hifiasm/meta.yml
@@ -32,7 +32,7 @@ input:
         type: file
         description: ONT long reads to use with --ul.
         ontologies: []
-  - - meta1:
+  - - meta2:
         type: map
         description: |
           Groovy Map containing information about parental kmers.
@@ -46,7 +46,7 @@ input:
         description: Yak kmer dump file for maternal reads (can be used for
           haplotype resolution). It can have an arbitrary extension.
         ontologies: []
-  - - meta2:
+  - - meta3:
         type: map
         description: |
           Groovy Map containing information about Hi-C reads
@@ -58,7 +58,7 @@ input:
         type: file
         description: Hi-C data Reverse reads.
         ontologies: []
-  - - meta3:
+  - - meta4:
         type: map
         description: |
           Groovy Map containing information about the input bin files

--- a/modules/nf-core/hifiasm/tests/main.nf.test
+++ b/modules/nf-core/hifiasm/tests/main.nf.test
@@ -12,7 +12,7 @@ nextflow_process {
     test("homo_sapiens pacbio hifi [fastq, [,], [,], [,]]") {
         when {
             params {
-                extra_output = "--write-ec --write-paf"
+                module_args = "-f0 --write-ec --write-paf"
             }
 
             process {
@@ -98,7 +98,8 @@ nextflow_process {
 
         when {
             params {
-                extra_output = ""
+                setup_args = '-f0 --bin-only'
+                module_args = '-f0'
             }
 
             process {
@@ -143,7 +144,7 @@ nextflow_process {
 
         when {
             params {
-                extra_output = ""
+                module_args = "-f0"
             }
 
             process {
@@ -200,7 +201,7 @@ nextflow_process {
     test("homo_sapiens pacbio hifi [fastq, [yak, yak], [,], [,] ]") {
         when {
             params {
-                extra_output = ""
+                module_args = "-f0"
             }
 
             process {
@@ -258,7 +259,7 @@ nextflow_process {
     test("homo_sapiens pacbio hifi [fastq, [,], [fastq, fastq], [,] ]") {
         when {
             params {
-                extra_output = ""
+                module_args = "-f0"
             }
 
             process {
@@ -318,7 +319,7 @@ nextflow_process {
     test("homo_sapiens pacbio hifi [fastq, [yak, yak], [fastq, fastq], [,] ]") {
         when {
             params {
-                extra_output = ""
+                module_args = "-f0"
             }
             process {
                 """
@@ -354,7 +355,7 @@ nextflow_process {
     test("homo_sapiens pacbio hifi [fastq, [yak, ], [,], [,] ]") {
         when {
             params {
-                extra_output = ""
+                module_args = "-f0"
             }
 
             process {
@@ -387,7 +388,7 @@ nextflow_process {
     test("homo_sapiens pacbio hifi [fastq, [,], [, fastq], [,] ]") {
         when {
             params {
-                extra_output = ""
+                module_args = "-f0"
             }
 
             process {
@@ -421,7 +422,7 @@ nextflow_process {
         options "-stub"
         when {
             params {
-                extra_output = ""
+                module_args = "-f0"
             }
 
             process {

--- a/modules/nf-core/hifiasm/tests/nextflow.config
+++ b/modules/nf-core/hifiasm/tests/nextflow.config
@@ -1,3 +1,8 @@
 process {
-    ext.args = "-f0 ${params.extra_output}"
+    withName: "HIFIASM" {
+        ext.args = params.module_args
+    }
+    withName: "HIFIASM_INITIAL" {
+        ext.args = { params.setup_args ?: '' }
+    }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## Description

Hifiasm can now create bins with `--bin-only` but it still expects `raw_unitigs` as a mandatory outputs. This PR changes the `raw_unitigs` output to optional, so that we can use the `--bin-only` parameter with the hifiasm nf-core module.


## PR checklist


- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
