### PR TITLE
feat(fastqscan): add stub block and migrate to topic channel versions

### DIFF
--- a/modules/nf-core/fastqscan/main.nf
+++ b/modules/nf-core/fastqscan/main.nf
@@ -12,7 +12,7 @@ process FASTQSCAN {
 
     output:
     tuple val(meta), path("*.json"), emit: json
-    path "versions.yml"            , emit: versions
+    tuple val("${task.process}"), val('fastqscan'), eval('echo $(fastq-scan -v 2>&1) | sed \'s/^.*fastq-scan //\''), emit: versions_fastqscan, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,10 +24,11 @@ process FASTQSCAN {
     zcat $reads | \\
         fastq-scan \\
         $args > ${prefix}.json
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        fastqscan: \$( echo \$(fastq-scan -v 2>&1) | sed 's/^.*fastq-scan //' )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.json
     """
 }

--- a/modules/nf-core/fastqscan/main.nf
+++ b/modules/nf-core/fastqscan/main.nf
@@ -12,7 +12,7 @@ process FASTQSCAN {
 
     output:
     tuple val(meta), path("*.json"), emit: json
-    tuple val("${task.process}"), val('fastqscan'), eval('echo $(fastq-scan -v 2>&1) | sed \'s/^.*fastq-scan //\''), emit: versions_fastqscan, topic: versions
+    tuple val("${task.process}"), val('fastqscan'), eval('fastq-scan -v 2>&1 | sed \'s/^.*fastq-scan //\''), emit: versions_fastqscan, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/fastqscan/meta.yml
+++ b/modules/nf-core/fastqscan/meta.yml
@@ -10,7 +10,8 @@ tools:
       homepage: https://github.com/rpetit3/fastq-scan
       documentation: https://github.com/rpetit3/fastq-scan
       tool_dev_url: https://github.com/rpetit3/fastq-scan
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 input:
   - - meta:
@@ -35,14 +36,28 @@ output:
           description: JSON formatted file of summary statistics
           pattern: "*.json"
           ontologies:
-            - edam: http://edamontology.org/format_3464 # JSON
+            - edam: http://edamontology.org/format_3464
+  versions_fastqscan:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - fastqscan:
+          type: string
+          description: The name of the tool
+      - echo $(fastq-scan -v 2>&1) | sed 's/^.*fastq-scan //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - fastqscan:
+          type: string
+          description: The name of the tool
+      - echo $(fastq-scan -v 2>&1) | sed 's/^.*fastq-scan //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/fastqscan/meta.yml
+++ b/modules/nf-core/fastqscan/meta.yml
@@ -36,7 +36,7 @@ output:
           description: JSON formatted file of summary statistics
           pattern: "*.json"
           ontologies:
-            - edam: http://edamontology.org/format_3464
+            - edam: http://edamontology.org/format_3464 # JSON
   versions_fastqscan:
     - - ${task.process}:
           type: string
@@ -44,7 +44,7 @@ output:
       - fastqscan:
           type: string
           description: The name of the tool
-      - echo $(fastq-scan -v 2>&1) | sed 's/^.*fastq-scan //':
+      - fastq-scan -v 2>&1 | sed 's/^.*fastq-scan //':
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -55,7 +55,7 @@ topics:
       - fastqscan:
           type: string
           description: The name of the tool
-      - echo $(fastq-scan -v 2>&1) | sed 's/^.*fastq-scan //':
+      - fastq-scan -v 2>&1 | sed 's/^.*fastq-scan //':
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/fastqscan/tests/main.nf.test
+++ b/modules/nf-core/fastqscan/tests/main.nf.test
@@ -26,7 +26,34 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("fastqscan - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] =  [
+                                [ id:'test', single_end:true ], // meta map
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                            ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/fastqscan/tests/main.nf.test
+++ b/modules/nf-core/fastqscan/tests/main.nf.test
@@ -10,9 +10,6 @@ nextflow_process {
     test("Should run without failures") {
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
                 input[0] =  [
@@ -37,9 +34,6 @@ nextflow_process {
         options "-stub"
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
                 input[0] =  [

--- a/modules/nf-core/fastqscan/tests/main.nf.test.snap
+++ b/modules/nf-core/fastqscan/tests/main.nf.test.snap
@@ -1,19 +1,34 @@
 {
-    "Should run without failures": {
+    "fastqscan - stub": {
         "content": [
             {
-                "0": [
+                "json": [
                     [
                         {
                             "id": "test",
                             "single_end": true
                         },
-                        "test.json:md5,2748bcc8d6dbe09ad2233ae5a22edcbe"
+                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,900a4e8a5bd719abdee37e7b61c9339f"
-                ],
+                "versions_fastqscan": [
+                    [
+                        "FASTQSCAN",
+                        "fastqscan",
+                        "0.4.4"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T17:42:13.640813",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Should run without failures": {
+        "content": [
+            {
                 "json": [
                     [
                         {
@@ -23,11 +38,19 @@
                         "test.json:md5,2748bcc8d6dbe09ad2233ae5a22edcbe"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,900a4e8a5bd719abdee37e7b61c9339f"
+                "versions_fastqscan": [
+                    [
+                        "FASTQSCAN",
+                        "fastqscan",
+                        "0.4.4"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2023-10-17T14:28:58.206046021"
+        "timestamp": "2026-04-29T17:42:08.229869",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Contribution to #4570 — Stub+Topic Channel Migration

Migrates `fastqscan` to the nf-core v4.0.1 topic channel versioning standard and adds a stub block.

### Changes
- **`main.nf`**: Replaced `versions.yml` / `END_VERSIONS` heredoc with topic channel emit (`versions_fastqscan`). Added `stub` block with `touch` for `.json` output.
- **`meta.yml`**: Removed legacy `versions:` output block; lint fixed.
- **`tests/main.nf.test`**: Added `sanitizeOutput(process.out)` on both tests; added stub test case.
- **`tests/main.nf.test.snap`**: Regenerated snapshots (2 created).

### Test results (local, `--profile docker,wave`)
```
SUCCESS: Executed 2 tests in 76.401s
```

Part of the systematic migration tracked in nf-core/modules#4570.

Closes #10889