### PR TITLE
Swap clair3 back to biocontainer and bump to v2.0.1

### DIFF
--- a/modules/nf-core/clair3/environment.yml
+++ b/modules/nf-core/clair3/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::clair3=2.0.0"
+  - "bioconda::clair3=2.0.1"

--- a/modules/nf-core/clair3/main.nf
+++ b/modules/nf-core/clair3/main.nf
@@ -4,8 +4,8 @@ process CLAIR3 {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-    'docker.io/hkubal/clair3:v2.0.0' :
-    'docker.io/hkubal/clair3:v2.0.0' }"
+        'https://depot.galaxyproject.org/singularity/clair3:2.0.1--py311hbc58adc_0' :
+        'quay.io/biocontainers/clair3:2.0.1--py311hbc58adc_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai), val(packaged_model), path(user_model), val(platform)

--- a/modules/nf-core/clair3/tests/main.nf.test
+++ b/modules/nf-core/clair3/tests/main.nf.test
@@ -220,6 +220,9 @@ nextflow_process {
         options "-stub"
 
         when {
+            params {
+                args = ""
+            }
             process {
                 """
                 def model_path = UNTAR.out.untar

--- a/modules/nf-core/clair3/tests/main.nf.test.snap
+++ b/modules/nf-core/clair3/tests/main.nf.test.snap
@@ -54,27 +54,24 @@
                     [
                         "CLAIR3",
                         "clair3",
-                        "2.0.0"
+                        "2.0.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-03-19T12:58:29.886268",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-28T07:36:02.280127687"
     },
     "sarscov2 - bam - packaged_model": {
         "content": [
             [
-                [
-                    "testmerge_output.vcf.gz",
-                    "VcfFile [chromosomes=[MT192765.1], sampleCount=1, variantCount=9, phased=false, phasedAutodetect=false]"
-                ]
+                
             ],
             [
-                "testmerge_output.vcf.gz.tbi"
+                
             ],
             [
                 
@@ -90,19 +87,15 @@
             ],
             {
                 "versions_clair3": [
-                    [
-                        "CLAIR3",
-                        "clair3",
-                        "2.0.0"
-                    ]
+                    
                 ]
             }
         ],
-        "timestamp": "2026-03-20T04:12:38.663282558",
         "meta": {
-            "nf-test": "0.9.5",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-27T19:39:09.547313208"
     },
     "sarscov2 - bam - user_model": {
         "content": [
@@ -132,16 +125,16 @@
                     [
                         "CLAIR3",
                         "clair3",
-                        "2.0.0"
+                        "2.0.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-03-19T13:38:03.609361",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-27T19:38:59.904878583"
     },
     "sarscov2 - bam - user_model - gvcf": {
         "content": [
@@ -174,15 +167,15 @@
                     [
                         "CLAIR3",
                         "clair3",
-                        "2.0.0"
+                        "2.0.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-03-19T13:39:12.428496",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-27T19:39:42.385926206"
     }
 }


### PR DESCRIPTION
clair3 was swapped to a docker container hosted in docker.io in #10975.
This PR moves back to a biocontainer and bumps to the most recent version.