### PR TITLE
Update shovill: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/shovill/main.nf
+++ b/modules/nf-core/shovill/main.nf
@@ -34,4 +34,12 @@ process SHOVILL {
         --outdir ./ \\
         --force
     """
+
+    stub:
+    """
+    touch contigs.fa
+    touch shovill.corrections
+    touch shovill.log
+    touch spades.fasta
+    """
 }

--- a/modules/nf-core/shovill/meta.yml
+++ b/modules/nf-core/shovill/meta.yml
@@ -9,7 +9,8 @@ tools:
       description: Microbial assembly pipeline for Illumina paired-end reads
       homepage: https://github.com/tseemann/shovill
       documentation: https://github.com/tseemann/shovill/blob/master/README.md
-      licence: ["GPL v2"]
+      licence:
+        - "GPL v2"
       identifier: biotools:shovill
 input:
   - - meta:
@@ -63,8 +64,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "{skesa,spades,megahit,velvet}.fasta":
           type: file
-          description: Raw assembly produced by the assembler (SKESA, SPAdes, MEGAHIT,
-            or Velvet)
+          description: Raw assembly produced by the assembler (SKESA, SPAdes,
+            MEGAHIT, or Velvet)
           pattern: "{skesa,spades,megahit,velvet}.fasta"
           ontologies: []
   gfa:
@@ -89,7 +90,6 @@ output:
       - shovill --version 2>&1 | sed "s/^.*shovill //":
           type: eval
           description: The expression to obtain the version of the tool
-
 topics:
   versions:
     - - "${task.process}":

--- a/modules/nf-core/shovill/tests/main.nf.test
+++ b/modules/nf-core/shovill/tests/main.nf.test
@@ -115,4 +115,28 @@ nextflow_process {
         }
 
     }
+
+    test("shovill - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                  file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
 }

--- a/modules/nf-core/shovill/tests/main.nf.test.snap
+++ b/modules/nf-core/shovill/tests/main.nf.test.snap
@@ -1,4 +1,61 @@
 {
+    "shovill - stub": {
+        "content": [
+            {
+                "contigs": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "contigs.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "corrections": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "shovill.corrections:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "gfa": [
+                    
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "shovill.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "raw_contigs": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "spades.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_shovill": [
+                    [
+                        "SHOVILL",
+                        "shovill",
+                        "1.1.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T15:24:15.540469",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
     "shovill with velvet": {
         "content": [
             {
@@ -11,11 +68,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-30T14:21:23.359106945",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-30T14:21:23.359106945"
+        }
     },
     "shovill with spades": {
         "content": [
@@ -29,11 +86,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-30T14:20:53.648407714",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-30T14:20:53.648407714"
+        }
     },
     "shovill with skesa": {
         "content": [
@@ -47,11 +104,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-30T14:21:03.478997783",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-30T14:21:03.478997783"
+        }
     },
     "shovill with megahit": {
         "content": [
@@ -65,10 +122,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-30T14:21:13.799742064",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-30T14:21:13.799742064"
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **shovill** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_shovill` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570