### PR TITLE
feat(racon): add stub block and migrate to topic channel versions

### DIFF
--- a/modules/nf-core/racon/main.nf
+++ b/modules/nf-core/racon/main.nf
@@ -12,7 +12,7 @@ process RACON {
 
     output:
     tuple val(meta), path('*_assembly_consensus.fasta.gz') , emit: improved_assembly
-    path "versions.yml"          , emit: versions
+    tuple val("${task.process}"), val('racon'), eval('racon --version 2>&1 | sed "s/^.*v//"'), emit: versions_racon, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,10 +29,11 @@ process RACON {
         ${prefix}_assembly_consensus.fasta
 
     gzip -n ${prefix}_assembly_consensus.fasta
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        racon: \$( racon --version 2>&1 | sed 's/^.*v//' )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}_assembly_consensus.fasta.gz
     """
 }

--- a/modules/nf-core/racon/meta.yml
+++ b/modules/nf-core/racon/meta.yml
@@ -1,5 +1,6 @@
 name: racon
-description: Consensus module for raw de novo DNA assembly of long uncorrected reads
+description: Consensus module for raw de novo DNA assembly of long uncorrected
+  reads
 keywords:
   - assembly
   - pacbio
@@ -7,13 +8,14 @@ keywords:
   - polish
 tools:
   - racon:
-      description: Ultrafast consensus module for raw de novo genome assembly of long
-        uncorrected reads.
+      description: Ultrafast consensus module for raw de novo genome assembly of
+        long uncorrected reads.
       homepage: https://github.com/lbcb-sci/racon
       documentation: https://github.com/lbcb-sci/racon
       tool_dev_url: https://github.com/lbcb-sci/racon
       doi: 10.1101/gr.214270.116
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:Racon
 input:
   - - meta:
@@ -26,7 +28,7 @@ input:
         description: List of input FastQ files. Racon expects single end reads
         pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
         ontologies:
-          - edam: http://edamontology.org/format_1930 # FASTQ
+          - edam: http://edamontology.org/format_1930
     - assembly:
         type: file
         description: Genome assembly to be improved
@@ -49,14 +51,28 @@ output:
           description: Improved genome assembly
           pattern: "*_assembly_consensus.fasta.gz"
           ontologies:
-            - edam: http://edamontology.org/format_3989 # GZIP format
+            - edam: http://edamontology.org/format_3989
+  versions_racon:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - racon:
+          type: string
+          description: The name of the tool
+      - racon --version 2>&1 | sed "s/^.*v//":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - racon:
+          type: string
+          description: The name of the tool
+      - racon --version 2>&1 | sed "s/^.*v//":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@avantonder"
 maintainers:

--- a/modules/nf-core/racon/tests/main.nf.test
+++ b/modules/nf-core/racon/tests/main.nf.test
@@ -26,7 +26,33 @@ nextflow_process {
         then {
             assertAll (
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("single-end - bacteroides_fragilis - [fastq_gz, fna_gz, paf] - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.paf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/racon/tests/main.nf.test.snap
+++ b/modules/nf-core/racon/tests/main.nf.test.snap
@@ -1,19 +1,34 @@
 {
-    "single-end - bacteroides_fragilis - [fastq_gz, fna_gz, paf]": {
+    "single-end - bacteroides_fragilis - [fastq_gz, fna_gz, paf] - stub": {
         "content": [
             {
-                "0": [
+                "improved_assembly": [
                     [
                         {
                             "id": "test",
                             "single_end": true
                         },
-                        "test_assembly_consensus.fasta.gz:md5,e610bf2e1df1701b88675e36a844baf9"
+                        "test_assembly_consensus.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,7eeab4e50acdc04c648149c2b5a01c84"
-                ],
+                "versions_racon": [
+                    [
+                        "RACON",
+                        "racon",
+                        "1.4.20"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T17:03:57.718531",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "single-end - bacteroides_fragilis - [fastq_gz, fna_gz, paf]": {
+        "content": [
+            {
                 "improved_assembly": [
                     [
                         {
@@ -23,15 +38,19 @@
                         "test_assembly_consensus.fasta.gz:md5,e610bf2e1df1701b88675e36a844baf9"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7eeab4e50acdc04c648149c2b5a01c84"
+                "versions_racon": [
+                    [
+                        "RACON",
+                        "racon",
+                        "1.4.20"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T17:03:47.50875",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
-        },
-        "timestamp": "2024-05-23T11:31:56.975593"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Contribution to #4570 — Stub+Topic Channel Migration

Migrates `racon` to the nf-core v4.0.1 topic channel versioning standard and adds a stub block.

### Changes
- **`main.nf`**: Replaced `versions.yml` / `END_VERSIONS` heredoc with topic channel emit (`versions_racon`). Added `stub` block with `echo "" | gzip` pattern for compressed output.
- **`meta.yml`**: Removed legacy `versions:` output block; `nf-core modules lint --fix` added `versions_racon` and `topics:` sections.
- **`tests/main.nf.test`**: Replaced `process.out.versions` assertion with `sanitizeOutput(process.out)`; added stub test case.
- **`tests/main.nf.test.snap`**: Regenerated snapshots (2 created: standard + stub).

### Test results (local, `--profile docker`)
```
SUCCESS: Executed 2 tests in 36.873s
```
Stability run: ✅ 2/2 passed

Part of the systematic migration tracked in nf-core/modules#4570.