### PR TITLE
Add samplesheetparser modules (convert, diff, filter, info, merge, split, validate)

### DIFF
--- a/modules/nf-core/samplesheetparser/convert/environment.yml
+++ b/modules/nf-core/samplesheetparser/convert/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/convert/main.nf
+++ b/modules/nf-core/samplesheetparser/convert/main.nf
@@ -1,0 +1,40 @@
+process SAMPLESHEETPARSER_CONVERT {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+    val target_version
+
+    output:
+    tuple val(meta), path("*.converted.csv"), emit: samplesheet
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (!['v1', 'v2'].contains(target_version.toLowerCase())) {
+        error "target_version must be 'v1' or 'v2', got: ${target_version}"
+    }
+    """
+    samplesheet convert \\
+        --to ${target_version} \\
+        --output ${prefix}.converted.csv \\
+        ${args} \\
+        ${samplesheet}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.converted.csv
+    """
+}

--- a/modules/nf-core/samplesheetparser/convert/meta.yml
+++ b/modules/nf-core/samplesheetparser/convert/meta.yml
@@ -1,0 +1,78 @@
+name: samplesheetparser_convert
+description: |
+  Convert an Illumina SampleSheet.csv between IEM V1 (bcl2fastq) and
+  BCLConvert V2 formats. Format of the input is auto-detected.
+  V2 → V1 conversion is lossy: V2-only fields (OverrideCycles,
+  InstrumentPlatform, etc.) are dropped with a warning.
+keywords:
+  - illumina
+  - samplesheet
+  - conversion
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv (V1 or V2 format, auto-detected)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+  - target_version:
+      type: string
+      description: Target format — either 'v1' or 'v2'
+
+output:
+  samplesheet:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.converted.csv":
+          type: file
+          description: Converted SampleSheet.csv in the requested format
+          pattern: "*.converted.csv"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/convert/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/convert/tests/main.nf.test
@@ -1,0 +1,80 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_CONVERT"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_CONVERT"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_convert"
+    tag "samplesheetparser/convert"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 → V2 conversion") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v1_to_v2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                input[1] = 'v2'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V2 → V1 conversion") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v2_to_v1' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true)
+                ]
+                input[1] = 'v1'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 → V2 conversion - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                input[1] = 'v2'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/convert/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/convert/tests/main.nf.test.snap
@@ -1,0 +1,125 @@
+{
+    "V1 \u2192 V2 conversion": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v1_to_v2"
+                        },
+                        "test_v1_to_v2.converted.csv:md5,ec162c986b57f987cf4f5c2c96849c46"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_CONVERT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "samplesheet": [
+                    [
+                        {
+                            "id": "test_v1_to_v2"
+                        },
+                        "test_v1_to_v2.converted.csv:md5,ec162c986b57f987cf4f5c2c96849c46"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_CONVERT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:06:10.346538",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V2 \u2192 V1 conversion": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v2_to_v1"
+                        },
+                        "test_v2_to_v1.converted.csv:md5,5256cdd912c2aaa326e629ebc5d59385"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_CONVERT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "samplesheet": [
+                    [
+                        {
+                            "id": "test_v2_to_v1"
+                        },
+                        "test_v2_to_v1.converted.csv:md5,5256cdd912c2aaa326e629ebc5d59385"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_CONVERT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:06:18.576125",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V1 \u2192 V2 conversion - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.converted.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_CONVERT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "samplesheet": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.converted.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_CONVERT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:06:26.220288",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/diff/environment.yml
+++ b/modules/nf-core/samplesheetparser/diff/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/diff/main.nf
+++ b/modules/nf-core/samplesheetparser/diff/main.nf
@@ -1,0 +1,35 @@
+process SAMPLESHEETPARSER_DIFF {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(old_sheet, stageAs: "old/*"), path(new_sheet, stageAs: "new/*")
+
+    output:
+    tuple val(meta), path("*.diff.json"), emit: json
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    samplesheet diff \\
+        --format json \\
+        ${args} \\
+        ${old_sheet} ${new_sheet} > ${prefix}.diff.json || true
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo '{"has_changes": false, "header_changes": [], "samples_added": [], "samples_removed": [], "sample_changes": []}' > ${prefix}.diff.json
+    """
+}

--- a/modules/nf-core/samplesheetparser/diff/meta.yml
+++ b/modules/nf-core/samplesheetparser/diff/meta.yml
@@ -1,0 +1,85 @@
+name: samplesheetparser_diff
+description: |
+  Compare two Illumina SampleSheet.csv files (any combination of V1 and V2)
+  and emit a structured JSON diff covering header changes, added/removed
+  samples, and per-sample field changes. Exits 0 if identical, 1 if
+  differences are detected — useful as a CI pre-run guard.
+keywords:
+  - illumina
+  - samplesheet
+  - diff
+  - comparison
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet pair.
+    - old_sheet:
+        type: file
+        description: Original (reference) SampleSheet.csv (V1 or V2)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+    - new_sheet:
+        type: file
+        description: Updated SampleSheet.csv to compare against the original (V1 or V2)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+
+output:
+  json:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.diff.json":
+          type: file
+          description: |
+            Structured JSON diff report with has_changes, source_version,
+            target_version, header_changes, samples_added, samples_removed,
+            and sample_changes fields.
+          pattern: "*.diff.json"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/diff/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/diff/tests/main.nf.test
@@ -1,0 +1,80 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_DIFF"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_DIFF"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_diff"
+    tag "samplesheetparser/diff"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 vs V1 - identical sheets") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_identical' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 vs V2 - cross-format diff") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_cross_format' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 vs V1 - identical sheets - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/diff/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/diff/tests/main.nf.test.snap
@@ -1,0 +1,125 @@
+{
+    "V1 vs V2 - cross-format diff": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_cross_format"
+                        },
+                        "test_cross_format.diff.json:md5,2d29b0bf3db1e4e02ad03397a1f91e29"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_DIFF",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_cross_format"
+                        },
+                        "test_cross_format.diff.json:md5,2d29b0bf3db1e4e02ad03397a1f91e29"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_DIFF",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:06:47.915945",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V1 vs V1 - identical sheets - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.diff.json:md5,6b97bb69ae7ad9188eda21ed06b088e0"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_DIFF",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.diff.json:md5,6b97bb69ae7ad9188eda21ed06b088e0"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_DIFF",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:06:55.739993",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V1 vs V1 - identical sheets": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_identical"
+                        },
+                        "test_identical.diff.json:md5,ac51d98bdf110ad786d3f05ff7231663"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_DIFF",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_identical"
+                        },
+                        "test_identical.diff.json:md5,ac51d98bdf110ad786d3f05ff7231663"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_DIFF",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:06:39.302012",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/filter/environment.yml
+++ b/modules/nf-core/samplesheetparser/filter/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/filter/main.nf
+++ b/modules/nf-core/samplesheetparser/filter/main.nf
@@ -1,0 +1,38 @@
+process SAMPLESHEETPARSER_FILTER {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+
+    output:
+    tuple val(meta), path("*.filtered.csv"), emit: samplesheet, optional: true
+    tuple val(meta), path("*.filter.json"),  emit: json
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    samplesheet filter \\
+        --output ${prefix}.filtered.csv \\
+        --format json \\
+        ${args} \\
+        ${samplesheet} > ${prefix}.filter.json || true
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.filtered.csv
+    echo '{"matched_count": 0, "total_count": 0, "output_path": null, "criteria": {}}' > ${prefix}.filter.json
+    """
+}

--- a/modules/nf-core/samplesheetparser/filter/meta.yml
+++ b/modules/nf-core/samplesheetparser/filter/meta.yml
@@ -1,0 +1,90 @@
+name: samplesheetparser_filter
+description: |
+  Extract a subset of samples from an Illumina SampleSheet.csv by project,
+  lane, or sample ID. Multiple criteria are ANDed — a sample must match all
+  provided criteria. Sample ID supports glob patterns (e.g. 'CTRL_*').
+  Exits 0 if at least one sample matched, 1 if no samples matched.
+  Filter criteria are passed via task.ext.args (e.g. '--project ProjectA').
+keywords:
+  - illumina
+  - samplesheet
+  - filter
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+          Pass filter criteria via task.ext.args:
+          e.g. ext.args = '--project ProjectA --lane 1'
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv to filter (V1 or V2)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+
+output:
+  samplesheet:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.filtered.csv":
+          type: file
+          description: |
+            Filtered SampleSheet.csv. Not emitted when no samples match
+            the criteria (optional output).
+          pattern: "*.filtered.csv"
+  json:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.filter.json":
+          type: file
+          description: |
+            Structured JSON filter report with matched_count, total_count,
+            output_path, summary, and criteria fields.
+          pattern: "*.filter.json"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/filter/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/filter/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_FILTER"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_FILTER"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_filter"
+    tag "samplesheetparser/filter"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("Filter V1 sheet by project") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_filter_project' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Filter V1 sheet by project - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/filter/tests/main.nf.test.snap
@@ -1,0 +1,106 @@
+{
+    "Filter V1 sheet by project": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_filter_project"
+                        },
+                        "test_filter_project.filter.json:md5,90b6c529d46e9cb2e94a71cdaa14c609"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SAMPLESHEETPARSER_FILTER",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_filter_project"
+                        },
+                        "test_filter_project.filter.json:md5,90b6c529d46e9cb2e94a71cdaa14c609"
+                    ]
+                ],
+                "samplesheet": [
+                    
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_FILTER",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:08.854538",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Filter V1 sheet by project - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.filtered.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.filter.json:md5,f30e6b9ea350e3b507f84525c2d4afe2"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SAMPLESHEETPARSER_FILTER",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.filter.json:md5,f30e6b9ea350e3b507f84525c2d4afe2"
+                    ]
+                ],
+                "samplesheet": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.filtered.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_FILTER",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:16.445694",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/filter/tests/nextflow.config
+++ b/modules/nf-core/samplesheetparser/filter/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'SAMPLESHEETPARSER_FILTER' {
+        ext.args = '--project default'
+    }
+}

