### PR TITLE
Update seqsero2: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/seqsero2/main.nf
+++ b/modules/nf-core/seqsero2/main.nf
@@ -14,7 +14,7 @@ process SEQSERO2 {
     tuple val(meta), path("results/*_log.txt")   , emit: log
     tuple val(meta), path("results/*_result.tsv"), emit: tsv
     tuple val(meta), path("results/*_result.txt"), emit: txt
-    path "versions.yml"                          , emit: versions
+    tuple val("${task.process}"), val('seqsero2'), eval('SeqSero2_package.py --version 2>&1 | sed \'s/^.*SeqSero2_package.py //\''), emit: versions_seqsero2, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,10 +29,14 @@ process SEQSERO2 {
         -n $prefix \\
         -p $task.cpus \\
         -i $seqs
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        seqsero2: \$( echo \$( SeqSero2_package.py --version 2>&1) | sed 's/^.*SeqSero2_package.py //' )
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p results
+    touch results/${prefix}_log.txt
+    touch results/${prefix}_result.tsv
+    touch results/${prefix}_result.txt
     """
 }

--- a/modules/nf-core/seqsero2/meta.yml
+++ b/modules/nf-core/seqsero2/meta.yml
@@ -60,13 +60,27 @@ output:
           description: Detailed summary of the SeqSero2 results
           pattern: "*_result.txt"
           ontologies: []
+  versions_seqsero2:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - seqsero2:
+          type: string
+          description: The name of the tool
+      - SeqSero2_package.py --version 2>&1 | sed 's/^.*SeqSero2_package.py //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - seqsero2:
+          type: string
+          description: The name of the tool
+      - SeqSero2_package.py --version 2>&1 | sed 's/^.*SeqSero2_package.py //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@rpetit3"
 maintainers:

--- a/modules/nf-core/seqsero2/tests/main.nf.test
+++ b/modules/nf-core/seqsero2/tests/main.nf.test
@@ -1,4 +1,3 @@
-
 nextflow_process {
 
     name "Test Process SEQSERO2"
@@ -16,8 +15,8 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
-				    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ]
 
                 """
@@ -28,12 +27,36 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-					file(process.out.log[0][1]).name,
-					file(process.out.tsv[0][1]).readLines()[0],
-					file(process.out.txt[0][1]).readLines()[0],
-					process.out.versions
-					).match()
-				}
+                    file(process.out.log[0][1]).name,
+                    file(process.out.tsv[0][1]).readLines()[0],
+                    file(process.out.txt[0][1]).readLines()[0],
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("test-seqsero2 - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/seqsero2/tests/main.nf.test.snap
+++ b/modules/nf-core/seqsero2/tests/main.nf.test.snap
@@ -1,17 +1,68 @@
 {
+    "test-seqsero2 - stub": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_log.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_result.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "txt": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_result.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_seqsero2": [
+                    [
+                        "SEQSERO2",
+                        "seqsero2",
+                        "1.2.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T23:05:46.062686884",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
     "test-seqsero2": {
         "content": [
             "SeqSero_log.txt",
             "Sample name\tOutput directory\tInput files\tO antigen prediction\tH1 antigen prediction(fliC)\tH2 antigen prediction(fljB)\tPredicted identification\tPredicted antigenic profile\tPredicted serotype\tNote",
             "Sample name:\ttest",
-            [
-                "versions.yml:md5,58aed3e038f84e5d4827dd22f5c88a13"
-            ]
+            {
+                "versions_seqsero2": [
+                    [
+                        "SEQSERO2",
+                        "seqsero2",
+                        "1.2.1"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-05-18T23:05:40.348910385",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-27T13:25:13.677371"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **seqsero2** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_seqsero2` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570