### PR TITLE
feat(hicap): migrate to topic channel versions (stub block already present)

### DIFF
--- a/modules/nf-core/hicap/main.nf
+++ b/modules/nf-core/hicap/main.nf
@@ -16,7 +16,7 @@ process HICAP {
     tuple val(meta), path("*.gbk"), emit: gbk, optional: true
     tuple val(meta), path("*.svg"), emit: svg, optional: true
     tuple val(meta), path("*.tsv"), emit: tsv, optional: true
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('hicap'), eval('hicap --version 2>&1 | sed \'s/^.*hicap //\''), emit: versions_hicap, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -38,23 +38,13 @@ process HICAP {
         $args \\
         --threads $task.cpus \\
         -o ./
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        hicap: \$( echo \$( hicap --version 2>&1 ) | sed 's/^.*hicap //' )
-    END_VERSIONS
     """
 
     stub:
-    def fasta_name = fasta.getName().split('\\.')[0] // Get the base name without extension
+    def fasta_name = fasta.getName().split('\\.')[0]
     """
     touch ${fasta_name}.gbk
     touch ${fasta_name}.svg
     touch ${fasta_name}.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        hicap: \$( echo \$( hicap --version 2>&1 ) | sed 's/^.*hicap //' )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/hicap/meta.yml
+++ b/modules/nf-core/hicap/meta.yml
@@ -1,6 +1,6 @@
 name: hicap
-description: Identify cap locus serotype and structure in your Haemophilus influenzae
-  assemblies
+description: Identify cap locus serotype and structure in your Haemophilus
+  influenzae assemblies
 keywords:
   - fasta
   - serotype
@@ -12,7 +12,8 @@ tools:
       documentation: https://github.com/scwatts/hicap
       tool_dev_url: https://github.com/scwatts/hicap
       doi: "10.1128/JCM.00190-19"
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: ""
 input:
   - - meta:
@@ -69,13 +70,27 @@ output:
           pattern: "*.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
+  versions_hicap:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - hicap:
+          type: string
+          description: The name of the tool
+      - hicap --version 2>&1 | sed 's/^.*hicap //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - hicap:
+          type: string
+          description: The name of the tool
+      - hicap --version 2>&1 | sed 's/^.*hicap //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/hicap/tests/main.nf.test
+++ b/modules/nf-core/hicap/tests/main.nf.test
@@ -1,4 +1,3 @@
-
 nextflow_process {
 
     name "Test Process HICAP"
@@ -15,11 +14,11 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-				    [ id:'test', single_end:false ], // meta map
+                    [ id:'test', single_end:false ],
                     file(params.modules_testdata_base_path + 'genomics/prokaryotes/haemophilus_influenzae/genome/genome.fna.gz', checkIfExists: true)
-				]
-				input[1] = []
-				input[2] = []
+                ]
+                input[1] = []
+                input[2] = []
 
                 """
             }
@@ -29,28 +28,28 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-					file(process.out.gbk[0][1]).readLines()[3..7],
-					file(process.out.svg[0][1]).readLines()[3..7],
-					process.out.tsv,
-					process.out.versions
-					).match()
-				}
+                    file(process.out.gbk[0][1]).readLines()[3..7],
+                    file(process.out.svg[0][1]).readLines()[3..7],
+                    process.out.tsv,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
             )
         }
     }
 
-    test("test-hicap-stub") {
+    test("test-hicap - stub") {
         options '-stub'
 
         when {
             process {
                 """
                 input[0] = [
-				    [ id:'test', single_end:false ], // meta map
+                    [ id:'test', single_end:false ],
                     file(params.modules_testdata_base_path + 'genomics/prokaryotes/haemophilus_influenzae/genome/genome.fna.gz', checkIfExists: true)
-				]
-				input[1] = []
-				input[2] = []
+                ]
+                input[1] = []
+                input[2] = []
 
                 """
             }
@@ -59,7 +58,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/hicap/tests/main.nf.test.snap
+++ b/modules/nf-core/hicap/tests/main.nf.test.snap
@@ -24,15 +24,66 @@
                     "genome.tsv:md5,cd148cbec8c707e9c732c417a0e93d3b"
                 ]
             ],
-            [
-                "versions.yml:md5,8f155331d348220ce0f7d6467340608a"
-            ]
+            {
+                "versions_hicap": [
+                    [
+                        "HICAP",
+                        "hicap",
+                        "1.0.3"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-05-18T22:23:36.468425818",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-30T19:27:59.051626"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "test-hicap - stub": {
+        "content": [
+            {
+                "gbk": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.gbk:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "svg": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.svg:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_hicap": [
+                    [
+                        "HICAP",
+                        "hicap",
+                        "1.0.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T22:23:41.930816628",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "test-hicap-stub": {
         "content": [
@@ -99,10 +150,10 @@
                 ]
             }
         ],
+        "timestamp": "2024-08-30T19:25:16.144267",
         "meta": {
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-30T19:25:16.144267"
+        }
     }
 }


### PR DESCRIPTION
## Contribution to #4570 — Stub+Topic Channel Migration

Migrates `hicap` to the nf-core v4.0.1 topic channel versioning standard. This module already had a `stub:` block but still used the legacy `versions.yml` / `END_VERSIONS` pattern.

### Changes
- **`main.nf`**: Replaced `versions.yml` output + `END_VERSIONS` heredoc (in both script and stub) with topic channel emit (`versions_hicap`). Stub block cleaned up.
- **`meta.yml`**: Removed legacy `versions:` output block; lint fixed.
- **`tests/main.nf.test`**: Added `sanitizeOutput(process.out)` on both tests.
- **`tests/main.nf.test.snap`**: Regenerated snapshots (2 created).

### Test results (local, `--profile docker,wave`)
```
SUCCESS: Executed 2 tests in 167.007s
```

Part of the systematic migration tracked in nf-core/modules#4570.