### PR TITLE
Migrate snpdists to topic channel versions and add stub block

### DIFF
--- a/modules/nf-core/snpdists/main.nf
+++ b/modules/nf-core/snpdists/main.nf
@@ -12,7 +12,7 @@ process SNPDISTS {
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('snpdists'), eval('snp-dists -v 2>&1 | sed "s/snp-dists //;"'), emit: versions_snpdists, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,10 +24,11 @@ process SNPDISTS {
     snp-dists \\
         $args \\
         $alignment > ${prefix}.tsv
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        snpdists: \$(snp-dists -v 2>&1 | sed 's/snp-dists //;')
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.tsv
     """
 }

--- a/modules/nf-core/snpdists/meta.yml
+++ b/modules/nf-core/snpdists/meta.yml
@@ -11,7 +11,8 @@ tools:
       homepage: https://github.com/tseemann/snp-dists
       documentation: https://github.com/tseemann/snp-dists
       tool_dev_url: https://github.com/tseemann/snp-dists
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: ""
 input:
   - - meta:
@@ -37,13 +38,27 @@ output:
           pattern: "*.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
+  versions_snpdists:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - snpdists:
+          type: string
+          description: The name of the tool
+      - snp-dists -v 2>&1 | sed "s/snp-dists //;":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - snpdists:
+          type: string
+          description: The name of the tool
+      - snp-dists -v 2>&1 | sed "s/snp-dists //;":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@abhi18av"
 maintainers:

--- a/modules/nf-core/snpdists/tests/main.nf.test
+++ b/modules/nf-core/snpdists/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id:'test', single_end:false ], // meta map
-				file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/informative_sites.fas', checkIfExists: true) ]
+                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/informative_sites.fas', checkIfExists: true) ]
 
                 """
             }
@@ -24,7 +24,29 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test-snpdists - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/informative_sites.fas', checkIfExists: true) ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/snpdists/tests/main.nf.test.snap
+++ b/modules/nf-core/snpdists/tests/main.nf.test.snap
@@ -2,18 +2,6 @@
     "test-snpdists": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.tsv:md5,0018e5ec43990eb16abe2411fff4e47e"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,62490c6d1f42c5d2eebeea9fcf78f619"
-                ],
                 "tsv": [
                     [
                         {
@@ -23,15 +11,46 @@
                         "test.tsv:md5,0018e5ec43990eb16abe2411fff4e47e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,62490c6d1f42c5d2eebeea9fcf78f619"
+                "versions_snpdists": [
+                    [
+                        "SNPDISTS",
+                        "snpdists",
+                        "0.8.2"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T15:56:14.816906",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-28T17:00:19.004853"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "test-snpdists - stub": {
+        "content": [
+            {
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_snpdists": [
+                    [
+                        "SNPDISTS",
+                        "snpdists",
+                        "0.8.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T15:56:18.686968",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Description

Migrates the `snpdists` module to the new stub+topic channel architecture.

### Changes
- Converted `versions.yml` output to topic channel (`versions_snpdists`)
- Removed `END_VERSIONS` heredoc from script block
- Added `stub:` block
- Updated tests to use `sanitizeOutput(process.out)` and added stub test case
- Removed legacy `versions` output block from `meta.yml`
- Restored EDAM ontology comments

Contributes to #4570