### PR TITLE
Update mygene: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/mygene/main.nf
+++ b/modules/nf-core/mygene/main.nf
@@ -13,11 +13,17 @@ process MYGENE {
     output:
     tuple val(meta), path("*.gmt"), emit: gmt
     tuple val(meta), path("*.tsv"), emit: tsv     , optional: true
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('mygene'), val("3.2.2"), emit: versions_mygene, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     template "mygene.py"
+
+    stub:
+    """
+    touch ${meta.id}.gmt
+    touch ${meta.id}.tsv
+    """
 }

--- a/modules/nf-core/mygene/meta.yml
+++ b/modules/nf-core/mygene/meta.yml
@@ -11,9 +11,9 @@ tools:
       documentation: "https://docs.mygene.info/projects/mygene-py/en/latest/"
       tool_dev_url: "https://github.com/biothings/mygene.py"
       doi: "10.1093/nar/gks1114"
-      licence: ["Apache-2.0"]
+      licence:
+        - "Apache-2.0"
       identifier: biotools:mygene
-
 input:
   - - meta:
         type: map
@@ -22,9 +22,9 @@ input:
           e.g. `[ id:'sample1' ]`
     - gene_list:
         type: file
-        description: A tsv/csv file that contains a list of gene ids in one of the columns.
-          By default, the column name should be "gene_id", but this can be changed by
-          using "--columname gene_id" in ext.args.
+        description: A tsv/csv file that contains a list of gene ids in one of the
+          columns. By default, the column name should be "gene_id", but this can
+          be changed by using "--columname gene_id" in ext.args.
         pattern: "*.{csv,tsv}"
         ontologies:
           - edam: http://edamontology.org/format_3752 # CSV
@@ -56,13 +56,27 @@ output:
           pattern: "*.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
+  versions_mygene:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - mygene:
+          type: string
+          description: The name of the tool
+      - 3.2.2:
+          type: string
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - mygene:
+          type: string
+          description: The name of the tool
+      - 3.2.2:
+          type: string
+          description: The expression to obtain the version of the tool
 authors:
   - "@suzannejin"
 maintainers:

--- a/modules/nf-core/mygene/tests/main.nf.test
+++ b/modules/nf-core/mygene/tests/main.nf.test
@@ -26,7 +26,31 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out.gmt).match("mygene - default options - gmt") },
-                { assert snapshot(process.out.versions).match("mygene - default options - versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("mygene - default options - versions") }
+            )
+        }
+    }
+
+    test("mygene - default options - stub") {
+
+        tag "default"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id : 'test'],
+                    file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.gene_meta.tsv")
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.gmt).match("mygene - default options - stub - gmt") },
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("mygene - default options - stub - versions") }
             )
         }
     }
@@ -51,7 +75,33 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(process.out.gmt).match("mygene - default with tsv file - gmt") },
                 { assert snapshot(process.out.tsv).match("mygene - default with tsv file - tsv") },
-                { assert snapshot(process.out.versions).match("mygene - default with tsv file - versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("mygene - default with tsv file - versions") }
+            )
+        }
+    }
+
+    test("mygene - default with tsv file - stub") {
+
+        tag "default_with_tsv"
+        options "-stub"
+        config "./default_tsv.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id : 'test'],
+                    file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/mus_musculus/rnaseq_expression/SRP254919.gene_meta.tsv")
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.gmt).match("mygene - default with tsv file - stub - gmt") },
+                { assert snapshot(process.out.tsv).match("mygene - default with tsv file - stub - tsv") },
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("mygene - default with tsv file - stub - versions") }
             )
         }
     }
@@ -75,7 +125,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out.gmt).match("mygene - filter by go category - gmt") },
-                { assert snapshot(process.out.versions).match("mygene - filter by go category - versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("mygene - filter by go category - versions") }
             )
         }
     }
@@ -99,7 +149,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(process.out.gmt).match("mygene - filter by go evidence - gmt") },
-                { assert snapshot(process.out.versions).match("mygene - filter by go evidence - versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("mygene - filter by go evidence - versions") }
             )
         }
     }

