### PR TITLE
Migrate sistr to topic channel versions and add stub block

### DIFF
--- a/modules/nf-core/sistr/main.nf
+++ b/modules/nf-core/sistr/main.nf
@@ -15,7 +15,7 @@ process SISTR {
     tuple val(meta), path("*-allele.fasta"), emit: allele_fasta
     tuple val(meta), path("*-allele.json") , emit: allele_json
     tuple val(meta), path("*-cgmlst.csv")  , emit: cgmlst_csv
-    path "versions.yml"                    , emit: versions
+    tuple val("${task.process}"), val('sistr'), eval('sistr --version 2>&1 | sed "s/^.*sistr_cmd //; s/ .*\$//"'), emit: versions_sistr, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -40,10 +40,14 @@ process SISTR {
         --output-prediction ${prefix} \\
         --output-format tab \\
         $fasta_name
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sistr: \$(echo \$(sistr --version 2>&1) | sed 's/^.*sistr_cmd //; s/ .*\$//' )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.tab
+    touch ${prefix}-allele.fasta
+    touch ${prefix}-allele.json
+    touch ${prefix}-cgmlst.csv
     """
 }

--- a/modules/nf-core/sistr/meta.yml
+++ b/modules/nf-core/sistr/meta.yml
@@ -6,8 +6,8 @@ keywords:
   - salmonella
 tools:
   - sistr:
-      description: Salmonella In Silico Typing Resource (SISTR) commandline tool for
-        serovar prediction
+      description: Salmonella In Silico Typing Resource (SISTR) commandline tool
+        for serovar prediction
       homepage: https://github.com/phac-nml/sistr_cmd
       documentation: https://github.com/phac-nml/sistr_cmd
       tool_dev_url: https://github.com/phac-nml/sistr_cmd
@@ -73,13 +73,27 @@ output:
           pattern: "*.{csv}"
           ontologies:
             - edam: http://edamontology.org/format_3752 # CSV
+  versions_sistr:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - sistr:
+          type: string
+          description: The name of the tool
+      - sistr --version 2>&1 | sed "s/^.*sistr_cmd //; s/ .*\$//":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - sistr:
+          type: string
+          description: The name of the tool
+      - sistr --version 2>&1 | sed "s/^.*sistr_cmd //; s/ .*\$//":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/sistr/tests/main.nf.test
+++ b/modules/nf-core/sistr/tests/main.nf.test
@@ -1,4 +1,3 @@
-
 nextflow_process {
 
     name "Test Process SISTR"
@@ -15,9 +14,9 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-				    [ id:'test', single_end:false ], // meta map
-				    file(params.modules_testdata_base_path + 'genomics/prokaryotes/haemophilus_influenzae/genome/genome.fna.gz', checkIfExists: true)
-				]
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/haemophilus_influenzae/genome/genome.fna.gz', checkIfExists: true)
+                ]
 
                 """
             }
@@ -31,9 +30,33 @@ nextflow_process {
                     process.out.allele_fasta[0][1],
                     process.out.allele_json[0][1],
                     process.out.cgmlst_csv[0][1],
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 }
+            )
+        }
+    }
+
+    test("test-sistr - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/haemophilus_influenzae/genome/genome.fna.gz', checkIfExists: true)
+                ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/sistr/tests/main.nf.test.snap
+++ b/modules/nf-core/sistr/tests/main.nf.test.snap
@@ -5,14 +5,74 @@
             "test-allele.fasta:md5,144a74999eb9dd01520be5c61e8bd210",
             "test-allele.json:md5,3eb993c9489904621f539a93ff9a90ec",
             "test-cgmlst.csv:md5,c50a2144955fe1b98a6d5792bf295088",
-            [
-                "versions.yml:md5,14120b7cc2130310678a4820f12a0436"
-            ]
+            {
+                "versions_sistr": [
+                    [
+                        "SISTR",
+                        "sistr",
+                        "1.1.1"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-05-18T22:06:46.739611961",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-27T13:01:48.796795"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "test-sistr - stub": {
+        "content": [
+            {
+                "allele_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test-allele.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "allele_json": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test-allele.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cgmlst_csv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test-cgmlst.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tab:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_sistr": [
+                    [
+                        "SISTR",
+                        "sistr",
+                        "1.1.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T22:06:52.930664336",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     }
 }


### PR DESCRIPTION
## Description

Migrates the `sistr` module to the new stub+topic channel architecture.

### Changes
- Converted `versions.yml` output to topic channel (`versions_sistr`)
- Removed `END_VERSIONS` heredoc from script block
- Added `stub:` block with touch for all 4 outputs (.tab, -allele.fasta, -allele.json, -cgmlst.csv)
- Updated existing test assertions (removed versions snapshot reference)
- Added stub test case with `sanitizeOutput(process.out)`
- Removed legacy `versions` output block from `meta.yml`
- Restored EDAM ontology comments (# TSV, # JSON, # CSV)

Contributes to #4570