### PR TITLE
switch from pdiff to fast-diff for CI nf-test diffs

### DIFF
--- a/.github/actions/get-shards/action.yml
+++ b/.github/actions/get-shards/action.yml
@@ -29,7 +29,7 @@ runs:
       uses: nf-core/setup-nf-test@4069fbbaabe94c08faba4ad261bfa88225ba133f # v2
       with:
         version: ${{ env.NFT_VER }}
-        install-pdiff: true
+        install-fast-diff: true
 
     - name: Get number of shards
       id: shards

--- a/.github/actions/nf-test-action/action.yml
+++ b/.github/actions/nf-test-action/action.yml
@@ -40,7 +40,7 @@ runs:
       uses: nf-core/setup-nf-test@4069fbbaabe94c08faba4ad261bfa88225ba133f # v2
       with:
         version: "${{ env.NFT_VER }}"
-        install-pdiff: true
+        install-fast-diff: true
 
     - name: Set up apptainer
       if: contains(inputs.profile, 'singularity')

--- a/.github/workflows/update-gpu-snapshot.yml
+++ b/.github/workflows/update-gpu-snapshot.yml
@@ -74,7 +74,7 @@ jobs:
         uses: nf-core/setup-nf-test@4069fbbaabe94c08faba4ad261bfa88225ba133f # v2
         with:
           version: "${{ env.NFT_VER }}"
-          install-pdiff: true
+          install-fast-diff: true
 
       - name: Update gpu snapshot
         id: update-gpu-snapshot

--- a/.github/workflows/update-sentieon-snapshot.yml
+++ b/.github/workflows/update-sentieon-snapshot.yml
@@ -77,7 +77,7 @@ jobs:
         uses: nf-core/setup-nf-test@4069fbbaabe94c08faba4ad261bfa88225ba133f # v2
         with:
           version: "${{ env.NFT_VER }}"
-          install-pdiff: true
+          install-fast-diff: true
 
       # Set up secrets
       - name: Set up Nextflow secrets


### PR DESCRIPTION
this will provide more compact diffs better for github action logs, see fast-diff version 
<img width="833" height="315" alt="Screenshot 2026-04-27 at 10 02 59" src="https://github.com/user-attachments/assets/699f6eed-19eb-4d6d-a53b-fca7b63000cf" />
vs the previous pdiff version
<img width="696" height="302" alt="Screenshot 2026-04-27 at 10 02 37" src="https://github.com/user-attachments/assets/1797045e-db43-4164-9068-fb5bb8ca5852" />
