### PR TITLE
Update filtlong: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/filtlong/main.nf
+++ b/modules/nf-core/filtlong/main.nf
@@ -31,4 +31,11 @@ process FILTLONG {
         2>| >(tee ${prefix}.log >&2) \\
         | gzip -n > ${prefix}.fastq.gz
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.fastq.gz
+    touch ${prefix}.log
+    """
 }

--- a/modules/nf-core/filtlong/meta.yml
+++ b/modules/nf-core/filtlong/meta.yml
@@ -30,13 +30,13 @@ input:
         description: fastq file
         pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
         ontologies:
-          - edam: http://edamontology.org/format_1930 # FASTQ
+          - edam: http://edamontology.org/format_1930
     - longreads:
         type: file
         description: fastq file
         pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
         ontologies:
-          - edam: http://edamontology.org/format_1930 # FASTQ
+          - edam: http://edamontology.org/format_1930
 output:
   reads:
     - - meta:
@@ -49,7 +49,7 @@ output:
           description: Filtered (compressed) fastq file
           pattern: "*.fastq.gz"
           ontologies:
-            - edam: http://edamontology.org/format_3989 # GZIP format
+            - edam: http://edamontology.org/format_3989
   log:
     - - meta:
           type: map

--- a/modules/nf-core/filtlong/meta.yml
+++ b/modules/nf-core/filtlong/meta.yml
@@ -1,5 +1,6 @@
 name: filtlong
-description: Filtlong filters long reads based on quality measures or short read data.
+description: Filtlong filters long reads based on quality measures or short read
+  data.
 keywords:
   - nanopore
   - quality control
@@ -9,13 +10,14 @@ keywords:
   - short reads
 tools:
   - filtlong:
-      description: Filtlong is a tool for filtering long reads. It can take a set of
-        long reads and produce a smaller, better subset. It uses both read length (longer
-        is better) and read identity (higher is better) when choosing which reads pass
-        the filter.
+      description: Filtlong is a tool for filtering long reads. It can take a set
+        of long reads and produce a smaller, better subset. It uses both read
+        length (longer is better) and read identity (higher is better) when
+        choosing which reads pass the filter.
       homepage: https://anaconda.org/bioconda/filtlong
       tool_dev_url: https://github.com/rrwick/Filtlong
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: biotools:filtlong
 input:
   - - meta:
@@ -71,12 +73,12 @@ output:
           description: The expression to obtain the version of the tool
 topics:
   versions:
-    - - "${task.process}":
+    - - ${task.process}:
           type: string
-          description: The name of the process
+          description: The process the versions were collected from
       - filtlong:
           type: string
-          description: The name of the tool
+          description: The tool name
       - 'filtlong --version | sed -e "s/Filtlong v//g"':
           type: eval
           description: The expression to obtain the version of the tool

--- a/modules/nf-core/filtlong/tests/main.nf.test
+++ b/modules/nf-core/filtlong/tests/main.nf.test
@@ -29,7 +29,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 
@@ -57,7 +57,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 
@@ -88,7 +88,35 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 nanopore [fastq] - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    [],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/nanopore/fastq/test.fastq.gz', checkIfExists: true) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/filtlong/tests/main.nf.test.snap
+++ b/modules/nf-core/filtlong/tests/main.nf.test.snap
@@ -2,31 +2,6 @@
     "sarscov2 nanopore [fastq]": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_lr.log:md5,99b1a8e5c6debbb0754872498f0614d7"
-                    ]
-                ],
-                "2": [
-                    [
-                        "FILTLONG",
-                        "filtlong",
-                        "0.2.1"
-                    ]
-                ],
                 "log": [
                     [
                         {
@@ -54,40 +29,51 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-08T12:54:22.043052422",
+        "timestamp": "2026-04-29T14:47:05.469854",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 nanopore [fastq] - stub": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_lr.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_lr.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_filtlong": [
+                    [
+                        "FILTLONG",
+                        "filtlong",
+                        "0.2.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T14:47:17.623243",
+        "meta": {
+            "nf-test": "0.9.5",
             "nextflow": "25.10.4"
         }
     },
     "sarscov2 nanopore [fastq] + Illumina paired-end [fastq]": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_lr.log:md5,5dc53086954a5b01c38aa7945ea4a7af"
-                    ]
-                ],
-                "2": [
-                    [
-                        "FILTLONG",
-                        "filtlong",
-                        "0.2.1"
-                    ]
-                ],
                 "log": [
                     [
                         {
@@ -115,40 +101,15 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-08T12:54:29.409242138",
+        "timestamp": "2026-04-29T14:47:14.186871",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.5",
             "nextflow": "25.10.4"
         }
     },
     "sarscov2 nanopore [fastq] + Illumina single-end [fastq]": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test_lr.log:md5,1540be73c90d4ca7bf23b26151cc84b7"
-                    ]
-                ],
-                "2": [
-                    [
-                        "FILTLONG",
-                        "filtlong",
-                        "0.2.1"
-                    ]
-                ],
                 "log": [
                     [
                         {
@@ -176,9 +137,9 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-08T12:54:25.664779624",
+        "timestamp": "2026-04-29T14:47:09.924687",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.5",
             "nextflow": "25.10.4"
         }
     }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **filtlong** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block with valid gzip stubs for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_filtlong` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570