### PR TITLE
fix the collision between input and output filename for single read

### DIFF
--- a/modules/nf-core/deacon/filter/main.nf
+++ b/modules/nf-core/deacon/filter/main.nf
@@ -22,6 +22,7 @@ process DEACON_FILTER {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     def read_type = (reads instanceof List) ? "-o ${prefix}_1.fq -O ${prefix}_2.fq" : "> ${prefix}.fq" // deacon's automatic compression does not work
+    if (!(reads instanceof List) && "${reads}" == "${prefix}.fq.gz") error "Input and output names are the same, set prefix in module configuration to disambiguate!"
     """
     deacon \\
         filter \\

--- a/modules/nf-core/deacon/filter/tests/main.nf.test
+++ b/modules/nf-core/deacon/filter/tests/main.nf.test
@@ -45,7 +45,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     file(process.out.log[0][1]).name,
-                    file(process.out.log[0][1]).readLines()[14..15],  // seqs_in and seqs_out
+                    file(process.out.log[0][1]).readLines()[15..16],  // seqs_in and seqs_out
                     process.out.fastq_filtered,
                     process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match()}

--- a/modules/nf-core/deacon/filter/tests/main.nf.test
+++ b/modules/nf-core/deacon/filter/tests/main.nf.test
@@ -45,6 +45,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     file(process.out.log[0][1]).name,
+                    file(process.out.log[0][1]).readLines()[14..15],  // seqs_in and seqs_out
                     process.out.fastq_filtered,
                     process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match()}

--- a/modules/nf-core/deacon/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/deacon/filter/tests/main.nf.test.snap
@@ -104,8 +104,8 @@
         "content": [
             "test.json",
             [
-                "  \"rename_random\": false,",
-                "  \"seqs_in\": 100,"
+                "  \"seqs_in\": 100,",
+                "  \"seqs_out\": 3,"
             ],
             [
                 [
@@ -126,7 +126,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-10T18:14:01.528085031",
+        "timestamp": "2026-05-10T18:28:28.935825108",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/modules/nf-core/deacon/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/deacon/filter/tests/main.nf.test.snap
@@ -63,11 +63,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-02-12T12:46:45.282375511",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-12T12:46:45.282375511"
+        }
     },
     "sarscov2 - fastq - paired-end": {
         "content": [
@@ -94,15 +94,19 @@
                 ]
             }
         ],
+        "timestamp": "2026-02-12T12:46:37.539497096",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-12T12:46:37.539497096"
+        }
     },
     "sarscov2 - fastq - single-end": {
         "content": [
             "test.json",
+            [
+                "  \"rename_random\": false,",
+                "  \"seqs_in\": 100,"
+            ],
             [
                 [
                     {
@@ -122,10 +126,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-05-10T18:14:01.528085031",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-12T12:46:29.822244006"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }


### PR DESCRIPTION

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #11302 <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

Now when single read input is passed to the process, the output filename gets a `_filtered` suffix so that there's no collision with the input filename.
No changes for paired reads.
Also now the test for single read checks that some seqs are actually filtered.