### PR TITLE
Update rasusa: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/rasusa/main.nf
+++ b/modules/nf-core/rasusa/main.nf
@@ -30,4 +30,13 @@ process RASUSA {
         --input $reads \\
         $output
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}_1.fastq.gz
+    if [ "${meta.single_end}" == "false" ]; then
+        echo "" | gzip > ${prefix}_2.fastq.gz
+    fi
+    """
 }

--- a/modules/nf-core/rasusa/meta.yml
+++ b/modules/nf-core/rasusa/meta.yml
@@ -11,7 +11,8 @@ tools:
       documentation: https://github.com/mbhall88/rasusa/blob/master/README.md
       tool_dev_url: https://github.com/mbhall88/rasusa
       doi: "10.5281/zenodo.3731394"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:rasusa
 input:
   - - meta:
@@ -52,7 +53,6 @@ output:
       - 'rasusa --version 2>&1 | sed -e "s/rasusa //g"':
           type: eval
           description: The expression to obtain the version of the tool
-
 topics:
   versions:
     - - ${task.process}:

--- a/modules/nf-core/rasusa/tests/main.nf.test
+++ b/modules/nf-core/rasusa/tests/main.nf.test
@@ -29,7 +29,37 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("Should run without failures - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] =  [ [ id:'testfile', single_end:false], // meta map
+                                [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                                  file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                                ],
+                                "1000000b"
+                            ]
+                input[1] = 100
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/rasusa/tests/main.nf.test.snap
+++ b/modules/nf-core/rasusa/tests/main.nf.test.snap
@@ -1,26 +1,37 @@
 {
-    "Should run without failures": {
+    "Should run without failures - stub": {
         "content": [
             {
-                "0": [
+                "reads": [
                     [
                         {
                             "id": "testfile",
                             "single_end": false
                         },
                         [
-                            "testfile_1.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec",
-                            "testfile_2.fastq.gz:md5,2ebae722295ea66d84075a3b042e2b42"
+                            "testfile_1.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "testfile_2.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                         ]
                     ]
                 ],
-                "1": [
+                "versions_rasusa": [
                     [
                         "RASUSA",
                         "rasusa",
                         "0.3.0"
                     ]
-                ],
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T14:51:44.171586",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Should run without failures": {
+        "content": [
+            {
                 "reads": [
                     [
                         {
@@ -42,10 +53,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-29T14:51:40.458162",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.3"
-        },
-        "timestamp": "2024-07-31T14:08:55.918357445"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **rasusa** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_rasusa` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570