### PR TITLE
fix: propr/propd write properly headed genewise TSV

### DIFF
--- a/modules/nf-core/propr/propd/main.nf
+++ b/modules/nf-core/propr/propd/main.nf
@@ -20,7 +20,7 @@ process PROPR_PROPD {
     tuple val(meta), path("*.propd.adjacency.csv")        , emit: adjacency                , optional:true
     tuple val(meta), path("*.propd.fdr.tsv")              , emit: fdr                      , optional:true
     path "*.R_sessionInfo.log"                            , emit: session_info
-    path "versions.yml"                                   , emit: versions
+    path "versions.yml"                                   , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/propr/propd/meta.yml
+++ b/modules/nf-core/propr/propd/meta.yml
@@ -14,7 +14,8 @@ tools:
       documentation: "https://rdrr.io/cran/propr/man/propr.html"
       tool_dev_url: "https://github.com/tpq/propr"
       doi: "10.1038/s41598-017-16520-0"
-      licence: ["GPL-2"]
+      licence:
+        - "GPL-2"
       identifier: biotools:propr
 input:
   - - meta:
@@ -64,7 +65,7 @@ output:
             information as compiled from the propd results
           pattern: "*.propd.genewise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
       - "*.propd.genewise.tsv":
           type: file
           description: |
@@ -72,7 +73,7 @@ output:
             information as compiled from the propd results
           pattern: "*.propd.genewise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
   genewise_plot:
     - - meta:
           type: file
@@ -81,7 +82,7 @@ output:
             information as compiled from the propd results
           pattern: "*.propd.genewise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
       - "*.propd.genewise.png":
           type: file
           description: |
@@ -98,7 +99,7 @@ output:
             information as compiled from the propd results
           pattern: "*.propd.genewise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
       - "*.propd.rds":
           type: file
           description: |
@@ -113,7 +114,7 @@ output:
             information as compiled from the propd results
           pattern: "*.propd.genewise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
       - "*.propd.pairwise.tsv":
           type: file
           description: |
@@ -122,7 +123,7 @@ output:
             each pair of genes.
           pattern: "*.propd.pairwise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
   results_pairwise_filtered:
     - - meta:
           type: file
@@ -131,7 +132,7 @@ output:
             information as compiled from the propd results
           pattern: "*.propd.genewise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
       - "*.propd.pairwise_filtered.tsv":
           type: file
           description: |
@@ -140,7 +141,7 @@ output:
             proportionality values.
           pattern: "*.propd.pairwise_filtered.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
   adjacency:
     - - meta:
           type: file
@@ -149,7 +150,7 @@ output:
             information as compiled from the propd results
           pattern: "*.propd.genewise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
       - "*.propd.adjacency.csv":
           type: file
           description: |
@@ -158,7 +159,7 @@ output:
             proportional.
           pattern: "*.propd.adjacency.csv"
           ontologies:
-            - edam: http://edamontology.org/format_3752 # CSV
+            - edam: http://edamontology.org/format_3752
   fdr:
     - - meta:
           type: file
@@ -167,7 +168,7 @@ output:
             information as compiled from the propd results
           pattern: "*.propd.genewise.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
       - "*.propd.fdr.tsv":
           type: file
           description: |
@@ -177,7 +178,7 @@ output:
             computationally expensive.
           pattern: "*.propd.fdr.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
   session_info:
     - "*.R_sessionInfo.log":
         type: file
@@ -190,7 +191,12 @@ output:
         description: File containing software versions
         pattern: "versions.yml"
         ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+          - edam: http://edamontology.org/format_3750
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
 authors:
   - "@suzannejin"
   - "@caraiz2001"

--- a/modules/nf-core/propr/propd/templates/propd.R
+++ b/modules/nf-core/propr/propd/templates/propd.R
@@ -657,7 +657,15 @@ if (nrow(results_genewise) > 0) {
 }
 
 # save main results - genewise
+# Move gene IDs from rownames into an explicit features_id_col column so the
+# resulting TSV has a header aligned with the data rows (otherwise the first
+# row has one more field than the header line).
 results_genewise <- as.data.frame(results_genewise)
+results_genewise <- cbind(
+    setNames(data.frame(rownames(results_genewise), stringsAsFactors = FALSE), opt\$features_id_col),
+    results_genewise
+)
+rownames(results_genewise) <- NULL
 results_genewise <- results_genewise[order(
     results_genewise\$rcDdis, # sort by increasing rcDdis (from most significant to least significant)
     -abs(results_genewise\$LFC), # sort by decreasing absolute LFC (from most to least differential)
@@ -676,7 +684,7 @@ write.table(
     results_genewise,
     file      = paste0(opt\$prefix, '.propd.genewise.tsv'),
     col.names = TRUE,
-    row.names = TRUE,
+    row.names = FALSE,
     sep       = '\\t',
     quote     = FALSE
 )

--- a/modules/nf-core/propr/propd/templates/propd.R
+++ b/modules/nf-core/propr/propd/templates/propd.R
@@ -659,13 +659,18 @@ if (nrow(results_genewise) > 0) {
 # save main results - genewise
 # Move gene IDs from rownames into an explicit features_id_col column so the
 # resulting TSV has a header aligned with the data rows (otherwise the first
-# row has one more field than the header line).
+# row has one more field than the header line). The empty-results branch
+# above (when no significant theta is found) already builds the data frame
+# with features_id_col as a regular column, so only run the rewrite when it
+# isn't there yet - otherwise we would emit two columns with that name.
 results_genewise <- as.data.frame(results_genewise)
-results_genewise <- cbind(
-    setNames(data.frame(rownames(results_genewise), stringsAsFactors = FALSE), opt\$features_id_col),
-    results_genewise
-)
-rownames(results_genewise) <- NULL
+if (!(opt\$features_id_col %in% colnames(results_genewise))) {
+    results_genewise <- cbind(
+        setNames(data.frame(rownames(results_genewise), stringsAsFactors = FALSE), opt\$features_id_col),
+        results_genewise
+    )
+    rownames(results_genewise) <- NULL
+}
 results_genewise <- results_genewise[order(
     results_genewise\$rcDdis, # sort by increasing rcDdis (from most significant to least significant)
     -abs(results_genewise\$LFC), # sort by decreasing absolute LFC (from most to least differential)

--- a/modules/nf-core/propr/propd/tests/main.nf.test.snap
+++ b/modules/nf-core/propr/propd/tests/main.nf.test.snap
@@ -10,7 +10,7 @@
                         "target": "hND6",
                         "blocking": ""
                     },
-                    "treatment_mCherry_hND6_.propd.genewise.tsv:md5,f59ac89d54c5c5c48469b40c90293043"
+                    "treatment_mCherry_hND6_.propd.genewise.tsv:md5,3673576dbafb9e9f48ca707871f3f6a6"
                 ]
             ],
             [
@@ -18,11 +18,11 @@
             ],
             "treatment_mCherry_hND6_.propd.genewise.png"
         ],
+        "timestamp": "2026-05-13T17:11:38.287539538",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-10-29T13:18:33.094065"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
     "Test propr/propd when using Box-cox transformation": {
         "content": [
@@ -35,7 +35,7 @@
                         "target": "hND6",
                         "blocking": ""
                     },
-                    "treatment_mCherry_hND6_.propd.genewise.tsv:md5,591cbee69aaeff2eb08be10b1709f5eb"
+                    "treatment_mCherry_hND6_.propd.genewise.tsv:md5,918f1bd489443235b2d0e22e12731985"
                 ]
             ],
             [
@@ -43,11 +43,11 @@
             ],
             "treatment_mCherry_hND6_.propd.genewise.png"
         ],
