### PR TITLE
Bump mosdepth's version

### DIFF
--- a/modules/nf-core/mosdepth/environment.yml
+++ b/modules/nf-core/mosdepth/environment.yml
@@ -5,5 +5,5 @@ channels:
   - bioconda
 dependencies:
   # renovate: datasource=conda depName=bioconda/mosdepth
-  - htslib=1.22.1
-  - mosdepth=0.3.11=h0ec343a_1
+  - htslib=1.23.1
+  - mosdepth=0.3.14

--- a/modules/nf-core/mosdepth/environment.yml
+++ b/modules/nf-core/mosdepth/environment.yml
@@ -5,5 +5,5 @@ channels:
   - bioconda
 dependencies:
   # renovate: datasource=conda depName=bioconda/mosdepth
-  - htslib=1.23.1
-  - mosdepth=0.3.14
+  - bioconda::mosdepth=0.3.14
+  - conda-forge::gzip=1.14

--- a/modules/nf-core/mosdepth/main.nf
+++ b/modules/nf-core/mosdepth/main.nf
@@ -4,8 +4,8 @@ process MOSDEPTH {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/16/167a8e2913700403615f5f6d0e4c215c17d0590375f74e05821802153545382d/data' :
-        'community.wave.seqera.io/library/htslib_mosdepth:3f7eda5b7d75a18f'}"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a6/a61c7c22f3c92b38befbf872f07e32540804e874e9df41593a7158e36280961b/data' :
+        'community.wave.seqera.io/library/mosdepth_gzip:e51d2330d6cdd31f'}"
 
     input:
     tuple val(meta),  path(bam), path(bai), path(bed)
@@ -26,7 +26,7 @@ process MOSDEPTH {
     tuple val(meta), path('*.thresholds.bed.gz')    , optional:true, emit: thresholds_bed
     tuple val(meta), path('*.thresholds.bed.gz.csi'), optional:true, emit: thresholds_csi
     tuple val("${task.process}"), val('mosdepth'), eval("mosdepth --version | sed 's/mosdepth //g'"), topic: versions, emit: versions_mosdepth
-
+    tuple val("${task.process}"), val('gzip'), eval("gzip -V 2>&1 | sed 's/gzip \\([0-9.]*\\).*/\\1/;q'"), topic: versions, emit: versions_gzip
     when:
     task.ext.when == null || task.ext.when
 

--- a/modules/nf-core/mosdepth/main.nf
+++ b/modules/nf-core/mosdepth/main.nf
@@ -4,8 +4,8 @@ process MOSDEPTH {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/00/00d32b53160c26794959da7303ee6e2107afd4d292060c9f287b0af1fddbd847/data' :
-        'community.wave.seqera.io/library/mosdepth_htslib:0f58993cb6d93294'}"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/16/167a8e2913700403615f5f6d0e4c215c17d0590375f74e05821802153545382d/data' :
+        'community.wave.seqera.io/library/htslib_mosdepth:3f7eda5b7d75a18f'}"
 
     input:
     tuple val(meta),  path(bam), path(bai), path(bed)

--- a/modules/nf-core/mosdepth/meta.yml
+++ b/modules/nf-core/mosdepth/meta.yml
@@ -193,9 +193,19 @@ output:
       - mosdepth:
           type: string
           description: The tool name
-      - "mosdepth --version | sed 's/mosdepth //g'":
+      - mosdepth --version | sed 's/mosdepth //g':
           type: eval
           description: The command used to generate the version of the tool
+  versions_gzip:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gzip:
+          type: string
+          description: The name of the tool
+      - gzip -V 2>&1 | sed 's/gzip \([0-9.]*\).*/\1/;q':
+          type: eval
+          description: The expression to obtain the version of the tool
 topics:
   versions:
     - - ${task.process}:
@@ -204,9 +214,18 @@ topics:
       - mosdepth:
           type: string
           description: The tool name
-      - "mosdepth --version | sed 's/mosdepth //g'":
+      - mosdepth --version | sed 's/mosdepth //g':
           type: eval
           description: The command used to generate the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gzip:
