### PR TITLE
fix: match expected input for bwa/mem (no fai) using map. updated tes…

### DIFF
--- a/subworkflows/nf-core/fastq_align_bamcmp_bwa/main.nf
+++ b/subworkflows/nf-core/fastq_align_bamcmp_bwa/main.nf
@@ -21,7 +21,9 @@ workflow FASTQ_ALIGN_BAMCMP_BWA {
     // Map reads with BWA to the primary index, must be queryname sorted (controlled by config)
     //
 
-    BWA_MEM_PRIMARY(ch_reads, ch_primary_index, ch_fasta_fai, true)
+    ch_fasta = ch_fasta_fai.map { it -> tuple(it[0], it[1]) }
+    
+    BWA_MEM_PRIMARY(ch_reads, ch_primary_index, ch_fasta, true)
 
     //
     // Map reads with BWA to the contaminant index, must be queryname sorted (controlled by config)

--- a/subworkflows/nf-core/fastq_align_bamcmp_bwa/main.nf
+++ b/subworkflows/nf-core/fastq_align_bamcmp_bwa/main.nf
@@ -22,7 +22,7 @@ workflow FASTQ_ALIGN_BAMCMP_BWA {
     //
 
     ch_fasta = ch_fasta_fai.map { it -> tuple(it[0], it[1]) }
-    
+
     BWA_MEM_PRIMARY(ch_reads, ch_primary_index, ch_fasta, true)
 
     //

--- a/subworkflows/nf-core/fastq_align_bamcmp_bwa/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_bamcmp_bwa/tests/main.nf.test
@@ -21,8 +21,7 @@ nextflow_workflow {
                 process {
                     """
                     input[0] = [[ id:'homo_sapiens_genome' ],
-                                file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                                file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true) ]
+                                file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     """
                 }
             }
@@ -32,8 +31,7 @@ nextflow_workflow {
                 process {
                     """
                     input[0] = [[ id:'sarscov2_genome' ],
-                                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
-                                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true) ]
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
                     """
                 }
             }
@@ -47,9 +45,9 @@ nextflow_workflow {
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 input[1] = BWA_INDEX_HUMAN.out.index
                 input[2] = BWA_INDEX_COV2.out.index
-                input[3] = [[ id:'homo_sapiens_genome' ],
+                input[3] = Channel.value([[ id:'homo_sapiens_genome' ],
                             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-                            file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true) ]
+                            file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true) ])
                 """
             }
         }

--- a/subworkflows/nf-core/fastq_align_bamcmp_bwa/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_align_bamcmp_bwa/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                     {
                         "id": "test"
                     },
-                    "test.stats:md5,b4a1975d77621f5f53b39df70eb6305b"
+                    "test.stats:md5,232056b2a0ab3de47a8e26823fef7f5c"
                 ]
             ],
             [
@@ -35,7 +35,7 @@
                     {
                         "id": "test"
                     },
-                    "test.stats:md5,1b2dfa572f9e4e861af42cbbeb391c7c"
+                    "test.stats:md5,2cbde4490cf6e9bc981a47374463ae29"
                 ]
             ],
             [
@@ -55,11 +55,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-03-12T15:06:29.770312897",
+        "timestamp": "2026-05-07T10:40:23.473586595",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-13T08:06:04.461962"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #11548 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`


The test now passes the expected arguments for `BWA_INDEX` (no `fai`).
For the workflow, the expected input is passed to `BWA_MEM` using `.map`. To do so, the test must pass a channel.value as expected by the workflow.
Also the snapshots are updated to reconcile with the new test.