### PR TITLE
Add gcta/makegrm module

### DIFF
--- a/modules/nf-core/gcta/makegrm/environment.yml
+++ b/modules/nf-core/gcta/makegrm/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::gcta=1.94.1

--- a/modules/nf-core/gcta/makegrm/main.nf
+++ b/modules/nf-core/gcta/makegrm/main.nf
@@ -1,0 +1,42 @@
+process GCTA_MAKEGRM {
+    tag "${meta.id}"
+    label 'process_medium'
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/46b0d05f0daa47561d87d2a9cac5e51edc2c78e26f1bbab439c688386241a274/data'
+        : 'community.wave.seqera.io/library/gcta:1.94.1--9bc35dc424fcf6e9'}"
+
+    input:
+    tuple val(meta), path(mfile), path(bed_pgen), path(bim_pvar), path(fam_psam)
+
+    output:
+    tuple val(meta), path("*.grm.id"), path("*.grm.bin"), path("*.grm.N.bin"), emit: grm_files
+    tuple val("${task.process}"), val("gcta"), eval("gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'"), emit: versions_gcta, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def extra_args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def genotype_files = bed_pgen instanceof List ? bed_pgen : [bed_pgen]
+    def genotype_extension = genotype_files[0].name.tokenize('.').last()
+    def multi_file_flag = genotype_extension == 'pgen' ? '--mpfile' : '--mbfile'
+
+    """
+
+    gcta \\
+        ${multi_file_flag} ${mfile} \\
+        --make-grm \\
+        --thread-num ${task.cpus} \\
+        --out ${prefix} ${extra_args}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.grm.id
+    touch ${prefix}.grm.bin
+    touch ${prefix}.grm.N.bin
+    """
+}

