### PR TITLE
fix(trimgalore): narrow same-workdir cleanup to PE intermediates only

### DIFF
--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -46,9 +46,8 @@ process TRIMGALORE {
         def args_list = args.split("\\s(?=--)").toList()
         args_list.removeAll { arg -> arg.toLowerCase().contains('_r2 ') }
         """
-        # Remove any trim_galore outputs left behind by a previous attempt that
-        # ran in this same workdir (e.g. AWS Batch retry after a Spot reclaim).
-        rm -f *.fq.gz *.html *.zip *_trimming_report.txt
+        # Drop any trim_galore output left over from an interrupted previous attempt.
+        rm -f ${prefix}_trimmed.fq.gz
         [ ! -f  ${prefix}.fastq.gz ] && ln -s ${reads} ${prefix}.fastq.gz
         trim_galore \\
             ${args_list.join(' ')} \\
@@ -59,9 +58,10 @@ process TRIMGALORE {
     }
     else {
         """
-        # Remove any trim_galore outputs left behind by a previous attempt that
-        # ran in this same workdir (e.g. AWS Batch retry after a Spot reclaim).
-        rm -f *.fq.gz *.html *.zip *_trimming_report.txt
+        # Drop the per-mate intermediates --paired writes before validate_paired_end_files
+        # unlinks them. An attempt interrupted between cutadapt and validation leaves these
+        # behind and the output glob then matches 3 fastqs instead of 2.
+        rm -f ${prefix}_1_trimmed.fq.gz ${prefix}_2_trimmed.fq.gz
         [ ! -f  ${prefix}_1.fastq.gz ] && ln -s ${reads[0]} ${prefix}_1.fastq.gz
         [ ! -f  ${prefix}_2.fastq.gz ] && ln -s ${reads[1]} ${prefix}_2.fastq.gz
         trim_galore \\


### PR DESCRIPTION
## Summary

Follow-up to #11308.

The cleanup added there used \`rm -f *.fq.gz *.html *.zip *_trimming_report.txt\`, which deletes Nextflow-staged input files when those happen to be named with a \`.fq.gz\` extension (e.g. nf-core/rnaseq's prokaryotic test profile uses \`.fq.gz\` test data). The module's \`ln -s\` then creates a symlink pointing at the just-deleted target, and trim_galore fails with \`No such file\`.

Replace with targeted patterns:

- **PE branch**: \`rm -f \${prefix}_1_trimmed.fq.gz \${prefix}_2_trimmed.fq.gz\`, the exact orphan filenames trim_galore writes during the per-mate cutadapt pass and would unlink itself once \`validate_paired_end_files\` succeeds.
- **SE branch**: \`rm -f \${prefix}_trimmed.fq.gz\`, defensively pre-removing the output (overwritten by trim_galore on rerun anyway).

These patterns can't collide with:
- input symlinks (\`\${prefix}.fastq.gz\` / \`\${prefix}_<N>.fastq.gz\` — different extension), or
- raw upstream inputs staged in the workdir (different prefix or different \`_trimmed\` suffix position).

## Why

Caught by nf-core/rnaseq's prokaryotic test profile. CI on [nf-core/rnaseq#1823](https://github.com/nf-core/rnaseq/pull/1823) is green with the same patch applied locally.

## Notes for reviewers

- All 5 module nf-tests still pass locally with docker.
- No glob change, no env.yml change, no test/snapshot change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)