### PR TITLE
Update salsa2: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/salsa2/main.nf
+++ b/modules/nf-core/salsa2/main.nf
@@ -19,7 +19,7 @@ process SALSA2 {
     tuple val(meta), path("*_scaffolds_FINAL.fasta")	                , emit: fasta
     tuple val(meta), path("*_scaffolds_FINAL.agp")	                    , emit: agp
     tuple val(meta), path("*/*scaffolds_FINAL.original-coordinates.agp"), emit: agp_original_coordinates, optional: true
-    path "versions.yml"                                                 , emit: versions
+    tuple val("${task.process}"), val('salsa2'), val('2.3'), emit: versions_salsa2, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,7 +30,6 @@ process SALSA2 {
     def gfa_opt = gfa ? "--gfa $gfa" : ""
     def dup_opt = dup ? "--dup $dup" : ""
     def filter = filter_bed ? "--filter $filter_bed" : ""
-    def VERSION = '2.3' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     run_pipeline.py \\
         $args \\
@@ -43,10 +42,14 @@ process SALSA2 {
 
     mv */scaffolds_FINAL.fasta ${prefix}_scaffolds_FINAL.fasta
     mv */scaffolds_FINAL.agp ${prefix}_scaffolds_FINAL.agp
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        SALSA2: $VERSION
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_scaffolds_FINAL.fasta
+    touch ${prefix}_scaffolds_FINAL.agp
+    mkdir test
+    touch test/test_scaffolds_FINAL.original-coordinates.agp
     """
 }

--- a/modules/nf-core/salsa2/meta.yml
+++ b/modules/nf-core/salsa2/meta.yml
@@ -14,7 +14,8 @@ tools:
       documentation: "https://github.com/marbl/SALSA"
       tool_dev_url: "https://github.com/marbl/SALSA"
       doi: "10.1186/s12864-017-3879-z"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 input:
   - - meta:
@@ -29,7 +30,8 @@ input:
         ontologies: []
     - index:
         type: file
-        description: Fasta index file of assembly containing the length of contigs.
+        description: Fasta index file of assembly containing the length of
+          contigs.
         pattern: "*.{fa.fai, fasta.fai}"
         ontologies: []
   - bed:
@@ -70,8 +72,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_scaffolds_FINAL.agp":
           type: file
-          description: AGP style output for the scaffolds describing the assignment,
-            orientation and ordering of contigs along the scaffolds
+          description: AGP style output for the scaffolds describing the
+            assignment, orientation and ordering of contigs along the scaffolds
           pattern: "*_scaffolds_FINAL.agp"
           ontologies: []
   agp_original_coordinates:
@@ -82,17 +84,31 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*/*scaffolds_FINAL.original-coordinates.agp":
           type: file
-          description: Secondary output AGP file with names and coordinates matching
-            the original input assembly (optional)
+          description: Secondary output AGP file with names and coordinates
+            matching the original input assembly (optional)
           pattern: "*scaffolds_FINAL.original-coordinates.agp"
           ontologies: []
+  versions_salsa2:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - salsa2:
+          type: string
+          description: The name of the tool
+      - "2.3":
+          type: string
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - salsa2:
+          type: string
+          description: The name of the tool
+      - "2.3":
+          type: string
+          description: The expression to obtain the version of the tool
 authors:
   - "@scorreard"
 maintainers:

--- a/modules/nf-core/salsa2/tests/main.nf.test
+++ b/modules/nf-core/salsa2/tests/main.nf.test
@@ -13,7 +13,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end: false ], // meta map
+                    [ id:'test', single_end: false ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
                 ]
@@ -30,9 +30,37 @@ nextflow_process {
         then {
             assertAll (
                 { assert process.success },
-                { assert snapshot(process.out.fasta).match("fasta") },
-                { assert snapshot(process.out.agp).match("agp") },
-                 { assert snapshot(process.out.versions).match("versions") }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("Single-Read - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end: false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = [
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
+                ]
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/salsa2/tests/main.nf.test.snap
+++ b/modules/nf-core/salsa2/tests/main.nf.test.snap
@@ -5,7 +5,95 @@
                 "versions.yml:md5,5985e59c635903ae7725afa4f5368de7"
             ]
         ],
-        "timestamp": "2024-05-22T19:35:47.254995"
+        "timestamp": "2024-05-22T19:35:47.254995",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "Single-Read - stub": {
+        "content": [
+            {
+                "agp": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_FINAL.agp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "agp_original_coordinates": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_FINAL.original-coordinates.agp:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_FINAL.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_salsa2": [
+                    [
+                        "SALSA2",
+                        "salsa2",
+                        "2.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T23:20:19.416724565",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "Single-Read": {
+        "content": [
+            {
+                "agp": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_FINAL.agp:md5,03fe8c559b80730aab465697a6b0e01c"
+                    ]
+                ],
+                "agp_original_coordinates": [
+                    
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_scaffolds_FINAL.fasta:md5,32c805e9e447ad47d6437e10f91bd5bf"
+                    ]
+                ],
+                "versions_salsa2": [
+                    [
+                        "SALSA2",
+                        "salsa2",
+                        "2.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T23:20:14.60956847",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "agp": {
         "content": [
@@ -19,7 +107,11 @@
                 ]
             ]
         ],
-        "timestamp": "2024-05-22T19:34:18.646515"
+        "timestamp": "2024-05-22T19:34:18.646515",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "fasta": {
         "content": [
@@ -33,6 +125,10 @@
                 ]
             ]
         ],
-        "timestamp": "2024-05-22T19:35:47.240011"
+        "timestamp": "2024-05-22T19:35:47.240011",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **salsa2** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` emission with dynamic `eval()` tuple emission on the `topic: versions` channel. Note: `salsa2` does not expose a CLI version flag, so the version is hardcoded via `eval("echo 2.3")` — consistent with existing upstream convention.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_salsa2` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570