### PR TITLE
Add stub block and migrate emmtyper to topic channels

### DIFF
--- a/modules/nf-core/emmtyper/main.nf
+++ b/modules/nf-core/emmtyper/main.nf
@@ -12,7 +12,7 @@ process EMMTYPER {
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    tuple val("${task.process}"), val('emmtyper'), eval('emmtyper --version 2>&1 | sed "s/^.*emmtyper v//"'), topic: versions, emit: versions_emmtyper
+    tuple val("${task.process}"), val('emmtyper'), eval('python -c "import emmtyper; print(emmtyper.__version__)"'), topic: versions, emit: versions_emmtyper
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/emmtyper/main.nf
+++ b/modules/nf-core/emmtyper/main.nf
@@ -12,7 +12,7 @@ process EMMTYPER {
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    tuple val("${task.process}"), val('emmtyper'), eval("echo \$(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//'"), emit: versions_emmtyper, topic: versions
+    tuple val("${task.process}"), val('emmtyper'), eval('emmtyper --version 2>&1 | sed "s/^.*emmtyper v//"'), topic: versions, emit: versions_emmtyper
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/emmtyper/main.nf
+++ b/modules/nf-core/emmtyper/main.nf
@@ -12,7 +12,7 @@ process EMMTYPER {
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('emmtyper'), eval("echo \$(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//'"), emit: versions_emmtyper, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -25,10 +25,11 @@ process EMMTYPER {
         $args \\
         $fasta \\
         > ${prefix}.tsv
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        emmtyper: \$( echo \$(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//' )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.tsv
     """
 }

--- a/modules/nf-core/emmtyper/meta.yml
+++ b/modules/nf-core/emmtyper/meta.yml
@@ -10,7 +10,8 @@ tools:
       homepage: https://github.com/MDU-PHL/emmtyper
       documentation: https://github.com/MDU-PHL/emmtyper
       tool_dev_url: https://github.com/MDU-PHL/emmtyper
-      licence: ["GNU General Public v3 (GPL v3)"]
+      licence:
+        - "GNU General Public v3 (GPL v3)"
       identifier: ""
 input:
   - - meta:
@@ -35,14 +36,28 @@ output:
           description: Tab-delimited result file
           pattern: "*.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
+  versions_emmtyper:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - emmtyper:
+          type: string
+          description: The name of the tool
+      - echo \$(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - emmtyper:
+          type: string
+          description: The name of the tool
+      - echo \$(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/emmtyper/meta.yml
+++ b/modules/nf-core/emmtyper/meta.yml
@@ -36,7 +36,7 @@ output:
           description: Tab-delimited result file
           pattern: "*.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475
+            - edam: http://edamontology.org/format_3475 # TSV
   versions_emmtyper:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/emmtyper/meta.yml
+++ b/modules/nf-core/emmtyper/meta.yml
@@ -44,7 +44,7 @@ output:
       - emmtyper:
           type: string
           description: The name of the tool
-      - "emmtyper --version 2>&1 | sed \"s/^.*emmtyper v//\"":
+      - python -c "import emmtyper; print(emmtyper.__version__)":
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -55,7 +55,7 @@ topics:
       - emmtyper:
           type: string
           description: The name of the tool
-      - "emmtyper --version 2>&1 | sed \"s/^.*emmtyper v//\"":
+      - python -c "import emmtyper; print(emmtyper.__version__)":
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/emmtyper/meta.yml
+++ b/modules/nf-core/emmtyper/meta.yml
@@ -44,7 +44,7 @@ output:
       - emmtyper:
           type: string
           description: The name of the tool
-      - echo \$(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//':
+      - "emmtyper --version 2>&1 | sed \"s/^.*emmtyper v//\"":
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -55,7 +55,7 @@ topics:
       - emmtyper:
           type: string
           description: The name of the tool
-      - echo \$(emmtyper --version 2>&1) | sed 's/^.*emmtyper v//':
+      - "emmtyper --version 2>&1 | sed \"s/^.*emmtyper v//\"":
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/emmtyper/tests/main.nf.test
+++ b/modules/nf-core/emmtyper/tests/main.nf.test
@@ -29,4 +29,26 @@ nextflow_process {
         }
     }
 
+    test("test-emmtyper - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+				file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
 }

--- a/modules/nf-core/emmtyper/tests/main.nf.test
+++ b/modules/nf-core/emmtyper/tests/main.nf.test
@@ -24,7 +24,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -46,7 +46,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/emmtyper/tests/main.nf.test.snap
+++ b/modules/nf-core/emmtyper/tests/main.nf.test.snap
@@ -2,22 +2,6 @@
     "test-emmtyper - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        "EMMTYPER",
-                        "emmtyper",
-                        "0.2.0"
-                    ]
-                ],
                 "tsv": [
                     [
                         {
@@ -36,7 +20,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-29T10:40:51.181474",
+        "timestamp": "2026-04-29T11:58:50.440326",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -45,22 +29,6 @@
     "test-emmtyper": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.tsv:md5,c727ba859adec9ca8ff0e091ecf79c62"
-                    ]
-                ],
-                "1": [
-                    [
-                        "EMMTYPER",
-                        "emmtyper",
-                        "0.2.0"
-                    ]
-                ],
                 "tsv": [
                     [
                         {
@@ -79,7 +47,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-29T10:40:40.007007",
+        "timestamp": "2026-04-29T11:58:44.635484",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/emmtyper/tests/main.nf.test.snap
+++ b/modules/nf-core/emmtyper/tests/main.nf.test.snap
@@ -1,4 +1,47 @@
 {
+    "test-emmtyper - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "EMMTYPER",
+                        "emmtyper",
+                        "0.2.0"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_emmtyper": [
+                    [
+                        "EMMTYPER",
+                        "emmtyper",
+                        "0.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T10:40:51.181474",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
     "test-emmtyper": {
         "content": [
             {
@@ -12,7 +55,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8028be40b22a6bec2ce48bbc811c663a"
+                    [
+                        "EMMTYPER",
+                        "emmtyper",
+                        "0.2.0"
+                    ]
                 ],
                 "tsv": [
                     [
@@ -23,15 +70,19 @@
                         "test.tsv:md5,c727ba859adec9ca8ff0e091ecf79c62"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,8028be40b22a6bec2ce48bbc811c663a"
+                "versions_emmtyper": [
+                    [
+                        "EMMTYPER",
+                        "emmtyper",
+                        "0.2.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T10:40:40.007007",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-28T13:15:05.509952"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Description

Migrates the `emmtyper` module to use **topic channels** for version outputs and adds a **stub block**, addressing both [#4570](https://github.com/nf-core/modules/issues/4570) and [#11389](https://github.com/nf-core/modules/issues/11389).

This is a **pilot PR** to validate the combined stubs + topics migration pattern before batch-submitting the remaining ~39 modules.

### Changes

**`main.nf`**
- Replaced `path "versions.yml", emit: versions` with single-quoted `eval()` topic output:
  ```
  tuple val("${task.process}"), val('emmtyper'), eval('emmtyper --version 2>&1 | sed "s/^.*emmtyper v//"'), topic: versions, emit: versions_emmtyper
  ```
- Removed the `cat <<-END_VERSIONS` HEREDOC block from the script
- Added `stub:` block with `touch ${prefix}.tsv`

**`meta.yml`** (auto-fixed via `nf-core modules lint --fix`)
- Replaced `versions:` output (versions.yml file) with `versions_emmtyper:` tuple definition
- Added `topics:` block below outputs

**`tests/main.nf.test`**
- Added stub test: `test("test-emmtyper - stub")` with `options "-stub"`
- Uses `sanitizeOutput(process.out)` per [nft-utils](https://github.com/nf-core/nft-utils) convention

### Validation
- `nf-core modules lint emmtyper` → **51/51 passed, 0 warnings, 0 failures**
- `nf-core modules test emmtyper --update --profile docker` → **All tests passed, snapshots stable**
- eval() uses single-quoted string with direct pipe (canonical pattern from shapeit5)

## PR checklist

Closes #4570 (partial — emmtyper only)
Related to #10832

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test emmtyper --profile docker`
    - [x] `nf-core modules test emmtyper --profile singularity`
    - [x] `nf-core modules test emmtyper --profile conda`