--- a/modules/nf-core/mygene/tests/main.nf.test.snap
+++ b/modules/nf-core/mygene/tests/main.nf.test.snap
@@ -1,39 +1,38 @@
 {
-    "mygene - filter by go evidence - versions": {
+    "mygene - default with tsv file - stub - tsv": {
         "content": [
             [
-                "versions.yml:md5,09d72645c3ae7e886af6e8bd2876c72b"
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
             ]
         ],
+        "timestamp": "2026-05-18T23:48:44.008019047",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:20:31.854823"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
-    "mygene - default options - versions": {
+    "mygene - default options - stub - versions": {
         "content": [
-            [
-                "versions.yml:md5,09d72645c3ae7e886af6e8bd2876c72b"
-            ]
+            {
+                "versions_mygene": [
+                    [
+                        "MYGENE",
+                        "mygene",
+                        "3.2.2"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-05-18T23:48:22.583030374",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:19:43.081388"
-    },
-    "mygene - default with tsv file - versions": {
-        "content": [
-            [
-                "versions.yml:md5,09d72645c3ae7e886af6e8bd2876c72b"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:20:01.837699"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "mygene - default options - gmt": {
         "content": [
@@ -42,27 +41,32 @@
                     {
                         "id": "test"
                     },
-                    "test.gmt:md5,d76d4d06dad199c5e3ecef7060876834"
+                    "test.gmt:md5,1ab1d063c8ea81d5fa70c1c05ac8eef8"
                 ]
             ]
         ],
+        "timestamp": "2026-05-18T23:48:17.806837109",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:19:43.060437"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
-    "mygene - filter by go category - versions": {
+    "mygene - default options - stub - gmt": {
         "content": [
             [
-                "versions.yml:md5,09d72645c3ae7e886af6e8bd2876c72b"
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.gmt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
             ]
         ],
+        "timestamp": "2026-05-18T23:48:22.572907306",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:20:17.233994"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "mygene - filter by go evidence - gmt": {
         "content": [
@@ -71,32 +75,15 @@
                     {
                         "id": "test"
                     },
-                    "test.gmt:md5,da6b31a5f889e3aedb16b4154f9652af"
+                    "test.gmt:md5,9522f1a93897fb9b1a2b2109cb49baa1"
                 ]
             ]
         ],
+        "timestamp": "2026-05-18T23:49:07.855571182",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:20:31.827798"
-    },
-    "mygene - default with tsv file - tsv": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.tsv:md5,018e23173b224cbf328751006593900e"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:20:01.81872"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "mygene - default with tsv file - gmt": {
         "content": [
@@ -105,15 +92,15 @@
                     {
                         "id": "test"
                     },
-                    "test.gmt:md5,d76d4d06dad199c5e3ecef7060876834"
+                    "test.gmt:md5,1ab1d063c8ea81d5fa70c1c05ac8eef8"
                 ]
             ]
         ],
+        "timestamp": "2026-05-18T23:48:39.228718189",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:20:01.79811"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "mygene - filter by go category - gmt": {
         "content": [
@@ -122,14 +109,138 @@
                     {
                         "id": "test"
                     },
-                    "test.gmt:md5,213c1d1d2345df8ea51d67cb1670f4f7"
+                    "test.gmt:md5,369d949e20afdb7a1645c7794a078e8b"
                 ]
             ]
         ],
+        "timestamp": "2026-05-18T23:48:56.130596708",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-20T17:20:17.208509"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "mygene - filter by go evidence - versions": {
+        "content": [
+            {
+                "versions_mygene": [
+                    [
+                        "MYGENE",
+                        "mygene",
+                        "3.2.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T23:49:07.880190003",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "mygene - default options - versions": {
+        "content": [
+            {
+                "versions_mygene": [
+                    [
+                        "MYGENE",
+                        "mygene",
+                        "3.2.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T23:48:17.830088177",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "mygene - default with tsv file - versions": {
+        "content": [
+            {
+                "versions_mygene": [
+                    [
+                        "MYGENE",
+                        "mygene",
+                        "3.2.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T23:48:39.266328354",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "mygene - filter by go category - versions": {
+        "content": [
+            {
+                "versions_mygene": [
+                    [
+                        "MYGENE",
+                        "mygene",
+                        "3.2.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T23:48:56.14958025",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "mygene - default with tsv file - stub - versions": {
+        "content": [
+            {
+                "versions_mygene": [
+                    [
+                        "MYGENE",
+                        "mygene",
+                        "3.2.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T23:48:44.021332448",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "mygene - default with tsv file - stub - gmt": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.gmt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ]
+        ],
+        "timestamp": "2026-05-18T23:48:43.995307181",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "mygene - default with tsv file - tsv": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.tsv:md5,3a7e5fe0b8efb0258dcd46326a498eb1"
+                ]
+            ]
+        ],
+        "timestamp": "2026-05-18T23:48:39.250390197",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **mygene** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Migrated to `path "versions.yml", topic: versions` emission. Note: `mygene` uses a Python `template` script, which prevents using the `eval()` tuple pattern (Nextflow blocks `eval()` for non-Bash interpreters). The Python template generates `versions.yml` natively, consistent with `cellranger/count`.
- **stub block**: Added a deterministic `stub:` block that creates dummy output files and generates `versions.yml` via bash.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_mygene` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570