### PR TITLE
Fix stub `touch .gz` producing invalid gzip files across 17 modules

### DIFF
--- a/modules/nf-core/bcftools/split/main.nf
+++ b/modules/nf-core/bcftools/split/main.nf
@@ -30,7 +30,7 @@ process BCFTOOLS_SPLIT {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch "${prefix}.chr1.vcf.gz"
-    touch "${prefix}.chr2.vcf.gz"
+    echo '' | gzip > "${prefix}.chr1.vcf.gz"
+    echo '' | gzip > "${prefix}.chr2.vcf.gz"
     """
 }

--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -83,9 +83,9 @@ process BOWTIE2_ALIGN {
     def extension = (args2 ==~ extension_pattern) ? (args2 =~ extension_pattern)[0][2].toLowerCase() : "bam"
     def create_unmapped = ""
     if (meta.single_end) {
-        create_unmapped = save_unaligned ? "touch ${prefix}.unmapped.fastq.gz" : ""
+        create_unmapped = save_unaligned ? "echo '' | gzip > ${prefix}.unmapped.fastq.gz" : ""
     } else {
-        create_unmapped = save_unaligned ? "touch ${prefix}.unmapped_1.fastq.gz && touch ${prefix}.unmapped_2.fastq.gz" : ""
+        create_unmapped = save_unaligned ? "echo '' | gzip > ${prefix}.unmapped_1.fastq.gz && echo '' | gzip > ${prefix}.unmapped_2.fastq.gz" : ""
     }
     if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
 

--- a/modules/nf-core/clustalo/align/main.nf
+++ b/modules/nf-core/clustalo/align/main.nf
@@ -54,6 +54,10 @@ process CLUSTALO_ALIGN {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.aln${compress ? '.gz' : ''}
+    if [ "${compress}" = "true" ]; then
+        echo '' | gzip > ${prefix}.aln.gz
+    else
+        touch ${prefix}.aln
+    fi
     """
 }