--- a/modules/nf-core/samplesheetparser/info/environment.yml
+++ b/modules/nf-core/samplesheetparser/info/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/info/main.nf
+++ b/modules/nf-core/samplesheetparser/info/main.nf
@@ -1,0 +1,35 @@
+process SAMPLESHEETPARSER_INFO {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+
+    output:
+    tuple val(meta), path("*.info.json"), emit: json
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    samplesheet info \\
+        --format json \\
+        ${args} \\
+        ${samplesheet} > ${prefix}.info.json
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo '{"format": "V1", "sample_count": 0, "lanes": [], "index_type": "none"}' > ${prefix}.info.json
+    """
+}

--- a/modules/nf-core/samplesheetparser/info/meta.yml
+++ b/modules/nf-core/samplesheetparser/info/meta.yml
@@ -1,0 +1,77 @@
+name: samplesheetparser_info
+description: |
+  Display a structured JSON summary of an Illumina SampleSheet.csv (V1 or V2)
+  including format version, sample count, lanes, index type, read lengths,
+  adapter sequences, experiment name, and instrument platform.
+  Useful for logging run metadata or conditional branching in pipelines.
+keywords:
+  - illumina
+  - samplesheet
+  - metadata
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv (V1 or V2 format, auto-detected)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+
+output:
+  json:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.info.json":
+          type: file
+          description: |
+            JSON summary with file, format, sample_count, lanes, index_type,
+            read_lengths, adapters, experiment_name, and instrument fields.
+          pattern: "*.info.json"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/info/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/info/tests/main.nf.test
@@ -1,0 +1,77 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_INFO"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_INFO"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_info"
+    tag "samplesheetparser/info"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 sheet - info") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v1' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V2 sheet - info") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 sheet - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/info/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/info/tests/main.nf.test.snap
@@ -1,0 +1,125 @@
+{
+    "V1 sheet - info": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v1"
+                        },
+                        "test_v1.info.json:md5,70a050f386343c867655216bf657ee7a"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_v1"
+                        },
+                        "test_v1.info.json:md5,70a050f386343c867655216bf657ee7a"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:28.55317",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V2 sheet - info": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v2"
+                        },
+                        "test_v2.info.json:md5,05ce66a4fe3a71083500e9ef9c1dd827"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_v2"
+                        },
+                        "test_v2.info.json:md5,05ce66a4fe3a71083500e9ef9c1dd827"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:36.28689",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V1 sheet - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.info.json:md5,ce5acbba729ff67e15b951a2e5cb62c0"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.info.json:md5,ce5acbba729ff67e15b951a2e5cb62c0"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:44.035976",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/merge/environment.yml
+++ b/modules/nf-core/samplesheetparser/merge/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/merge/main.nf
+++ b/modules/nf-core/samplesheetparser/merge/main.nf
@@ -1,0 +1,44 @@
+process SAMPLESHEETPARSER_MERGE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheets, stageAs: "?/*")
+    val target_version
+
+    output:
+    tuple val(meta), path("*.merged.csv"), emit: samplesheet
+    tuple val(meta), path("*.merge.json"), emit: json
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (!['v1', 'v2'].contains(target_version.toLowerCase())) {
+        error "target_version must be 'v1' or 'v2', got: ${target_version}"
+    }
+    """
+    samplesheet merge \\
+        --to ${target_version} \\
+        --output ${prefix}.merged.csv \\
+        --format json \\
+        --force \\
+        ${args} \\
+        ${samplesheets} > ${prefix}.merge.json || true
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.merged.csv
+    echo '{"has_conflicts": false, "sample_count": 0, "conflicts": [], "warnings": []}' > ${prefix}.merge.json
+    """
+}

--- a/modules/nf-core/samplesheetparser/merge/meta.yml
+++ b/modules/nf-core/samplesheetparser/merge/meta.yml
@@ -1,0 +1,89 @@
+name: samplesheetparser_merge
+description: |
+  Merge multiple per-project Illumina SampleSheet.csv files into one
+  combined sheet. Detects index collisions, Hamming distance violations,
+  and read-length mismatches across sheets. Mixed V1/V2 inputs are
+  auto-converted to the target format.
+  Exits 0 on clean merge, 1 if conflicts or warnings were found.
+keywords:
+  - illumina
+  - samplesheet
+  - merge
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the merged run.
+    - samplesheets:
+        type: file
+        description: Two or more Illumina SampleSheet.csv files to merge (V1 or V2)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+  - target_version:
+      type: string
+      description: Output format — either 'v1' or 'v2'
+
+output:
+  samplesheet:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.merged.csv":
+          type: file
+          description: Merged SampleSheet.csv in the requested format
+          pattern: "*.merged.csv"
+  json:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.merge.json":
+          type: file
+          description: |
+            Structured JSON merge report with has_conflicts, sample_count,
+            source_versions, conflicts, and warnings fields.
+          pattern: "*.merge.json"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/merge/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/merge/tests/main.nf.test
@@ -1,0 +1,89 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_MERGE"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_MERGE"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_merge"
+    tag "samplesheetparser/merge"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("Merge two V1 sheets into V2") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_merge_v2' ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                    ]
+                ]
+                input[1] = 'v2'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Merge two V2 sheets into V2") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_merge_v2_v2' ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true)
+                    ]
+                ]
+                input[1] = 'v2'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Merge two V1 sheets into V2 - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                    ]
+                ]
+                input[1] = 'v2'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/merge/tests/main.nf.test.snap
@@ -1,0 +1,173 @@
+{
+    "Merge two V1 sheets into V2 - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.merged.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.merge.json:md5,82f86ea84bf35b1e2e593eef93dd582b"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SAMPLESHEETPARSER_MERGE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.merge.json:md5,82f86ea84bf35b1e2e593eef93dd582b"
+                    ]
+                ],
+                "samplesheet": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.merged.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_MERGE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:08:13.647678",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Merge two V1 sheets into V2": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_merge_v2"
+                        },
+                        "test_merge_v2.merged.csv:md5,bac03afe2464529d02d1b463e50839cd"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_merge_v2"
+                        },
+                        "test_merge_v2.merge.json:md5,c09f7ba7c707a860993eab1fc433709d"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SAMPLESHEETPARSER_MERGE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_merge_v2"
+                        },
+                        "test_merge_v2.merge.json:md5,c09f7ba7c707a860993eab1fc433709d"
+                    ]
+                ],
+                "samplesheet": [
+                    [
+                        {
+                            "id": "test_merge_v2"
+                        },
+                        "test_merge_v2.merged.csv:md5,bac03afe2464529d02d1b463e50839cd"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_MERGE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:57.829357",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Merge two V2 sheets into V2": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_merge_v2_v2"
+                        },
+                        "test_merge_v2_v2.merged.csv:md5,dc288d0c76345f2755d1f2328721ad6d"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_merge_v2_v2"
+                        },
+                        "test_merge_v2_v2.merge.json:md5,aa43c155ad2a990dcf9536f93e22adea"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SAMPLESHEETPARSER_MERGE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_merge_v2_v2"
+                        },
+                        "test_merge_v2_v2.merge.json:md5,aa43c155ad2a990dcf9536f93e22adea"
+                    ]
+                ],
+                "samplesheet": [
+                    [
+                        {
+                            "id": "test_merge_v2_v2"
+                        },
+                        "test_merge_v2_v2.merged.csv:md5,dc288d0c76345f2755d1f2328721ad6d"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_MERGE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:08:05.960852",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/split/environment.yml
+++ b/modules/nf-core/samplesheetparser/split/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/split/main.nf
+++ b/modules/nf-core/samplesheetparser/split/main.nf
@@ -1,0 +1,46 @@
+process SAMPLESHEETPARSER_SPLIT {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+    val by
+
+    output:
+    tuple val(meta), path("split/*.csv"), emit: samplesheets
+    tuple val(meta), path("*.split.json"), emit: json
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (!['project', 'lane'].contains(by.toLowerCase())) {
+        error "by must be 'project' or 'lane', got: ${by}"
+    }
+    """
+    mkdir -p split
+
+    samplesheet split \\
+        --by ${by} \\
+        --output-dir split \\
+        --format json \\
+        ${args} \\
+        ${samplesheet} > ${prefix}.split.json
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p split
+    touch split/stub_SampleSheet.csv
+    echo '{"by": "${by}", "files": {}, "sample_counts": {}, "warnings": []}' > ${prefix}.split.json
+    """
+}

--- a/modules/nf-core/samplesheetparser/split/meta.yml
+++ b/modules/nf-core/samplesheetparser/split/meta.yml
@@ -1,0 +1,89 @@
+name: samplesheetparser_split
+description: |
+  Split a combined Illumina SampleSheet.csv into one file per project or
+  per lane. Header, reads, and settings are copied into every output file;
+  only the sample rows are divided. Output filenames follow the pattern
+  ``{prefix}{group}_SampleSheet.csv``.
+  Exits 0 on success, 1 if warnings were produced.
+keywords:
+  - illumina
+  - samplesheet
+  - split
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Combined Illumina SampleSheet.csv to split (V1 or V2)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+  - by:
+      type: string
+      description: Grouping key — either 'project' or 'lane'
+
+output:
+  samplesheets:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "split/*.csv":
+          type: file
+          description: Per-group SampleSheet.csv files written to the split/ subdirectory
+          pattern: "split/*.csv"
+  json:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.split.json":
+          type: file
+          description: |
+            Structured JSON split report with by, output_dir, files,
+            sample_counts, and warnings fields.
+          pattern: "*.split.json"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/split/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/split/tests/main.nf.test
@@ -1,0 +1,80 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_SPLIT"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_SPLIT"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_split"
+    tag "samplesheetparser/split"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("Split V1 sheet by project") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_split_project' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                input[1] = 'project'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Split V2 sheet by lane") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_split_lane' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true)
+                ]
+                input[1] = 'lane'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("Split V1 sheet by project - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                input[1] = 'project'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/split/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/split/tests/main.nf.test.snap
@@ -1,0 +1,185 @@
+{
+    "Split V1 sheet by project - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "stub_SampleSheet.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.split.json:md5,5b13daf664b786c199ed3434cd9caea9"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SAMPLESHEETPARSER_SPLIT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.split.json:md5,5b13daf664b786c199ed3434cd9caea9"
+                    ]
+                ],
+                "samplesheets": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "stub_SampleSheet.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_SPLIT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:08:41.190529",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Split V1 sheet by project": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_split_project"
+                        },
+                        [
+                            "ProjectAlpha_SampleSheet.csv:md5,c3fd8834bf1ab0fdfddc934e6f10a00b",
+                            "ProjectBeta_SampleSheet.csv:md5,32e478b1e46d75bbfe6d9fe2049798df"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_split_project"
+                        },
+                        "test_split_project.split.json:md5,17ec26f0b001a3dff9e761e9a6500c42"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SAMPLESHEETPARSER_SPLIT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_split_project"
+                        },
+                        "test_split_project.split.json:md5,17ec26f0b001a3dff9e761e9a6500c42"
+                    ]
+                ],
+                "samplesheets": [
+                    [
+                        {
+                            "id": "test_split_project"
+                        },
+                        [
+                            "ProjectAlpha_SampleSheet.csv:md5,c3fd8834bf1ab0fdfddc934e6f10a00b",
+                            "ProjectBeta_SampleSheet.csv:md5,32e478b1e46d75bbfe6d9fe2049798df"
+                        ]
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_SPLIT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:08:25.693701",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Split V2 sheet by lane": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_split_lane"
+                        },
+                        [
+                            "1_SampleSheet.csv:md5,49e0c049416cbd40e9a39d04d235bd4e",
+                            "2_SampleSheet.csv:md5,8eaff4f0475996107dbde8e5a19374ea"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_split_lane"
+                        },
+                        "test_split_lane.split.json:md5,1dfaa8364a9e5714248d58aa14121e2d"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SAMPLESHEETPARSER_SPLIT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_split_lane"
+                        },
+                        "test_split_lane.split.json:md5,1dfaa8364a9e5714248d58aa14121e2d"
+                    ]
+                ],
+                "samplesheets": [
+                    [
+                        {
+                            "id": "test_split_lane"
+                        },
+                        [
+                            "1_SampleSheet.csv:md5,49e0c049416cbd40e9a39d04d235bd4e",
+                            "2_SampleSheet.csv:md5,8eaff4f0475996107dbde8e5a19374ea"
+                        ]
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_SPLIT",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:08:33.624389",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/validate/environment.yml
+++ b/modules/nf-core/samplesheetparser/validate/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/validate/main.nf
+++ b/modules/nf-core/samplesheetparser/validate/main.nf
@@ -1,0 +1,35 @@
+process SAMPLESHEETPARSER_VALIDATE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+
+    output:
+    tuple val(meta), path("*.validation.json"), emit: json
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    samplesheet validate \\
+        --format json \\
+        ${args} \\
+        ${samplesheet} > ${prefix}.validation.json
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo '{"is_valid": true, "errors": [], "warnings": []}' > ${prefix}.validation.json
+    """
+}

