### PR TITLE
Update ncbigenomedownload: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/ncbigenomedownload/main.nf
+++ b/modules/nf-core/ncbigenomedownload/main.nf
@@ -47,4 +47,21 @@ process NCBIGENOMEDOWNLOAD {
         $groups
 
     """
+
+    stub:
+    """
+    echo "" | gzip > test_genomic.gbff.gz
+    echo "" | gzip > test_genomic.fna.gz
+    echo "" | gzip > test_rm.out.gz
+    echo "" | gzip > test_feature_table.txt.gz
+    echo "" | gzip > test_genomic.gff.gz
+    echo "" | gzip > test_protein.faa.gz
+    echo "" | gzip > test_protein.gpff.gz
+    echo "" | gzip > test_wgsmaster.gbff.gz
+    echo "" | gzip > test_cds_from_genomic.fna.gz
+    echo "" | gzip > test_rna.fna.gz
+    echo "" | gzip > test_rna_from_genomic.fna.gz
+    touch test_assembly_report.txt
+    touch test_assembly_stats.txt
+    """
 }

--- a/modules/nf-core/ncbigenomedownload/meta.yml
+++ b/modules/nf-core/ncbigenomedownload/meta.yml
@@ -10,7 +10,8 @@ tools:
       homepage: https://github.com/kblin/ncbi-genome-download
       documentation: https://github.com/kblin/ncbi-genome-download
       tool_dev_url: https://github.com/kblin/ncbi-genome-download
-      licence: ["Apache Software License"]
+      licence:
+        - "Apache Software License"
       identifier: ""
 input:
   - meta:
@@ -30,9 +31,10 @@ input:
       ontologies: []
   - groups:
       type: string
-      description: NCBI taxonomic groups to download. Can be a comma-separated list.
-        Options are ['all', 'archaea', 'bacteria', 'fungi', 'invertebrate', 'metagenomes',
-        'plant', 'protozoa', 'vertebrate_mammalian', 'vertebrate_other', 'viral']
+      description: NCBI taxonomic groups to download. Can be a comma-separated
+        list. Options are ['all', 'archaea', 'bacteria', 'fungi', 'invertebrate',
+        'metagenomes', 'plant', 'protozoa', 'vertebrate_mammalian',
+        'vertebrate_other', 'viral']
 output:
   gbk:
     - - meta:
@@ -78,8 +80,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_feature_table.txt.gz":
           type: file
-          description: Tab-delimited text file reporting locations and attributes for
-            a subset of annotated features
+          description: Tab-delimited text file reporting locations and attributes
+            for a subset of annotated features
           pattern: "*_feature_table.txt.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -103,8 +105,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_protein.faa.gz":
           type: file
-          description: FASTA format of the accessioned protein products annotated on
-            the genome assembly.
+          description: FASTA format of the accessioned protein products annotated
+            on the genome assembly.
           pattern: "*_protein.faa.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -116,8 +118,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_protein.gpff.gz":
           type: file
-          description: GenPept format of the accessioned protein products annotated
-            on the genome assembly.
+          description: GenPept format of the accessioned protein products
+            annotated on the genome assembly.
           pattern: "*_protein.gpff.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -141,8 +143,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_cds_from_genomic.fna.gz":
           type: file
-          description: FASTA format of the nucleotide sequences corresponding to all
-            CDS features annotated on the assembly
+          description: FASTA format of the nucleotide sequences corresponding to
+            all CDS features annotated on the assembly
           pattern: "*_cds_from_genomic.fna.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -154,8 +156,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_rna.fna.gz":
           type: file
-          description: FASTA format of accessioned RNA products annotated on the genome
-            assembly
+          description: FASTA format of accessioned RNA products annotated on the
+            genome assembly
           pattern: "*_rna.fna.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -167,8 +169,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_rna_from_genomic.fna.gz":
           type: file
-          description: FASTA format of the nucleotide sequences corresponding to all
-            RNA features annotated on the assembly
+          description: FASTA format of the nucleotide sequences corresponding to
+            all RNA features annotated on the assembly
           pattern: "*_rna_from_genomic.fna.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format
@@ -180,8 +182,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_assembly_report.txt":
           type: file
-          description: Tab-delimited text file reporting the name, role and sequence
-            accession.version for objects in the assembly
+          description: Tab-delimited text file reporting the name, role and
+            sequence accession.version for objects in the assembly
           pattern: "*_assembly_report.txt"
           ontologies: []
   stats:
@@ -192,7 +194,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_assembly_stats.txt":
           type: file
-          description: Tab-delimited text file reporting statistics for the assembly
+          description: Tab-delimited text file reporting statistics for the
+            assembly
           pattern: "*_assembly_stats.txt"
           ontologies: []
   versions_ncbigenomedownload:

--- a/modules/nf-core/ncbigenomedownload/tests/main.nf.test
+++ b/modules/nf-core/ncbigenomedownload/tests/main.nf.test
@@ -38,4 +38,28 @@ nextflow_process {
         }
     }
 
+    test("test-ncbigenomedownload - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ] ]
+                input[1] = []
+                input[2] = []
+                input[3] = 'bacteria'
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
 }

--- a/modules/nf-core/ncbigenomedownload/tests/main.nf.test.snap
+++ b/modules/nf-core/ncbigenomedownload/tests/main.nf.test.snap
@@ -1,4 +1,169 @@
 {
+    "test-ncbigenomedownload - stub": {
+        "content": [
+            {
+                "cds": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_cds_from_genomic.fna.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "faa": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_protein.faa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "features": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_feature_table.txt.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "fna": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        [
+                            "test_cds_from_genomic.fna.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_genomic.fna.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_rna_from_genomic.fna.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "gbk": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_genomic.gbff.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "gff": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_genomic.gff.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "gpff": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_protein.gpff.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "report": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_assembly_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "rm": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_rm.out.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "rna": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_rna.fna.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "rna_fna": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_rna_from_genomic.fna.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "stats": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_assembly_stats.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ncbigenomedownload": [
+                    [
+                        "NCBIGENOMEDOWNLOAD",
+                        "ncbigenomedownload",
+                        "0.3.3"
+                    ]
+                ],
+                "wgs_gbk": [
+                    [
+                        [
+                            {
+                                "id": "test",
+                                "single_end": false
+                            }
+                        ],
+                        "test_wgsmaster.gbff.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T15:39:43.025957",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
     "test-ncbigenomedownload": {
         "content": [
             [


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **ncbigenomedownload** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_ncbigenomedownload` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570