--- a/modules/nf-core/gatk4/haplotypecaller/main.nf
+++ b/modules/nf-core/gatk4/haplotypecaller/main.nf
@@ -61,7 +61,7 @@ process GATK4_HAPLOTYPECALLER {
 
     def stub_realigned_bam = bamout_command ? "touch ${prefix.replaceAll('.g\\s*$', '')}.realigned.bam" : ""
     """
-    touch ${prefix}.vcf.gz
+    echo '' | gzip > ${prefix}.vcf.gz
     touch ${prefix}.vcf.gz.tbi
     ${stub_realigned_bam}
     """

--- a/modules/nf-core/kalign/align/main.nf
+++ b/modules/nf-core/kalign/align/main.nf
@@ -46,6 +46,10 @@ process KALIGN_ALIGN {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.aln${compress ? '.gz' : ''}
+    if [ "${compress}" = "true" ]; then
+        echo '' | gzip > ${prefix}.aln.gz
+    else
+        touch ${prefix}.aln
+    fi
     """
 }

--- a/modules/nf-core/metamdbg/asm/main.nf
+++ b/modules/nf-core/metamdbg/asm/main.nf
@@ -44,6 +44,6 @@ process METAMDBG_ASM {
     """
     echo ${args}
     touch ${prefix}.metaMDBG.log
-    touch ${prefix}.contigs.fasta.gz
+    echo '' | gzip > ${prefix}.contigs.fasta.gz
     """
 }

--- a/modules/nf-core/mtmalign/align/main.nf
+++ b/modules/nf-core/mtmalign/align/main.nf
@@ -52,7 +52,12 @@ process MTMALIGN_ALIGN {
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.aln${compress ? '.gz' : ''}
-    touch ${prefix}.pdb${compress ? '.gz' : ''}
+    if [ "${compress}" = "true" ]; then
+        echo '' | gzip > ${prefix}.aln.gz
+        echo '' | gzip > ${prefix}.pdb.gz
+    else
+        touch ${prefix}.aln
+        touch ${prefix}.pdb
+    fi
     """
 }

--- a/modules/nf-core/muscle5/super5/main.nf
+++ b/modules/nf-core/muscle5/super5/main.nf
@@ -46,6 +46,10 @@ process MUSCLE5_SUPER5 {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.aln${compress ? '.gz' : ''}
+    if [ "${compress}" = "true" ]; then
+        echo '' | gzip > ${prefix}.aln.gz
+    else
+        touch ${prefix}.aln
+    fi
     """
 }

--- a/modules/nf-core/pharokka/installdatabases/main.nf
+++ b/modules/nf-core/pharokka/installdatabases/main.nf
@@ -41,7 +41,7 @@ process PHAROKKA_INSTALLDATABASES {
     touch $prefix/CARD_h
     touch $prefix/CARD_h.dbtype
     touch $prefix/CARD_h.index
-    touch $prefix/VFDB_setB_pro.fas.gz
+    echo '' | gzip > $prefix/VFDB_setB_pro.fas.gz
     touch $prefix/VFDBclusterRes_cluster.tsv
     touch $prefix/VFDBclusterRes_rep_seq.fasta
     touch $prefix/all_phrogs.h3m

--- a/modules/nf-core/popscle/freemuxlet/main.nf
+++ b/modules/nf-core/popscle/freemuxlet/main.nf
@@ -44,13 +44,13 @@ process POPSCLE_FREEMUXLET {
     def VERSION = '0.1' // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
 
     """
-    touch ${prefix}.clust1.samples.gz
-    touch ${prefix}.clust1.vcf.gz
+    echo '' | gzip > ${prefix}.clust1.samples.gz
+    echo '' | gzip > ${prefix}.clust1.vcf.gz
     touch ${prefix}.lmix
 
     if [[ "$args" == *"--aux-files"* ]]; then
-        touch ${prefix}.clust0.samples.gz
-        touch ${prefix}.clust0.vcf.gz
+        echo '' | gzip > ${prefix}.clust0.samples.gz
+        echo '' | gzip > ${prefix}.clust0.vcf.gz
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/rastair/methylkit/main.nf
+++ b/modules/nf-core/rastair/methylkit/main.nf
@@ -31,7 +31,7 @@ process RASTAIR_METHYLKIT {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.methylkit.txt.gz
+    echo '' | gzip > ${prefix}.methylkit.txt.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/ripgrep/main.nf
+++ b/modules/nf-core/ripgrep/main.nf
@@ -42,7 +42,7 @@ process RIPGREP {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def write_output = compress ? "touch ${prefix}.txt.gz" : "touch ${prefix}.txt"
+    def write_output = compress ? "echo '' | gzip > ${prefix}.txt.gz" : "touch ${prefix}.txt"
     """
     $write_output
 

--- a/modules/nf-core/staramr/search/main.nf
+++ b/modules/nf-core/staramr/search/main.nf
@@ -52,8 +52,13 @@ process STARAMR_SEARCH {
     """
     mkdir ${prefix}_results
     touch ${prefix}_results/results.xlsx
-    touch ${prefix}_results/{summary,detailed_summary,resfinder,pointfinder,plasmidfinder,mlst}.tsv.gz
-    touch ${prefix}_results/settings.txt.gz
+    echo '' | gzip > ${prefix}_results/summary.tsv.gz
+    echo '' | gzip > ${prefix}_results/detailed_summary.tsv.gz
+    echo '' | gzip > ${prefix}_results/resfinder.tsv.gz
+    echo '' | gzip > ${prefix}_results/pointfinder.tsv.gz
+    echo '' | gzip > ${prefix}_results/plasmidfinder.tsv.gz
+    echo '' | gzip > ${prefix}_results/mlst.tsv.gz
+    echo '' | gzip > ${prefix}_results/settings.txt.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/tcoffee/align/main.nf
+++ b/modules/nf-core/tcoffee/align/main.nf
@@ -53,6 +53,10 @@ process TCOFFEE_ALIGN {
     export TEMP='./'
     export TMP_4_TCOFFEE="./"
     export HOME="./"
-    touch ${prefix}.aln${compress ? '.gz':''}
+    if [ "${compress}" = "true" ]; then
+        echo '' | gzip > ${prefix}.aln.gz
+    else
+        touch ${prefix}.aln
+    fi
     """
 }

--- a/modules/nf-core/tcoffee/consensus/main.nf
+++ b/modules/nf-core/tcoffee/consensus/main.nf
@@ -42,6 +42,10 @@ process TCOFFEE_CONSENSUS {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     export TEMP='./'
-    touch ${prefix}.aln${compress ? '.gz':''}
+    if [ "${compress}" = "true" ]; then
+        echo '' | gzip > ${prefix}.aln.gz
+    else
+        touch ${prefix}.aln
+    fi
     """
 }

--- a/modules/nf-core/tcoffee/regressive/main.nf
+++ b/modules/nf-core/tcoffee/regressive/main.nf
@@ -50,6 +50,10 @@ process TCOFFEE_REGRESSIVE {
     """
     # Otherwise, tcoffee will crash when calling its version
     export TEMP='./'
-    touch ${prefix}.aln${compress ? '.gz':''}
+    if [ "${compress}" = "true" ]; then
+        echo '' | gzip > ${prefix}.aln.gz
+    else
+        touch ${prefix}.aln
+    fi
     """
 }

--- a/modules/nf-core/vt/decomposeblocksub/main.nf
+++ b/modules/nf-core/vt/decomposeblocksub/main.nf
@@ -48,7 +48,7 @@ process VT_DECOMPOSEBLOCKSUB {
     }
 
     """
-    touch ${prefix}.vcf.gz
+    echo '' | gzip > ${prefix}.vcf.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the [module](https://nf-co.re/docs/contributing/modules) or [subworkflow](https://nf-co.re/docs/contributing/subworkflows) guidelines?
- [ ] If necessary, also make a PR on the nf-core/modules [branch](https://github.com/nf-core/modules/tree/master) of [nf-core/test-datasets](https://github.com/nf-core/test-datasets)
- [x] Make sure your code lints (`nf-core modules lint <module>`).
- [ ] Ensure the test works (`nf-core modules test <module>`).

## Description of changes

Fixes #5409

### Problem

Using `touch file.gz` in module stub blocks creates empty files with a `.gz` extension that are not valid gzip archives. This causes `EOFException` errors in nf-test when the test framework attempts to validate these files as compressed data.

### Fix

Replace `touch file.gz` with `echo '' | gzip > file.gz` to produce minimal but structurally valid gzip files.

For modules with conditional compression (via a `compress` parameter), the fix replaces the ternary `touch` expression with an explicit `if/else` block that only applies `gzip` when compression is enabled.

### Modules fixed (17 remaining from the original 19)

| Module | Fix Type |
|--------|----------|
| `bcftools/split` | Simple touch → gzip |
| `bowtie2/align` | Conditional variable assignment |
| `clustalo/align` | Conditional compress param |
| `gatk4/haplotypecaller` | Simple touch → gzip |
| `kalign/align` | Conditional compress param |
| `metamdbg/asm` | Simple touch → gzip |
| `mtmalign/align` | Conditional compress param (2 files) |
| `muscle5/super5` | Conditional compress param |
| `pharokka/installdatabases` | Simple touch → gzip |
| `popscle/freemuxlet` | Simple touch → gzip (4 files) |
| `rastair/methylkit` | Simple touch → gzip |
| `ripgrep` | Conditional variable assignment |
| `staramr/search` | Expanded brace expression (7 files) |
| `tcoffee/align` | Conditional compress param |
| `tcoffee/consensus` | Conditional compress param |
| `tcoffee/regressive` | Conditional compress param |
| `vt/decomposeblocksub` | Simple touch → gzip |

**Note:** `famsa/align` and `getorganelle/fromreads` were already fixed in prior PRs.

### Additional detail for `staramr/search`

The original `touch` used bash brace expansion (`touch {a,b,c}.gz`) which works because `touch` accepts multiple arguments. However, `echo '' | gzip > {a,b,c}.gz` would fail in bash due to ambiguous redirect, so each file is expanded into its own command.