### PR TITLE
fix: pass the expected input to bwamem1_index and bwamem2_index

### DIFF
--- a/subworkflows/nf-core/fastq_create_umi_consensus_fgbio/main.nf
+++ b/subworkflows/nf-core/fastq_create_umi_consensus_fgbio/main.nf
@@ -50,10 +50,13 @@ workflow FASTQ_CREATE_UMI_CONSENSUS_FGBIO {
     // the user can choose here to use either bwa-mem (default) or bwa-mem2
     aligned_bam = channel.empty()
 
+    fasta = fasta_fai_dict.map { it -> tuple(it[0], it[1]) }
+    fasta_fai = fasta_fai_dict.map { it -> tuple(it[0], it[1], it[2]) }
+
     if (aligner == "bwa-mem") {
 
         if (!bwa_index) {
-            BWAMEM1_INDEX(fasta_fai_dict)
+            BWAMEM1_INDEX(fasta)
         }
 
         // sets bwaindex to correct input
@@ -61,13 +64,13 @@ workflow FASTQ_CREATE_UMI_CONSENSUS_FGBIO {
         // appropriately tagged interleaved FASTQ reads are mapped to the reference
         // the aligner should be set with the following parameters "-p -K 150000000 -Y"
         // to be configured in ext.args of your config
-        BWAMEM1_MEM_PRE(BAM2FASTQ_PRE.out.fastq, bwaindex, fasta_fai_dict, false)
+        BWAMEM1_MEM_PRE(BAM2FASTQ_PRE.out.fastq, bwaindex, fasta, false)
         aligned_bam = aligned_bam.mix(BWAMEM1_MEM_PRE.out.bam)
     }
     else {
 
         if (!bwa_index) {
-            BWAMEM2_INDEX(fasta_fai_dict)
+            BWAMEM2_INDEX(fasta)
         }
 
         // sets bwaindex to correct input
@@ -75,7 +78,7 @@ workflow FASTQ_CREATE_UMI_CONSENSUS_FGBIO {
         // appropriately tagged interleaved FASTQ reads are mapped to the reference
         // the aligner should be set with the following parameters "-p -K 150000000 -Y"
         // to be configured in ext.args of your config
-        BWAMEM2_MEM_PRE(BAM2FASTQ_PRE.out.fastq, bwaindex, fasta_fai_dict, false)
+        BWAMEM2_MEM_PRE(BAM2FASTQ_PRE.out.fastq, bwaindex, fasta, false)
         aligned_bam = BWAMEM2_MEM_PRE.out.bam
     }
 
@@ -116,12 +119,12 @@ workflow FASTQ_CREATE_UMI_CONSENSUS_FGBIO {
 
     if (aligner == "bwa-mem") {
         // index made available through previous steps
-        BWAMEM1_MEM_POST(BAM2FASTQ_POST.out.fastq, bwaindex, fasta_fai_dict, false)
+        BWAMEM1_MEM_POST(BAM2FASTQ_POST.out.fastq, bwaindex, fasta, false)
         aligned_bam_post = BWAMEM1_MEM_POST.out.bam
     }
     else {
         // index made available through previous steps
-        BWAMEM2_MEM_POST(BAM2FASTQ_POST.out.fastq, bwaindex, fasta_fai_dict, false)
+        BWAMEM2_MEM_POST(BAM2FASTQ_POST.out.fastq, bwaindex, fasta, false)
         aligned_bam_post = BWAMEM2_MEM_POST.out.bam
     }
 
@@ -131,7 +134,7 @@ workflow FASTQ_CREATE_UMI_CONSENSUS_FGBIO {
     // FGBIO versions are emitted via topic channels
 
     // finally sort bam file
-    SORTBAM(ZIPPERBAMS_POST.out.bam, fasta_fai_dict, '')
+    SORTBAM(ZIPPERBAMS_POST.out.bam, fasta_fai, '')
 
     emit:
     ubam               = FASTQTOBAM.out.bam // channel: [ val(meta), [ bam ] ]

--- a/subworkflows/nf-core/fastq_create_umi_consensus_fgbio/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_create_umi_consensus_fgbio/tests/main.nf.test
@@ -38,19 +38,19 @@ nextflow_workflow {
             }
             workflow {
                 """
-                input[0] = [
+                input[0] = Channel.value([
                     [ id:'test_single', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test.umi_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test.umi_2.fastq.gz', checkIfExists: true),
                     ]
-                ]
-                input[1] = [
+                ])
+                input[1] = Channel.value([
                     [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
-                ]
+                ])
                 input[2] = false
                 input[3] = "Adjacency"
                 input[4] = "bwa-mem"
@@ -85,19 +85,19 @@ nextflow_workflow {
             }
             workflow {
                 """
-                input[0] = [
+                input[0] = Channel.value([
                     [ id:'test_single', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_duplex_umi_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_duplex_umi_2.fastq.gz', checkIfExists: true),
                     ]
-                ]
-                input[1] = [
+                ])
+                input[1] = Channel.value([
                     [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
-                ]
+                ])
                 input[2] = false
                 input[3] = "Adjacency"
                 input[4] = "bwa-mem"
@@ -133,19 +133,19 @@ nextflow_workflow {
             }
             workflow {
                 """
-                input[0] = [
+                input[0] = Channel.value([
                     [ id:'test_single', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test.umi_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test.umi_2.fastq.gz', checkIfExists: true),
                     ]
-                ]
-                input[1] = [
+                ])
+                input[1] = Channel.value([
                     [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
-                ]
+                ])
                 input[2] = false
                 input[3] = "Adjacency"
                 input[4] = "bwa-mem"


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #11519 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`


Fix the input for `BWA_MEM`, `BWA_MEM2` and `SORTBAM` as they expect `[meta, fasta]` and `[meta, fasta, fai]`