+        "timestamp": "2026-05-13T17:12:08.650175696",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-10-29T13:19:24.03108"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
     "Test propr/propd when using permutation tests": {
         "content": [
@@ -60,7 +60,7 @@
                         "target": "hND6",
                         "blocking": ""
                     },
-                    "treatment_mCherry_hND6_.propd.genewise.tsv:md5,f59ac89d54c5c5c48469b40c90293043"
+                    "treatment_mCherry_hND6_.propd.genewise.tsv:md5,3673576dbafb9e9f48ca707871f3f6a6"
                 ]
             ],
             [
@@ -80,11 +80,11 @@
             ],
             "treatment_mCherry_hND6_.propd.genewise.png"
         ],
+        "timestamp": "2026-05-13T17:12:39.811022624",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-10-29T13:20:49.704914"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
     "Test propr/propd when saving all outputs": {
         "content": [
@@ -97,7 +97,7 @@
                         "target": "hND6",
                         "blocking": ""
                     },
-                    "treatment_mCherry_hND6_.propd.genewise.tsv:md5,f59ac89d54c5c5c48469b40c90293043"
+                    "treatment_mCherry_hND6_.propd.genewise.tsv:md5,3673576dbafb9e9f48ca707871f3f6a6"
                 ]
             ],
             [
@@ -131,10 +131,10 @@
             "treatment_mCherry_hND6_.propd.genewise.png",
             "treatment_mCherry_hND6_.propd.rds"
         ],
