### PR TITLE
feat(maltextract): add stub block and migrate to topic channel versions

### DIFF
--- a/modules/nf-core/maltextract/main.nf
+++ b/modules/nf-core/maltextract/main.nf
@@ -14,7 +14,7 @@ process MALTEXTRACT {
 
     output:
     tuple val(meta), path("results")      , emit: results
-    path "versions.yml"                   , emit: versions
+    tuple val("${task.process}"), val('maltextract'), eval('MaltExtract --help | head -n 2 | tail -n 1 | sed \'s/MaltExtract version//\''), emit: versions_maltextract, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,10 +30,10 @@ process MALTEXTRACT {
         -r $ncbi_dir \\
         -o results/ \\
         $args
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        maltextract: \$(MaltExtract --help | head -n 2 | tail -n 1 | sed 's/MaltExtract version//')
-    END_VERSIONS
+    stub:
+    """
+    mkdir -p results
     """
 }

--- a/modules/nf-core/maltextract/meta.yml
+++ b/modules/nf-core/maltextract/meta.yml
@@ -1,6 +1,6 @@
 name: maltextract
-description: Tool for evaluation of MALT results for true positives of ancient metagenomic
-  taxonomic screening
+description: Tool for evaluation of MALT results for true positives of ancient
+  metagenomic taxonomic screening
 keywords:
   - malt
   - MaltExtract
@@ -22,7 +22,8 @@ tools:
       documentation: https://github.com/rhuebler/hops
       tool_dev_url: https://github.com/rhuebler/hops
       doi: "10.1186/s13059-019-1903-0"
-      licence: ["GPL 3"]
+      licence:
+        - "GPL 3"
       identifier: ""
 input:
   - - meta:
@@ -54,13 +55,28 @@ output:
           type: directory
           description: Directory containing MaltExtract text results files
           pattern: "results/"
+
+  versions_maltextract:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - maltextract:
+          type: string
+          description: The name of the tool
+      - MaltExtract --help | head -n 2 | tail -n 1 | sed 's/MaltExtract version//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - maltextract:
+          type: string
+          description: The name of the tool
+      - MaltExtract --help | head -n 2 | tail -n 1 | sed 's/MaltExtract version//':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/maltextract/tests/main.nf.test
+++ b/modules/nf-core/maltextract/tests/main.nf.test
@@ -24,7 +24,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = [ [], // meta map
+                input[0] = [ [],
                     file(params.modules_testdata_base_path + 'delete_me/malt/test.rma6')
                 ]
                 input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/maltextract/taxon_list.txt')
@@ -37,9 +37,35 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.versions,
-                    path("${process.out.results.get(0).get(1)}/ScanSummary.txt")
-                ).match() },
+                    path("${process.out.results.get(0).get(1)}/ScanSummary.txt"),
+                    path("${process.out.results.get(0).get(1)}/error.txt").text == "",
+                    file("${process.out.results.get(0).get(1)}/log.txt").name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("test_maltextract - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [],
+                    file(params.modules_testdata_base_path + 'delete_me/malt/test.rma6')
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/maltextract/taxon_list.txt')
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/maltextract/tests/main.nf.test.snap
+++ b/modules/nf-core/maltextract/tests/main.nf.test.snap
@@ -1,15 +1,51 @@
 {
+    "test_maltextract - stub": {
+        "content": [
+            {
+                "results": [
+                    [
+                        [
+                            
+                        ],
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "versions_maltextract": [
+                    [
+                        "MALTEXTRACT",
+                        "maltextract",
+                        "1.7"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T22:34:21.854841",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
     "test_maltextract": {
         "content": [
-            [
-                "versions.yml:md5,4d87de5def1287321effde6545901cf6"
-            ],
-            "ScanSummary.txt:md5,209fb35426f6a459db0f4af0dc544b10"
+            "ScanSummary.txt:md5,209fb35426f6a459db0f4af0dc544b10",
+            true,
+            "log.txt",
+            {
+                "versions_maltextract": [
+                    [
+                        "MALTEXTRACT",
+                        "maltextract",
+                        "1.7"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-05-16T00:10:24.709917",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
-        },
-        "timestamp": "2024-07-01T08:19:20.696046683"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }


### PR DESCRIPTION
## Contribution to #4570 — Stub+Topic Channel Migration

Migrates `maltextract` to the nf-core v4.0.1 topic channel versioning standard and adds a stub block.

### Changes
- **`main.nf`**: Replaced `versions.yml` / `END_VERSIONS` heredoc with topic channel emit (`versions_maltextract`). Version eval: `MaltExtract --help | head -n 2 | tail -n 1 | sed 's/MaltExtract version//'`. Added `stub` block with `mkdir -p results`.
- **`meta.yml`**: Removed legacy `versions:` output block; lint fixed.
- **`tests/main.nf.test`**: Replaced `process.out.versions` with `sanitizeOutput(process.out)`. Added stub test case (stub uses empty `ncbi_dir` input).
- **`tests/main.nf.test.snap`**: Regenerated snapshots (2 created).

### Test results (local, `--profile docker,wave`)
```
SUCCESS: Executed 2 tests in 278.944s
```
Stability run: ✅ 2/2 passed

Part of the systematic migration tracked in nf-core/modules#4570.