### PR TITLE
Update zip: topic versions, stub block, sanitizeOutput

### DIFF
--- a/modules/nf-core/zip/main.nf
+++ b/modules/nf-core/zip/main.nf
@@ -28,4 +28,10 @@ process ZIP {
         $args \\
         "${prefix}.zip" ./inputs/*
     """
+
+    stub:
+    prefix = task.ext.prefix ?: ( meta.id ? "${meta.id}" : 'zipped_files')
+    """
+    touch ${prefix}.zip
+    """
 }

--- a/modules/nf-core/zip/tests/main.nf.test
+++ b/modules/nf-core/zip/tests/main.nf.test
@@ -30,4 +30,26 @@ nextflow_process {
             )
         }
     }
+
+    test("sarscov2 - fasta - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test', single_end:false ], // meta map
+                             file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                           ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
 }

--- a/modules/nf-core/zip/tests/main.nf.test.snap
+++ b/modules/nf-core/zip/tests/main.nf.test.snap
@@ -1,4 +1,31 @@
 {
+    "sarscov2 - fasta - stub": {
+        "content": [
+            {
+                "versions_zip": [
+                    [
+                        "ZIP",
+                        "zip",
+                        "16.02 "
+                    ]
+                ],
+                "zipped_archive": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-29T15:30:30.188422",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
     "versions": {
         "content": [
             {


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, add `--profile docker,wave` tests.
- [x] Make sure your code lints (`nf-core modules lint`).
- [x] Ensure the test suite passes (`nf-test test`).

## Description of changes

Migrates the **zip** module to the nf-core v4.0.1 architecture:

- **topic: versions**: Replaced legacy `versions.yml` file emission with dynamic `eval()` tuple emission on the `topic: versions` channel.
- **stub block**: Added a deterministic `stub:` block for CI/CD stub-run support.
- **sanitizeOutput**: Refactored all test assertions to use `sanitizeOutput(process.out)` per nf-test best practices.
- **meta.yml**: Updated to include `topics: versions` section.

Part of the v4.0.1 standardization effort tracked in #11323.

Part of #4570