### PR TITLE
fix(trimgalore): pin output globs to finals only, exclude PE intermediates

### DIFF
--- a/modules/nf-core/trimgalore/environment.yml
+++ b/modules/nf-core/trimgalore/environment.yml
@@ -5,4 +5,3 @@ channels:
   - bioconda
 dependencies:
   - bioconda::trim-galore=0.6.10
-  - bioconda::cutadapt=5.2

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -11,8 +11,8 @@ process TRIMGALORE {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path(reads_glob)                            , emit: reads
-    tuple val(meta), path(report_glob)                           , emit: log     , optional: true
+    tuple val(meta), path("${reads_glob}")                       , emit: reads
+    tuple val(meta), path("${report_glob}")                      , emit: log     , optional: true
     tuple val(meta), path("${prefix}_{1,2}_unpaired_{1,2}.fq.gz"), emit: unpaired, optional: true
     tuple val(meta), path("${prefix}*_fastqc.html")              , emit: html    , optional: true
     tuple val(meta), path("${prefix}*_fastqc.zip")               , emit: zip     , optional: true

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -11,11 +11,11 @@ process TRIMGALORE {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt")                               , emit: log     , optional: true
-    tuple val(meta), path("*unpaired{,_1,_2}.fq.gz")                   , emit: unpaired, optional: true
-    tuple val(meta), path("*.html")                                    , emit: html    , optional: true
-    tuple val(meta), path("*.zip")                                     , emit: zip     , optional: true
+    tuple val(meta), path(reads_glob)                            , emit: reads
+    tuple val(meta), path(report_glob)                           , emit: log     , optional: true
+    tuple val(meta), path("${prefix}_{1,2}_unpaired_{1,2}.fq.gz"), emit: unpaired, optional: true
+    tuple val(meta), path("${prefix}*_fastqc.html")              , emit: html    , optional: true
+    tuple val(meta), path("${prefix}*_fastqc.zip")               , emit: zip     , optional: true
     tuple val("${task.process}"), val("trimgalore"), eval('trim_galore --version | grep -Eo "[0-9]+(\\.[0-9]+)+"'), topic: versions, emit: versions_trimgalore
 
     when:
@@ -41,13 +41,19 @@ process TRIMGALORE {
     }
 
     // Added soft-links to original fastqs for consistent naming in MultiQC
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
+    // Pin output globs to exactly the finals trim_galore can produce across modes
+    // (default trimming -> `*_trimmed`/`*_val_*`, hardtrim5/3 -> `*<N>bp_<3,5>prime`).
+    // PE intermediates `${prefix}_<N>_trimmed.fq.gz` are deliberately excluded so an
+    // incomplete cleanup of those files cannot leak into the `reads` channel.
+    reads_glob  = meta.single_end ? "${prefix}{_trimmed,.*bp_3prime,.*bp_5prime}.fq.gz"
+                                  : "${prefix}_{1_val_1,2_val_2,1.*bp_3prime,1.*bp_5prime,2.*bp_3prime,2.*bp_5prime}.fq.gz"
+    report_glob = meta.single_end ? "${prefix}.fastq.gz_trimming_report.txt"
+                                  : "${prefix}_{1,2}.fastq.gz_trimming_report.txt"
     if (meta.single_end) {
         def args_list = args.split("\\s(?=--)").toList()
         args_list.removeAll { arg -> arg.toLowerCase().contains('_r2 ') }
         """
-        # Drop any trim_galore output left over from an interrupted previous attempt.
-        rm -f ${prefix}_trimmed.fq.gz
         [ ! -f  ${prefix}.fastq.gz ] && ln -s ${reads} ${prefix}.fastq.gz
         trim_galore \\
             ${args_list.join(' ')} \\
@@ -58,10 +64,6 @@ process TRIMGALORE {
     }
     else {
         """
-        # Drop the per-mate intermediates --paired writes before validate_paired_end_files
-        # unlinks them. An attempt interrupted between cutadapt and validation leaves these
-        # behind and the output glob then matches 3 fastqs instead of 2.
-        rm -f ${prefix}_1_trimmed.fq.gz ${prefix}_2_trimmed.fq.gz
         [ ! -f  ${prefix}_1.fastq.gz ] && ln -s ${reads[0]} ${prefix}_1.fastq.gz
         [ ! -f  ${prefix}_2.fastq.gz ] && ln -s ${reads[1]} ${prefix}_2.fastq.gz
         trim_galore \\
@@ -75,15 +77,19 @@ process TRIMGALORE {
     }
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
+    reads_glob  = meta.single_end ? "${prefix}{_trimmed,.*bp_3prime,.*bp_5prime}.fq.gz"
+                                  : "${prefix}_{1_val_1,2_val_2,1.*bp_3prime,1.*bp_5prime,2.*bp_3prime,2.*bp_5prime}.fq.gz"
+    report_glob = meta.single_end ? "${prefix}.fastq.gz_trimming_report.txt"
+                                  : "${prefix}_{1,2}.fastq.gz_trimming_report.txt"
     if (meta.single_end) {
         output_command = "echo '' | gzip > ${prefix}_trimmed.fq.gz ;"
         output_command += "touch ${prefix}.fastq.gz_trimming_report.txt"
     }
     else {
-        output_command = "echo '' | gzip > ${prefix}_1_trimmed.fq.gz ;"
+        output_command = "echo '' | gzip > ${prefix}_1_val_1.fq.gz ;"
         output_command += "touch ${prefix}_1.fastq.gz_trimming_report.txt ;"
-        output_command += "echo '' | gzip > ${prefix}_2_trimmed.fq.gz ;"
+        output_command += "echo '' | gzip > ${prefix}_2_val_2.fq.gz ;"
         output_command += "touch ${prefix}_2.fastq.gz_trimming_report.txt"
     }
     """

--- a/modules/nf-core/trimgalore/tests/main.nf.test.snap
+++ b/modules/nf-core/trimgalore/tests/main.nf.test.snap
@@ -8,8 +8,8 @@
                         "single_end": false
                     },
                     [
-                        "test_1_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                        "test_2_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test_1_val_1.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                        "test_2_val_2.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ]
             ],
@@ -37,9 +37,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-12-15T14:40:14.896140126"
+        "timestamp": "2026-04-27T14:47:47.934288"
     },
     "sarscov2 - fastq - paired-end - keep-unpaired": {
         "content": [


### PR DESCRIPTION
## Summary

Replaces the broad `*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz` reads glob with a script-block-conditional glob pinned to exactly the finals trim_galore can produce in each mode:

| Mode | Glob |
|---|---|
| SE default | `\${prefix}_trimmed.fq.gz` |
| SE hardtrim5/3 | `\${prefix}.<N>bp_<3,5>prime.fq.gz` |
| PE default | `\${prefix}_<mate>_val_<mate>.fq.gz` |
| PE hardtrim5/3 | `\${prefix}_<mate>.<N>bp_<3,5>prime.fq.gz` |

The PE intermediate `\${prefix}_<mate>_trimmed.fq.gz` (which trim_galore writes during paired-end processing and `unlink`s after `validate_paired_end_files`) is no longer matched by the reads glob. An incomplete cleanup of those intermediates can no longer leak into the `reads` channel. No script-block hacks required.

Also drops the `cutadapt=5.2` pin from `environment.yml` (added in #11308) — unnecessary; the trim-galore conda package already pulls a working cutadapt.

## Why a static glob can't do this

PE intermediate ends in `_<digit>_trimmed.fq.gz`. SE final ends in `_trimmed.fq.gz` where the prefix may itself end in a digit (`WT_REP1_trimmed.fq.gz`). Distinguishing these requires negative lookbehind, which bash/Java glob syntax doesn't support. So a static-glob solution either includes the PE intermediate (current bug) or excludes legitimate SE finals for digit-suffixed sample IDs.

## Lint state

- 56 tests pass, 1 warning (bioconda update available — irrelevant)
- 2 failures:
  - `container_links` — **pre-existing on master**, unrelated to this PR
  - `correct_meta_outputs` — caused by this PR's use of bare-variable output paths

The `correct_meta_outputs` check does naive static parsing of `path(...)` and treats `path(reads_glob)` as the literal pattern `reads_glob` rather than resolving the script-block `def`. The same pattern is used elsewhere in nf-core/modules (e.g. [`samtools/sort`](https://github.com/nf-core/modules/blob/master/modules/nf-core/samtools/sort/main.nf) uses a `def extension` in script with `path("*.${extension}")` in output). The lint check should evaluate or skip variable-only output paths to support this conditional-output pattern, which is the only path-shape solution to the trimgalore intermediate-leak problem.

## Supersedes / alternative to

- #11308, #11309 — script-block `rm` hacks
- #11315 — subdir + `mv` approach (works, passes lint, also valid)

This PR is opened as **draft** for the lint discussion. If `correct_meta_outputs` can be made to handle this, this is structurally cleaner than #11315. If not, #11315 is the fallback.

## Test plan

- [x] All 5 module nf-tests pass locally with docker
- [ ] CI green on the test/snapshot side
- [ ] Lint discussion resolves `correct_meta_outputs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)