### PR TITLE
feat: allow bwa-mem to output sam format

### DIFF
--- a/modules/nf-core/bwa/mem/main.nf
+++ b/modules/nf-core/bwa/mem/main.nf
@@ -16,6 +16,7 @@ process BWA_MEM {
     output:
     tuple val(meta), path("*.bam")  , emit: bam,    optional: true
     tuple val(meta), path("*.cram") , emit: cram,   optional: true
+    tuple val(meta), path("*.sam")  , emit: sam,    optional: true
     tuple val(meta), path("*.csi")  , emit: csi,    optional: true
     tuple val(meta), path("*.crai") , emit: crai,   optional: true
     tuple val("${task.process}"), val('bwa'), eval('bwa 2>&1 | sed -n "s/^Version: //p"'), topic: versions, emit: versions_bwa
@@ -36,6 +37,15 @@ process BWA_MEM {
                     "bam"
     def reference = fasta && extension=="cram"  ? "--reference ${fasta}" : ""
     if (!fasta && extension=="cram") error "Fasta reference is required for CRAM output"
+    //
+    // For SAM output we can skip samtools view
+    //
+    def pipe_command = ""
+    if (extension == "sam") {
+        pipe_command = "> ${prefix}.${extension}"
+    } else {
+        pipe_command = "| samtools $samtools_command $args2 ${reference} --threads $task.cpus -o ${prefix}.${extension} -"
+    }
     """
     INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
 
@@ -44,7 +54,7 @@ process BWA_MEM {
         -t $task.cpus \\
         \$INDEX \\
         $reads \\
-        | samtools $samtools_command $args2 ${reference} --threads $task.cpus -o ${prefix}.${extension} -
+        $pipe_command
     """
 
     stub:

--- a/modules/nf-core/bwa/mem/meta.yml
+++ b/modules/nf-core/bwa/mem/meta.yml
@@ -81,6 +81,16 @@ output:
           pattern: "*.{cram}"
           ontologies:
             - edam: "http://edamontology.org/format_3462"
+  sam:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.sam":
+          type: file
+          description: Output SAM file containing read alignments
+          pattern: "*.{sam}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2573"
   csi:
     - - meta:
           type: map

--- a/modules/nf-core/bwa/mem/tests/main.nf.test
+++ b/modules/nf-core/bwa/mem/tests/main.nf.test
@@ -99,7 +99,7 @@ nextflow_process {
 
         when {
             params {
-                module_args = "--output-fmt sam"
+                module_args2 = "--output-fmt sam"
             }
 
             process {
@@ -248,7 +248,7 @@ nextflow_process {
 
         when {
             params {
-                module_args = "--output-fmt sam"
+                module_args2 = "--output-fmt sam"
             }
 
             process {

--- a/modules/nf-core/bwa/mem/tests/main.nf.test
+++ b/modules/nf-core/bwa/mem/tests/main.nf.test
@@ -46,6 +46,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.cram,
+                    process.out.sam,
                     process.out.csi,
                     process.out.crai,
                     process.out.findAll { key, val -> key.startsWith("versions") },
@@ -80,10 +81,52 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.cram,
+                    process.out.sam,
                     process.out.csi,
                     process.out.crai,
                     process.out.findAll { key, val -> key.startsWith("versions") },
                     bam(process.out.bam[0][1]).getReadsMD5()
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("Single-End - SAM output") {
+
+        config "./nextflow_sam.config"
+
+        when {
+            params {
+                module_args = "--output-fmt sam"
+            }
+
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)]
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.bam,
+                    process.out.cram,
+                    process.out.csi,
+                    process.out.crai,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                    bam(process.out.sam[0][1]).getReadsMD5()
                     ).match()
                 }
             )
@@ -115,6 +158,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.cram,
+                    process.out.sam,
                     process.out.csi,
                     process.out.crai,
                     process.out.findAll { key, val -> key.startsWith("versions") },
@@ -150,6 +194,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.cram,
+                    process.out.sam,
                     process.out.csi,
                     process.out.crai,
                     process.out.findAll { key, val -> key.startsWith("versions") },
@@ -185,10 +230,53 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.cram,
+                    process.out.sam,
                     process.out.csi,
                     process.out.crai,
                     process.out.findAll { key, val -> key.startsWith("versions") },
                     bam(process.out.bam[0][1]).getReadsMD5()
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test ("Paired-end - SAM output") {
+
+        config "./nextflow_sam.config"
+
+        when {
+            params {
+                module_args = "--output-fmt sam"
+            }
+
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ]
+                input[1] = BWA_INDEX.out.index
+                input[2] = [[:],[]]
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.bam,
+                    process.out.cram,
+                    process.out.csi,
+                    process.out.crai,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                    bam(process.out.sam[0][1]).getReadsMD5()
                     ).match()
                 }
             )

--- a/modules/nf-core/bwa/mem/tests/main.nf.test.snap
+++ b/modules/nf-core/bwa/mem/tests/main.nf.test.snap
@@ -1,6 +1,9 @@
 {
-    "Single-End": {
+    "Single-End - SAM output": {
         "content": [
+            [
+                
+            ],
             [
                 
             ],
@@ -28,14 +31,55 @@
             },
             "798439cbd7fd81cbcc5078022dc5479d"
         ],
-        "timestamp": "2026-02-18T12:42:52.901827",
+        "timestamp": "2026-05-11T12:09:32.334359515",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "Single-End": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "versions_bwa": [
+                    [
+                        "BWA_MEM",
+                        "bwa",
+                        "0.7.19-r1273"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "BWA_MEM",
+                        "samtools",
+                        "1.22.1"
+                    ]
+                ]
+            },
+            "798439cbd7fd81cbcc5078022dc5479d"
+        ],
+        "timestamp": "2026-05-11T12:07:21.233636979",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "Single-End Sort": {
         "content": [
+            [
+                
+            ],
             [
                 
             ],
@@ -63,14 +107,17 @@
             },
             "94fcf617f5b994584c4e8d4044e16b4f"
         ],
-        "timestamp": "2026-02-18T12:43:01.149915",
+        "timestamp": "2026-05-11T12:07:28.74614221",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "Paired-End": {
         "content": [
+            [
+                
+            ],
             [
                 
             ],
@@ -98,14 +145,17 @@
             },
             "57aeef88ed701a8ebc8e2f0a381b2a6"
         ],
-        "timestamp": "2026-02-18T12:43:09.528042",
+        "timestamp": "2026-05-11T12:07:42.612131595",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "Paired-End Sort": {
         "content": [
+            [
+                
+            ],
             [
                 
             ],
@@ -133,10 +183,10 @@
             },
             "af8628d9df18b2d3d4f6fd47ef2bb872"
         ],
-        "timestamp": "2026-02-18T12:43:17.876121",
+        "timestamp": "2026-05-11T12:09:45.938323098",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "Single-end - stub": {
@@ -155,6 +205,9 @@
                     
                 ],
                 "2": [
+                    
+                ],
+                "3": [
                     [
                         {
                             "id": "test",
@@ -163,7 +216,7 @@
                         "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "3": [
+                "4": [
                     [
                         {
                             "id": "test",
@@ -172,14 +225,14 @@
                         "test.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "4": [
+                "5": [
                     [
                         "BWA_MEM",
                         "bwa",
                         "0.7.19-r1273"
                     ]
                 ],
-                "5": [
+                "6": [
                     [
                         "BWA_MEM",
                         "samtools",
@@ -216,6 +269,9 @@
                         "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "sam": [
+                    
+                ],
                 "versions_bwa": [
                     [
                         "BWA_MEM",
@@ -232,14 +288,17 @@
                 ]
             }
         ],
-        "timestamp": "2026-02-18T12:43:33.853248",
+        "timestamp": "2026-05-11T12:10:09.92486753",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "Paired-End - no fasta": {
         "content": [
+            [
+                
+            ],
             [
                 
             ],
@@ -267,10 +326,48 @@
             },
             "57aeef88ed701a8ebc8e2f0a381b2a6"
         ],
-        "timestamp": "2026-02-18T12:43:26.121474",
+        "timestamp": "2026-05-11T12:09:52.820539909",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "Paired-end - SAM output": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            {
+                "versions_bwa": [
+                    [
+                        "BWA_MEM",
+                        "bwa",
+                        "0.7.19-r1273"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "BWA_MEM",
+                        "samtools",
+                        "1.22.1"
+                    ]
+                ]
+            },
+            "57aeef88ed701a8ebc8e2f0a381b2a6"
+        ],
+        "timestamp": "2026-05-11T12:10:00.199968933",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "Paired-end - stub": {
@@ -289,6 +386,9 @@
                     
                 ],
                 "2": [
+                    
+                ],
+                "3": [
                     [
                         {
                             "id": "test",
@@ -297,7 +397,7 @@
                         "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "3": [
+                "4": [
                     [
                         {
                             "id": "test",
@@ -306,14 +406,14 @@
                         "test.crai:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "4": [
+                "5": [
                     [
                         "BWA_MEM",
                         "bwa",
                         "0.7.19-r1273"
                     ]
                 ],
-                "5": [
+                "6": [
                     [
                         "BWA_MEM",
                         "samtools",
@@ -350,6 +450,9 @@
                         "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "sam": [
+                    
+                ],
                 "versions_bwa": [
                     [
                         "BWA_MEM",
@@ -366,10 +469,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-02-18T12:43:42.119907",
+        "timestamp": "2026-05-11T12:10:16.940291647",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/modules/nf-core/bwa/mem/tests/nextflow_sam.config
+++ b/modules/nf-core/bwa/mem/tests/nextflow_sam.config
@@ -1,0 +1,5 @@
+process {
+    withName: BWA_MEM {
+        ext.args2 = params.module_args2
+    }
+}


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #11456 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

The patch allows BWA/MEM to produce SAM format outputs when `task.ext.args2 = '--output-fmt sam'`. In that case, we can skip samtools view as bwa mem already produces that format.