### PR TITLE
Migrate mlst to topic channel versions and add stub block

### DIFF
--- a/modules/nf-core/mlst/main.nf
+++ b/modules/nf-core/mlst/main.nf
@@ -12,7 +12,7 @@ process MLST {
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('mlst'), eval('mlst --version 2>&1 | sed "s/mlst //"'), emit: versions_mlst, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,11 +26,11 @@ process MLST {
         --threads $task.cpus \\
         $fasta \\
         > ${prefix}.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        mlst: \$( echo \$(mlst --version 2>&1) | sed 's/mlst //' )
-    END_VERSIONS
     """
 
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.tsv
+    """
 }

--- a/modules/nf-core/mlst/meta.yml
+++ b/modules/nf-core/mlst/meta.yml
@@ -9,7 +9,8 @@ tools:
   - mlst:
       description: Scan contig files against PubMLST typing schemes
       homepage: https://github.com/tseemann/mlst
-      licence: ["GPL v2"]
+      licence:
+        - "GPL v2"
       identifier: biotools:mlst
 input:
   - - meta:
@@ -35,13 +36,27 @@ output:
           pattern: "*.{tsv}"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
+  versions_mlst:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - mlst:
+          type: string
+          description: The name of the tool
+      - mlst --version 2>&1 | sed "s/mlst //":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - mlst:
+          type: string
+          description: The name of the tool
+      - mlst --version 2>&1 | sed "s/mlst //":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@lskatz"
   - "@tseemann"

--- a/modules/nf-core/mlst/tests/main.nf.test
+++ b/modules/nf-core/mlst/tests/main.nf.test
@@ -10,12 +10,9 @@ nextflow_process {
     test("Should run without failures") {
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
-                input[0] = [ [ id:'test', single_end:false ], // meta map
+                input[0] = [ [ id:'test', single_end:false ],
                              file(params.modules_testdata_base_path + "genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz", checkIfExists: true)
                            ]
                 """
@@ -25,7 +22,30 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("Should run without failures - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ],
+                             file(params.modules_testdata_base_path + "genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz", checkIfExists: true)
+                           ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/mlst/tests/main.nf.test.snap
+++ b/modules/nf-core/mlst/tests/main.nf.test.snap
@@ -1,19 +1,34 @@
 {
-    "Should run without failures": {
+    "Should run without failures - stub": {
         "content": [
             {
-                "0": [
+                "tsv": [
                     [
                         {
                             "id": "test",
                             "single_end": false
                         },
-                        "test.tsv:md5,c500a2c893c5cbfe6eaae0ce2287b2e6"
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,ac9190646b911923189e7d3a1f069b77"
-                ],
+                "versions_mlst": [
+                    [
+                        "MLST",
+                        "mlst",
+                        "2.25.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T21:44:15.733419808",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "Should run without failures": {
+        "content": [
+            {
                 "tsv": [
                     [
                         {
@@ -23,15 +38,19 @@
                         "test.tsv:md5,c500a2c893c5cbfe6eaae0ce2287b2e6"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,ac9190646b911923189e7d3a1f069b77"
+                "versions_mlst": [
+                    [
+                        "MLST",
+                        "mlst",
+                        "2.25.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-05-18T21:44:10.652890647",
         "meta": {
-            "nf-test": "0.9.3",
+            "nf-test": "0.9.5",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-23T09:35:14.293292"
+        }
     }
 }


### PR DESCRIPTION
## Description

Migrates the `mlst` module to the new stub+topic channel architecture.

### Changes
- Converted `versions.yml` output to topic channel (`versions_mlst`)
- Removed `END_VERSIONS` heredoc from script block
- Added `stub:` block with touch for output files
- Updated tests to use `sanitizeOutput(process.out)` and added stub test case
- Removed legacy `versions` output block from `meta.yml`
- Restored EDAM ontology comments

Contributes to #4570