### PR TITLE
fix(modules): replace invalid touch .gz stubs with valid gzip

### DIFF
--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -83,9 +83,9 @@ process BOWTIE2_ALIGN {
     def extension = (args2 ==~ extension_pattern) ? (args2 =~ extension_pattern)[0][2].toLowerCase() : "bam"
     def create_unmapped = ""
     if (meta.single_end) {
-        create_unmapped = save_unaligned ? "touch ${prefix}.unmapped.fastq.gz" : ""
+        create_unmapped = save_unaligned ? "echo '' | gzip > ${prefix}.unmapped.fastq.gz" : ""
     } else {
-        create_unmapped = save_unaligned ? "touch ${prefix}.unmapped_1.fastq.gz && touch ${prefix}.unmapped_2.fastq.gz" : ""
+        create_unmapped = save_unaligned ? "echo '' | gzip > ${prefix}.unmapped_1.fastq.gz && echo '' | gzip > ${prefix}.unmapped_2.fastq.gz" : ""
     }
     if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
 

--- a/modules/nf-core/bowtie2/align/main.nf
+++ b/modules/nf-core/bowtie2/align/main.nf
@@ -83,9 +83,9 @@ process BOWTIE2_ALIGN {
     def extension = (args2 ==~ extension_pattern) ? (args2 =~ extension_pattern)[0][2].toLowerCase() : "bam"
     def create_unmapped = ""
     if (meta.single_end) {
-        create_unmapped = save_unaligned ? "echo '' | gzip > ${prefix}.unmapped.fastq.gz" : ""
+        create_unmapped = save_unaligned ? "echo | gzip > ${prefix}.unmapped.fastq.gz" : ""
     } else {
-        create_unmapped = save_unaligned ? "echo '' | gzip > ${prefix}.unmapped_1.fastq.gz && echo '' | gzip > ${prefix}.unmapped_2.fastq.gz" : ""
+        create_unmapped = save_unaligned ? "echo | gzip > ${prefix}.unmapped_1.fastq.gz && echo | gzip > ${prefix}.unmapped_2.fastq.gz" : ""
     }
     if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
 

--- a/modules/nf-core/gatk4/haplotypecaller/main.nf
+++ b/modules/nf-core/gatk4/haplotypecaller/main.nf
@@ -62,7 +62,7 @@ process GATK4_HAPLOTYPECALLER {
     def stub_realigned_bam = bamout_command ? "touch ${prefix.replaceAll('.g\\s*$', '')}.realigned.bam" : ""
     """
     echo "" | gzip > ${prefix}.vcf.gz
-    echo "" | gzip > ${prefix}.vcf.gz.tbi
+    touch > ${prefix}.vcf.gz.tbi
     ${stub_realigned_bam}
     """
 }

--- a/modules/nf-core/gatk4/haplotypecaller/main.nf
+++ b/modules/nf-core/gatk4/haplotypecaller/main.nf
@@ -61,8 +61,8 @@ process GATK4_HAPLOTYPECALLER {
 
     def stub_realigned_bam = bamout_command ? "touch ${prefix.replaceAll('.g\\s*$', '')}.realigned.bam" : ""
     """
-    touch ${prefix}.vcf.gz
-    touch ${prefix}.vcf.gz.tbi
+    echo "" | gzip > ${prefix}.vcf.gz
+    echo "" | gzip > ${prefix}.vcf.gz.tbi
     ${stub_realigned_bam}
     """
 }

--- a/modules/nf-core/gatk4/haplotypecaller/main.nf
+++ b/modules/nf-core/gatk4/haplotypecaller/main.nf
@@ -61,7 +61,7 @@ process GATK4_HAPLOTYPECALLER {
 
     def stub_realigned_bam = bamout_command ? "touch ${prefix.replaceAll('.g\\s*$', '')}.realigned.bam" : ""
     """
-    echo "" | gzip > ${prefix}.vcf.gz
+    echo | gzip > ${prefix}.vcf.gz
     touch > ${prefix}.vcf.gz.tbi
     ${stub_realigned_bam}
     """

--- a/modules/nf-core/gatk4/haplotypecaller/main.nf
+++ b/modules/nf-core/gatk4/haplotypecaller/main.nf
@@ -62,7 +62,7 @@ process GATK4_HAPLOTYPECALLER {
     def stub_realigned_bam = bamout_command ? "touch ${prefix.replaceAll('.g\\s*$', '')}.realigned.bam" : ""
     """
     echo | gzip > ${prefix}.vcf.gz
-    touch > ${prefix}.vcf.gz.tbi
+    touch ${prefix}.vcf.gz.tbi
     ${stub_realigned_bam}
     """
 }

--- a/modules/nf-core/metamdbg/asm/main.nf
+++ b/modules/nf-core/metamdbg/asm/main.nf
@@ -44,6 +44,6 @@ process METAMDBG_ASM {
     """
     echo ${args}
     touch ${prefix}.metaMDBG.log
-    echo "" | gzip > ${prefix}.contigs.fasta.gz
+    echo | gzip > ${prefix}.contigs.fasta.gz
     """
 }

--- a/modules/nf-core/metamdbg/asm/main.nf
+++ b/modules/nf-core/metamdbg/asm/main.nf
@@ -44,6 +44,6 @@ process METAMDBG_ASM {
     """
     echo ${args}
     touch ${prefix}.metaMDBG.log
-    touch ${prefix}.contigs.fasta.gz
+    echo "" | gzip > ${prefix}.contigs.fasta.gz
     """
 }

--- a/modules/nf-core/pharokka/installdatabases/main.nf
+++ b/modules/nf-core/pharokka/installdatabases/main.nf
@@ -41,7 +41,7 @@ process PHAROKKA_INSTALLDATABASES {
     touch $prefix/CARD_h
     touch $prefix/CARD_h.dbtype
     touch $prefix/CARD_h.index
-    echo "" | gzip > $prefix/VFDB_setB_pro.fas.gz
+    echo | gzip > $prefix/VFDB_setB_pro.fas.gz
     touch $prefix/VFDBclusterRes_cluster.tsv
     touch $prefix/VFDBclusterRes_rep_seq.fasta
     touch $prefix/all_phrogs.h3m

--- a/modules/nf-core/pharokka/installdatabases/main.nf
+++ b/modules/nf-core/pharokka/installdatabases/main.nf
@@ -41,7 +41,7 @@ process PHAROKKA_INSTALLDATABASES {
     touch $prefix/CARD_h
     touch $prefix/CARD_h.dbtype
     touch $prefix/CARD_h.index
-    touch $prefix/VFDB_setB_pro.fas.gz
+    echo "" | gzip > $prefix/VFDB_setB_pro.fas.gz
     touch $prefix/VFDBclusterRes_cluster.tsv
     touch $prefix/VFDBclusterRes_rep_seq.fasta
     touch $prefix/all_phrogs.h3m

--- a/modules/nf-core/popscle/freemuxlet/main.nf
+++ b/modules/nf-core/popscle/freemuxlet/main.nf
@@ -44,13 +44,13 @@ process POPSCLE_FREEMUXLET {
     def VERSION = '0.1' // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
 
     """
-    touch ${prefix}.clust1.samples.gz
-    touch ${prefix}.clust1.vcf.gz
+    echo "" | gzip > ${prefix}.clust1.samples.gz
+    echo "" | gzip > ${prefix}.clust1.vcf.gz
     touch ${prefix}.lmix
 
     if [[ "$args" == *"--aux-files"* ]]; then
-        touch ${prefix}.clust0.samples.gz
-        touch ${prefix}.clust0.vcf.gz
+        echo "" | gzip > ${prefix}.clust0.samples.gz
+        echo "" | gzip > ${prefix}.clust0.vcf.gz
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/popscle/freemuxlet/main.nf
+++ b/modules/nf-core/popscle/freemuxlet/main.nf
@@ -44,13 +44,13 @@ process POPSCLE_FREEMUXLET {
     def VERSION = '0.1' // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
 
     """
-    echo "" | gzip > ${prefix}.clust1.samples.gz
-    echo "" | gzip > ${prefix}.clust1.vcf.gz
+    echo | gzip > ${prefix}.clust1.samples.gz
+    echo | gzip > ${prefix}.clust1.vcf.gz
     touch ${prefix}.lmix
 
     if [[ "$args" == *"--aux-files"* ]]; then
-        echo "" | gzip > ${prefix}.clust0.samples.gz
-        echo "" | gzip > ${prefix}.clust0.vcf.gz
+        echo | gzip > ${prefix}.clust0.samples.gz
+        echo | gzip > ${prefix}.clust0.vcf.gz
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/rastair/methylkit/main.nf
+++ b/modules/nf-core/rastair/methylkit/main.nf
@@ -31,7 +31,7 @@ process RASTAIR_METHYLKIT {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}.methylkit.txt.gz
+    echo "" | gzip > ${prefix}.methylkit.txt.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/rastair/methylkit/main.nf
+++ b/modules/nf-core/rastair/methylkit/main.nf
@@ -31,7 +31,7 @@ process RASTAIR_METHYLKIT {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo "" | gzip > ${prefix}.methylkit.txt.gz
+    echo | gzip > ${prefix}.methylkit.txt.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/staramr/search/main.nf
+++ b/modules/nf-core/staramr/search/main.nf
@@ -52,8 +52,8 @@ process STARAMR_SEARCH {
     """
     mkdir ${prefix}_results
     touch ${prefix}_results/results.xlsx
-    echo "" | gzip > ${prefix}_results/{summary,detailed_summary,resfinder,pointfinder,plasmidfinder,mlst}.tsv.gz
-    echo "" | gzip > ${prefix}_results/settings.txt.gz
+    echo | gzip > ${prefix}_results/{summary,detailed_summary,resfinder,pointfinder,plasmidfinder,mlst}.tsv.gz
+    echo | gzip > ${prefix}_results/settings.txt.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/staramr/search/main.nf
+++ b/modules/nf-core/staramr/search/main.nf
@@ -52,8 +52,8 @@ process STARAMR_SEARCH {
     """
     mkdir ${prefix}_results
     touch ${prefix}_results/results.xlsx
-    touch ${prefix}_results/{summary,detailed_summary,resfinder,pointfinder,plasmidfinder,mlst}.tsv.gz
-    touch ${prefix}_results/settings.txt.gz
+    echo "" | gzip > ${prefix}_results/{summary,detailed_summary,resfinder,pointfinder,plasmidfinder,mlst}.tsv.gz
+    echo "" | gzip > ${prefix}_results/settings.txt.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/vt/decomposeblocksub/main.nf
+++ b/modules/nf-core/vt/decomposeblocksub/main.nf
@@ -48,7 +48,7 @@ process VT_DECOMPOSEBLOCKSUB {
     }
 
     """
-    touch ${prefix}.vcf.gz
+    echo "" | gzip > ${prefix}.vcf.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/vt/decomposeblocksub/main.nf
+++ b/modules/nf-core/vt/decomposeblocksub/main.nf
@@ -48,7 +48,7 @@ process VT_DECOMPOSEBLOCKSUB {
     }
 
     """
-    echo "" | gzip > ${prefix}.vcf.gz
+    echo | gzip > ${prefix}.vcf.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
## Description

Fixes #5409. Replaces `touch filename.gz` with `echo '' | gzip > filename.gz` in stub blocks for 8 modules. Empty files created by `touch` are not valid gzip and cause `EOFException` in nf-test snapshot assertions.

After this PR, `git grep -cP "touch .*\.gz(\\s+.*)*$" -- 'modules/'` returns **zero matches** across the entire repository.

## Modules Fixed
- `bowtie2/align` — unmapped `.fastq.gz` stubs (supplementary to PR #7978)
- `gatk4/haplotypecaller`
- `metamdbg/asm`
- `pharokka/installdatabases`
- `popscle/freemuxlet`
- `rastair/methylkit`
- `staramr/search`
- `vt/decomposeblocksub`

## Fix Pattern
```diff
- touch ${prefix}.output.vcf.gz
+ echo '' | gzip > ${prefix}.output.vcf.gz
```

## PR Checklist
- [x] This comment contains all information about changes made
- [x] All `touch filename.gz` replaced with `echo '' | gzip > filename.gz`
- [x] No other changes to module logic, meta.yml, or tests
- [x] Snapshot updates may be needed — happy to run `nf-core modules test --update` if requested