--- a/modules/nf-core/samplesheetparser/validate/meta.yml
+++ b/modules/nf-core/samplesheetparser/validate/meta.yml
@@ -1,0 +1,78 @@
+name: samplesheetparser_validate
+description: |
+  Validate an Illumina SampleSheet.csv (V1 or V2) for index, adapter, and
+  structural issues. Format is auto-detected. Exits 0 if valid, 1 if errors
+  are found — causing the pipeline to fail early with a clear message rather
+  than discovering demultiplexing problems downstream.
+keywords:
+  - illumina
+  - samplesheet
+  - validation
+  - demultiplexing
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv (V1 or V2 format)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+
+output:
+  json:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.validation.json":
+          type: file
+          description: |
+            Structured JSON validation report with is_valid, errors, warnings,
+            and min_hamming_distance fields.
+          pattern: "*.validation.json"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/validate/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/validate/tests/main.nf.test
@@ -1,0 +1,77 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_VALIDATE"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_VALIDATE"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_validate"
+    tag "samplesheetparser/validate"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 dual-index sheet - validate") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v1' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V2 dual-index sheet - validate") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 dual-index sheet - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/validate/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/validate/tests/main.nf.test.snap
@@ -1,0 +1,125 @@
+{
+    "V1 dual-index sheet - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.validation.json:md5,b275f250d57108916e3f263f1a57d5a8"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.validation.json:md5,b275f250d57108916e3f263f1a57d5a8"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:09:11.117233",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V1 dual-index sheet - validate": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v1"
+                        },
+                        "test_v1.validation.json:md5,281264d5a33913d0e97051a803a704be"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_v1"
+                        },
+                        "test_v1.validation.json:md5,281264d5a33913d0e97051a803a704be"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:08:53.891329",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V2 dual-index sheet - validate": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v2"
+                        },
+                        "test_v2.validation.json:md5,20eec3331cf1b392e01da9dc0b5f480f"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_v2"
+                        },
+                        "test_v2.validation.json:md5,20eec3331cf1b392e01da9dc0b5f480f"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:09:01.937955",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds seven new nf-core modules under `samplesheetparser/` (convert, diff, filter, info, merge, split, validate) wrapping the [`samplesheet-parser`](https://github.com/chaitanyakasaraneni/samplesheet-parser) tool to operate on Illumina SampleSheet.csv files (IEM V1 / BCLConvert V2) with format auto-detection.

