### PR TITLE
Fixing subworkflow input channels for parabricks fq2bam and bwamem

### DIFF
--- a/subworkflows/nf-core/fastq_align_bwa/main.nf
+++ b/subworkflows/nf-core/fastq_align_bwa/main.nf
@@ -17,8 +17,8 @@ workflow FASTQ_ALIGN_BWA {
     //
     // Map reads with BWA
     //
-
-    BWA_MEM(ch_reads, ch_index, ch_fasta_fai, val_sort_bam)
+    ch_fasta = ch_fasta_fai.map { meta, fasta, _fai -> [meta, fasta] }
+    BWA_MEM(ch_reads, ch_index, ch_fasta, val_sort_bam)
 
     //
     // Sort, index BAM file and run samtools stats, flagstat and idxstats

--- a/subworkflows/nf-core/fastq_align_bwa/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_bwa/tests/main.nf.test
@@ -20,7 +20,7 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/bwa/index/main.nf"
                 process {
                     """
-                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true), file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)])
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
                     """
                 }
             }
@@ -50,7 +50,7 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/bwa/index/main.nf"
                 process {
                     """
-                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true), file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)])
+                    input[0] = Channel.value([ [ id:'genome' ],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
                     """
                 }
             }

--- a/subworkflows/nf-core/fastq_align_bwa/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_bwa/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.sorted.bam:md5,b2a9528e15248e99477fff72416a2812"
+                        "test.sorted.bam:md5,8ad8cbe24a043b395cbb49ad3f88cc18"
                     ]
                 ],
                 "2": [
@@ -35,7 +35,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.sorted.bam.stats:md5,857f7d95f507269e5375d690c1a906e6"
+                        "test.sorted.bam.stats:md5,21b91a04b74c3498ebb73d185a2bfc95"
                     ]
                 ],
                 "4": [
@@ -62,7 +62,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.sorted.bam:md5,b2a9528e15248e99477fff72416a2812"
+                        "test.sorted.bam:md5,8ad8cbe24a043b395cbb49ad3f88cc18"
                     ]
                 ],
                 "bam_orig": [
@@ -107,16 +107,16 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.sorted.bam.stats:md5,857f7d95f507269e5375d690c1a906e6"
+                        "test.sorted.bam.stats:md5,21b91a04b74c3498ebb73d185a2bfc95"
                     ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.1"
         },
-        "timestamp": "2026-03-13T11:01:24.643867"
+        "timestamp": "2026-04-29T11:14:26.020303576"
     },
     "fastq_align_bwa_single_end": {
         "content": [
@@ -136,7 +136,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.sorted.bam:md5,bc357087e97ca9a8a75d33d260507890"
+                        "test.sorted.bam:md5,00b7c143a13d0881b6d0ef0f4f8665ae"
                     ]
                 ],
                 "2": [
@@ -145,7 +145,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.sorted.bam.bai:md5,caffca5a0e2edb797d9032e62ae8f45e"
+                        "test.sorted.bam.bai:md5,9257847727b20a8f7288ad6912fbada4"
                     ]
                 ],
                 "3": [
@@ -154,7 +154,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.sorted.bam.stats:md5,c5d12d30b12bb8604259dc1dea15d4e0"
+                        "test.sorted.bam.stats:md5,28f7879551f22fca1e2c788f1eb712d8"
                     ]
                 ],
                 "4": [
@@ -181,7 +181,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.sorted.bam:md5,bc357087e97ca9a8a75d33d260507890"
+                        "test.sorted.bam:md5,00b7c143a13d0881b6d0ef0f4f8665ae"
                     ]
                 ],
                 "bam_orig": [
@@ -217,7 +217,7 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.sorted.bam.bai:md5,caffca5a0e2edb797d9032e62ae8f45e"
+                        "test.sorted.bam.bai:md5,9257847727b20a8f7288ad6912fbada4"
                     ]
                 ],
                 "stats": [
@@ -226,15 +226,15 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.sorted.bam.stats:md5,c5d12d30b12bb8604259dc1dea15d4e0"
+                        "test.sorted.bam.stats:md5,28f7879551f22fca1e2c788f1eb712d8"
                     ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.1"
         },
-        "timestamp": "2026-03-13T10:59:58.369213"
+        "timestamp": "2026-04-29T11:14:09.893784807"
     }
 }

