### PR TITLE
Update smoothxg: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/smoothxg/main.nf
+++ b/modules/nf-core/smoothxg/main.nf
@@ -13,7 +13,7 @@ process SMOOTHXG {
     output:
     tuple val(meta), path("*smoothxg.gfa"), emit: gfa
     path("*.maf") , optional: true, emit: maf
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('smoothxg'), eval("smoothxg --version 2>&1 | sed 's/^v//; s/-.*//'"  ), topic: versions, emit: versions_smoothxg
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,10 +27,11 @@ process SMOOTHXG {
         --gfa-in=${gfa} \\
         --smoothed-out=${prefix}.smoothxg.gfa \\
         $args
+    """
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        smoothxg: \$(smoothxg --version 2>&1 | cut -f 1 -d '-' | cut -f 2 -d 'v')
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.smoothxg.gfa
     """
 }

--- a/modules/nf-core/smoothxg/meta.yml
+++ b/modules/nf-core/smoothxg/meta.yml
@@ -1,6 +1,6 @@
 name: smoothxg
-description: Linearize and simplify variation graph in GFA format using blocked partial
-  order alignment
+description: Linearize and simplify variation graph in GFA format using blocked
+  partial order alignment
 keywords:
   - gfa
   - graph
@@ -14,7 +14,8 @@ tools:
         order alignment.
       homepage: https://github.com/pangenome/smoothxg
       documentation: https://github.com/pangenome/smoothxg
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 input:
   - - meta:
@@ -27,7 +28,7 @@ input:
         description: Variation graph in GFA 1.0 format
         pattern: "*.{gfa}"
         ontologies:
-          - edam: http://edamontology.org/format_3975 # GFA 1
+          - edam: http://edamontology.org/format_3975
 output:
   gfa:
     - - meta:
@@ -40,21 +41,35 @@ output:
           description: Linearized and simplified graph in GFA 1.0 format
           pattern: "*.smoothxg.{gfa}"
           ontologies:
-            - edam: http://edamontology.org/format_3975 # GFA 1
+            - edam: http://edamontology.org/format_3975
   maf:
     - "*.maf":
         type: file
-        description: write the multiple sequence alignments (MSAs) in MAF format in
-          this file (optional)
+        description: write the multiple sequence alignments (MSAs) in MAF format
+          in this file (optional)
         pattern: "*.{maf}"
         ontologies: []
+  versions_smoothxg:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - smoothxg:
+          type: string
+          description: The name of the tool
+      - smoothxg --version 2>&1 | sed 's/^v//; s/-.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - smoothxg:
+          type: string
+          description: The name of the tool
+      - smoothxg --version 2>&1 | sed 's/^v//; s/-.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@heuermh, @subwaystation"
 maintainers:

--- a/modules/nf-core/smoothxg/tests/main.nf.test
+++ b/modules/nf-core/smoothxg/tests/main.nf.test
@@ -15,7 +15,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test', single_end:false ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/gfa/assembly.gfa', checkIfExists: true)
                     ]
                 """
@@ -25,7 +25,10 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-//                 { assert snapshot(process.out).match() } // SMOOTHXG is never deterministic
+                { assert process.out.gfa },
+                { assert snapshot(
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match("sarscov2_versions") }
             )
         }
 
@@ -37,7 +40,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test', single_end:false ],
                     file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.seqwish.gfa', checkIfExists: true)
                     ]
                 """
@@ -47,7 +50,34 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-//                 { assert snapshot(process.out).match() } // SMOOTHXG is never deterministic
+                { assert process.out.gfa },
+                { assert snapshot(
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match("pangenome_versions") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - illumina - assembly_gfa - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/gfa/assembly.gfa', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/smoothxg/tests/main.nf.test.snap
+++ b/modules/nf-core/smoothxg/tests/main.nf.test.snap
@@ -1,39 +1,66 @@
 {
-    "sarscov2 - illumina - assembly_gfa": {
+    "sarscov2_versions": {
         "content": [
             {
-                "0": [
+                "versions_smoothxg": [
                     [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.smoothxg.gfa:md5,c85140490fb255f8361499c01d0dd15b"
+                        "SMOOTHXG",
+                        "smoothxg",
+                        "0.8.0"
                     ]
-                ],
-                "1": [
-                    "test.maf:md5,a6d82f572a5358926b87c69683d7825e"
-                ],
-                "2": [
-                    "versions.yml:md5,14c3d1a28b189a6db45facabbb5dc274"
-                ],
+                ]
+            }
+        ],
+        "timestamp": "2026-05-15T04:39:30.870143276",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "pangenome_versions": {
+        "content": [
+            {
+                "versions_smoothxg": [
+                    [
+                        "SMOOTHXG",
+                        "smoothxg",
+                        "0.8.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-15T04:39:39.623869966",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - illumina - assembly_gfa - stub": {
+        "content": [
+            {
                 "gfa": [
                     [
                         {
                             "id": "test",
                             "single_end": false
                         },
-                        "test.smoothxg.gfa:md5,c85140490fb255f8361499c01d0dd15b"
+                        "test.smoothxg.gfa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "maf": [
-                    "test.maf:md5,a6d82f572a5358926b87c69683d7825e"
-                ],
-                "versions": [
-                    "versions.yml:md5,14c3d1a28b189a6db45facabbb5dc274"
+                "maf": [],
+                "versions_smoothxg": [
+                    [
+                        "SMOOTHXG",
+                        "smoothxg",
+                        "0.8.0"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2024-01-25T16:06:35.857843316"
+        "timestamp": "2026-05-15T04:39:45.245789943",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **smoothxg** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_smoothxg` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570