### PR TITLE
feat(slimfastq): add stub block and migrate to topic channel versions

### DIFF
--- a/modules/nf-core/slimfastq/main.nf
+++ b/modules/nf-core/slimfastq/main.nf
@@ -13,7 +13,7 @@ process SLIMFASTQ {
 
     output:
     tuple val(meta), path("*.sfq"), emit: sfq
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('slimfastq'), eval('echo 2.04'), emit: versions_slimfastq, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -21,17 +21,11 @@ process SLIMFASTQ {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '2.04' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     if (meta.single_end) {
         """
         gzip -d -c '${fastq}' | slimfastq \\
             $args \\
             -f '${prefix}.sfq'
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            slimfastq: ${VERSION}
-        END_VERSIONS
         """
     } else {
         """
@@ -42,11 +36,12 @@ process SLIMFASTQ {
         gzip -d -c '${fastq[1]}' | slimfastq \\
             $args \\
             -f '${prefix}_2.sfq'
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            slimfastq: ${VERSION}
-        END_VERSIONS
         """
     }
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.sfq
+    """
 }

--- a/modules/nf-core/slimfastq/meta.yml
+++ b/modules/nf-core/slimfastq/meta.yml
@@ -9,7 +9,8 @@ tools:
       description: "slimfastq efficiently compresses/decompresses FASTQ files"
       homepage: "https://github.com/Infinidat/slimfastq"
       tool_dev_url: "https://github.com/Infinidat/slimfastq"
-      licence: ["BSD-3-clause"]
+      licence:
+        - "BSD-3-clause"
       identifier: ""
 input:
   - - meta:
@@ -31,16 +32,31 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.sfq":
           type: file
-          description: Either one or two sequence files in slimfastq compressed format.
+          description: Either one or two sequence files in slimfastq compressed
+            format.
           pattern: "*.{sfq}"
           ontologies: []
+  versions_slimfastq:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - slimfastq:
+          type: string
+          description: The name of the tool
+      - echo 2.04:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - slimfastq:
+          type: string
+          description: The name of the tool
+      - echo 2.04:
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@Midnighter"
 maintainers:

--- a/modules/nf-core/slimfastq/tests/main.nf.test
+++ b/modules/nf-core/slimfastq/tests/main.nf.test
@@ -26,7 +26,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -51,7 +51,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -73,7 +73,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -95,7 +95,31 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test-slimfastq-stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+				    [ id:'test', single_end:true ], // meta map
+				    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+				]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/slimfastq/tests/main.nf.test.snap
+++ b/modules/nf-core/slimfastq/tests/main.nf.test.snap
@@ -1,19 +1,34 @@
 {
-    "test-slimfastq-single-end": {
+    "test-slimfastq-stub": {
         "content": [
             {
-                "0": [
+                "sfq": [
                     [
                         {
                             "id": "test",
                             "single_end": true
                         },
-                        "test.sfq:md5,6a942eeca6c99ee9a9a0cedab5d246f1"
+                        "test.sfq:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,7748fa634f2a5590ee75c5ac5c175fc4"
-                ],
+                "versions_slimfastq": [
+                    [
+                        "SLIMFASTQ",
+                        "slimfastq",
+                        "2.04"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T17:06:28.697297",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "test-slimfastq-single-end": {
+        "content": [
+            {
                 "sfq": [
                     [
                         {
@@ -23,32 +38,24 @@
                         "test.sfq:md5,6a942eeca6c99ee9a9a0cedab5d246f1"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7748fa634f2a5590ee75c5ac5c175fc4"
+                "versions_slimfastq": [
+                    [
+                        "SLIMFASTQ",
+                        "slimfastq",
+                        "2.04"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T17:06:13.556213",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-28T17:02:38.517873"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "test-slimfastq-nanopore": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.sfq:md5,e17f14d64d3a75356b03ff2f9e8881f7"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,7748fa634f2a5590ee75c5ac5c175fc4"
-                ],
                 "sfq": [
                     [
                         {
@@ -58,35 +65,24 @@
                         "test.sfq:md5,e17f14d64d3a75356b03ff2f9e8881f7"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7748fa634f2a5590ee75c5ac5c175fc4"
+                "versions_slimfastq": [
+                    [
+                        "SLIMFASTQ",
+                        "slimfastq",
+                        "2.04"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T17:06:21.551684",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-28T17:02:48.495305"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "test-slimfastq-paired-end": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        [
-                            "test_1.sfq:md5,6a942eeca6c99ee9a9a0cedab5d246f1",
-                            "test_2.sfq:md5,0d2c60b52a39f7c2cb7843e848d90afd"
-                        ]
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,7748fa634f2a5590ee75c5ac5c175fc4"
-                ],
                 "sfq": [
                     [
                         {
@@ -99,32 +95,24 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7748fa634f2a5590ee75c5ac5c175fc4"
+                "versions_slimfastq": [
+                    [
+                        "SLIMFASTQ",
+                        "slimfastq",
+                        "2.04"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T17:06:17.784674",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-28T17:02:43.505991"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "test-slimfastq-pacbio": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.sfq:md5,9e8389e47e6ddf8c25e92412dd628339"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,7748fa634f2a5590ee75c5ac5c175fc4"
-                ],
                 "sfq": [
                     [
                         {
@@ -134,15 +122,19 @@
                         "test.sfq:md5,9e8389e47e6ddf8c25e92412dd628339"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7748fa634f2a5590ee75c5ac5c175fc4"
+                "versions_slimfastq": [
+                    [
+                        "SLIMFASTQ",
+                        "slimfastq",
+                        "2.04"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-29T17:06:25.231373",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-28T17:02:53.475716"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Contribution to #4570 — Stub+Topic Channel Migration

Migrates `slimfastq` to the nf-core v4.0.1 topic channel versioning standard and adds a stub block.

### Changes
- **`main.nf`**: Replaced `versions.yml` / `END_VERSIONS` heredoc with topic channel emit (`versions_slimfastq`). Version uses `eval('echo 2.04')` since the tool provides no `--version` CLI flag. Added `stub` block with `touch` for `.sfq` output.
- **`meta.yml`**: Removed legacy `versions:` output block; lint fixed to add `versions_slimfastq` and `topics:`.
- **`tests/main.nf.test`**: Replaced `process.out.versions` with `sanitizeOutput(process.out)`; added stub test case.
- **`tests/main.nf.test.snap`**: Regenerated snapshots (5 created: 4 standard + stub).

### Test results (local, `--profile docker`)
```
SUCCESS: Executed 5 tests in 19.572s
```
Stability run: ✅ 5/5 passed

Part of the systematic migration tracked in nf-core/modules#4570.