### PR TITLE
Add samplesheetparser/info and samplesheetparser/validate modules

### DIFF
--- a/modules/nf-core/samplesheetparser/info/environment.yml
+++ b/modules/nf-core/samplesheetparser/info/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/info/main.nf
+++ b/modules/nf-core/samplesheetparser/info/main.nf
@@ -5,7 +5,7 @@ process SAMPLESHEETPARSER_INFO {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
-        'biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(samplesheet)

--- a/modules/nf-core/samplesheetparser/info/main.nf
+++ b/modules/nf-core/samplesheetparser/info/main.nf
@@ -5,7 +5,7 @@ process SAMPLESHEETPARSER_INFO {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
-        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+        'biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(samplesheet)

--- a/modules/nf-core/samplesheetparser/info/main.nf
+++ b/modules/nf-core/samplesheetparser/info/main.nf
@@ -1,0 +1,35 @@
+process SAMPLESHEETPARSER_INFO {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+
+    output:
+    tuple val(meta), path("*.info.json"), emit: json
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    samplesheet info \\
+        --format json \\
+        ${args} \\
+        ${samplesheet} > ${prefix}.info.json
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo '{"format": "V1", "sample_count": 0, "lanes": [], "index_type": "none"}' > ${prefix}.info.json
+    """
+}

--- a/modules/nf-core/samplesheetparser/info/main.nf
+++ b/modules/nf-core/samplesheetparser/info/main.nf
@@ -3,7 +3,7 @@ process SAMPLESHEETPARSER_INFO {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
         'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
 
@@ -12,7 +12,7 @@ process SAMPLESHEETPARSER_INFO {
 
     output:
     tuple val(meta), path("*.info.json"), emit: json
-    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheetparser
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,7 +22,6 @@ process SAMPLESHEETPARSER_INFO {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     samplesheet info \\
-        --format json \\
         ${args} \\
         ${samplesheet} > ${prefix}.info.json
     """
@@ -30,6 +29,6 @@ process SAMPLESHEETPARSER_INFO {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo '{"format": "V1", "sample_count": 0, "lanes": [], "index_type": "none"}' > ${prefix}.info.json
+    touch ${prefix}.info.json
     """
 }

--- a/modules/nf-core/samplesheetparser/info/meta.yml
+++ b/modules/nf-core/samplesheetparser/info/meta.yml
@@ -11,10 +11,9 @@ keywords:
   - bclconvert
   - bcl2fastq
   - genomics
-
 tools:
   - samplesheet-parser:
-      description: >
+      description: |
         Format-agnostic parser for Illumina SampleSheet.csv files.
         Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
         bidirectional conversion, index validation, and Hamming distance checking.
@@ -22,9 +21,9 @@ tools:
       documentation: https://illumina-samplesheet.readthedocs.io
       tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
       doi: "10.5281/zenodo.18989694"
-      licence: ["Apache-2.0"]
+      licence:
+        - "Apache-2.0"
       identifier: biotools:samplesheet-parser
-
 input:
   - - meta:
         type: map
@@ -37,7 +36,6 @@ input:
         pattern: "*.{csv,CSV}"
         ontologies:
           - edam: "http://edamontology.org/format_3752"
-
 output:
   json:
     - - meta:
@@ -49,7 +47,9 @@ output:
             JSON summary with file, format, sample_count, lanes, index_type,
             read_lengths, adapters, experiment_name, and instrument fields.
           pattern: "*.info.json"
-  versions_samplesheet_parser:
+          ontologies:
+            - edam: http://edamontology.org/format_3464
+  versions_samplesheetparser:
     - - ${task.process}:
           type: string
           description: The name of the process
@@ -70,7 +70,6 @@ topics:
       - samplesheet --version | sed 's/samplesheet-parser //':
           type: eval
           description: The expression to obtain the version of the tool
-
 authors:
   - "@chaitanyakasaraneni"
 maintainers:

--- a/modules/nf-core/samplesheetparser/info/meta.yml
+++ b/modules/nf-core/samplesheetparser/info/meta.yml
@@ -1,0 +1,77 @@
+name: samplesheetparser_info
+description: |
+  Display a structured JSON summary of an Illumina SampleSheet.csv (V1 or V2)
+  including format version, sample count, lanes, index type, read lengths,
+  adapter sequences, experiment name, and instrument platform.
+  Useful for logging run metadata or conditional branching in pipelines.
+keywords:
+  - illumina
+  - samplesheet
+  - metadata
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv (V1 or V2 format, auto-detected)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+
+output:
+  json:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.info.json":
+          type: file
+          description: |
+            JSON summary with file, format, sample_count, lanes, index_type,
+            read_lengths, adapters, experiment_name, and instrument fields.
+          pattern: "*.info.json"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/info/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/info/tests/main.nf.test
@@ -5,7 +5,6 @@ nextflow_process {
     process "SAMPLESHEETPARSER_INFO"
 
     tag "samplesheetparser"
-    tag "samplesheetparser_info"
     tag "samplesheetparser/info"
     tag "modules"
     tag "modules_nfcore"
@@ -26,7 +25,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -47,7 +46,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -70,7 +69,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/samplesheetparser/info/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/info/tests/main.nf.test
@@ -1,0 +1,77 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_INFO"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_INFO"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_info"
+    tag "samplesheetparser/info"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 sheet - info") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v1' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V2 sheet - info") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 sheet - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/info/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/info/tests/main.nf.test.snap
@@ -1,0 +1,125 @@
+{
+    "V1 sheet - info": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v1"
+                        },
+                        "test_v1.info.json:md5,70a050f386343c867655216bf657ee7a"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_v1"
+                        },
+                        "test_v1.info.json:md5,70a050f386343c867655216bf657ee7a"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:28.55317",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V2 sheet - info": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v2"
+                        },
+                        "test_v2.info.json:md5,05ce66a4fe3a71083500e9ef9c1dd827"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_v2"
+                        },
+                        "test_v2.info.json:md5,05ce66a4fe3a71083500e9ef9c1dd827"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:36.28689",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V1 sheet - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.info.json:md5,ce5acbba729ff67e15b951a2e5cb62c0"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.info.json:md5,ce5acbba729ff67e15b951a2e5cb62c0"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_INFO",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:07:44.035976",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/info/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/info/tests/main.nf.test.snap
@@ -2,30 +2,15 @@
     "V1 sheet - info": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_v1"
-                        },
-                        "test_v1.info.json:md5,70a050f386343c867655216bf657ee7a"
-                    ]
-                ],
-                "1": [
-                    [
-                        "SAMPLESHEETPARSER_INFO",
-                        "samplesheet-parser",
-                        "1.2.0"
-                    ]
-                ],
                 "json": [
                     [
                         {
                             "id": "test_v1"
                         },
-                        "test_v1.info.json:md5,70a050f386343c867655216bf657ee7a"
+                        "test_v1.info.json:md5,432ca46ec470fc47c7c5af5d698cbde8"
                     ]
                 ],
-                "versions_samplesheet_parser": [
+                "versions_samplesheetparser": [
                     [
                         "SAMPLESHEETPARSER_INFO",
                         "samplesheet-parser",
@@ -34,7 +19,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-10T14:07:28.55317",
+        "timestamp": "2026-05-13T09:46:13.123399",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -43,30 +28,15 @@
     "V2 sheet - info": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_v2"
-                        },
-                        "test_v2.info.json:md5,05ce66a4fe3a71083500e9ef9c1dd827"
-                    ]
-                ],
-                "1": [
-                    [
-                        "SAMPLESHEETPARSER_INFO",
-                        "samplesheet-parser",
-                        "1.2.0"
-                    ]
-                ],
                 "json": [
                     [
                         {
                             "id": "test_v2"
                         },
-                        "test_v2.info.json:md5,05ce66a4fe3a71083500e9ef9c1dd827"
+                        "test_v2.info.json:md5,b02a9f7d581f1e14aeeaa8b30a42e8b6"
                     ]
                 ],
-                "versions_samplesheet_parser": [
+                "versions_samplesheetparser": [
                     [
                         "SAMPLESHEETPARSER_INFO",
                         "samplesheet-parser",
@@ -75,7 +45,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-10T14:07:36.28689",
+        "timestamp": "2026-05-13T09:46:25.541946",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -84,30 +54,15 @@
     "V1 sheet - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_stub"
-                        },
-                        "test_stub.info.json:md5,ce5acbba729ff67e15b951a2e5cb62c0"
-                    ]
-                ],
-                "1": [
-                    [
-                        "SAMPLESHEETPARSER_INFO",
-                        "samplesheet-parser",
-                        "1.2.0"
-                    ]
-                ],
                 "json": [
                     [
                         {
                             "id": "test_stub"
                         },
-                        "test_stub.info.json:md5,ce5acbba729ff67e15b951a2e5cb62c0"
+                        "test_stub.info.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions_samplesheet_parser": [
+                "versions_samplesheetparser": [
                     [
                         "SAMPLESHEETPARSER_INFO",
                         "samplesheet-parser",
@@ -116,7 +71,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-10T14:07:44.035976",
+        "timestamp": "2026-05-13T09:46:37.243217",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/samplesheetparser/validate/environment.yml
+++ b/modules/nf-core/samplesheetparser/validate/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samplesheet-parser=1.2.0

--- a/modules/nf-core/samplesheetparser/validate/main.nf
+++ b/modules/nf-core/samplesheetparser/validate/main.nf
@@ -5,7 +5,7 @@ process SAMPLESHEETPARSER_VALIDATE {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
-        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+        'biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(samplesheet)

--- a/modules/nf-core/samplesheetparser/validate/main.nf
+++ b/modules/nf-core/samplesheetparser/validate/main.nf
@@ -1,0 +1,35 @@
+process SAMPLESHEETPARSER_VALIDATE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(samplesheet)
+
+    output:
+    tuple val(meta), path("*.validation.json"), emit: json
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    samplesheet validate \\
+        --format json \\
+        ${args} \\
+        ${samplesheet} > ${prefix}.validation.json
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo '{"is_valid": true, "errors": [], "warnings": []}' > ${prefix}.validation.json
+    """
+}

--- a/modules/nf-core/samplesheetparser/validate/main.nf
+++ b/modules/nf-core/samplesheetparser/validate/main.nf
@@ -3,7 +3,7 @@ process SAMPLESHEETPARSER_VALIDATE {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
         'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
 
@@ -12,7 +12,7 @@ process SAMPLESHEETPARSER_VALIDATE {
 
     output:
     tuple val(meta), path("*.validation.json"), emit: json
-    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheet_parser
+    tuple val("${task.process}"), val('samplesheet-parser'), eval("samplesheet --version | sed 's/samplesheet-parser //'"), topic: versions, emit: versions_samplesheetparser
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,7 +22,6 @@ process SAMPLESHEETPARSER_VALIDATE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     samplesheet validate \\
-        --format json \\
         ${args} \\
         ${samplesheet} > ${prefix}.validation.json
     """
@@ -30,6 +29,6 @@ process SAMPLESHEETPARSER_VALIDATE {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo '{"is_valid": true, "errors": [], "warnings": []}' > ${prefix}.validation.json
+    touch ${prefix}.validation.json
     """
 }

--- a/modules/nf-core/samplesheetparser/validate/main.nf
+++ b/modules/nf-core/samplesheetparser/validate/main.nf
@@ -5,7 +5,7 @@ process SAMPLESHEETPARSER_VALIDATE {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samplesheet-parser:1.2.0--pyhdfd78af_0' :
-        'biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
+        'quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(samplesheet)

--- a/modules/nf-core/samplesheetparser/validate/meta.yml
+++ b/modules/nf-core/samplesheetparser/validate/meta.yml
@@ -1,0 +1,78 @@
+name: samplesheetparser_validate
+description: |
+  Validate an Illumina SampleSheet.csv (V1 or V2) for index, adapter, and
+  structural issues. Format is auto-detected. Exits 0 if valid, 1 if errors
+  are found — causing the pipeline to fail early with a clear message rather
+  than discovering demultiplexing problems downstream.
+keywords:
+  - illumina
+  - samplesheet
+  - validation
+  - demultiplexing
+  - bclconvert
+  - bcl2fastq
+  - genomics
+
+tools:
+  - samplesheet-parser:
+      description: >
+        Format-agnostic parser for Illumina SampleSheet.csv files.
+        Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
+        bidirectional conversion, index validation, and Hamming distance checking.
+      homepage: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      documentation: https://illumina-samplesheet.readthedocs.io
+      tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
+      doi: "10.5281/zenodo.18989694"
+      licence: ["Apache-2.0"]
+      identifier: biotools:samplesheet-parser
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information.
+          Use [ id:'run_id' ] to identify the sheet.
+    - samplesheet:
+        type: file
+        description: Illumina SampleSheet.csv (V1 or V2 format)
+        pattern: "*.{csv,CSV}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3752"
+
+output:
+  json:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.validation.json":
+          type: file
+          description: |
+            Structured JSON validation report with is_valid, errors, warnings,
+            and min_hamming_distance fields.
+          pattern: "*.validation.json"
+  versions_samplesheet_parser:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samplesheet-parser:
+          type: string
+          description: The name of the tool
+      - samplesheet --version | sed 's/samplesheet-parser //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@chaitanyakasaraneni"
+maintainers:
+  - "@chaitanyakasaraneni"

--- a/modules/nf-core/samplesheetparser/validate/meta.yml
+++ b/modules/nf-core/samplesheetparser/validate/meta.yml
@@ -12,10 +12,9 @@ keywords:
   - bclconvert
   - bcl2fastq
   - genomics
-
 tools:
   - samplesheet-parser:
-      description: >
+      description: |
         Format-agnostic parser for Illumina SampleSheet.csv files.
         Supports IEM V1 (bcl2fastq) and BCLConvert V2 with auto-detection,
         bidirectional conversion, index validation, and Hamming distance checking.
@@ -23,9 +22,9 @@ tools:
       documentation: https://illumina-samplesheet.readthedocs.io
       tool_dev_url: https://github.com/chaitanyakasaraneni/samplesheet-parser
       doi: "10.5281/zenodo.18989694"
-      licence: ["Apache-2.0"]
+      licence:
+        - "Apache-2.0"
       identifier: biotools:samplesheet-parser
-
 input:
   - - meta:
         type: map
@@ -38,7 +37,6 @@ input:
         pattern: "*.{csv,CSV}"
         ontologies:
           - edam: "http://edamontology.org/format_3752"
-
 output:
   json:
     - - meta:
@@ -50,7 +48,9 @@ output:
             Structured JSON validation report with is_valid, errors, warnings,
             and min_hamming_distance fields.
           pattern: "*.validation.json"
-  versions_samplesheet_parser:
+          ontologies:
+            - edam: http://edamontology.org/format_3464
+  versions_samplesheetparser:
     - - ${task.process}:
           type: string
           description: The name of the process
@@ -71,7 +71,6 @@ topics:
       - samplesheet --version | sed 's/samplesheet-parser //':
           type: eval
           description: The expression to obtain the version of the tool
-
 authors:
   - "@chaitanyakasaraneni"
 maintainers:

--- a/modules/nf-core/samplesheetparser/validate/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/validate/tests/main.nf.test
@@ -1,0 +1,77 @@
+nextflow_process {
+
+    name "Test Process SAMPLESHEETPARSER_VALIDATE"
+    script "../main.nf"
+    process "SAMPLESHEETPARSER_VALIDATE"
+
+    tag "samplesheetparser"
+    tag "samplesheetparser_validate"
+    tag "samplesheetparser/validate"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("V1 dual-index sheet - validate") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v1' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V2 dual-index sheet - validate") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_v2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v2.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("V1 dual-index sheet - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bcl/flowcell_samplesheet.v1.csv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samplesheetparser/validate/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/validate/tests/main.nf.test
@@ -5,7 +5,6 @@ nextflow_process {
     process "SAMPLESHEETPARSER_VALIDATE"
 
     tag "samplesheetparser"
-    tag "samplesheetparser_validate"
     tag "samplesheetparser/validate"
     tag "modules"
     tag "modules_nfcore"
@@ -26,7 +25,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -47,7 +46,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -70,7 +69,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/samplesheetparser/validate/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/validate/tests/main.nf.test.snap
@@ -2,30 +2,15 @@
     "V1 dual-index sheet - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_stub"
-                        },
-                        "test_stub.validation.json:md5,b275f250d57108916e3f263f1a57d5a8"
-                    ]
-                ],
-                "1": [
-                    [
-                        "SAMPLESHEETPARSER_VALIDATE",
-                        "samplesheet-parser",
-                        "1.2.0"
-                    ]
-                ],
                 "json": [
                     [
                         {
                             "id": "test_stub"
                         },
-                        "test_stub.validation.json:md5,b275f250d57108916e3f263f1a57d5a8"
+                        "test_stub.validation.json:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions_samplesheet_parser": [
+                "versions_samplesheetparser": [
                     [
                         "SAMPLESHEETPARSER_VALIDATE",
                         "samplesheet-parser",
@@ -34,7 +19,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-10T14:09:11.117233",
+        "timestamp": "2026-05-13T09:48:36.19601",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -43,30 +28,15 @@
     "V1 dual-index sheet - validate": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_v1"
-                        },
-                        "test_v1.validation.json:md5,281264d5a33913d0e97051a803a704be"
-                    ]
-                ],
-                "1": [
-                    [
-                        "SAMPLESHEETPARSER_VALIDATE",
-                        "samplesheet-parser",
-                        "1.2.0"
-                    ]
-                ],
                 "json": [
                     [
                         {
                             "id": "test_v1"
                         },
-                        "test_v1.validation.json:md5,281264d5a33913d0e97051a803a704be"
+                        "test_v1.validation.json:md5,143aaf104ade709ffaa8da864274cd8e"
                     ]
                 ],
-                "versions_samplesheet_parser": [
+                "versions_samplesheetparser": [
                     [
                         "SAMPLESHEETPARSER_VALIDATE",
                         "samplesheet-parser",
@@ -75,7 +45,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-10T14:08:53.891329",
+        "timestamp": "2026-05-13T09:48:13.246282",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -84,30 +54,15 @@
     "V2 dual-index sheet - validate": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_v2"
-                        },
-                        "test_v2.validation.json:md5,20eec3331cf1b392e01da9dc0b5f480f"
-                    ]
-                ],
-                "1": [
-                    [
-                        "SAMPLESHEETPARSER_VALIDATE",
-                        "samplesheet-parser",
-                        "1.2.0"
-                    ]
-                ],
                 "json": [
                     [
                         {
                             "id": "test_v2"
                         },
-                        "test_v2.validation.json:md5,20eec3331cf1b392e01da9dc0b5f480f"
+                        "test_v2.validation.json:md5,3a89a0aef11dd189df07693cfdd9882c"
                     ]
                 ],
-                "versions_samplesheet_parser": [
+                "versions_samplesheetparser": [
                     [
                         "SAMPLESHEETPARSER_VALIDATE",
                         "samplesheet-parser",
@@ -116,7 +71,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-10T14:09:01.937955",
+        "timestamp": "2026-05-13T09:48:25.089445",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/samplesheetparser/validate/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/validate/tests/main.nf.test.snap
@@ -1,0 +1,125 @@
+{
+    "V1 dual-index sheet - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.validation.json:md5,b275f250d57108916e3f263f1a57d5a8"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.validation.json:md5,b275f250d57108916e3f263f1a57d5a8"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:09:11.117233",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V1 dual-index sheet - validate": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v1"
+                        },
+                        "test_v1.validation.json:md5,281264d5a33913d0e97051a803a704be"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_v1"
+                        },
+                        "test_v1.validation.json:md5,281264d5a33913d0e97051a803a704be"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:08:53.891329",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "V2 dual-index sheet - validate": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_v2"
+                        },
+                        "test_v2.validation.json:md5,20eec3331cf1b392e01da9dc0b5f480f"
+                    ]
+                ],
+                "1": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test_v2"
+                        },
+                        "test_v2.validation.json:md5,20eec3331cf1b392e01da9dc0b5f480f"
+                    ]
+                ],
+                "versions_samplesheet_parser": [
+                    [
+                        "SAMPLESHEETPARSER_VALIDATE",
+                        "samplesheet-parser",
+                        "1.2.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-10T14:09:01.937955",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds two read-only nf-core modules for inspecting Illumina SampleSheet.csv files — `samplesheetparser/info` and `samplesheetparser/validate` — built on the [`samplesheet-parser`](https://github.com/chaitanyakasaraneni/samplesheet-parser) tool with auto-detection of IEM V1 / BCLConvert V2 format.

## Why
Pipelines that demultiplex Illumina runs benefit from inspecting and validating SampleSheet.csv files **before** invoking `bcl2fastq`/`bclconvert`. Today this is re-implemented as ad-hoc bash/Python across pipelines. These two modules give nf-core a shared, tested way to:

- **validate** early and fail fast with a clear error rather than discovering structural or index problems at demux time,
- **expose run metadata** (sample count, lanes, index type, read lengths, adapters, experiment, instrument) for conditional branching or logging.

Both are read-only and have no side effects, making them the natural starting point for adopting the `samplesheet-parser` toolkit.

## Changes

### New modules
- `samplesheetparser/info` — emits a structured JSON summary of the sheet (format, sample count, lanes, index type, read lengths, adapter sequences, experiment, instrument)
- `samplesheetparser/validate` — runs structural and index validation (V1/V2 auto-detected); JSON report with `is_valid`, `errors`, `warnings`, `min_hamming_distance`

### Conventions
- Containers: `quay.io/biocontainers/samplesheet-parser:1.2.0--pyhdfd78af_0` (Docker) and `depot.galaxyproject.org/singularity/...` (Singularity); conda env pins `bioconda::samplesheet-parser=1.2.0`
- Versions emitted via `topic: versions` (eval of `samplesheet --version`) — no `versions.yml` file
- Both modules include stub blocks for `-stub` runs
- Tests cover real V1 / V2 sheets plus `-stub` mode; snapshots regenerated locally with Docker

### Verified
- `nf-core modules lint samplesheetparser/info` and `samplesheetparser/validate` — **0 warnings, 0 failures**
- `pre-commit run` — all hooks pass
- `nf-test --profile docker` — **6/6 tests pass** across both modules

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->