### PR TITLE
fix(shinyngs/validatefomcomponents): emit valid TSV in stub block

### DIFF
--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -42,10 +42,18 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
     stub:
     def prefix = task.ext.prefix ?: meta.id
     """
-    mkdir $prefix
-    touch $prefix/${prefix}.sample_metadata.tsv
-    touch $prefix/${prefix}.feature_metadata.tsv
-    touch $prefix/${prefix}.assay.tsv
-    touch $prefix/${prefix}.contrasts_file.tsv
+    mkdir -p $prefix
+
+    printf 'sample\\tcondition\\nsample1\\tcondition1\\nsample2\\tcondition2\\n' \\
+        > $prefix/${prefix}.sample_metadata.tsv
+
+    printf 'gene_id\\tgene_name\\ngene1\\tname1\\n' \\
+        > $prefix/${prefix}.feature_metadata.tsv
+
+    printf 'gene_id\\tsample1\\tsample2\\ngene1\\t1\\t2\\n' \\
+        > $prefix/${prefix}.assay.tsv
+
+    printf 'id\\tvariable\\treference\\ttarget\\tblocking\\tformula\\tmake_contrasts_str\\ncontrast1\\tcondition\\tcondition1\\tcondition2\\t\\t\\t\\n' \\
+        > $prefix/${prefix}.contrasts_file.tsv
     """
 }

--- a/modules/nf-core/shinyngs/validatefomcomponents/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/validatefomcomponents/tests/main.nf.test.snap
@@ -96,7 +96,7 @@
                         {
                             "id": "SRP254919"
                         },
-                        "SRP254919.sample_metadata.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "SRP254919.sample_metadata.tsv:md5,8ac57c8e06615779a68533ff8cabef50"
                     ]
                 ],
                 "1": [
@@ -104,7 +104,7 @@
                         {
                             "id": "SRP254919"
                         },
-                        "SRP254919.feature_metadata.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "SRP254919.feature_metadata.tsv:md5,7eeadd5ba8d617f93e7ee7307230172b"
                     ]
                 ],
                 "2": [
@@ -112,7 +112,7 @@
                         {
                             "id": "SRP254919"
                         },
-                        "SRP254919.assay.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "SRP254919.assay.tsv:md5,9f2b31bec63221f2db9b238b28be31b2"
                     ]
                 ],
                 "3": [
@@ -120,7 +120,7 @@
                         {
                             "id": "SRP254919"
                         },
-                        "SRP254919.contrasts_file.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "SRP254919.contrasts_file.tsv:md5,df0d9b4ee123fbfc298577c138562da8"
                     ]
                 ],
                 "4": [
@@ -135,7 +135,7 @@
                         {
                             "id": "SRP254919"
                         },
-                        "SRP254919.assay.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "SRP254919.assay.tsv:md5,9f2b31bec63221f2db9b238b28be31b2"
                     ]
                 ],
                 "contrasts": [
@@ -143,7 +143,7 @@
                         {
                             "id": "SRP254919"
                         },
-                        "SRP254919.contrasts_file.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "SRP254919.contrasts_file.tsv:md5,df0d9b4ee123fbfc298577c138562da8"
                     ]
                 ],
                 "feature_meta": [
@@ -151,7 +151,7 @@
                         {
                             "id": "SRP254919"
                         },
-                        "SRP254919.feature_metadata.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "SRP254919.feature_metadata.tsv:md5,7eeadd5ba8d617f93e7ee7307230172b"
                     ]
                 ],
                 "sample_meta": [
@@ -159,7 +159,7 @@
                         {
                             "id": "SRP254919"
                         },
-                        "SRP254919.sample_metadata.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "SRP254919.sample_metadata.tsv:md5,8ac57c8e06615779a68533ff8cabef50"
                     ]
                 ],
                 "versions_shinyngs": [
@@ -171,7 +171,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:24:18.191848094",
+        "timestamp": "2026-05-12T17:51:50.819361",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"


### PR DESCRIPTION
## Summary

The `SHINYNGS_VALIDATEFOMCOMPONENTS` stub block emits empty files via `touch`. Pipelines that pipe its `contrasts_file.tsv` output through `splitCsv(header:true)` then fail with `IllegalStateException: Missing 'header' in CSV file`, taking the whole `-stub-run` down with them.

This PR replaces each `touch` with a `printf` that writes a minimal header-bearing TSV. Column names match what `validate_fom_components.R` actually emits in real runs, so downstream consumers see the same schema in stub and live mode.

Snapshot refreshed for the existing `test("stub")` case.

## Motivation

Reported in [nf-core/differentialabundance#717](https://github.com/nf-core/differentialabundance/issues/717): `-stub-run` is currently unusable for that pipeline, which is a real productivity hit during development.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests! (existing stub test still exercises this path; snapshot updated.)
- [x] Ensure the test suite passes (`nf-core modules test shinyngs/validatefomcomponents --profile docker`).
- [x] Used the `nf-core modules test <module>` command to make sure the tests pass.
- [x] `main.nf` only changes the stub block; the `script` block is untouched.
- [x] Module follows the [DSL2 process guidelines](https://nf-co.re/docs/contributing/modules#dsl2-process-guidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)