### PR TITLE
RFC: document GPU container variants in meta.yml (ribodetector)

### DIFF
--- a/modules/nf-core/ribodetector/environment.gpu.yml
+++ b/modules/nf-core/ribodetector/environment.gpu.yml
@@ -5,4 +5,5 @@ channels:
   - bioconda
 dependencies:
   - "bioconda::ribodetector=0.3.3"
-  - "conda-forge::pytorch-gpu=1.11.0"
+  - "conda-forge::pytorch-gpu=2.10.0"
+  - "conda-forge::cuda-version>=12,<13"

--- a/modules/nf-core/ribodetector/main.nf
+++ b/modules/nf-core/ribodetector/main.nf
@@ -4,8 +4,8 @@ process RIBODETECTOR {
 
 	conda "${ task.accelerator ? "${moduleDir}/environment.gpu.yml" : "${moduleDir}/environment.yml" }"
 	container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        (task.accelerator ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/eb/ebcccef2cd8b4c10d4bbd8fce542b46502b7817115cb144b9566792b0aac9bc0/data' : 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/463b8ad941e7f1f2decef20844d666c1c8ac233e166d2bc766164c4a93905a3c/data') :
-        (task.accelerator ? 'community.wave.seqera.io/library/ribodetector_pytorch-gpu:f2d45093d4093307' : 'community.wave.seqera.io/library/ribodetector:0.3.3--ad3d7071e408b502') }"
+        (task.accelerator ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b7/b71fb81b909f9d1e1090e3d1d8f10b9da95405bed1d0f01a6be71f0ef0b51170/data' : 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/463b8ad941e7f1f2decef20844d666c1c8ac233e166d2bc766164c4a93905a3c/data') :
+        (task.accelerator ? 'community.wave.seqera.io/library/ribodetector_pytorch-gpu_cuda-version:811a681473448f10' : 'community.wave.seqera.io/library/ribodetector:0.3.3--ad3d7071e408b502') }"
 
 	input:
 	tuple val(meta), path(fastq)

--- a/modules/nf-core/ribodetector/meta.yml
+++ b/modules/nf-core/ribodetector/meta.yml
@@ -93,3 +93,38 @@ authors:
   - "@maxibor"
 maintainers:
   - "@maxibor"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/ribodetector:0.3.3--ad3d7071e408b502
+      build_id: bd-ad3d7071e408b502_1
+      scan_id: sc-408506540aa13673_3
+    linux/arm64:
+      name: community.wave.seqera.io/library/ribodetector:0.3.3--6a7080e95297ee85
+      build_id: bd-6a7080e95297ee85_1
+      scan_id: sc-616160e1b9188bd4_2
+    linux/amd64+cuda12:
+      name: community.wave.seqera.io/library/ribodetector_pytorch-gpu_cuda-version:811a681473448f10
+      build_id: bd-811a681473448f10_1
+      scan_id: sc-bd9352efb9c141d2_1
+    linux/amd64+cuda11:
+      name: community.wave.seqera.io/library/ribodetector_pytorch-gpu_cuda-version:b13a02b25508139f
+      build_id: bd-b13a02b25508139f_1
+      scan_id: sc-60e9801765c6a0f0_1
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/ribodetector:0.3.3--5932c2e0c31912db
+      build_id: bd-5932c2e0c31912db_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/463b8ad941e7f1f2decef20844d666c1c8ac233e166d2bc766164c4a93905a3c/data
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/ribodetector:0.3.3--9376f5e1554cc026
+      build_id: bd-9376f5e1554cc026_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8ad4d85aa47f5b2562e9ecfa7e464e7d1e054eb321043d8e8a33c3a9159ae811/data
+    linux/amd64+cuda12:
+      name: oras://community.wave.seqera.io/library/ribodetector_pytorch-gpu_cuda-version:cced3ad1f9589501
+      build_id: bd-cced3ad1f9589501_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b7/b71fb81b909f9d1e1090e3d1d8f10b9da95405bed1d0f01a6be71f0ef0b51170/data
+    linux/amd64+cuda11:
+      name: oras://community.wave.seqera.io/library/ribodetector_pytorch-gpu_cuda-version:98b9ed04a509e20d
+      build_id: bd-98b9ed04a509e20d_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/56/562a5060502d049a50cf863a323c216dd3ca81f1817dfff73970169c704800d4/data


### PR DESCRIPTION
## RFC: GPU container variants in `meta.yml`

Opened as a draft/RFC. Depends on #11258 (the non-controversial container bump) landing first, since the new URIs referenced here match that PR's build.

GPU containers are tied to a CUDA major version (full forward compat within each, so only a couple of variants matter in practice). This PR proposes extending the existing \`containers\` block (see fastqc, multiqc) with CUDA-versioned platform keys so that pipeline developers have pre-built URIs documented when they need to offer users a choice:

```yaml
containers:
  docker:
    linux/amd64: ...
    linux/arm64: ...
    linux/amd64+cuda12: ...    # default GPU container
    linux/amd64+cuda11: ...    # alternative for older drivers
  singularity:
    linux/amd64: ...
    linux/arm64: ...
    linux/amd64+cuda12: ...
    linux/amd64+cuda11: ...
```

The `+cuda12`/`+cuda11` suffix convention is new. Open to feedback on the naming and on whether this belongs in `meta.yml` at all versus a separate doc mechanism.

## Related

- #11258 - container bump this builds on
- Supersedes the meta.yml portion of #11197