### PR TITLE
feat(islandpath): migrate to topic: versions tuple

### DIFF
--- a/modules/nf-core/islandpath/main.nf
+++ b/modules/nf-core/islandpath/main.nf
@@ -2,6 +2,7 @@ process ISLANDPATH {
     tag "$meta.id"
     label 'process_medium'
 
+    // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/islandpath:1.0.6--hdfd78af_0':
@@ -13,7 +14,7 @@ process ISLANDPATH {
     output:
     tuple val(meta), path("*.gff")        , emit: gff
     path "Dimob.log"                      , emit: log
-    path "versions.yml"                   , emit: versions
+    tuple val("${task.process}"), val('islandpath'), val('1.0.6'), topic: versions, emit: versions_islandpath
 
     when:
     task.ext.when == null || task.ext.when
@@ -21,17 +22,17 @@ process ISLANDPATH {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
-    def VERSION = '1.0.6'
     """
     islandpath \\
         $genome \\
         ${prefix}.gff \\
         $args
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        islandpath: $VERSION
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.gff
+    touch Dimob.log
     """
 }

--- a/modules/nf-core/islandpath/meta.yml
+++ b/modules/nf-core/islandpath/meta.yml
@@ -14,7 +14,8 @@ tools:
       documentation: https://github.com/brinkmanlab/islandpath#readme
       tool_dev_url: https://github.com/brinkmanlab/islandpath
       doi: "10.1093/bioinformatics/bty095"
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: biotools:islandpath
 input:
   - - meta:
@@ -32,12 +33,14 @@ output:
   gff:
     - - meta:
           type: file
-          description: GFF file listing the predicted genomic islands and their coordinates
+          description: GFF file listing the predicted genomic islands and their
+            coordinates
           pattern: "*.gff"
           ontologies: []
       - "*.gff":
           type: file
-          description: GFF file listing the predicted genomic islands and their coordinates
+          description: GFF file listing the predicted genomic islands and their
+            coordinates
           pattern: "*.gff"
           ontologies: []
   log:
@@ -46,13 +49,27 @@ output:
         description: Log file of the islandpath run
         pattern: "*.log"
         ontologies: []
+  versions_islandpath:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - islandpath:
+          type: string
+          description: The name of the tool
+      - 1.0.6:
+          type: string
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - islandpath:
+          type: string
+          description: The name of the tool
+      - 1.0.6:
+          type: string
+          description: The expression to obtain the version of the tool
 authors:
   - "@jvfe"
 maintainers:

--- a/modules/nf-core/islandpath/tests/main.nf.test
+++ b/modules/nf-core/islandpath/tests/main.nf.test
@@ -18,7 +18,7 @@ nextflow_process {
                 process {
                     """
                     input[0] = Channel.fromList([
-                                    tuple([ id:'test' ], // meta map
+                                    tuple([ id:'test' ],
                                     file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.gbff.gz', checkIfExists: true)),
                                 ])
                     """
@@ -37,9 +37,46 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.gff[0]).match() },
-                { assert snapshot(process.out.versions).match("version") },
-                { assert path(process.out[1][0]).text.contains("Running IslandPath-DIMOB") }
+                { assert snapshot(
+                    process.out.gff[0],
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() },
+                { assert path(process.out.log[0]).text.contains("Running IslandPath-DIMOB") }
+            )
+        }
+
+    }
+
+    test("bacteroides_fragilis - gbff - stub") {
+
+        options "-stub"
+
+        setup {
+            run("GUNZIP") {
+                script "../../gunzip/main.nf"
+                process {
+                    """
+                    input[0] = Channel.fromList([
+                                    tuple([ id:'test' ],
+                                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.gbff.gz', checkIfExists: true)),
+                                ])
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = GUNZIP.out.gunzip
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/islandpath/tests/main.nf.test.snap
+++ b/modules/nf-core/islandpath/tests/main.nf.test.snap
@@ -1,4 +1,33 @@
 {
+    "bacteroides_fragilis - gbff - stub": {
+        "content": [
+            {
+                "gff": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    "Dimob.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
+                "versions_islandpath": [
+                    [
+                        "ISLANDPATH",
+                        "islandpath",
+                        "1.0.6"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-15T04:21:12.106055003",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
     "bacteroides_fragilis - gbff": {
         "content": [
             [
@@ -6,24 +35,21 @@
                     "id": "test"
                 },
                 "test.gff:md5,d4719f73e9af606346fade238aa191fa"
-            ]
+            ],
+            {
+                "versions_islandpath": [
+                    [
+                        "ISLANDPATH",
+                        "islandpath",
+                        "1.0.6"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-05-15T04:21:05.127929655",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T09:50:55.704306082"
-    },
-    "version": {
-        "content": [
-            [
-                "versions.yml:md5,abe6848c95b81992712dafd663a94c81"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T10:46:30.654025238"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     }
 }


### PR DESCRIPTION
Fixes #11323
Closes #11821

Migrates the `islandpath` module to use the standardized `topic: versions` channel tuple emission, removes legacy `versions.yml` generation, and incorporates strict-syntax validations.