### PR TITLE
Update wfmash: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/wfmash/main.nf
+++ b/modules/nf-core/wfmash/main.nf
@@ -14,8 +14,7 @@ process WFMASH {
 
     output:
     tuple val(meta), path("*.paf"), emit: paf
-    path "versions.yml"           , emit: versions
-
+    tuple val("${task.process}"), val('wfmash'), eval('wfmash --version 2>&1 | cut -f 1 -d "-" | cut -f 2 -d "v"'), emit: versions_wfmash, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -34,11 +33,11 @@ process WFMASH {
         --threads $task.cpus \\
         $paf_mappings \\
         $args > ${prefix}.paf
+    """
 
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        wfmash: \$(echo \$(wfmash --version 2>&1) | cut -f 1 -d '-' | cut -f 2 -d 'v')
-    END_VERSIONS
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.paf
     """
 }

--- a/modules/nf-core/wfmash/meta.yml
+++ b/modules/nf-core/wfmash/meta.yml
@@ -13,7 +13,8 @@ tools:
       documentation: https://github.com/waveygang/wfmash
       tool_dev_url: https://github.com/waveygang/wfmash
       doi: 10.5281/zenodo.6949373
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 input:
   - - meta:
@@ -28,8 +29,8 @@ input:
         ontologies: []
     - paf:
         type: file
-        description: Optional inpute file in PAF format to derive the precise alignments
-          for.
+        description: Optional inpute file in PAF format to derive the precise
+          alignments for.
         pattern: "*.{paf}"
         ontologies: []
     - gzi:
@@ -44,11 +45,12 @@ input:
         ontologies: []
   - query_self:
       type: boolean
-      description: If set to true, the input FASTA will also be used as the query FASTA.
+      description: If set to true, the input FASTA will also be used as the query
+        FASTA.
   - fasta_query_list:
       type: file
-      description: Optional inpute file in FASTA format specifying the query sequences
-        as a list.
+      description: Optional inpute file in FASTA format specifying the query
+        sequences as a list.
       pattern: "*.{fa,fna,fasta}"
       ontologies: []
 output:
@@ -63,13 +65,27 @@ output:
           description: Alignments in PAF format
           pattern: "*.{paf}"
           ontologies: []
+  versions_wfmash:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - wfmash:
+          type: string
+          description: The name of the tool
+      - wfmash --version 2>&1 | cut -f 1 -d "-" | cut -f 2 -d "v":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - wfmash:
+          type: string
+          description: The name of the tool
+      - wfmash --version 2>&1 | cut -f 1 -d "-" | cut -f 2 -d "v":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@subwaystation"
 maintainers:

--- a/modules/nf-core/wfmash/tests/main.nf.test
+++ b/modules/nf-core/wfmash/tests/main.nf.test
@@ -15,13 +15,13 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test', single_end:false ],
                     file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.fa.gz', checkIfExists: true),
-                    [], // empty paf input
-                    file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.fa.gz.gzi', checkIfExists: true), // gzi
-                    file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.fa.gz.fai', checkIfExists: true) // fai
+                    [],
+                    file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.fa.gz.gzi', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.fa.gz.fai', checkIfExists: true)
                 ]
-                input[1] = true // empty paf input
+                input[1] = true
                 input[2] = []
                 """
             }
@@ -30,7 +30,36 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.versions).match("versions") }
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["paf"])).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - pangenome - pangenome_fa_bgzip - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.fa.gz', checkIfExists: true),
+                    [],
+                    file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.fa.gz.gzi', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'pangenomics/homo_sapiens/pangenome.fa.gz.fai', checkIfExists: true)
+                ]
+                input[1] = true
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/wfmash/tests/main.nf.test.snap
+++ b/modules/nf-core/wfmash/tests/main.nf.test.snap
@@ -1,14 +1,68 @@
 {
+    "homo_sapiens - pangenome - pangenome_fa_bgzip - stub": {
+        "content": [
+            {
+                "paf": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.paf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_wfmash": [
+                    [
+                        "WFMASH",
+                        "wfmash",
+                        "0.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T22:48:44.403851128",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
     "versions": {
         "content": [
             [
                 "versions.yml:md5,9f9bd116e78512f26ddf28b51a46e64e"
             ]
         ],
+        "timestamp": "2024-04-11T15:02:01.736721962",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-04-11T15:02:01.736721962"
+        }
+    },
+    "homo_sapiens - pangenome - pangenome_fa_bgzip": {
+        "content": [
+            {
+                "paf": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.paf"
+                    ]
+                ],
+                "versions_wfmash": [
+                    [
+                        "WFMASH",
+                        "wfmash",
+                        "0.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-18T22:48:39.474854629",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **wfmash** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include both `output: versions_wfmash` and `topics: versions` sections.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570