### PR TITLE
fix(trimgalore): stack process_low_memory on top of process_low

### DIFF
--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -1,6 +1,7 @@
 process TRIMGALORE {
     tag "${meta.id}"
     label 'process_low'
+    label 'process_low_memory'
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -1,6 +1,5 @@
 process TRIMGALORE {
     tag "${meta.id}"
-    label 'process_low'
     label 'process_low_memory'
 
     conda "${moduleDir}/environment.yml"

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -1,5 +1,6 @@
 process TRIMGALORE {
     tag "${meta.id}"
+    label 'process_medium'
     label 'process_low_memory'
 
     conda "${moduleDir}/environment.yml"


### PR DESCRIPTION
## Summary

Replaces `label 'process_low'` with `process_medium` + `process_low_memory` (the latter shipped in [nf-core/tools#4264](https://github.com/nf-core/tools/pull/4264)).

```groovy
label 'process_medium'
label 'process_low_memory'
```

Effective first-attempt budget: 6 cpus / 1 GB / 8 h.

## Why

[#11531](https://github.com/nf-core/modules/pull/11531) couldn't drop memory below 12 GB without also losing the cpu band; `process_low_memory` now lets us pick the axes independently. `process_medium` is the first cpu band where trim_galore actually gets a second worker thread (`cores = max(1, task.cpus - 4)` paired → 2 workers at cpus=6, still 1 at cpus≤5). Memory drops to 1 GB, ~10× the observed ~100 MB peak on 30M PE.

## Downstream

Requires the consuming pipeline's `base.config` to define `process_low_memory` (synced from a tools release including #4264). Otherwise memory falls through to the process default; the module still works.
