### PR TITLE
fix(centrifuger/centrifuger): allow prefixes other than meta.id

### DIFF
--- a/modules/nf-core/centrifuger/centrifuger/main.nf
+++ b/modules/nf-core/centrifuger/centrifuger/main.nf
@@ -3,7 +3,7 @@ process CENTRIFUGER_CENTRIFUGER {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/centrifuger:1.1.0--hf426362_0':
         'quay.io/biocontainers/centrifuger:1.1.0--hf426362_0' }"
 

--- a/modules/nf-core/centrifuger/centrifuger/main.nf
+++ b/modules/nf-core/centrifuger/centrifuger/main.nf
@@ -16,9 +16,9 @@ process CENTRIFUGER_CENTRIFUGER {
     path umi
 
     output:
-    tuple val(meta), path("${meta.id}.tsv"), emit: classification_file
-    tuple val(meta), path("${meta.id}.classified*"), optional: true, emit: fastq_classified
-    tuple val(meta), path("${meta.id}.unclassified*"), optional: true, emit: fastq_unclassified
+    tuple val(meta), path("*.tsv")                , emit: classification_file
+    tuple val(meta), path("*.classified*.fq.gz")  , emit: fastq_classified  , optional: true
+    tuple val(meta), path("*.unclassified*.fq.gz"), emit: fastq_unclassified, optional: true
     tuple val("${task.process}"), val('centrifuger'), eval("centrifuger -v 2>&1 | sed 's/Centrifuger v//'"),emit: versions_centrifuger,  topic: versions
 
     when:
@@ -35,7 +35,7 @@ process CENTRIFUGER_CENTRIFUGER {
     def umi_arg = umi ? "--UMI ${umi}" : ""
 
     """
-    db_name=`find -L ${db} -name "*.1.cfr" -not -name "._*"  | sed 's/\\.1.cfr\$//'`
+    db_name=`find -L . -name "*.1.cfr" -not -name "._*"  | sed 's/\\.1.cfr\$//'`
 
     centrifuger \\
         -x \$db_name \\

--- a/modules/nf-core/centrifuger/centrifuger/meta.yml
+++ b/modules/nf-core/centrifuger/centrifuger/meta.yml
@@ -56,7 +56,7 @@ output:
           type: map
           description: Groovy Map containing sample information. e.g. `[
             id:'sample1', single_end:false ]`
-      - ${meta.id}.tsv:
+      - "*.tsv":
           type: file
           description: |
             File containing classification results
@@ -69,7 +69,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - ${meta.id}.classified*:
+      - "*.classified*.fq.gz":
           type: file
           description: FASTQ file(s) containing classified reads
           pattern: "*.{fastq,fq,fastq.gz,fq.gz}"
@@ -81,7 +81,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - ${meta.id}.unclassified*:
+      - "*.unclassified*.fq.gz":
           type: file
           description: FASTQ file(s) containing unclassified reads
           pattern: "*.{fastq,fq,fastq.gz,fq.gz}"


### PR DESCRIPTION
centrifuger/centrifuger hard-coded `meta.id` in the output file glob, meaning that any non-standard prefix didn't produce output files.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