+          type: string
+          description: The name of the tool
+      - gzip -V 2>&1 | sed 's/gzip \([0-9.]*\).*/\1/;q':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/mosdepth/tests/main.nf.test.snap
+++ b/modules/nf-core/mosdepth/tests/main.nf.test.snap
@@ -42,7 +42,7 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ],
                 "2": [
@@ -229,15 +229,15 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-09-23T13:06:13.219131",
+        "timestamp": "2026-04-28T14:37:04.195511575",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
         }
     },
     "homo_sapiens - cram, crai, bed": {
@@ -271,7 +271,7 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ],
                 "2": [
@@ -301,7 +301,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "6": [
@@ -319,7 +319,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.regions.bed.gz.csi:md5,c33ac5c86370039463796f01434fc0e4"
+                        "test.regions.bed.gz.csi:md5,e0045e73eb8e8c2b88544f0bc346e002"
                     ]
                 ],
                 "8": [
@@ -352,7 +352,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "per_base_d4": [
@@ -379,7 +379,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.regions.bed.gz.csi:md5,c33ac5c86370039463796f01434fc0e4"
+                        "test.regions.bed.gz.csi:md5,e0045e73eb8e8c2b88544f0bc346e002"
                     ]
                 ],
                 "regions_txt": [
@@ -410,15 +410,15 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-09-23T13:22:14.011309",
+        "timestamp": "2026-04-28T14:36:37.330500517",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
         }
     },
     "homo_sapiens - bam, bai, [] - quantized": {
@@ -452,7 +452,7 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ],
                 "2": [
@@ -476,7 +476,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "6": [
@@ -500,7 +500,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.quantized.bed.gz.csi:md5,7e0413e355b920bafe8800e670e26547"
+                        "test.quantized.bed.gz.csi:md5,59bb21dd686bf095ea8ef75bfbe2c85c"
                     ]
                 ],
                 "global_txt": [
@@ -527,7 +527,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "per_base_d4": [
@@ -548,7 +548,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.quantized.bed.gz.csi:md5,7e0413e355b920bafe8800e670e26547"
+                        "test.quantized.bed.gz.csi:md5,59bb21dd686bf095ea8ef75bfbe2c85c"
                     ]
                 ],
                 "regions_bed": [
@@ -579,14 +579,14 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-27T17:07:22.405843995",
+        "timestamp": "2026-04-28T14:36:48.371731202",
         "meta": {
-            "nf-test": "0.9.5",
+            "nf-test": "0.9.4",
             "nextflow": "25.10.4"
         }
     },
@@ -621,7 +621,7 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ],
                 "2": [
@@ -651,7 +651,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "6": [
@@ -669,7 +669,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.regions.bed.gz.csi:md5,c33ac5c86370039463796f01434fc0e4"
+                        "test.regions.bed.gz.csi:md5,e0045e73eb8e8c2b88544f0bc346e002"
                     ]
                 ],
                 "8": [
@@ -702,7 +702,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "per_base_d4": [
@@ -729,7 +729,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.regions.bed.gz.csi:md5,c33ac5c86370039463796f01434fc0e4"
+                        "test.regions.bed.gz.csi:md5,e0045e73eb8e8c2b88544f0bc346e002"
                     ]
                 ],
                 "regions_txt": [
@@ -760,15 +760,15 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-09-23T13:22:04.449943",
+        "timestamp": "2026-04-28T14:36:24.354259946",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
         }
     },
     "homo_sapiens - bam, bai, [] - window": {
@@ -802,7 +802,7 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ],
                 "2": [
@@ -832,7 +832,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "6": [
@@ -850,7 +850,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.regions.bed.gz.csi:md5,17a2cbe22a948d7c004b90a1f28347a1"
+                        "test.regions.bed.gz.csi:md5,fb57a83d60532cb601d274fb53854bea"
                     ]
                 ],
                 "8": [
@@ -883,7 +883,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "per_base_d4": [
@@ -910,7 +910,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.regions.bed.gz.csi:md5,17a2cbe22a948d7c004b90a1f28347a1"
+                        "test.regions.bed.gz.csi:md5,fb57a83d60532cb601d274fb53854bea"
                     ]
                 ],
                 "regions_txt": [
@@ -941,15 +941,15 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-09-23T13:22:18.435089",
+        "timestamp": "2026-04-28T14:36:43.187915462",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
         }
     },
     "homo_sapiens - bam, bai, []": {
@@ -983,7 +983,7 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ],
                 "2": [
@@ -1007,7 +1007,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "6": [
@@ -1046,7 +1046,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "per_base_d4": [
@@ -1086,15 +1086,15 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-09-23T13:21:59.785829",
+        "timestamp": "2026-04-28T14:36:18.928982024",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
         }
     },
     "homo_sapiens - cram, crai, []": {
@@ -1128,7 +1128,7 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ],
                 "2": [
@@ -1152,7 +1152,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "6": [
@@ -1191,7 +1191,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "per_base_d4": [
@@ -1231,15 +1231,15 @@
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-09-23T13:22:09.294766",
+        "timestamp": "2026-04-28T14:36:31.154936258",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
         }
     },
     "homo_sapiens - bam, bai, bed - thresholds": {
@@ -1278,14 +1278,14 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.thresholds.bed.gz.csi:md5,2c52ab89e7496af475de3cb2ca04c7b3"
+                        "test.thresholds.bed.gz.csi:md5,5e0a68f8a0f2044ae36a7f50abfa291d"
                     ]
                 ],
                 "12": [
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ],
                 "2": [
@@ -1315,7 +1315,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "6": [
@@ -1333,7 +1333,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.regions.bed.gz.csi:md5,c33ac5c86370039463796f01434fc0e4"
+                        "test.regions.bed.gz.csi:md5,e0045e73eb8e8c2b88544f0bc346e002"
                     ]
                 ],
                 "8": [
@@ -1366,7 +1366,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.per-base.bed.gz.csi:md5,6adccf94ed775c9f53422e3e9c7af27f"
+                        "test.per-base.bed.gz.csi:md5,524a822fc4863b450fda9e0f99ccdf04"
                     ]
                 ],
                 "per_base_d4": [
@@ -1393,7 +1393,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.regions.bed.gz.csi:md5,c33ac5c86370039463796f01434fc0e4"
+                        "test.regions.bed.gz.csi:md5,e0045e73eb8e8c2b88544f0bc346e002"
                     ]
                 ],
                 "regions_txt": [
@@ -1429,22 +1429,22 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.thresholds.bed.gz.csi:md5,2c52ab89e7496af475de3cb2ca04c7b3"
+                        "test.thresholds.bed.gz.csi:md5,5e0a68f8a0f2044ae36a7f50abfa291d"
                     ]
                 ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
                         "mosdepth",
