### PR TITLE
Fix `ABUNDANCE_DIFFERENTIAL_FILTER` join operation

### DIFF
--- a/subworkflows/nf-core/abundance_differential_filter/main.nf
+++ b/subworkflows/nf-core/abundance_differential_filter/main.nf
@@ -75,7 +75,13 @@ workflow ABUNDANCE_DIFFERENTIAL_FILTER {
     // not returning the full normalized matrix as NORM modules would do.
     norm_inputs = ch_input
         .combine(ch_samplesheet_with_control, by:0)
-        .join(ch_contrasts.transpose().unique { meta, _features -> [meta] }) // by using join instead of combine, it only returns the inner join with the first contrast
+        .join(ch_contrasts
+            .transpose()
+            .groupTuple()           // Group all contrasts by key
+            .map { key, items -> 
+                [key, items[0]]     // Take only the first contrast for each key
+            }
+        )
         .multiMap(criteria)
 
     // ----------------------------------------------------

--- a/subworkflows/nf-core/abundance_differential_filter/main.nf
+++ b/subworkflows/nf-core/abundance_differential_filter/main.nf
@@ -75,7 +75,7 @@ workflow ABUNDANCE_DIFFERENTIAL_FILTER {
     // not returning the full normalized matrix as NORM modules would do.
     norm_inputs = ch_input
         .combine(ch_samplesheet_with_control, by:0)
-        .join(ch_contrasts.transpose()) // by using join instead of combine, it only returns the inner join with the first contrast
+        .join(ch_contrasts.transpose().first()) // by using join instead of combine, it only returns the inner join with the first contrast
         .multiMap(criteria)
 
     // ----------------------------------------------------

--- a/subworkflows/nf-core/abundance_differential_filter/main.nf
+++ b/subworkflows/nf-core/abundance_differential_filter/main.nf
@@ -73,15 +73,13 @@ workflow ABUNDANCE_DIFFERENTIAL_FILTER {
     // simply use the first output from DIFFERENTIAL modules is that depending
     // on the contrast setting etc, these modules may subset matrices, hence
     // not returning the full normalized matrix as NORM modules would do.
+    ch_first_contrast = ch_contrasts
+        .map { meta, contrasts, variables, references, targets, formulas, comparisons ->
+            tuple(meta, contrasts[0], variables[0], references[0], targets[0], formulas[0], comparisons[0])
+        }
     norm_inputs = ch_input
         .combine(ch_samplesheet_with_control, by:0)
-        .join(ch_contrasts
-            .transpose()
-            .groupTuple()           // Group all contrasts by key
-            .map { key, items -> 
-                [key, items[0]]     // Take only the first contrast for each key
-            }
-        )
+        .combine(ch_first_contrast, by:0)
         .multiMap(criteria)
 
     // ----------------------------------------------------

--- a/subworkflows/nf-core/abundance_differential_filter/main.nf
+++ b/subworkflows/nf-core/abundance_differential_filter/main.nf
@@ -75,7 +75,7 @@ workflow ABUNDANCE_DIFFERENTIAL_FILTER {
     // not returning the full normalized matrix as NORM modules would do.
     norm_inputs = ch_input
         .combine(ch_samplesheet_with_control, by:0)
-        .join(ch_contrasts.transpose().first()) // by using join instead of combine, it only returns the inner join with the first contrast
+        .join(ch_contrasts.transpose().unique { meta, _features -> [meta] }) // by using join instead of combine, it only returns the inner join with the first contrast
         .multiMap(criteria)
 
     // ----------------------------------------------------

--- a/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test
+++ b/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test
@@ -540,9 +540,9 @@ nextflow_workflow {
                 ch_control_features = Channel.value([ [], [] ])
                 ch_contrasts = Channel.fromPath(file(testData.expression_test_data_dir + testData.contrasts_file))
                     .splitCsv ( header:true, sep:',' )
-                    .map{
-                        tuple([ id:'test' ], it, it.variable, it.reference, it.target, it.formula, it.comparison)
-                    }
+                    .map{[
+                        [ id:'test' ], it, it.variable, it.reference, it.target, it.formula, it.comparison
+                    ]}
                     .groupTuple()
                 ch_input = Channel.of(
                     [

--- a/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test.snap
@@ -56,11 +56,11 @@
                 "versions.yml:md5,1ddaab440e2528c688c05a02dd066f12"
             ]
         ],
+        "timestamp": "2026-03-24T15:43:26.461974792",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-24T15:43:26.461974792"
+        }
     },
     "deseq2 and limma - mouse - basic": {
         "content": [
@@ -107,7 +107,7 @@
                         "blocking": "sample_number",
                         "differential_method": "limma"
                     },
-                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.results.tsv:md5,abb9add5a95f032cd8ad2aa2af26cb88"
+                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.results.tsv:md5,9b1e9ff42dac05db2dfd9005a14b2e87"
                 ]
             ],
             [
@@ -234,7 +234,7 @@
                         "blocking": "sample_number",
                         "differential_method": "limma"
                     },
-                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.model.txt:md5,3b96713b4e3f027b0347859f02a9038d"
+                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.model.txt:md5,cb9d919594a83c8d15e3693bd599a0bb"
                 ]
             ],
             [
@@ -269,11 +269,11 @@
                 "versions.yml:md5,b80e2c320ea0429466a7b7c3c3ac78fa"
             ]
         ],
