### PR TITLE
Revert "Fix dumpParametersToJson to be compatible with parameter typing" (#11532)

### DIFF
--- a/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
@@ -73,23 +73,11 @@ def getWorkflowVersion() {
 def dumpParametersToJSON(outdir) {
     def timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
     def filename  = "params_${timestamp}.json"
-    def temp_pf       = workflow.launchDir.resolve(".${filename}")
-    def jsonGenerator = new groovy.json.JsonGenerator.Options()
-        .excludeNulls()
-        .addConverter(Path) { Path path -> path.toUriString() }
-        .addConverter(Duration) { Duration duration -> duration.toMillis() }
-        .addConverter(MemoryUnit) { MemoryUnit memory -> memory.toBytes() }
-        .addConverter(nextflow.script.types.VersionNumber) { nextflow.script.types.VersionNumber version -> version.toString() }
-        .build()
-    def jsonStr   = jsonGenerator.toJson(params)
+    def temp_pf   = new File(workflow.launchDir.toString(), ".${filename}")
+    def jsonStr   = groovy.json.JsonOutput.toJson(params)
     temp_pf.text  = groovy.json.JsonOutput.prettyPrint(jsonStr)
-    if (outdir instanceof Path) {
-        temp_pf.copyTo(outdir.resolve("pipeline_info/${filename}"))
-    } else if (outdir instanceof String) {
-        temp_pf.copyTo("${outdir}/pipeline_info/params_${timestamp}.json")
-    } else {
-        log.warn("Could not determine type of outdir, parameters JSON file will not be copied to output directory!")
-    }
+
+    nextflow.extension.FilesEx.copyTo(temp_pf.toPath(), "${outdir}/pipeline_info/params_${timestamp}.json")
     temp_pf.delete()
 }
 


### PR DESCRIPTION
Reverts #11532 (commit 1a545fcbd762911c21a64ced3dbef99b2b51ac75).

The change in #11532 uses syntax that is only supported on Nextflow 26.04.0+ (a bug in Nextflow 25.10.x). With the modules repo currently pinned to 25.10.x, the merge of #11532 has broken CI on all open module PRs.

The alternative fix is to bump Nextflow (#11543), but per discussion on Slack the preference is to revert here for now so module PRs unblock immediately, since 26.04.0 is arguably ahead of what we officially support. #11532 can be reapplied once the Nextflow bump lands.