### PR TITLE
Migrate rapidnj to topic channel versions and add stub block

### DIFF
--- a/modules/nf-core/rapidnj/main.nf
+++ b/modules/nf-core/rapidnj/main.nf
@@ -13,14 +13,15 @@ process RAPIDNJ {
     output:
     path "*.sth"       , emit: stockholm_alignment
     path "*.tre"       , emit: phylogeny
-    path "versions.yml", emit: versions
+    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
+    tuple val("${task.process}"), val('rapidnj'), eval('echo 2.3.2'), emit: versions_rapidnj, topic: versions
+    tuple val("${task.process}"), val('biopython'), eval('python -c "import Bio; print(Bio.__version__)"'), emit: versions_biopython, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    def VERSION = '2.3.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     python \\
         -c 'from Bio import SeqIO; SeqIO.convert("$alignment", "fasta", "alignment.sth", "stockholm")'
@@ -31,11 +32,11 @@ process RAPIDNJ {
         -i sth \\
         -c $task.cpus \\
         -x rapidnj_phylogeny.tre
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        rapidnj: $VERSION
-        biopython: \$(python -c "import Bio; print(Bio.__version__)")
-    END_VERSIONS
+    stub:
+    """
+    touch alignment.sth
+    touch rapidnj_phylogeny.tre
     """
 }

--- a/modules/nf-core/rapidnj/meta.yml
+++ b/modules/nf-core/rapidnj/meta.yml
@@ -1,21 +1,24 @@
 name: rapidnj
-description: Produces a Newick format phylogeny from a multiple sequence alignment
-  using a Neighbour-Joining algorithm. Capable of bacterial genome size alignments.
+description: Produces a Newick format phylogeny from a multiple sequence
+  alignment using a Neighbour-Joining algorithm. Capable of bacterial genome
+  size alignments.
 keywords:
   - phylogeny
   - newick
   - neighbour-joining
 tools:
   - rapidnj:
-      description: RapidNJ is an algorithmic engineered implementation of canonical
-        neighbour-joining. It uses an efficient search heuristic to speed-up the core
-        computations of the neighbour-joining method that enables RapidNJ to outperform
-        other state-of-the-art neighbour-joining implementations.
+      description: RapidNJ is an algorithmic engineered implementation of
+        canonical neighbour-joining. It uses an efficient search heuristic to
+        speed-up the core computations of the neighbour-joining method that
+        enables RapidNJ to outperform other state-of-the-art neighbour-joining
+        implementations.
       homepage: https://birc.au.dk/software/rapidnj
       documentation: https://birc.au.dk/software/rapidnj
       tool_dev_url: https://github.com/somme89/rapidNJ
       doi: "10.1007/978-3-540-87361-7_10"
-      licence: ["GPL v2"]
+      licence:
+        - "GPL v2"
       identifier: biotools:rapidnj
 input:
   - alignment:
@@ -36,13 +39,46 @@ output:
         description: A phylogeny in Newick format
         pattern: "*.{tre}"
         ontologies: []
+  versions_rapidnj:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - rapidnj:
+          type: string
+          description: The name of the tool
+      - echo 2.3.2:
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_biopython:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - biopython:
+          type: string
+          description: The name of the tool
+      - python -c "import Bio; print(Bio.__version__)":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - rapidnj:
+          type: string
+          description: The name of the tool
+      - echo 2.3.2:
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - biopython:
+          type: string
+          description: The name of the tool
+      - python -c "import Bio; print(Bio.__version__)":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@aunderwo"
   - "@avantonder"

--- a/modules/nf-core/rapidnj/tests/main.nf.test
+++ b/modules/nf-core/rapidnj/tests/main.nf.test
@@ -24,11 +24,28 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert process.out.phylogeny },
-                { assert snapshot(
-					process.out.stockholm_alignment,
-					process.out.versions
-					).match()
-				}
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("sarscov2-fasta - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/informative_sites.fas', checkIfExists: true) ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/rapidnj/tests/main.nf.test.snap
+++ b/modules/nf-core/rapidnj/tests/main.nf.test.snap
@@ -1,17 +1,64 @@
 {
-    "test-rapidnj": {
+    "sarscov2-fasta": {
         "content": [
-            [
-                "alignment.sth:md5,d2e995c5dd3e3a8212a98414ae5b5de7"
-            ],
-            [
-                "versions.yml:md5,6949732c2fc12b8a5a3e478f197e7fe7"
-            ]
+            {
+                "phylogeny": [
+                    "rapidnj_phylogeny.tre:md5,775909ea40138101976592cfa1814a1d"
+                ],
+                "stockholm_alignment": [
+                    "alignment.sth:md5,d2e995c5dd3e3a8212a98414ae5b5de7"
+                ],
+                "versions_biopython": [
+                    [
+                        "RAPIDNJ",
+                        "biopython",
+                        "1.78"
+                    ]
+                ],
+                "versions_rapidnj": [
+                    [
+                        "RAPIDNJ",
+                        "rapidnj",
+                        "2.3.2"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-04-29T16:04:21.689431",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-23T11:53:44.324999"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2-fasta - stub": {
+        "content": [
+            {
+                "phylogeny": [
+                    "rapidnj_phylogeny.tre:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
+                "stockholm_alignment": [
+                    "alignment.sth:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
+                "versions_biopython": [
+                    [
+                        "RAPIDNJ",
+                        "biopython",
+                        "1.78"
+                    ]
+                ],
+                "versions_rapidnj": [
+                    [
+                        "RAPIDNJ",
+                        "rapidnj",
+                        "2.3.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T16:04:26.633818",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Description

Migrates the `rapidnj` module to the new stub+topic channel architecture.

### Changes
- Converted `versions.yml` output to dual topic channels (`versions_rapidnj` hardcoded, `versions_biopython` via eval)
- Removed `END_VERSIONS` heredoc from script block
- Added `stub:` block
- Updated tests to use `sanitizeOutput(process.out)` and added stub test case
- Removed legacy `versions` output block from `meta.yml`
- Restored EDAM ontology comments

Contributes to #4570