+        "timestamp": "2026-04-20T22:53:31.132826222",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-24T15:47:16.379223242"
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.2"
+        }
     },
     "limma - voom": {
         "content": [
@@ -336,7 +336,7 @@
                         "blocking": "sample_number",
                         "differential_method": "limma"
                     },
-                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.model.txt:md5,3b96713b4e3f027b0347859f02a9038d"
+                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.model.txt:md5,cb9d919594a83c8d15e3693bd599a0bb"
                 ]
             ],
             [
@@ -357,11 +357,11 @@
                 "versions.yml:md5,b80e2c320ea0429466a7b7c3c3ac78fa"
             ]
         ],
+        "timestamp": "2026-04-20T22:52:09.661989618",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-24T15:45:01.909392414"
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.2"
+        }
     },
     "dream": {
         "content": [
@@ -394,11 +394,11 @@
                 "versions.yml:md5,736da31f06f854355d45aeb9d9c874e0"
             ]
         ],
+        "timestamp": "2026-03-23T16:09:15.466767644",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-23T16:09:15.466767644"
+        }
     },
     "deseq2 + limma-voom + propd - mouse - basic": {
         "content": [
@@ -456,7 +456,7 @@
                         "blocking": "sample_number",
                         "differential_method": "limma"
                     },
-                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.results.tsv:md5,abb9add5a95f032cd8ad2aa2af26cb88"
+                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.results.tsv:md5,9b1e9ff42dac05db2dfd9005a14b2e87"
                 ],
                 [
                     {
@@ -644,7 +644,7 @@
                         "blocking": "sample_number",
                         "differential_method": "limma"
                     },
-                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.model.txt:md5,3b96713b4e3f027b0347859f02a9038d"
+                    "treatment_mCherry_hND6_sample_number_test_limma_voom.limma.model.txt:md5,cb9d919594a83c8d15e3693bd599a0bb"
                 ]
             ],
             [
@@ -680,11 +680,11 @@
                 "versions.yml:md5,ff5b7c1d83470f6f548f3643bb37a830"
             ]
         ],
+        "timestamp": "2026-04-20T22:54:03.048717509",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-24T15:48:06.008809772"
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.2"
+        }
     },
     "stub": {
         "content": [
@@ -1097,11 +1097,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-03-24T15:49:19.347075595",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-24T15:49:19.347075595"
+        }
     },
     "dream - voom": {
         "content": [
@@ -1143,11 +1143,11 @@
                 "versions.yml:md5,736da31f06f854355d45aeb9d9c874e0"
             ]
         ],
+        "timestamp": "2026-01-16T17:04:34.296086424",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        },
-        "timestamp": "2026-01-16T17:04:34.296086424"
+        }
     },
     "deseq2 - mouse - basic": {
         "content": [
@@ -1269,11 +1269,11 @@
                 "versions.yml:md5,2c0576aefff8da32c7c0cfd8529aa4b5"
             ]
         ],
+        "timestamp": "2026-03-24T15:32:07.906913925",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-24T15:32:07.906913925"
+        }
     },
     "dream - complex contrast - literal contrast string comparison": {
         "content": [
@@ -1306,11 +1306,11 @@
                 "versions.yml:md5,736da31f06f854355d45aeb9d9c874e0"
             ]
         ],
+        "timestamp": "2025-12-23T19:05:11.641088832",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-23T19:05:11.641088832"
+        }
     },
     "deseq2 - with transcript lengths": {
         "content": [
@@ -1432,11 +1432,11 @@
                 "versions.yml:md5,2c0576aefff8da32c7c0cfd8529aa4b5"
             ]
         ],
+        "timestamp": "2026-03-24T15:46:27.915203315",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-24T15:46:27.915203315"
+        }
     },
     "propd - mouse - basic": {
         "content": [
@@ -1521,10 +1521,10 @@
                 "versions.yml:md5,ff5b7c1d83470f6f548f3643bb37a830"
             ]
         ],
+        "timestamp": "2025-12-04T21:35:43.634876525",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-04T21:35:43.634876525"
+        }
     }
 }

