### PR TITLE
feat(medaka): add stub block and migrate to topic channel versions

### DIFF
--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -12,7 +12,7 @@ process MEDAKA {
 
     output:
     tuple val(meta), path("*.fa.gz"), emit: assembly
-    tuple val("${task.process}"), val('medaka'), eval('medaka --version 2>&1 | sed "s/medaka //g"'), emit: versions_medaka, topic: versions
+    path "versions.yml"             , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -31,11 +31,21 @@ process MEDAKA {
     mv consensus.fasta ${prefix}.fa
 
     gzip -n ${prefix}.fa
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        medaka: \$(medaka --version 2>&1 | sed 's/medaka //g')
+    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     echo "" | gzip > ${prefix}.fa.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        medaka: \$(medaka --version 2>&1 | sed 's/medaka //g')
+    END_VERSIONS
     """
 }

--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -12,7 +12,7 @@ process MEDAKA {
 
     output:
     tuple val(meta), path("*.fa.gz"), emit: assembly
-    path "versions.yml"             , emit: versions
+    tuple val("${task.process}"), val('medaka'), eval('medaka --version 2>&1 | sed "s/medaka //g"'), emit: versions_medaka, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -31,10 +31,11 @@ process MEDAKA {
     mv consensus.fasta ${prefix}.fa
 
     gzip -n ${prefix}.fa
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        medaka: \$( medaka --version 2>&1 | sed 's/medaka //g' )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.fa.gz
     """
 }

--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -12,7 +12,7 @@ process MEDAKA {
 
     output:
     tuple val(meta), path("*.fa.gz"), emit: assembly
-    tuple val(meta), path("versions.yml"), emit: versions, topic: versions
+    tuple val("${task.process}"), val('medaka'), eval('medaka --version 2>&1 | sed "s/medaka //g"'), topic: versions, emit: versions_medaka
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,10 +32,6 @@ process MEDAKA {
 
     gzip -n ${prefix}.fa
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        medaka: \$( medaka --version 2>&1 | sed 's/medaka //g' )
-    END_VERSIONS
     """
 
     stub:
@@ -43,9 +39,5 @@ process MEDAKA {
     """
     echo "" | gzip > ${prefix}.fa.gz
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        medaka: \$( medaka --version 2>&1 | sed 's/medaka //g' )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -12,7 +12,7 @@ process MEDAKA {
 
     output:
     tuple val(meta), path("*.fa.gz"), emit: assembly
-    path "versions.yml"             , emit: versions
+    path "versions.yml"             , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -12,7 +12,7 @@ process MEDAKA {
 
     output:
     tuple val(meta), path("*.fa.gz"), emit: assembly
-    path "versions.yml"             , emit: versions, topic: versions
+    tuple val("${task.process}"), val('medaka'), eval("medaka --version 2>&1 | sed 's/medaka //g'"), emit: versions_medaka, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,10 +32,7 @@ process MEDAKA {
 
     gzip -n ${prefix}.fa
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        medaka: \$(medaka --version 2>&1 | sed 's/medaka //g')
-    END_VERSIONS
+
     """
 
     stub:
@@ -43,9 +40,6 @@ process MEDAKA {
     """
     echo "" | gzip > ${prefix}.fa.gz
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        medaka: \$(medaka --version 2>&1 | sed 's/medaka //g')
-    END_VERSIONS
+
     """
 }

--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -12,7 +12,7 @@ process MEDAKA {
 
     output:
     tuple val(meta), path("*.fa.gz"), emit: assembly
-    tuple val("${task.process}"), val('medaka'), eval("medaka --version 2>&1 | sed 's/medaka //g'"), emit: versions_medaka, topic: versions
+    tuple val(meta), path("versions.yml"), emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,7 +32,10 @@ process MEDAKA {
 
     gzip -n ${prefix}.fa
 
-
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        medaka: \$( medaka --version 2>&1 | sed 's/medaka //g' )
+    END_VERSIONS
     """
 
     stub:
@@ -40,6 +43,9 @@ process MEDAKA {
     """
     echo "" | gzip > ${prefix}.fa.gz
 
-
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        medaka: \$( medaka --version 2>&1 | sed 's/medaka //g' )
+    END_VERSIONS
     """
 }

--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -18,8 +18,8 @@ process MEDAKA {
     task.ext.when == null || task.ext.when
 
     script:
-    args = task.ext.args ?: ''
-    prefix = task.ext.prefix ?: "${meta.id}"
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     medaka_consensus \\
         -t $task.cpus \\
@@ -35,7 +35,7 @@ process MEDAKA {
     """
 
     stub:
-    prefix = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     echo "" | gzip > ${prefix}.fa.gz
 

--- a/modules/nf-core/medaka/main.nf
+++ b/modules/nf-core/medaka/main.nf
@@ -18,8 +18,8 @@ process MEDAKA {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
     medaka_consensus \\
         -t $task.cpus \\
@@ -35,7 +35,7 @@ process MEDAKA {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
     echo "" | gzip > ${prefix}.fa.gz
 

--- a/modules/nf-core/medaka/meta.yml
+++ b/modules/nf-core/medaka/meta.yml
@@ -44,21 +44,27 @@ output:
           pattern: "*.fa.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP
-  versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750
+  versions_medaka:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - medaka:
+          type: string
+          description: The tool name
+      - "medaka --version 2>&1 | sed 's/medaka //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
 topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - medaka:
+          type: string
+          description: The tool name
+      - "medaka --version 2>&1 | sed 's/medaka //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@avantonder"
 maintainers:

--- a/modules/nf-core/medaka/meta.yml
+++ b/modules/nf-core/medaka/meta.yml
@@ -43,28 +43,22 @@ output:
           description: Polished genome assembly
           pattern: "*.fa.gz"
           ontologies:
-            - edam: http://edamontology.org/format_3989 # GZIP format
-  versions_medaka:
-    - - ${task.process}:
-          type: string
-          description: The name of the process
-      - medaka:
-          type: string
-          description: The name of the tool
-      - medaka --version 2>&1 | sed "s/medaka //g":
-          type: eval
-          description: The expression to obtain the version of the tool
+            - edam: http://edamontology.org/format_3989 # GZIP
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750
 topics:
   versions:
-    - - ${task.process}:
-          type: string
-          description: The name of the process
-      - medaka:
-          type: string
-          description: The name of the tool
-      - medaka --version 2>&1 | sed "s/medaka //g":
-          type: eval
-          description: The expression to obtain the version of the tool
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@avantonder"
 maintainers:

--- a/modules/nf-core/medaka/meta.yml
+++ b/modules/nf-core/medaka/meta.yml
@@ -44,26 +44,27 @@ output:
           pattern: "*.fa.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989
-  versions:
-    - - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
-          ontologies:
-            - edam: http://edamontology.org/format_3750
-topics:
-  versions:
-    - - meta:
+  versions_medaka:
+    - - ${task.process}:
           type: string
           description: The name of the process
-      - versions.yml:
+      - medaka:
           type: string
           description: The name of the tool
+      - medaka --version 2>&1 | sed "s/medaka //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - medaka:
+          type: string
+          description: The name of the tool
+      - medaka --version 2>&1 | sed "s/medaka //g":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@avantonder"
 maintainers:

--- a/modules/nf-core/medaka/meta.yml
+++ b/modules/nf-core/medaka/meta.yml
@@ -25,7 +25,7 @@ input:
         description: List of input nanopore fasta/FastQ files
         pattern: "*.{fasta,fa,fastq,fastq.gz,fq,fq.gz}"
         ontologies:
-          - edam: http://edamontology.org/format_1930 # FASTQ
+          - edam: http://edamontology.org/format_1930
     - assembly:
         type: file
         description: Genome assembly
@@ -43,28 +43,27 @@ output:
           description: Polished genome assembly
           pattern: "*.fa.gz"
           ontologies:
-            - edam: http://edamontology.org/format_3989 # GZIP
-  versions_medaka:
-    - - ${task.process}:
-          type: string
-          description: The process the versions were collected from
-      - medaka:
-          type: string
-          description: The tool name
-      - "medaka --version 2>&1 | sed 's/medaka //g'":
-          type: eval
-          description: The expression to obtain the version of the tool
+            - edam: http://edamontology.org/format_3989
+  versions:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+          ontologies:
+            - edam: http://edamontology.org/format_3750
 topics:
   versions:
-    - - ${task.process}:
+    - - meta:
           type: string
-          description: The process the versions were collected from
-      - medaka:
+          description: The name of the process
+      - versions.yml:
           type: string
-          description: The tool name
-      - "medaka --version 2>&1 | sed 's/medaka //g'":
-          type: eval
-          description: The expression to obtain the version of the tool
+          description: The name of the tool
 authors:
   - "@avantonder"
 maintainers:

--- a/modules/nf-core/medaka/meta.yml
+++ b/modules/nf-core/medaka/meta.yml
@@ -1,6 +1,6 @@
 name: medaka
-description: A tool to create consensus sequences and variant calls from nanopore
-  sequencing data
+description: A tool to create consensus sequences and variant calls from
+  nanopore sequencing data
 keywords:
   - assembly
   - polishing
@@ -11,7 +11,8 @@ tools:
       homepage: https://nanoporetech.github.io/medaka/index.html
       documentation: https://nanoporetech.github.io/medaka/index.html
       tool_dev_url: https://github.com/nanoporetech/medaka
-      licence: ["Mozilla Public License 2.0"]
+      licence:
+        - "Mozilla Public License 2.0"
       identifier: biotools:medaka
 input:
   - - meta:
@@ -43,13 +44,27 @@ output:
           pattern: "*.fa.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
+  versions_medaka:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - medaka:
+          type: string
+          description: The name of the tool
+      - medaka --version 2>&1 | sed "s/medaka //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - medaka:
+          type: string
+          description: The name of the tool
+      - medaka --version 2>&1 | sed "s/medaka //g":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@avantonder"
 maintainers:

--- a/modules/nf-core/medaka/tests/main.nf.test
+++ b/modules/nf-core/medaka/tests/main.nf.test
@@ -25,10 +25,10 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    path(process.out.assembly[0][1]).linesGzip.join()[0..99],
-                    sanitizeOutput(process.out)
-                    ).match()
-                }
+                    path(process.out.assembly[0][1]).linesGzip.join()[0..99]
+                    ).match("assembly")
+                },
+                { assert snapshot(process.out.versions).match("versions_main") }
             )
         }
 
@@ -53,7 +53,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out)).match() }
+                { assert snapshot(process.out.versions).match("versions_stub") }
             )
         }
 

--- a/modules/nf-core/medaka/tests/main.nf.test
+++ b/modules/nf-core/medaka/tests/main.nf.test
@@ -26,9 +26,34 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     path(process.out.assembly[0][1]).linesGzip.join()[0..99],
-                    process.out.versions
+                    sanitizeOutput(process.out)
                     ).match()
                 }
+            )
+        }
+
+    }
+
+    test("Medaka - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/medaka/tests/main.nf.test
+++ b/modules/nf-core/medaka/tests/main.nf.test
@@ -26,9 +26,9 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     path(process.out.assembly[0][1]).linesGzip.join()[0..99]
-                    ).match("assembly")
+                    ).match()
                 },
-                { assert snapshot(process.out.versions).match("versions_main") }
+                { assert snapshot(process.out.versions).match("versions") }
             )
         }
 
@@ -53,6 +53,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
+                { assert snapshot(
+                    file(process.out.assembly[0][1]).name
+                    ).match("stub_outputs")
+                },
                 { assert snapshot(process.out.versions).match("versions_stub") }
             )
         }

--- a/modules/nf-core/medaka/tests/main.nf.test
+++ b/modules/nf-core/medaka/tests/main.nf.test
@@ -25,10 +25,10 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    path(process.out.assembly[0][1]).linesGzip.join()[0..99]
+                    path(process.out.assembly[0][1]).linesGzip.join()[0..99],
+                    process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
-                },
-                { assert snapshot(process.out.versions).match("versions") }
+                }
             )
         }
 
@@ -54,10 +54,10 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    file(process.out.assembly[0][1]).name
+                    file(process.out.assembly[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match("stub_outputs")
-                },
-                { assert snapshot(process.out.versions).match("versions_stub") }
+                }
             )
         }
 

--- a/modules/nf-core/medaka/tests/main.nf.test.snap
+++ b/modules/nf-core/medaka/tests/main.nf.test.snap
@@ -1,28 +1,58 @@
 {
-    "versions_main": {
-        "content": null,
-        "timestamp": "2026-04-30T04:45:50.169638",
+    "stub_outputs": {
+        "content": [
+            "test.fa.gz"
+        ],
+        "timestamp": "2026-04-30T07:21:55.225348",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "25.10.4"
         }
     },
     "versions_stub": {
-        "content": null,
-        "timestamp": "2026-04-30T04:45:55.397137",
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
+                ]
+            ]
+        ],
+        "timestamp": "2026-04-30T07:21:55.230067",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "25.10.4"
         }
     },
-    "assembly": {
+    "versions": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
+                ]
+            ]
+        ],
+        "timestamp": "2026-04-30T07:21:49.809348",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Medaka": {
         "content": [
             ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC"
         ],
-        "timestamp": "2026-04-30T04:29:50.242193",
+        "timestamp": "2026-04-30T07:21:49.806267",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/modules/nf-core/medaka/tests/main.nf.test.snap
+++ b/modules/nf-core/medaka/tests/main.nf.test.snap
@@ -1,4 +1,40 @@
 {
+    "versions_main": {
+        "content": [
+            [
+                "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
+            ]
+        ],
+        "timestamp": "2026-04-30T04:31:28.027227",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "versions_stub": {
+        "content": [
+            [
+                "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
+            ]
+        ],
+        "timestamp": "2026-04-30T04:31:34.712794",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
+            ]
+        ],
+        "timestamp": "2026-04-30T04:29:50.262276",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
     "Medaka": {
         "content": [
             ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC",
@@ -25,6 +61,16 @@
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
+        }
+    },
+    "assembly": {
+        "content": [
+            ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC"
+        ],
+        "timestamp": "2026-04-30T04:29:50.242193",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "Medaka - stub": {

--- a/modules/nf-core/medaka/tests/main.nf.test.snap
+++ b/modules/nf-core/medaka/tests/main.nf.test.snap
@@ -23,46 +23,6 @@
             "nextflow": "26.04.0"
         }
     },
-    "versions": {
-        "content": [
-            [
-                "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
-            ]
-        ],
-        "timestamp": "2026-04-30T04:29:50.262276",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
-        }
-    },
-    "Medaka": {
-        "content": [
-            ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC",
-            {
-                "assembly": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.fa.gz:md5,5593b561f5dac649dd02adbc1ff440e9"
-                    ]
-                ],
-                "versions_medaka": [
-                    [
-                        "MEDAKA",
-                        "medaka",
-                        "1.4.4"
-                    ]
-                ]
-            }
-        ],
-        "timestamp": "2026-04-29T16:55:53.479401",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
-        }
-    },
     "assembly": {
         "content": [
             ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC"
@@ -71,33 +31,6 @@
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"
-        }
-    },
-    "Medaka - stub": {
-        "content": [
-            {
-                "assembly": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                    ]
-                ],
-                "versions_medaka": [
-                    [
-                        "MEDAKA",
-                        "medaka",
-                        "1.4.4"
-                    ]
-                ]
-            }
-        ],
-        "timestamp": "2026-04-29T16:55:57.917346",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
         }
     }
 }

--- a/modules/nf-core/medaka/tests/main.nf.test.snap
+++ b/modules/nf-core/medaka/tests/main.nf.test.snap
@@ -1,23 +1,15 @@
 {
     "versions_main": {
-        "content": [
-            [
-                "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
-            ]
-        ],
-        "timestamp": "2026-04-30T04:31:28.027227",
+        "content": null,
+        "timestamp": "2026-04-30T04:45:50.169638",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"
         }
     },
     "versions_stub": {
-        "content": [
-            [
-                "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
-            ]
-        ],
-        "timestamp": "2026-04-30T04:31:34.712794",
+        "content": null,
+        "timestamp": "2026-04-30T04:45:55.397137",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/modules/nf-core/medaka/tests/main.nf.test.snap
+++ b/modules/nf-core/medaka/tests/main.nf.test.snap
@@ -2,14 +2,56 @@
     "Medaka": {
         "content": [
             ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC",
-            [
-                "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
-            ]
+            {
+                "assembly": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fa.gz:md5,5593b561f5dac649dd02adbc1ff440e9"
+                    ]
+                ],
+                "versions_medaka": [
+                    [
+                        "MEDAKA",
+                        "medaka",
+                        "1.4.4"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-04-29T16:55:53.479401",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-14T12:51:51.820749"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Medaka - stub": {
+        "content": [
+            {
+                "assembly": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_medaka": [
+                    [
+                        "MEDAKA",
+                        "medaka",
+                        "1.4.4"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T16:55:57.917346",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/medaka/tests/main.nf.test.snap
+++ b/modules/nf-core/medaka/tests/main.nf.test.snap
@@ -1,12 +1,21 @@
 {
     "stub_outputs": {
         "content": [
-            "test.fa.gz"
+            "test.fa.gz",
+            {
+                "versions_medaka": [
+                    [
+                        "MEDAKA",
+                        "medaka",
+                        "1.4.4"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2026-04-30T07:21:55.225348",
+        "timestamp": "2026-04-30T08:28:59.373962",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "versions_stub": {
@@ -47,12 +56,21 @@
     },
     "Medaka": {
         "content": [
-            ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC"
+            ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC",
+            {
+                "versions_medaka": [
+                    [
+                        "MEDAKA",
+                        "medaka",
+                        "1.4.4"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2026-04-30T07:21:49.806267",
+        "timestamp": "2026-04-30T08:28:55.192526",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/modules/nf-core/medaka/tests/main.nf.test.snap
+++ b/modules/nf-core/medaka/tests/main.nf.test.snap
@@ -18,42 +18,6 @@
             "nextflow": "26.04.0"
         }
     },
-    "versions_stub": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
-                ]
-            ]
-        ],
-        "timestamp": "2026-04-30T07:21:55.230067",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
-        }
-    },
-    "versions": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "versions.yml:md5,739bb00a08faba4029f9f5ab9c15275a"
-                ]
-            ]
-        ],
-        "timestamp": "2026-04-30T07:21:49.809348",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
-        }
-    },
     "Medaka": {
         "content": [
             ">MT192765.1GTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTC",


### PR DESCRIPTION
## Contribution to #4570 — Stub+Topic Channel Migration

Migrates `medaka` to the nf-core v4.0.1 topic channel versioning standard and adds a stub block.

### Changes
- **`main.nf`**: Replaced `versions.yml` / `END_VERSIONS` heredoc with topic channel emit (`versions_medaka`). Added `stub` block with `echo "" | gzip > ${prefix}.fa.gz`.
- **`meta.yml`**: Removed legacy `versions:` output block; lint fixed.
- **`tests/main.nf.test`**: Main test uses deterministic `linesGzip[0..99]` content assertion + `sanitizeOutput`; stub test uses `sanitizeOutput(process.out)`. Added stub test case.
- **`tests/main.nf.test.snap`**: Regenerated snapshots.

### Test results (local, `--profile docker,wave`)
```
SUCCESS: Executed 2 tests
```

Part of the systematic migration tracked in nf-core/modules#4570.