### PR TITLE
fix(trimgalore): split reads emit into reads_se / reads_pe (alternative)

### DIFF
--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -11,11 +11,16 @@ process TRIMGALORE {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"), emit: reads
-    tuple val(meta), path("*report.txt")                               , emit: log     , optional: true
-    tuple val(meta), path("*unpaired{,_1,_2}.fq.gz")                   , emit: unpaired, optional: true
-    tuple val(meta), path("*.html")                                    , emit: html    , optional: true
-    tuple val(meta), path("*.zip")                                     , emit: zip     , optional: true
+    // Two `reads_*` emits with positive-only patterns covering every trim_galore
+    // output mode (default trim, --hardtrim5, --hardtrim3). PE per-mate intermediates
+    // (`${prefix}_<N>_trimmed.fq.gz`) deliberately match neither pattern, so an
+    // incomplete unlink of those files on retry can't leak into either channel.
+    tuple val(meta), path("${prefix}{_trimmed,.*bp_3prime,.*bp_5prime}.fq.gz")    , emit: reads_se, optional: true
+    tuple val(meta), path("${prefix}_*{_val_1,_val_2,bp_3prime,bp_5prime}.fq.gz") , emit: reads_pe, optional: true
+    tuple val(meta), path("*report.txt")                                          , emit: log     , optional: true
+    tuple val(meta), path("*unpaired{,_1,_2}.fq.gz")                              , emit: unpaired, optional: true
+    tuple val(meta), path("*.html")                                               , emit: html    , optional: true
+    tuple val(meta), path("*.zip")                                                , emit: zip     , optional: true
     tuple val("${task.process}"), val("trimgalore"), eval('trim_galore --version | grep -Eo "[0-9]+(\\.[0-9]+)+"'), topic: versions, emit: versions_trimgalore
 
     when:
@@ -41,13 +46,11 @@ process TRIMGALORE {
     }
 
     // Added soft-links to original fastqs for consistent naming in MultiQC
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     if (meta.single_end) {
         def args_list = args.split("\\s(?=--)").toList()
         args_list.removeAll { arg -> arg.toLowerCase().contains('_r2 ') }
         """
-        # Drop any trim_galore output left over from an interrupted previous attempt.
-        rm -f ${prefix}_trimmed.fq.gz
         [ ! -f  ${prefix}.fastq.gz ] && ln -s ${reads} ${prefix}.fastq.gz
         trim_galore \\
             ${args_list.join(' ')} \\
@@ -58,10 +61,6 @@ process TRIMGALORE {
     }
     else {
         """
-        # Drop the per-mate intermediates --paired writes before validate_paired_end_files
-        # unlinks them. An attempt interrupted between cutadapt and validation leaves these
-        # behind and the output glob then matches 3 fastqs instead of 2.
-        rm -f ${prefix}_1_trimmed.fq.gz ${prefix}_2_trimmed.fq.gz
         [ ! -f  ${prefix}_1.fastq.gz ] && ln -s ${reads[0]} ${prefix}_1.fastq.gz
         [ ! -f  ${prefix}_2.fastq.gz ] && ln -s ${reads[1]} ${prefix}_2.fastq.gz
         trim_galore \\
@@ -75,15 +74,15 @@ process TRIMGALORE {
     }
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     if (meta.single_end) {
         output_command = "echo '' | gzip > ${prefix}_trimmed.fq.gz ;"
         output_command += "touch ${prefix}.fastq.gz_trimming_report.txt"
     }
     else {
-        output_command = "echo '' | gzip > ${prefix}_1_trimmed.fq.gz ;"
+        output_command = "echo '' | gzip > ${prefix}_1_val_1.fq.gz ;"
         output_command += "touch ${prefix}_1.fastq.gz_trimming_report.txt ;"
-        output_command += "echo '' | gzip > ${prefix}_2_trimmed.fq.gz ;"
+        output_command += "echo '' | gzip > ${prefix}_2_val_2.fq.gz ;"
         output_command += "touch ${prefix}_2.fastq.gz_trimming_report.txt"
     }
     """

--- a/modules/nf-core/trimgalore/meta.yml
+++ b/modules/nf-core/trimgalore/meta.yml
@@ -32,16 +32,36 @@ input:
         ontologies:
           - edam: "http://edamontology.org/format_1930" # FASTQ
 output:
-  reads:
+  reads_se:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:true ]
+      - "${prefix}{_trimmed,.*bp_3prime,.*bp_5prime}.fq.gz":
+          type: file
+          description: |
+            Single-end trimmed reads. Brace alternatives cover trim_galore's
+            output modes: `_trimmed` (default), `.<N>bp_3prime` (--hardtrim3),
+            `.<N>bp_5prime` (--hardtrim5).
+          pattern: "${prefix}{_trimmed,.*bp_3prime,.*bp_5prime}.fq.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_1930" # FASTQ
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  reads_pe:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz":
+      - "${prefix}_*{_val_1,_val_2,bp_3prime,bp_5prime}.fq.gz":
           type: file
-          description: The trimmed/modified fastq reads
-          pattern: "*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"
+          description: |
+            Paired-end trimmed reads. Brace alternatives cover trim_galore's
+            output modes: `_val_<N>` (default), `bp_3prime` (--hardtrim3),
+            `bp_5prime` (--hardtrim5). PE per-mate intermediates
+            (`${prefix}_<N>_trimmed.fq.gz`) deliberately do not match this glob.
+          pattern: "${prefix}_*{_val_1,_val_2,bp_3prime,bp_5prime}.fq.gz"
           ontologies:
             - edam: "http://edamontology.org/format_1930" # FASTQ
             - edam: http://edamontology.org/format_3989 # GZIP format

--- a/modules/nf-core/trimgalore/tests/main.nf.test
+++ b/modules/nf-core/trimgalore/tests/main.nf.test
@@ -25,7 +25,7 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out.reads,
+                    process.out.reads_se,
                     file(process.out.log[0][1]).readLines()[0..9], // line 11 changes
                     file(process.out.log[0][1]).readLines()[11..59].findAll { !it.startsWith("This is cutadapt") }, // strip python version
                     process.out.findAll { key, val -> key.startsWith("versions")}
@@ -53,8 +53,8 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out.reads[0][1][0],
-                    process.out.reads[0][1][1],
+                    process.out.reads_pe[0][1][0],
+                    process.out.reads_pe[0][1][1],
                     file(process.out.log[0][1][0]).readLines()[0..9], // line 11 changes
                     file(process.out.log[0][1][0]).readLines()[11..58].findAll { !it.startsWith("This is cutadapt") }, // strip python version
                     file(process.out.log[0][1][1]).readLines()[0..9], // line 11 changes
@@ -90,8 +90,8 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out.reads[0][1][0],
-                    process.out.reads[0][1][1],
+                    process.out.reads_pe[0][1][0],
+                    process.out.reads_pe[0][1][1],
                     process.out.unpaired[0][1][0],
                     process.out.unpaired[0][1][1],
                     file(process.out.log[0][1][0]).readLines()[0..9], // line 11 changes
@@ -123,7 +123,7 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out.reads,
+                    process.out.reads_se,
                     process.out.log,
                     process.out.findAll { key, val -> key.startsWith("versions")}
                 ).match() }
@@ -152,7 +152,7 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out.reads,
+                    process.out.reads_pe,
                     process.out.log,
                     process.out.findAll { key, val -> key.startsWith("versions")}
                 ).match() }

--- a/modules/nf-core/trimgalore/tests/main.nf.test.snap
+++ b/modules/nf-core/trimgalore/tests/main.nf.test.snap
@@ -8,8 +8,8 @@
                         "single_end": false
                     },
                     [
-                        "test_1_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
-                        "test_2_trimmed.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test_1_val_1.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                        "test_2_val_2.fq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ]
             ],
@@ -37,9 +37,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-12-15T14:40:14.896140126"
+        "timestamp": "2026-04-28T10:39:33.698447"
     },
     "sarscov2 - fastq - paired-end - keep-unpaired": {
         "content": [


### PR DESCRIPTION
## Summary

Alternative to [#11317](https://github.com/nf-core/modules/pull/11317) and [#11315](https://github.com/nf-core/modules/pull/11315). Replaces the single broad `reads` emit:

```nextflow
tuple val(meta), path("*{3prime,5prime,trimmed,val}{,_1,_2}.fq.gz"), emit: reads
```

with two narrower static emits:

```nextflow
tuple val(meta), path("\${prefix}{_trimmed,.*bp_3prime,.*bp_5prime}.fq.gz")    , emit: reads_se, optional: true
tuple val(meta), path("\${prefix}_*{_val_1,_val_2,bp_3prime,bp_5prime}.fq.gz") , emit: reads_pe, optional: true
```

Each glob is positively scoped to one mode and uses only single-level brace expansion (Java PathMatcher rejects nesting). The two patterns combine to cover every trim_galore output mode:

| File shape | matched by |
|---|---|
| `\${prefix}_trimmed.fq.gz` (SE default) | `reads_se` via `_trimmed` |
| `\${prefix}.<N>bp_3prime.fq.gz` (SE --hardtrim3) | `reads_se` via `.*bp_3prime` |
| `\${prefix}.<N>bp_5prime.fq.gz` (SE --hardtrim5) | `reads_se` via `.*bp_5prime` |
| `\${prefix}_<N>_val_<N>.fq.gz` (PE default) | `reads_pe` via `_*_val_<N>` |
| `\${prefix}_<N>.<N>bp_3prime.fq.gz` (PE --hardtrim3) | `reads_pe` via `_*bp_3prime` |
| `\${prefix}_<N>.<N>bp_5prime.fq.gz` (PE --hardtrim5) | `reads_pe` via `_*bp_5prime` |
| **`\${prefix}_<N>_trimmed.fq.gz` (PE per-mate intermediate)** | **neither** — falls through unmatched |

The PE intermediate is the file that trim_galore writes between the per-mate cutadapt pass and `validate_paired_end_files`, and unlinks once validation succeeds. On any infrastructure where that unlink is asynchronous (Fusion-mounted S3, slow network FS, etc.) and doesn't always propagate before the next process scans the workdir, the orphan would otherwise be picked up by the broad reads glob and downstream consumers expecting paired arity (`fq/lint`, etc.) break.

With this PR, the orphan is structurally unmatched regardless of whether trim_galore's cleanup succeeded — neither glob has a literal segment that would catch a `_<N>_trimmed.fq.gz` file.

## Why split rather than narrow

A single static glob can't distinguish PE intermediate (`\${prefix}_<N>_trimmed.fq.gz`) from SE final (`\${prefix}_trimmed.fq.gz` where `\${prefix}` may itself end in a digit, e.g. `WT_REP1`) — the difference requires negative lookbehind, which bash/Java globs don't support. Two positive patterns sidestep that constraint without dropping support for digit-suffixed sample IDs.

## Cost

Consumers that previously took `TRIMGALORE.out.reads` need to choose `reads_se` / `reads_pe` (or `.mix(reads_se, reads_pe)` if they don't care). Affects rnaseq, atacseq, taxprofiler, smrnaseq, nascent, and any other pipeline using this module — each gets a one-line update.

## Supersedes / alternative to

- [#11308](https://github.com/nf-core/modules/pull/11308), [#11309](https://github.com/nf-core/modules/pull/11309) — script-block `rm` hacks (defensive only, didn't address root cause)
- [#11315](https://github.com/nf-core/modules/pull/11315) — subdir + `mv` (works, but adds workdir gymnastics)
- [#11317](https://github.com/nf-core/modules/pull/11317) — conditional `reads_glob` via script-block `def` (cleaner shape but blocked by `correct_meta_outputs` lint, requires [nf-core/tools#4226](https://github.com/nf-core/tools/pull/4226))

This approach has none of those costs:
- No script-block hacks
- No subdir / no `mv`
- No lint changes
- No schema changes
- Static globs that meta.yml can mirror exactly

## Test plan

- [x] All 5 module nf-tests pass locally with docker
- [x] `correct_meta_outputs` passes on vanilla nf-core/tools (no patch needed)
- [ ] CI green
- [ ] Confirm the consumer-side `.mix()` updates are scoped — list of pipelines using TRIMGALORE.out.reads:
  - nf-core/rnaseq (subworkflow `fastq_fastqc_umitools_trimgalore`)
  - nf-core/atacseq
  - nf-core/taxprofiler
  - nf-core/smrnaseq
  - nf-core/nascent
  - others — to enumerate before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)