--- a/subworkflows/nf-core/fastq_align_dedup_bwamem/main.nf
+++ b/subworkflows/nf-core/fastq_align_dedup_bwamem/main.nf
@@ -25,8 +25,9 @@ workflow FASTQ_ALIGN_DEDUP_BWAMEM {
     ch_multiqc_files = channel.empty()
     ch_fasta = ch_fasta_fai.map { meta, fasta, _fai -> [meta, fasta] }
     /*
-        Align with parabricks GPU enabled fq2bam implementation of bwa-mem
-        */    if (use_gpu) {
+    Align with parabricks GPU enabled fq2bam implementation of bwa-mem
+    */
+    if (use_gpu) {
         PARABRICKS_FQ2BAM(
             ch_reads,
             ch_fasta,
@@ -51,7 +52,7 @@ workflow FASTQ_ALIGN_DEDUP_BWAMEM {
             ch_reads,
             ch_bwamem_index,
             true,
-            ch_fasta,
+            ch_fasta_fai
         )
         ch_alignment = FASTQ_ALIGN_BWA.out.bam
     }

--- a/subworkflows/nf-core/fastq_align_dedup_bwamem/main.nf
+++ b/subworkflows/nf-core/fastq_align_dedup_bwamem/main.nf
@@ -23,12 +23,13 @@ workflow FASTQ_ALIGN_DEDUP_BWAMEM {
     ch_idxstats = channel.empty()
     ch_picard_metrics = channel.empty()
     ch_multiqc_files = channel.empty()
+    ch_fasta = ch_fasta_fai.map { meta, fasta, _fai -> [meta, fasta] }
     /*
         Align with parabricks GPU enabled fq2bam implementation of bwa-mem
         */    if (use_gpu) {
         PARABRICKS_FQ2BAM(
             ch_reads,
-            ch_fasta_fai,
+            ch_fasta,
             ch_bwamem_index,
             interval_file,
             known_sites,
@@ -50,7 +51,7 @@ workflow FASTQ_ALIGN_DEDUP_BWAMEM {
             ch_reads,
             ch_bwamem_index,
             true,
-            ch_fasta_fai,
+            ch_fasta,
         )
         ch_alignment = FASTQ_ALIGN_BWA.out.bam
     }

--- a/subworkflows/nf-core/fastq_align_dedup_bwamem/tests/gpu.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_dedup_bwamem/tests/gpu.nf.test.snap
@@ -22,7 +22,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.stats:md5,d9fcd18014ab57a01b37dd7480a79107"
+                    "test.stats:md5,c74a03de6d290804fd1b1d502eaec964"
                 ]
             ],
             null,
@@ -39,11 +39,11 @@
                 
             ]
         ],
-        "timestamp": "2026-03-13T13:42:04.585004957",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.1"
+        },
+        "timestamp": "2026-04-29T09:12:21.203195056"
     },
     "Sarscov2 fasta - PE - skip deduplication - with GPU parabricks/fq2bam": {
         "content": [
@@ -68,7 +68,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.stats:md5,857f7d95f507269e5375d690c1a906e6"
+                    "test.stats:md5,21b91a04b74c3498ebb73d185a2bfc95"
                 ]
             ],
             null,
@@ -84,11 +84,11 @@
                 
             ]
         ],
-        "timestamp": "2026-03-13T13:44:35.209786178",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.1"
+        },
+        "timestamp": "2026-04-29T09:18:12.151141742"
     },
     "Sarscov2 fasta - SE - skip deduplication - with GPU parabricks/fq2bam": {
         "content": [
@@ -113,7 +113,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.stats:md5,d9fcd18014ab57a01b37dd7480a79107"
+                    "test.stats:md5,c74a03de6d290804fd1b1d502eaec964"
                 ]
             ],
             null,
@@ -129,11 +129,11 @@
                 
             ]
         ],
-        "timestamp": "2026-03-13T13:43:20.275377853",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.1"
+        },
+        "timestamp": "2026-04-29T09:17:19.66501576"
     },
     "Sarscov2 fasta - SE - deduplicate - with GPU parabricks/fq2bam - stub": {
         "content": [
@@ -187,10 +187,10 @@
                 
             ]
         ],
-        "timestamp": "2026-03-13T14:33:18.72025",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-13T14:33:18.72025"
     }
 }

--- a/subworkflows/nf-core/fastq_align_dedup_bwamem/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_dedup_bwamem/tests/main.nf.test
@@ -86,8 +86,10 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                             [ id:'test', single_end:false ],
-                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            [
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            ]
                 ])
                 input[1] = Channel.of([
                             [:],
@@ -128,8 +130,10 @@ nextflow_workflow {
                 """
                 input[0] = Channel.of([
                             [ id:'test', single_end:false ],
-                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            [
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                            ]
                 ])
                 input[1] = Channel.of([
                             [:],

--- a/subworkflows/nf-core/fastq_align_dedup_bwamem/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_dedup_bwamem/tests/main.nf.test.snap
@@ -25,14 +25,14 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.1"
         },
-        "timestamp": "2026-03-12T16:06:17.190393"
+        "timestamp": "2026-04-29T09:54:59.147196538"
     },
     "Params: bwamem paired-end - skip_deduplication": {
         "content": [
             [
-                "94fcf617f5b994584c4e8d4044e16b4f"
+                "af8628d9df18b2d3d4f6fd47ef2bb872"
             ],
             [
                 
@@ -55,9 +55,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.1"
         },
-        "timestamp": "2026-03-12T16:07:14.384043"
+        "timestamp": "2026-04-29T10:49:09.270515998"
     },
     "Params: bwamem single-end - default - stub": {
         "content": [
@@ -107,7 +107,7 @@
     "Params: bwamem paired-end - default": {
         "content": [
             [
-                "b4ac761f4117f0c95693ce61825aa03d"
+                "af8628d9df18b2d3d4f6fd47ef2bb872"
             ],
             [
                 "test.deduped.sorted.md.bam.bai"
@@ -130,8 +130,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.1"
         },
-        "timestamp": "2026-03-12T16:06:59.873914"
+        "timestamp": "2026-04-29T10:47:10.434041343"
     }
 }

--- a/subworkflows/nf-core/fastq_align_dedup_bwamem/tests/nextflow.config
+++ b/subworkflows/nf-core/fastq_align_dedup_bwamem/tests/nextflow.config
@@ -1,6 +1,11 @@
 process {
     withName: PARABRICKS_FQ2BAM {
-        ext.args = '--low-memory'
+        // The nf-test config caps system memory usage to 4.GB
+        // This module requires at least 15 GB to run without error
+        // Note: The Github runners run GPU tests on a machine with 15.1 GB available memory
+        // See .github/workflows/nf-test-gpu.yml for exact machine specs
+        memory = 15.GB
+        accelerator = [request: 1]
     }
     withName: SAMTOOLS_SORT {
         ext.prefix = { "${meta.id}.sorted" }


### PR DESCRIPTION
The inputs for certain subworkflows got messed up (and somehow the ci runners didn't catch it). This will revert the code back to using separate fasta and fai inputs. 