--- a/subworkflows/nf-core/differential_functional_enrichment/tests/main.nf.test
+++ b/subworkflows/nf-core/differential_functional_enrichment/tests/main.nf.test
@@ -40,7 +40,10 @@ nextflow_workflow {
 
                 input[0] = ch_input
                 input[1] = channel.of([[], [], [], [], [], []])
-                input[2] = channel.of([[], []])
+                input[2] = channel.of([
+                    ['id':'Condition_genotype_WT_KO', 'variable':'Condition genotype', 'reference':'WT', 'target':'KO', 'blocking':'batch'],
+                    []
+                ])
                 input[3] = channel.of([
                     ['id':'Condition_genotype_WT_KO', 'variable':'Condition genotype', 'reference':'WT', 'target':'KO', 'blocking':'batch'],
                     [],  //
@@ -126,9 +129,14 @@ nextflow_workflow {
                         [meta, [], '', '']
                     }
 
+                ch_samplesheet = ch_input
+                    .map { meta, file, genesets, background, method ->
+                        [meta, []]
+                    }
+
                 input[0] = ch_input
                 input[1] = channel.of([[], [], [], [], [], []])
-                input[2] = channel.of([[], []])
+                input[2] = ch_samplesheet
                 input[3] = ch_featuresheet
                 """
             }
@@ -319,9 +327,13 @@ nextflow_workflow {
                     .map { meta, file, genesets, background, method ->
                         [meta, [], '', '']
                     }
+                ch_samplesheet = ch_input
+                    .map { meta, file, genesets, background, method ->
+                        [meta, []]
+                    }
                 input[0] = ch_input
                 input[1] = channel.of([[], [], [], [], [], []])
-                input[2] = channel.of([[], []])
+                input[2] = ch_samplesheet
                 input[3] = ch_featuresheet
                 """
             }
@@ -501,7 +513,16 @@ nextflow_workflow {
                 ])
 
                 ch_contrasts = channel.of([[], [], [], [], [], []])
-                ch_samplesheet = channel.of([[], []])
+                ch_samplesheet = channel.of([
+                    [
+                        'id':'treatment_mCherry_hND6',
+                        'method_differential':'deseq2',
+                        'params': [
+                            'differential_method': 'deseq2'
+                        ]
+                    ],
+                    []
+                ])
                 ch_featuresheet = channel.of([
                     [
                         'id':'treatment_mCherry_hND6',
@@ -563,7 +584,10 @@ nextflow_workflow {
 
                 input[0] = ch_input
                 input[1] = channel.of([[], [], [], [], [], []])
-                input[2] = channel.of([[], []])
+                input[2] = channel.of([
+                    ['id':'Condition_genotype_WT_KO', 'variable':'Condition genotype', 'reference':'WT', 'target':'KO', 'blocking':'batch'],
+                    []
+                ])
                 input[3] = channel.of([
                     ['id':'Condition_genotype_WT_KO', 'variable':'Condition genotype', 'reference':'WT', 'target':'KO', 'blocking':'batch'],
                     [],


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This subworkflow was failing due to duplicate result in the join operation (but only in 25.10.4 and not 26.03.2-edge)
The file(testData.expression_test_data_dir + testData.contrasts_file) produce a channel with many "duplicate" and the join operation doesn't work properly.

As it only need one of the ch_contrasts:
- ~~use first() operator to fix it~~
- ~~use unique to select only first instance~~
- ~~use groupTuple() to unsure uniqueness~~

For the following test:

| test | `.transpose.first()` | `.transpose()` | `ch_first_contrast` |
| ------ | ------------------------- | -------------------- | ------------------------- |
| dream | ✅ | ✅ | ✅ |
| dream - voom | ✅ | ✅ | ✅ |
| dream - complex contrast - literal contrast string comparison | ✅ | ✅ | ✅ |
| deseq2 - mouse - basic | ✅ | ❌ | ✅ |
| limma - basic - microarray | ✅ | ✅ | ✅ |
| limma - voom | MD5 | ❌ | MD5 |
| deseq2 - with transcript lengths | ✅ | ❌ | ✅ |
| propd - mouse - basic | ✅ | ❌ | ✅ |
| deseq2 and limma - mouse - basic | ❌ | ❌ | MD5 |
| deseq2 + limma-voom + propd - mouse - basic | ❌ | ❌ | MD5 |
| stub | ✅  | ❌ | ✅ |

The current implementation with ch_first_contrast does work for all the test but modify the limma results in multi tools test MD5 sum.
I reran the test as it was before by setting `export NXF_SYNTAX_PARSER=v2`, to make it work without the warnings, and these MD5 sum were also modified.

To Do:

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
