### PR TITLE
Update raven: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/raven/main.nf
+++ b/modules/nf-core/raven/main.nf
@@ -33,4 +33,11 @@ process RAVEN {
     # compress assembly graph
     gzip -c ${prefix}.gfa > ${prefix}.gfa.gz
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.fasta.gz
+    echo "" | gzip > ${prefix}.gfa.gz
+    """
 }

--- a/modules/nf-core/raven/meta.yml
+++ b/modules/nf-core/raven/meta.yml
@@ -13,7 +13,8 @@ tools:
       documentation: https://github.com/lbcb-sci/raven#usage
       tool_dev_url: https://github.com/lbcb-sci/raven
       doi: 10.1038/s43588-021-00073-4
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:raven
 input:
   - - meta:
@@ -62,7 +63,6 @@ output:
       - raven --version:
           type: eval
           description: The expression to obtain the version of the tool
-
 topics:
   versions:
     - - ${task.process}:
@@ -74,7 +74,6 @@ topics:
       - raven --version:
           type: eval
           description: The expression to obtain the version of the tool
-
 authors:
   - "@fmalmeida"
 maintainers:

--- a/modules/nf-core/raven/tests/main.nf.test
+++ b/modules/nf-core/raven/tests/main.nf.test
@@ -26,7 +26,31 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test-raven - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+				    [ id:'test', single_end:false ], // meta map
+				    [ file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true) ]
+				]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/raven/tests/main.nf.test.snap
+++ b/modules/nf-core/raven/tests/main.nf.test.snap
@@ -2,31 +2,6 @@
     "test-raven": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.fasta.gz:md5,775cca993a9dbcc09f7be65d801a696b"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.gfa.gz:md5,5342a527f24e7b15c5bd38c42ffd0be6"
-                    ]
-                ],
-                "2": [
-                    [
-                        "RAVEN",
-                        "raven",
-                        "1.6.1"
-                    ]
-                ],
                 "fasta": [
                     [
                         {
@@ -54,10 +29,46 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-29T15:05:10.680726",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-22T10:14:31.120844055"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "test-raven - stub": {
+        "content": [
+            {
+                "fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "gfa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.gfa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_raven": [
+                    [
+                        "RAVEN",
+                        "raven",
+                        "1.6.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T15:05:19.798581",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **raven** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_raven` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570