### PR TITLE
Migrate staphopiasccmec to topic channel versions and add stub block

### DIFF
--- a/modules/nf-core/staphopiasccmec/main.nf
+++ b/modules/nf-core/staphopiasccmec/main.nf
@@ -12,7 +12,7 @@ process STAPHOPIASCCMEC {
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('staphopiasccmec'), eval('staphopia-sccmec --version 2>&1 | sed "s/^.*staphopia-sccmec //"'), emit: versions_staphopiasccmec, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,10 +22,11 @@ process STAPHOPIASCCMEC {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     staphopia-sccmec --assembly $fasta $args > ${prefix}.tsv
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        staphopiasccmec: \$(staphopia-sccmec --version 2>&1 | sed 's/^.*staphopia-sccmec //')
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.tsv
     """
 }

--- a/modules/nf-core/staphopiasccmec/meta.yml
+++ b/modules/nf-core/staphopiasccmec/meta.yml
@@ -11,7 +11,8 @@ tools:
       documentation: https://github.com/staphopia/staphopia-sccmec
       tool_dev_url: https://github.com/staphopia/staphopia-sccmec
       doi: 10.7717/peerj.5261
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 input:
   - - meta:
@@ -37,13 +38,27 @@ output:
           pattern: "*.{tsv}"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
+  versions_staphopiasccmec:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - staphopiasccmec:
+          type: string
+          description: The name of the tool
+      - staphopia-sccmec --version 2>&1 | sed "s/^.*staphopia-sccmec //":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - staphopiasccmec:
+          type: string
+          description: The name of the tool
+      - staphopia-sccmec --version 2>&1 | sed "s/^.*staphopia-sccmec //":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/staphopiasccmec/tests/main.nf.test
+++ b/modules/nf-core/staphopiasccmec/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-				    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
 
                 """
@@ -26,7 +26,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -39,7 +39,7 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-				    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
 
                 """
@@ -49,7 +49,31 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test-staphopiasccmec - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/staphopiasccmec/tests/main.nf.test.snap
+++ b/modules/nf-core/staphopiasccmec/tests/main.nf.test.snap
@@ -2,17 +2,6 @@
     "test-staphopiasccmec": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.tsv:md5,e6460d4164f3af5b290c5ccdb11343bf"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,24bbe2b413d640d54d3bd98218c7f816"
-                ],
                 "tsv": [
                     [
                         {
@@ -21,31 +10,50 @@
                         "test.tsv:md5,e6460d4164f3af5b290c5ccdb11343bf"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,24bbe2b413d640d54d3bd98218c7f816"
+                "versions_staphopiasccmec": [
+                    [
+                        "STAPHOPIASCCMEC",
+                        "staphopiasccmec",
+                        "1.0.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T16:23:40.69101",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-09-02T17:10:09.415353"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "test-staphopiasccmec - stub": {
+        "content": [
+            {
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_staphopiasccmec": [
+                    [
+                        "STAPHOPIASCCMEC",
+                        "staphopiasccmec",
+                        "1.0.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T16:23:50.237222",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "test-staphopiasccmec-hamming": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.tsv:md5,164cda1b05b3b6814c1f0786d93ca070"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,24bbe2b413d640d54d3bd98218c7f816"
-                ],
                 "tsv": [
                     [
                         {
@@ -54,15 +62,19 @@
                         "test.tsv:md5,164cda1b05b3b6814c1f0786d93ca070"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,24bbe2b413d640d54d3bd98218c7f816"
+                "versions_staphopiasccmec": [
+                    [
+                        "STAPHOPIASCCMEC",
+                        "staphopiasccmec",
+                        "1.0.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T16:23:46.405586",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-09-02T17:10:18.008829"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Description

Migrates the `staphopiasccmec` module to the new stub+topic channel architecture.

### Changes
- Converted `versions.yml` output to topic channel (`versions_staphopiasccmec`)
- Removed `END_VERSIONS` heredoc from script block
- Added `stub:` block
- Updated tests to use `sanitizeOutput(process.out)` and added stub test case
- Removed legacy `versions` output block from `meta.yml`
- Restored EDAM ontology comments

Contributes to #4570