### PR TITLE
Migrate scoary to topic channel versions and add stub block

### DIFF
--- a/modules/nf-core/scoary/main.nf
+++ b/modules/nf-core/scoary/main.nf
@@ -13,7 +13,7 @@ process SCOARY {
 
     output:
     tuple val(meta), path("*.csv"), emit: csv
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('scoary'), eval('scoary --version 2>&1'), emit: versions_scoary, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,10 +29,11 @@ process SCOARY {
         --traits ${traits} \\
         --genes ${genes} \\
         ${newick_tree}
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        scoary: \$( scoary --version 2>&1 )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.csv
     """
 }

--- a/modules/nf-core/scoary/meta.yml
+++ b/modules/nf-core/scoary/meta.yml
@@ -11,7 +11,8 @@ tools:
       documentation: https://github.com/AdmiralenOla/Scoary
       tool_dev_url: https://github.com/AdmiralenOla/Scoary
       doi: "10.1186/s13059-016-1108-8"
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: biotools:scoary
 input:
   - - meta:
@@ -49,13 +50,27 @@ output:
           pattern: "*.csv"
           ontologies:
             - edam: http://edamontology.org/format_3752 # CSV
+  versions_scoary:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - scoary:
+          type: string
+          description: The name of the tool
+      - scoary --version 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - scoary:
+          type: string
+          description: The name of the tool
+      - scoary --version 2>&1:
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/scoary/tests/main.nf.test
+++ b/modules/nf-core/scoary/tests/main.nf.test
@@ -15,10 +15,10 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id:'test', single_end:false ], // meta map
-				    file("https://github.com/AdmiralenOla/Scoary/raw/master/scoary/exampledata/Gene_presence_absence.csv", checkIfExists: true),
-				    file("https://github.com/AdmiralenOla/Scoary/raw/master/scoary/exampledata/Tetracycline_resistance.csv", checkIfExists: true)
+                    file("https://github.com/AdmiralenOla/Scoary/raw/master/scoary/exampledata/Gene_presence_absence.csv", checkIfExists: true),
+                    file("https://github.com/AdmiralenOla/Scoary/raw/master/scoary/exampledata/Tetracycline_resistance.csv", checkIfExists: true)
                 ]
-				input[1] = []
+                input[1] = []
 
                 """
             }
@@ -27,7 +27,32 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test-scoary - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                    file("https://github.com/AdmiralenOla/Scoary/raw/master/scoary/exampledata/Gene_presence_absence.csv", checkIfExists: true),
+                    file("https://github.com/AdmiralenOla/Scoary/raw/master/scoary/exampledata/Tetracycline_resistance.csv", checkIfExists: true)
+                ]
+                input[1] = []
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/scoary/tests/main.nf.test.snap
+++ b/modules/nf-core/scoary/tests/main.nf.test.snap
@@ -1,22 +1,34 @@
 {
-    "test-scoary": {
+    "test-scoary - stub": {
         "content": [
             {
-                "0": [
+                "csv": [
                     [
                         {
                             "id": "test",
                             "single_end": false
                         },
-                        [
-                            "Bogus_trait.results.csv:md5,9550c692bbe6ff0ac844357bfabb809b",
-                            "Tetracycline_resistance.results.csv:md5,a87740818ab4de69a758fc75d7b879dd"
-                        ]
+                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,f8f8a2300f84de4e8184c9dd33579ccd"
-                ],
+                "versions_scoary": [
+                    [
+                        "SCOARY",
+                        "scoary",
+                        "1.6.16"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T16:12:22.645701",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "test-scoary": {
+        "content": [
+            {
                 "csv": [
                     [
                         {
@@ -29,15 +41,19 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,f8f8a2300f84de4e8184c9dd33579ccd"
+                "versions_scoary": [
+                    [
+                        "SCOARY",
+                        "scoary",
+                        "1.6.16"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T16:12:12.390948",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-23T10:40:51.183745"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Description

Migrates the `scoary` module to the new stub+topic channel architecture.

### Changes
- Converted `versions.yml` output to topic channel (`versions_scoary`)
- Removed `END_VERSIONS` heredoc from script block
- Added `stub:` block
- Updated tests to use `sanitizeOutput(process.out)` and added stub test case
- Removed legacy `versions` output block from `meta.yml`
- Restored EDAM ontology comments

Contributes to #4570