-                        "0.3.11"
+                        "0.3.14"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-09-23T13:22:27.300204",
+        "timestamp": "2026-04-28T14:36:53.804308495",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/modules/nf-core/mosdepth/tests/main.nf.test.snap
+++ b/modules/nf-core/mosdepth/tests/main.nf.test.snap
@@ -45,6 +45,13 @@
                         "0.3.14"
                     ]
                 ],
+                "13": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "2": [
                     [
                         {
@@ -225,6 +232,13 @@
                         "test.thresholds.bed.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "versions_gzip": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
@@ -234,7 +248,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-28T14:37:04.195511575",
+        "timestamp": "2026-04-28T16:21:32.6884639",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
@@ -274,6 +288,13 @@
                         "0.3.14"
                     ]
                 ],
+                "13": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "2": [
                     [
                         {
@@ -406,6 +427,13 @@
                 "thresholds_csi": [
                     
                 ],
+                "versions_gzip": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
@@ -415,7 +443,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-28T14:36:37.330500517",
+        "timestamp": "2026-04-28T16:21:04.254064193",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
@@ -455,6 +483,13 @@
                         "0.3.14"
                     ]
                 ],
+                "13": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "2": [
                     
                 ],
@@ -575,6 +610,13 @@
                 "thresholds_csi": [
                     
                 ],
+                "versions_gzip": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
@@ -584,7 +626,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-28T14:36:48.371731202",
+        "timestamp": "2026-04-28T16:21:15.811323229",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
@@ -624,6 +666,13 @@
                         "0.3.14"
                     ]
                 ],
+                "13": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "2": [
                     [
                         {
@@ -756,6 +805,13 @@
                 "thresholds_csi": [
                     
                 ],
+                "versions_gzip": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
@@ -765,7 +821,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-28T14:36:24.354259946",
+        "timestamp": "2026-04-28T16:20:50.674770475",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
@@ -805,6 +861,13 @@
                         "0.3.14"
                     ]
                 ],
+                "13": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "2": [
                     [
                         {
@@ -937,6 +1000,13 @@
                 "thresholds_csi": [
                     
                 ],
+                "versions_gzip": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
@@ -946,7 +1016,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-28T14:36:43.187915462",
+        "timestamp": "2026-04-28T16:21:10.058663002",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
@@ -986,6 +1056,13 @@
                         "0.3.14"
                     ]
                 ],
+                "13": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "2": [
                     
                 ],
@@ -1082,6 +1159,13 @@
                 "thresholds_csi": [
                     
                 ],
+                "versions_gzip": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
@@ -1091,7 +1175,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-28T14:36:18.928982024",
+        "timestamp": "2026-04-28T16:20:44.067692046",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
@@ -1131,6 +1215,13 @@
                         "0.3.14"
                     ]
                 ],
+                "13": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "2": [
                     
                 ],
@@ -1227,6 +1318,13 @@
                 "thresholds_csi": [
                     
                 ],
+                "versions_gzip": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
@@ -1236,7 +1334,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-28T14:36:31.154936258",
+        "timestamp": "2026-04-28T16:20:57.800996078",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
@@ -1288,6 +1386,13 @@
                         "0.3.14"
                     ]
                 ],
+                "13": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "2": [
                     [
                         {
@@ -1432,6 +1537,13 @@
                         "test.thresholds.bed.gz.csi:md5,5e0a68f8a0f2044ae36a7f50abfa291d"
                     ]
                 ],
+                "versions_gzip": [
+                    [
+                        "MOSDEPTH",
+                        "gzip",
+                        "1.14"
+                    ]
+                ],
                 "versions_mosdepth": [
                     [
                         "MOSDEPTH",
@@ -1441,7 +1553,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-28T14:36:53.804308495",
+        "timestamp": "2026-04-28T16:21:21.687826049",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"


### PR DESCRIPTION
This PR bumps mosdepth's version.

## PR checklist

- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`