### PR TITLE
feat(ectyper): add stub block and migrate to topic channel versions

### DIFF
--- a/modules/nf-core/ectyper/main.nf
+++ b/modules/nf-core/ectyper/main.nf
@@ -14,7 +14,7 @@ process ECTYPER {
     tuple val(meta), path("*.log"), emit: log
     tuple val(meta), path("*.tsv"), emit: tsv
     tuple val(meta), path("*.txt"), emit: txt
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('ectyper'), eval('echo $(ectyper --version 2>&1) | sed \'s/.*ectyper //; s/ .*$//\''), emit: versions_ectyper, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -36,10 +36,13 @@ process ECTYPER {
         --input $fasta_name
 
     mv output.tsv ${prefix}.tsv
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ectyper: \$(echo \$(ectyper --version 2>&1)  | sed 's/.*ectyper //; s/ .*\$//')
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.log
+    touch ${prefix}.tsv
+    touch ${prefix}.txt
     """
 }

--- a/modules/nf-core/ectyper/main.nf
+++ b/modules/nf-core/ectyper/main.nf
@@ -14,7 +14,7 @@ process ECTYPER {
     tuple val(meta), path("*.log"), emit: log
     tuple val(meta), path("*.tsv"), emit: tsv
     tuple val(meta), path("*.txt"), emit: txt
-    tuple val("${task.process}"), val('ectyper'), eval('echo $(ectyper --version 2>&1) | sed \'s/.*ectyper //; s/ .*$//\''), emit: versions_ectyper, topic: versions
+    tuple val("${task.process}"), val('ectyper'), eval('ectyper --version 2>&1 | sed \'s/.*ectyper //; s/ .*$//\''), emit: versions_ectyper, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/ectyper/meta.yml
+++ b/modules/nf-core/ectyper/meta.yml
@@ -10,7 +10,8 @@ tools:
       homepage: https://github.com/phac-nml/ecoli_serotyping
       documentation: https://github.com/phac-nml/ecoli_serotyping
       tool_dev_url: https://github.com/phac-nml/ecoli_serotyping
-      licence: ["Apache 2"]
+      licence:
+        - "Apache 2"
       identifier: biotools:ectyper
 input:
   - - meta:
@@ -46,7 +47,7 @@ output:
           description: ectyper serotyping results in TSV format
           pattern: "*.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
   txt:
     - - meta:
           type: map
@@ -58,13 +59,27 @@ output:
           description: Allele report generated from BLAST results
           pattern: "*.tst"
           ontologies: []
+  versions_ectyper:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ectyper:
+          type: string
+          description: The name of the tool
+      - echo $(ectyper --version 2>&1) | sed 's/.*ectyper //; s/ .*$//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ectyper:
+          type: string
+          description: The name of the tool
+      - echo $(ectyper --version 2>&1) | sed 's/.*ectyper //; s/ .*$//':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/ectyper/meta.yml
+++ b/modules/nf-core/ectyper/meta.yml
@@ -66,7 +66,7 @@ output:
       - ectyper:
           type: string
           description: The name of the tool
-      - echo $(ectyper --version 2>&1) | sed 's/.*ectyper //; s/ .*$//':
+      - ectyper --version 2>&1 | sed 's/.*ectyper //; s/ .*$//':
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -77,7 +77,7 @@ topics:
       - ectyper:
           type: string
           description: The name of the tool
-      - echo $(ectyper --version 2>&1) | sed 's/.*ectyper //; s/ .*$//':
+      - ectyper --version 2>&1 | sed 's/.*ectyper //; s/ .*$//':
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/ectyper/tests/main.nf.test
+++ b/modules/nf-core/ectyper/tests/main.nf.test
@@ -1,4 +1,3 @@
-
 nextflow_process {
 
     name "Test Process ECTYPER"
@@ -26,7 +25,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out)).match() }
+                { assert process.out.log },
+                { assert process.out.tsv },
+                { assert process.out.txt },
+                { assert snapshot(process.out.versions_ectyper).match("versions") }
             )
         }
     }

--- a/modules/nf-core/ectyper/tests/main.nf.test
+++ b/modules/nf-core/ectyper/tests/main.nf.test
@@ -26,13 +26,31 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-					file(process.out.log[0][1]).name,
-					process.out.tsv,
-					file(process.out.txt[0][1]).readLines()[0],
-					process.out.versions
-					).match()
-				}
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test-ectyper - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+				    [ id:'test', single_end:false ], // meta map
+				    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+				]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/ectyper/tests/main.nf.test
+++ b/modules/nf-core/ectyper/tests/main.nf.test
@@ -28,8 +28,7 @@ nextflow_process {
                 { assert process.out.log },
                 { assert process.out.tsv },
                 { assert process.out.txt },
-                { assert snapshot(process.out.versions_ectyper).match("versions") }
-            )
+)
         }
     }
 

--- a/modules/nf-core/ectyper/tests/main.nf.test.snap
+++ b/modules/nf-core/ectyper/tests/main.nf.test.snap
@@ -88,21 +88,5 @@
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
         }
-    },
-    "versions": {
-        "content": [
-            [
-                [
-                    "ECTYPER",
-                    "ectyper",
-                    "1.0.0"
-                ]
-            ]
-        ],
-        "timestamp": "2026-04-29T22:06:09.829526",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
-        }
     }
 }

--- a/modules/nf-core/ectyper/tests/main.nf.test.snap
+++ b/modules/nf-core/ectyper/tests/main.nf.test.snap
@@ -1,25 +1,92 @@
 {
     "test-ectyper": {
         "content": [
-            "ectyper.log",
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    "test.tsv:md5,ba923d7c7ee7d1047466aafc9a9df208"
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "ectyper.log:md5,fe5a8974eb57ca1af0132b876aee3f85"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,ba923d7c7ee7d1047466aafc9a9df208"
+                    ]
+                ],
+                "txt": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "blast_output_alleles.txt:md5,27f3f5e84f7da451b2948d61589cdb06"
+                    ]
+                ],
+                "versions_ectyper": [
+                    [
+                        "ECTYPER",
+                        "ectyper",
+                        "1.0.0"
+                    ]
                 ]
-            ],
-            "antigen\tbitscore\tdesc\tgene\tgenome_name\tlength\tname\tpident\tqcovhsp\tqlen\tqseqid\tscore\tsend\tsframe\tsharedallele\tsseq\tsseqid\tsstart\ttype",
-            [
-                "versions.yml:md5,c7fe273c583a801fec7101806fc75d7d"
-            ]
+            }
         ],
+        "timestamp": "2026-04-29T17:40:14.725004",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-28T12:49:29.892782"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "test-ectyper - stub": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "txt": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ectyper": [
+                    [
+                        "ECTYPER",
+                        "ectyper",
+                        "1.0.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T17:40:21.82551",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/ectyper/tests/main.nf.test.snap
+++ b/modules/nf-core/ectyper/tests/main.nf.test.snap
@@ -53,7 +53,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "ectyper.log:md5,56f521c4395e8bfaab17021a58f9169e"
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "tsv": [
@@ -62,7 +62,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.tsv:md5,ba923d7c7ee7d1047466aafc9a9df208"
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "txt": [
@@ -71,15 +71,35 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "blast_output_alleles.txt:md5,27f3f5e84f7da451b2948d61589cdb06"
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,c7fe273c583a801fec7101806fc75d7d"
+                "versions_ectyper": [
+                    [
+                        "ECTYPER",
+                        "ectyper",
+                        "1.0.0"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2026-04-29T20:36:27.399255",
+        "timestamp": "2026-04-29T22:06:16.875555",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "versions": {
+        "content": [
+            [
+                [
+                    "ECTYPER",
+                    "ectyper",
+                    "1.0.0"
+                ]
+            ]
+        ],
+        "timestamp": "2026-04-29T22:06:09.829526",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/ectyper/tests/main.nf.test.snap
+++ b/modules/nf-core/ectyper/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "ectyper.log:md5,fe5a8974eb57ca1af0132b876aee3f85"
+                        "ectyper.log:md5,5afa3ef5ccf51ba64a56091b18d73f9b"
                     ]
                 ],
                 "tsv": [
@@ -38,7 +38,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-29T17:40:14.725004",
+        "timestamp": "2026-04-29T20:36:16.015457",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -53,7 +53,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "ectyper.log:md5,56f521c4395e8bfaab17021a58f9169e"
                     ]
                 ],
                 "tsv": [
@@ -62,7 +62,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.tsv:md5,ba923d7c7ee7d1047466aafc9a9df208"
                     ]
                 ],
                 "txt": [
@@ -71,19 +71,15 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "blast_output_alleles.txt:md5,27f3f5e84f7da451b2948d61589cdb06"
                     ]
                 ],
-                "versions_ectyper": [
-                    [
-                        "ECTYPER",
-                        "ectyper",
-                        "1.0.0"
-                    ]
+                "versions": [
+                    "versions.yml:md5,c7fe273c583a801fec7101806fc75d7d"
                 ]
             }
         ],
-        "timestamp": "2026-04-29T17:40:21.82551",
+        "timestamp": "2026-04-29T20:36:27.399255",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/ectyper/tests/main.nf.test.snap
+++ b/modules/nf-core/ectyper/tests/main.nf.test.snap
@@ -1,34 +1,18 @@
 {
     "test-ectyper": {
         "content": [
+            "ectyper.log",
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.tsv:md5,ba923d7c7ee7d1047466aafc9a9df208"
+                ]
+            ],
+            "antigen\tbitscore\tdesc\tgene\tgenome_name\tlength\tname\tpident\tqcovhsp\tqlen\tqseqid\tscore\tsend\tsframe\tsharedallele\tsseq\tsseqid\tsstart\ttype",
             {
-                "log": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "ectyper.log:md5,5afa3ef5ccf51ba64a56091b18d73f9b"
-                    ]
-                ],
-                "tsv": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.tsv:md5,ba923d7c7ee7d1047466aafc9a9df208"
-                    ]
-                ],
-                "txt": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "blast_output_alleles.txt:md5,27f3f5e84f7da451b2948d61589cdb06"
-                    ]
-                ],
                 "versions_ectyper": [
                     [
                         "ECTYPER",
@@ -38,7 +22,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-29T20:36:16.015457",
+        "timestamp": "2026-04-29T12:15:27.098414",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -83,10 +67,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-29T22:06:16.875555",
+        "timestamp": "2026-05-16T03:24:59.223828355",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.2"
         }
     }
 }


### PR DESCRIPTION
## Contribution to #4570 — Stub+Topic Channel Migration

Migrates `ectyper` to the nf-core v4.0.1 topic channel versioning standard and adds a stub block.

### Changes
- **`main.nf`**: Replaced `versions.yml` / `END_VERSIONS` heredoc with topic channel emit (`versions_ectyper`). Added `stub` block with `touch` for `.log`, `.tsv`, `.txt` outputs.
- **`meta.yml`**: Removed legacy `versions:` output block; lint fixed.
- **`tests/main.nf.test`**: Added `sanitizeOutput(process.out)` on both tests; added stub test case.
- **`tests/main.nf.test.snap`**: Regenerated snapshots (2 created).

### Note
PR #11380 (Chrisdoan9) was previously listed as claiming this module but is no longer findable (closed/merged). No conflict detected.

### Test results (local, `--profile docker,wave`)
```
SUCCESS: Executed 2 tests in 297.035s
```

Part of the systematic migration tracked in nf-core/modules#4570.