+        "timestamp": "2026-05-13T17:11:56.096709291",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-10-29T13:21:30.746294"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     }
 }

--- a/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test.snap
@@ -430,7 +430,7 @@
                         "blocking": "",
                         "differential_method": "propd"
                     },
-                    "treatment_mCherry_hND6__test_propd.propd.genewise.tsv:md5,f59ac89d54c5c5c48469b40c90293043"
+                    "treatment_mCherry_hND6__test_propd.propd.genewise.tsv:md5,3673576dbafb9e9f48ca707871f3f6a6"
                 ],
                 [
                     {
@@ -463,7 +463,7 @@
                         "blocking": "sample_number",
                         "differential_method": "propd"
                     },
-                    "treatment_mCherry_hND6_sample_number_test_propd.propd.genewise.tsv:md5,f59ac89d54c5c5c48469b40c90293043"
+                    "treatment_mCherry_hND6_sample_number_test_propd.propd.genewise.tsv:md5,3673576dbafb9e9f48ca707871f3f6a6"
                 ]
             ],
             [
@@ -504,7 +504,7 @@
                         "fc_threshold": 1.5,
                         "stat_threshold": 0.05
                     },
-                    "treatment_mCherry_hND6__test_filtered.tsv:md5,6f9314d114c2be92ca1518511f9ce1cf"
+                    "treatment_mCherry_hND6__test_filtered.tsv:md5,8338b79b1d20d39928ec37d48db784f4"
                 ],
                 [
                     {
@@ -543,7 +543,7 @@
                         "fc_threshold": 1.5,
                         "stat_threshold": 0.05
                     },
-                    "treatment_mCherry_hND6_sample_number_test_filtered.tsv:md5,6f9314d114c2be92ca1518511f9ce1cf"
+                    "treatment_mCherry_hND6_sample_number_test_filtered.tsv:md5,8338b79b1d20d39928ec37d48db784f4"
                 ]
             ],
             [
@@ -675,10 +675,10 @@
                 "versions.yml:md5,ff5b7c1d83470f6f548f3643bb37a830"
             ]
         ],
-        "timestamp": "2026-04-21T18:20:14.47563948",
+        "timestamp": "2026-05-14T09:07:27.027442931",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.1"
         }
     },
     "stub": {
@@ -1439,7 +1439,7 @@
                         "blocking": "",
                         "differential_method": "propd"
                     },
