### PR TITLE
fix(custom/sratoolsncbisettings): fix config string escaping

### DIFF
--- a/modules/nf-core/custom/sratoolsncbisettings/main.nf
+++ b/modules/nf-core/custom/sratoolsncbisettings/main.nf
@@ -18,7 +18,7 @@ process CUSTOM_SRATOOLSNCBISETTINGS {
     task.ext.when == null || task.ext.when
 
     script:
-    config = "/LIBS/GUID = \"${UUID.randomUUID().toString()}\"\\n/libs/cloud/report_instance_identity = \"true\"\\n"
+    config = "/LIBS/GUID = \\\"${UUID.randomUUID().toString()}\\\"\\n/libs/cloud/report_instance_identity = \\\"true\\\"\\n"
 
     """
     echo ${config}


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`

## Description
Fix config string escaping in `custom/sratoolsncbisettings`.

The old code used `\"` which caused quotes to be lost in the final `.mkfg` 
file, resulting in a syntax error and `fasterq-dump` exit code 78.

### Root cause: escaping layers

**Old code (`\"`):**
1. Groovy: `\"` → `"` (literal quote)
2. Bash script: `printf "/LIBS/GUID = "abc-123"\n"` 
3. Bash: `"abc-123"` treated as separate unquoted argument
4. Output: `/LIBS/GUID = abc-123` ← quotes lost
5. fasterq-dump: syntax error → exit 78 ❌

**New code (`\\\"`):**
1. Groovy: `\\` → `\` and `\"` → `"` → combined: `\"`
2. Bash script: `printf "/LIBS/GUID = \"abc-123\"\n"`
3. Bash: `\"` = escaped quote, preserved
4. Output: `/LIBS/GUID = "abc-123"` ← quotes preserved
5. fasterq-dump: valid config → works ✓