## Why
Most Illumina demultiplexing pipelines need to read, validate, transform, or compare SampleSheet.csv files before running `bcl2fastq`/`bclconvert`. Today this is duplicated as ad-hoc bash and Python across pipelines. These modules provide a shared, format-agnostic toolkit so that pipelines can:
- **validate** sheets early to fail fast with a clear error rather than discovering issues at demux time,
- **convert** between V1 ↔ V2 to support mixed-instrument runs,
- **diff** sheets as a CI guard against accidental edits,
- **filter** / **split** / **merge** to support per-project or per-lane processing topologies,
- **info** to expose run metadata (sample count, lanes, indexes, instrument) for conditional branching.

## Changes

### New modules (each with `main.nf`, `meta.yml`, `environment.yml`, `tests/main.nf.test`, `tests/main.nf.test.snap`)
- `samplesheetparser/convert` — V1 ↔ V2 conversion with auto-detected input format
- `samplesheetparser/diff` — JSON diff report; exit 0 if identical, 1 on differences
- `samplesheetparser/filter` — subset by project / lane / sample-ID glob; AND-combined criteria
- `samplesheetparser/info` — JSON summary (format, sample count, lanes, index type, read lengths, adapters, experiment, instrument)
- `samplesheetparser/merge` — combine per-project sheets; detects index collisions, Hamming-distance violations, read-length mismatches
- `samplesheetparser/split` — emit one sheet per project or per lane
- `samplesheetparser/validate` — structural and index validation; fail-fast guard for pipelines

### Conventions followed
- Containers: `quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0` (Docker) and `depot.galaxyproject.org/singularity/...` (Singularity); conda env pins `bioconda::samplesheet-parser=1.2.0`
- Versions emitted via `topic: versions` (eval of `samplesheet --version`); no `versions.yml` file
- All seven modules have stub blocks; `merge`, `diff`, `filter` use `|| true` so a non-zero exit (conflict / no-match / differences) does not abort the process — the JSON report carries the diagnostic
- Tests cover both real runs (V1 and V2 inputs) and `-stub` mode; snapshots regenerated locally with Docker

### Verified
- `nf-core modules lint samplesheetparser` — **383 passed, 0 warnings, 0 failures**
- `pre-commit run` — all hooks pass
- `nf-test --profile docker` — **21/21 tests pass** across all seven modules

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`