-                    "treatment_mCherry_hND6__test.propd.genewise.tsv:md5,f59ac89d54c5c5c48469b40c90293043"
+                    "treatment_mCherry_hND6__test.propd.genewise.tsv:md5,3673576dbafb9e9f48ca707871f3f6a6"
                 ],
                 [
                     {
@@ -1450,7 +1450,7 @@
                         "blocking": "sample_number",
                         "differential_method": "propd"
                     },
-                    "treatment_mCherry_hND6_sample_number_test.propd.genewise.tsv:md5,f59ac89d54c5c5c48469b40c90293043"
+                    "treatment_mCherry_hND6_sample_number_test.propd.genewise.tsv:md5,3673576dbafb9e9f48ca707871f3f6a6"
                 ]
             ],
             [
@@ -1465,7 +1465,7 @@
                         "fc_threshold": 1.5,
                         "stat_threshold": 0.05
                     },
-                    "treatment_mCherry_hND6__test_filtered.tsv:md5,6f9314d114c2be92ca1518511f9ce1cf"
+                    "treatment_mCherry_hND6__test_filtered.tsv:md5,8338b79b1d20d39928ec37d48db784f4"
                 ],
                 [
                     {
@@ -1478,7 +1478,7 @@
                         "fc_threshold": 1.5,
                         "stat_threshold": 0.05
                     },
-                    "treatment_mCherry_hND6_sample_number_test_filtered.tsv:md5,6f9314d114c2be92ca1518511f9ce1cf"
+                    "treatment_mCherry_hND6_sample_number_test_filtered.tsv:md5,8338b79b1d20d39928ec37d48db784f4"
                 ]
             ],
             [
@@ -1509,10 +1509,10 @@
                 "versions.yml:md5,ff5b7c1d83470f6f548f3643bb37a830"
             ]
         ],
-        "timestamp": "2026-04-21T18:18:05.817756366",
+        "timestamp": "2026-05-14T09:06:41.621996671",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.1"
         }
     }
 }


### PR DESCRIPTION
## Summary

`propr/propd` writes the genewise results table using `write.table(..., row.names=TRUE, col.names=TRUE)`, which produces a header with N column names but data rows with N+1 fields (the row name + the N columns):

```
Nsig	LFC	lrmD	rcDdis	significant
ENSMUSG00000076613	981	-10.375	-20.868	0.001	0
```

This makes the file malformed for any downstream consumer that does positional/named column parsing (e.g. `csvtk join`, `read.delim` without explicit `row.names = 1`). This PR moves the gene IDs from rownames into an explicit `features_id_col` column and writes with `row.names = FALSE`.

The rewrite is guarded against the "no significant theta found" branch, which already constructs `results_genewise` with `features_id_col` as a regular column - applying the cbind there would produce a TSV header with two columns sharing that name.

The module test snapshot is re-recorded against nf-test 0.9.5 / Nextflow 26.04.1 to pick up the new TSV md5s.

## Why this matters

This bug only surfaced because the existing module test only verified the file by md5 - it never opens the TSV with anything that cares about header alignment. nf-core/differentialabundance is the (currently only) downstream consumer of `propr/propd`, and we discovered it while plumbing propd as a `--differential_method` option (see [nf-core/differentialabundance#724](https://github.com/nf-core/differentialabundance/issues/724) and its associated PR). With this fix the differentialabundance pipeline can drop a local patch and consume `propr/propd` from upstream directly.

## Test plan

- [x] `nf-core modules test propr/propd --profile docker` passes after re-recording the snapshot.
- [x] Header of `*.propd.genewise.tsv` has the same number of fields as data rows.
- [x] The empty-results branch (`theta_cutoff == FALSE`) also emits a properly aligned single-header TSV (guarded by `if (!(features_id_col %in% colnames(...)))`).
- [ ] `csvtk join --fields gene_id ...` against the genewise TSV finds the gene_id column (verified end-to-end via nf-core/differentialabundance#727 CI once that PR drops its local patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
