### PR TITLE
Fix container URIs for modules that missed recent bulk PRs

### DIFF
--- a/modules/nf-core/cobrameta/main.nf
+++ b/modules/nf-core/cobrameta/main.nf
@@ -5,7 +5,7 @@ process COBRAMETA {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/cobra-meta:1.2.3--pyhdfd78af_0':
-        'biocontainers/cobra-meta:1.2.3--pyhdfd78af_0' }"
+        'quay.io/biocontainers/cobra-meta:1.2.3--pyhdfd78af_0' }"
 
     input:
     tuple val(meta) , path(fasta)

--- a/modules/nf-core/csvtk/concat/main.nf
+++ b/modules/nf-core/csvtk/concat/main.nf
@@ -5,7 +5,7 @@ process CSVTK_CONCAT {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/csvtk:0.31.0--h9ee0642_0' :
-        'biocontainers/csvtk:0.31.0--h9ee0642_0' }"
+        'quay.io/biocontainers/csvtk:0.31.0--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(csv, name: 'inputs/csv*/*')

--- a/modules/nf-core/diamond/blastx/main.nf
+++ b/modules/nf-core/diamond/blastx/main.nf
@@ -4,7 +4,7 @@ process DIAMOND_BLASTX {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/diamond:2.1.16--h13889ed_0'
+        ? 'https://depot.galaxyproject.org/singularity/diamond:2.1.24--hf93d47f_0'
         : 'quay.io/biocontainers/diamond:2.1.24--hf93d47f_0'}"
 
     input:

--- a/modules/nf-core/diamond/blastx/main.nf
+++ b/modules/nf-core/diamond/blastx/main.nf
@@ -5,7 +5,7 @@ process DIAMOND_BLASTX {
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/diamond:2.1.16--h13889ed_0'
-        : 'biocontainers/diamond:2.1.24--hf93d47f_0'}"
+        : 'quay.io/biocontainers/diamond:2.1.24--hf93d47f_0'}"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/diamond/linclust/main.nf
+++ b/modules/nf-core/diamond/linclust/main.nf
@@ -3,7 +3,7 @@ process DIAMOND_LINCLUST {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/diamond:2.1.24--hf93d47f_0'
         : 'quay.io/biocontainers/diamond:2.1.24--hf93d47f_0'}"
 

--- a/modules/nf-core/diamond/makedb/main.nf
+++ b/modules/nf-core/diamond/makedb/main.nf
@@ -4,7 +4,7 @@ process DIAMOND_MAKEDB {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/diamond:2.1.16--h13889ed_0'
+        ? 'https://depot.galaxyproject.org/singularity/diamond:2.1.24--hf93d47f_0'
         : 'quay.io/biocontainers/diamond:2.1.24--hf93d47f_0'}"
 
     input:

--- a/modules/nf-core/diamond/makedb/main.nf
+++ b/modules/nf-core/diamond/makedb/main.nf
@@ -5,7 +5,7 @@ process DIAMOND_MAKEDB {
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/diamond:2.1.16--h13889ed_0'
-        : 'biocontainers/diamond:2.1.24--hf93d47f_0'}"
+        : 'quay.io/biocontainers/diamond:2.1.24--hf93d47f_0'}"
 
     input:
     tuple val(meta), path(fasta)


### PR DESCRIPTION
Updates a handful of modules that were merged between/around #11251 and #11260 and missed the bulk changes:

- `quay.io/` prefix added: `cobrameta`, `csvtk/concat`, `diamond/blastx`, `diamond/makedb`
- `apptainer` added alongside `singularity`: `diamond/linclust`