--- a/modules/nf-core/gcta/makegrm/main.nf
+++ b/modules/nf-core/gcta/makegrm/main.nf
@@ -17,19 +17,18 @@ process GCTA_MAKEGRM {
     task.ext.when == null || task.ext.when
 
     script:
-    def extra_args = task.ext.args ?: ''
+    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def genotype_files = bed_pgen instanceof List ? bed_pgen : [bed_pgen]
     def genotype_extension = genotype_files[0].name.tokenize('.').last()
     def multi_file_flag = genotype_extension == 'pgen' ? '--mpfile' : '--mbfile'
-
     """
-
     gcta \\
         ${multi_file_flag} ${mfile} \\
         --make-grm \\
         --thread-num ${task.cpus} \\
-        --out ${prefix} ${extra_args}
+        --out ${prefix} \\
+        ${args}
     """
 
     stub:

--- a/modules/nf-core/gcta/makegrm/main.nf
+++ b/modules/nf-core/gcta/makegrm/main.nf
@@ -10,7 +10,7 @@ process GCTA_MAKEGRM {
     tuple val(meta), path(mfile), path(bed_pgen), path(bim_pvar), path(fam_psam)
 
     output:
-    tuple val(meta), path("*.grm.id"), path("*.grm.bin"), path("*.grm.N.bin"), emit: grm_files
+    tuple val(meta), path("*.grm.*"), emit: grm_files
     tuple val("${task.process}"), val("gcta"), eval("gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'"), emit: versions_gcta, topic: versions
 
     when:

--- a/modules/nf-core/gcta/makegrm/meta.yml
+++ b/modules/nf-core/gcta/makegrm/meta.yml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "gcta_makegrm"
+description: Compute a whole dense GRM with GCTA
+keywords:
+  - gcta
+  - grm
+  - genetics
+tools:
+  - "gcta":
+      description: "GCTA is a tool for genome-wide complex trait analysis."
+      homepage: "https://yanglab.westlake.edu.cn/software/gcta/"
+      documentation: "https://yanglab.westlake.edu.cn/software/gcta/static/gcta_doc_latest.pdf"
+      tool_dev_url: "https://github.com/jianyangqt/gcta"
+      licence:
+        - "GPL-3.0-only"
+      identifier: biotools:gcta
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing GRM sample metadata
+          e.g. `[ id:'gcta_grm' ]`
+    - mfile:
+        type: file
+        description: GCTA multi-input manifest consumed by `--mbfile` or
+          `--mpfile`
+        pattern: "*.{mbfile,mpfile,txt}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2330"
+    - bed_pgen:
+        type: file
+        description: Collection of PLINK primary genotype files referenced by the
+          multi-input manifest
+        pattern: "*.{bed,pgen}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - bim_pvar:
+        type: file
+        description: Collection of PLINK variant metadata files referenced by the
+          multi-input manifest
+        pattern: "*.{bim,pvar}"
+        ontologies: []
+    - fam_psam:
+        type: file
+        description: Collection of PLINK sample metadata files referenced by the
+          multi-input manifest
+        pattern: "*.{fam,psam}"
+        ontologies: []
+
+output:
+  grm_files:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing GRM sample metadata
+            e.g. `[ id:'gcta_grm' ]`
+      - "*.grm.id":
+          type: file
+          description: GRM sample identifier file
+          pattern: "*.grm.id"
+          ontologies: []
+      - "*.grm.bin":
+          type: file
+          description: GRM binary matrix file
+          pattern: "*.grm.bin"
+          ontologies: []
+      - "*.grm.N.bin":
+          type: file
+          description: GRM sample-count matrix file
+          pattern: "*.grm.N.bin"
+          ontologies: []
+  versions_gcta:
+    - - ${task.process}:
+          type: string
+          description: The process the version was collected from
+      - gcta:
+          type: string
+          description: The tool name
+      - "gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'":
+          type: eval
+          description: The command used to generate the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gcta:
+          type: string
+          description: The tool name
+      - "gcta --version | sed -En 's/^[*] version v([0-9.]*).*/\\1/p'":
+          type: eval
+          description: The command used to generate the version of the tool
+
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/gcta/makegrm/meta.yml
+++ b/modules/nf-core/gcta/makegrm/meta.yml
@@ -3,7 +3,9 @@ name: "gcta_makegrm"
 description: Compute a whole dense GRM with GCTA
 keywords:
   - gcta
+  - genome-wide complex trait analysis
   - grm
+  - genetic relationship matrix
   - genetics
 tools:
   - "gcta":

--- a/modules/nf-core/gcta/makegrm/meta.yml
+++ b/modules/nf-core/gcta/makegrm/meta.yml
@@ -55,20 +55,10 @@ output:
           description: |
             Groovy Map containing GRM sample metadata
             e.g. `[ id:'gcta_grm' ]`
-      - "*.grm.id":
+      - "*.grm.*":
           type: file
-          description: GRM sample identifier file
-          pattern: "*.grm.id"
-          ontologies: []
-      - "*.grm.bin":
-          type: file
-          description: GRM binary matrix file
-          pattern: "*.grm.bin"
-          ontologies: []
-      - "*.grm.N.bin":
-          type: file
-          description: GRM sample-count matrix file
-          pattern: "*.grm.N.bin"
+          description: Dense GRM sidecar files
+          pattern: "*.grm.{id,bin,N.bin}"
           ontologies: []
   versions_gcta:
     - - ${task.process}:

--- a/modules/nf-core/gcta/makegrm/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrm/tests/main.nf.test
@@ -39,11 +39,15 @@ nextflow_process {
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm' },
                 { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
                 { assert process.out.grm_files.get(0).get(1).size() == 3 },
-                { assert file(process.out.grm_files.get(0).get(1)).name == 'gcta_grm.grm.id' },
-                { assert file(process.out.grm_files.get(0).get(2)).name == 'gcta_grm.grm.bin' },
-                { assert file(process.out.grm_files.get(0).get(3)).name == 'gcta_grm.grm.N.bin' },
-                { assert file(path(process.out.grm_files.get(0).get(1)).parent.toString() + '/.command.sh').text.contains('--make-grm') },
-                { assert file(path(process.out.grm_files.get(0).get(1)).parent.toString() + '/.command.sh').text.contains('--mpfile') },
+                {
+                    assert process.out.grm_files.get(0).get(1).collect { file(it).name }.toSet() == [
+                        'gcta_grm.grm.id',
+                        'gcta_grm.grm.bin',
+                        'gcta_grm.grm.N.bin'
+                    ] as Set
+                },
+                { assert file(path(process.out.grm_files.get(0).get(1)[0]).parent.toString() + '/.command.sh').text.contains('--make-grm') },
+                { assert file(path(process.out.grm_files.get(0).get(1)[0]).parent.toString() + '/.command.sh').text.contains('--mpfile') },
                 {
                     assert snapshot(
                         process.out.grm_files,
@@ -84,11 +88,15 @@ nextflow_process {
                 { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed' },
                 { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
                 { assert process.out.grm_files.get(0).get(1).size() == 3 },
-                { assert file(process.out.grm_files.get(0).get(1)).name == 'gcta_grm_bed.grm.id' },
-                { assert file(process.out.grm_files.get(0).get(2)).name == 'gcta_grm_bed.grm.bin' },
-                { assert file(process.out.grm_files.get(0).get(3)).name == 'gcta_grm_bed.grm.N.bin' },
-                { assert file(path(process.out.grm_files.get(0).get(1)).parent.toString() + '/.command.sh').text.contains('--make-grm') },
-                { assert file(path(process.out.grm_files.get(0).get(1)).parent.toString() + '/.command.sh').text.contains('--mbfile') },
+                {
+                    assert process.out.grm_files.get(0).get(1).collect { file(it).name }.toSet() == [
+                        'gcta_grm_bed.grm.id',
+                        'gcta_grm_bed.grm.bin',
+                        'gcta_grm_bed.grm.N.bin'
+                    ] as Set
+                },
+                { assert file(path(process.out.grm_files.get(0).get(1)[0]).parent.toString() + '/.command.sh').text.contains('--make-grm') },
+                { assert file(path(process.out.grm_files.get(0).get(1)[0]).parent.toString() + '/.command.sh').text.contains('--mbfile') },
                 {
                     assert snapshot(
                         process.out.grm_files,

--- a/modules/nf-core/gcta/makegrm/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrm/tests/main.nf.test
@@ -1,0 +1,134 @@
+nextflow_process {
+
+    name "Test Process GCTA_MAKEGRM"
+    script "../main.nf"
+    process "GCTA_MAKEGRM"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gcta"
+    tag "gcta/makegrm"
+
+    test("homo_sapiens popgen - plink2") {
+        when {
+            process {
+                """
+                file('gcta_grm.mpfile').text = 'plink_simulated plink_simulated.pgen plink_simulated.psam plink_simulated.pvar\\n'
+
+                input[0] = [
+                    [ id:'gcta_grm' ],
+                    file('gcta_grm.mpfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.grm_files.size() == 1 },
+                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm' },
+                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
+                { assert process.out.grm_files.get(0).get(1).size() == 3 },
+                { assert file(process.out.grm_files.get(0).get(1)).name == 'gcta_grm.grm.id' },
+                { assert file(process.out.grm_files.get(0).get(2)).name == 'gcta_grm.grm.bin' },
+                { assert file(process.out.grm_files.get(0).get(3)).name == 'gcta_grm.grm.N.bin' },
+                { assert file(path(process.out.grm_files.get(0).get(1)).parent.toString() + '/.command.sh').text.contains('--make-grm') },
+                { assert file(path(process.out.grm_files.get(0).get(1)).parent.toString() + '/.command.sh').text.contains('--mpfile') },
+                {
+                    assert snapshot(
+                        process.out.grm_files,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink1") {
+        when {
+            process {
+                """
+                file('gcta_grm.mbfile').text = 'plink_simulated\\n'
+
+                input[0] = [
+                    [ id:'gcta_grm_bed' ],
+                    file('gcta_grm.mbfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.grm_files.size() == 1 },
+                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed' },
+                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
+                { assert process.out.grm_files.get(0).get(1).size() == 3 },
+                { assert file(process.out.grm_files.get(0).get(1)).name == 'gcta_grm_bed.grm.id' },
+                { assert file(process.out.grm_files.get(0).get(2)).name == 'gcta_grm_bed.grm.bin' },
+                { assert file(process.out.grm_files.get(0).get(3)).name == 'gcta_grm_bed.grm.N.bin' },
+                { assert file(path(process.out.grm_files.get(0).get(1)).parent.toString() + '/.command.sh').text.contains('--make-grm') },
+                { assert file(path(process.out.grm_files.get(0).get(1)).parent.toString() + '/.command.sh').text.contains('--mbfile') },
+                {
+                    assert snapshot(
+                        process.out.grm_files,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - plink1 - stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                file('gcta_grm.mbfile').text = 'plink_simulated\\n'
+
+                input[0] = [
+                    [ id:'gcta_grm_bed' ],
+                    file('gcta_grm.mbfile'),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/gcta/makegrm/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/makegrm/tests/main.nf.test.snap
@@ -6,9 +6,11 @@
                     {
                         "id": "gcta_grm"
                     },
-                    "gcta_grm.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9",
-                    "gcta_grm.grm.bin:md5,45f8dff14bda17d50009a21050572228",
-                    "gcta_grm.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4"
+                    [
+                        "gcta_grm.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4",
+                        "gcta_grm.grm.bin:md5,45f8dff14bda17d50009a21050572228",
+                        "gcta_grm.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9"
+                    ]
                 ]
             ],
             {
@@ -25,7 +27,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-15T20:22:02.639433902"
+        "timestamp": "2026-05-15T21:08:43.209734458"
     },
     "homo_sapiens popgen - plink1": {
         "content": [
@@ -34,9 +36,11 @@
                     {
                         "id": "gcta_grm_bed"
                     },
-                    "gcta_grm_bed.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9",
-                    "gcta_grm_bed.grm.bin:md5,45f8dff14bda17d50009a21050572228",
-                    "gcta_grm_bed.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4"
+                    [
+                        "gcta_grm_bed.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4",
+                        "gcta_grm_bed.grm.bin:md5,45f8dff14bda17d50009a21050572228",
+                        "gcta_grm_bed.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9"
+                    ]
                 ]
             ],
             {
@@ -53,7 +57,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-15T20:22:52.907133415"
+        "timestamp": "2026-05-15T21:09:34.058651287"
     },
     "homo_sapiens popgen - plink1 - stub": {
         "content": [
@@ -63,9 +67,11 @@
                         {
                             "id": "gcta_grm_bed"
                         },
-                        "gcta_grm_bed.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        [
+                            "gcta_grm_bed.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "gcta_grm_bed.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "gcta_grm_bed.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
                     ]
                 ],
                 "1": [
@@ -80,9 +86,11 @@
                         {
                             "id": "gcta_grm_bed"
                         },
-                        "gcta_grm_bed.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "gcta_grm_bed.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        [
+                            "gcta_grm_bed.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "gcta_grm_bed.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "gcta_grm_bed.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
                     ]
                 ],
                 "versions_gcta": [
@@ -98,6 +106,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-15T20:23:43.032260106"
+        "timestamp": "2026-05-15T21:10:21.024687128"
     }
 }

--- a/modules/nf-core/gcta/makegrm/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/makegrm/tests/main.nf.test.snap
@@ -1,0 +1,103 @@
+{
+    "homo_sapiens popgen - plink2": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "gcta_grm"
+                    },
+                    "gcta_grm.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9",
+                    "gcta_grm.grm.bin:md5,45f8dff14bda17d50009a21050572228",
+                    "gcta_grm.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRM",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-15T20:22:02.639433902"
+    },
+    "homo_sapiens popgen - plink1": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "gcta_grm_bed"
+                    },
+                    "gcta_grm_bed.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9",
+                    "gcta_grm_bed.grm.bin:md5,45f8dff14bda17d50009a21050572228",
+                    "gcta_grm_bed.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4"
+                ]
+            ],
+            {
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRM",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-15T20:22:52.907133415"
+    },
+    "homo_sapiens popgen - plink1 - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "gcta_grm_bed"
+                        },
+                        "gcta_grm_bed.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "gcta_grm_bed.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "gcta_grm_bed.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "GCTA_MAKEGRM",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ],
+                "grm_files": [
+                    [
+                        {
+                            "id": "gcta_grm_bed"
+                        },
+                        "gcta_grm_bed.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "gcta_grm_bed.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "gcta_grm_bed.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRM",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-15T20:23:43.032260106"
+    }
+}

--- a/modules/nf-core/gcta/makegrm/tests/nextflow.config
+++ b/modules/nf-core/gcta/makegrm/tests/nextflow.config
@@ -1,0 +1,3 @@
+params {
+    modules_testdata_base_path = System.getenv("NF_MODULES_TESTDATA_BASE_PATH") ?: "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/"
+}

--- a/modules/nf-core/gcta/makegrm/tests/nextflow.config
+++ b/modules/nf-core/gcta/makegrm/tests/nextflow.config
@@ -1,3 +1,0 @@
-params {
-    modules_testdata_base_path = System.getenv("NF_MODULES_TESTDATA_BASE_PATH") ?: "https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/"
-}


### PR DESCRIPTION
This PR adds the `gcta/makegrm` module, which computes a whole GCTA genetic relationship matrix from PLINK inputs.

It is intended for workflows that need a dense GRM without the partitioned output naming used by `gcta/makegrmpart`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] `nf-core modules test gcta/makegrm --profile docker`
- [x] `nf-core modules test gcta/makegrm --profile singularity`
- [x] `nf-core modules test gcta/makegrm --profile conda`

