### PR TITLE
update scar scvi-tools version to 1.4.3

### DIFF
--- a/modules/nf-core/scvitools/scar/environment.yml
+++ b/modules/nf-core/scvitools/scar/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::scvi-tools=1.3.3
+  - conda-forge::scvi-tools=1.4.3

--- a/modules/nf-core/scvitools/scar/main.nf
+++ b/modules/nf-core/scvitools/scar/main.nf
@@ -3,9 +3,10 @@ process SCVITOOLS_SCAR {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c8/c8764e4208e9639a54d636fc65c839c55dedbfd68def57baea90d1d2007d6a7f/data':
-        'community.wave.seqera.io/library/scvi-tools:1.3.3--df115aabdccb7d6b' }"
+    container "${ task.ext.use_gpu ? 'ghcr.io/scverse/scvi-tools:py3.13-cu12-1.4.3-' :
+        workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/df/dfb4b54fd5cb5c5624d947914f5ab8ac86eeaa5f762ebc52c034fbd36cf30250/data':
+        'community.wave.seqera.io/library/scvi-tools:1.4.3--cce8c95b58ececa6' }"
 
     input:
     tuple val(meta), path(filtered), path(unfiltered)
@@ -16,7 +17,7 @@ process SCVITOOLS_SCAR {
 
     output:
     tuple val(meta), path("*.h5ad"), emit: h5ad
-    path "versions.yml"            , emit: versions
+    path "versions.yml"            , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/scvitools/scar/meta.yml
+++ b/modules/nf-core/scvitools/scar/meta.yml
@@ -69,6 +69,11 @@ output:
         pattern: "versions.yml"
         ontologies:
           - edam: http://edamontology.org/format_3750 # YAML
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
 authors:
   - "@nictru"
 maintainers:

--- a/modules/nf-core/scvitools/scar/templates/scar.py
+++ b/modules/nf-core/scvitools/scar/templates/scar.py
@@ -2,15 +2,14 @@
 
 import os
 
+os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", os.path.join(os.getcwd(), "torch_cache"))
+
 import anndata as ad
 import scvi
 import yaml
 from scipy.sparse import csr_matrix
 from scvi.external import SCAR
 from threadpoolctl import threadpool_limits
-
-os.environ.setdefault("USER", "scvi")
-os.environ.setdefault("HOME", os.getcwd())
 
 threadpool_limits(int("${task.cpus}"))
 

--- a/modules/nf-core/scvitools/scar/templates/scar.py
+++ b/modules/nf-core/scvitools/scar/templates/scar.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import os
+
 import anndata as ad
 import scvi
 import yaml
@@ -7,10 +9,12 @@ from scipy.sparse import csr_matrix
 from scvi.external import SCAR
 from threadpoolctl import threadpool_limits
 
+os.environ.setdefault("USER", "scvi")
+os.environ.setdefault("HOME", os.getcwd())
+
 threadpool_limits(int("${task.cpus}"))
 
 scvi.settings.seed = 0
-
 
 adata = ad.read_h5ad("${filtered}")
 adata_unfiltered = ad.read_h5ad("${unfiltered}")

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -37,7 +37,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,f6c25be06bfb18cdf3e82e50985d9a9b"
+                    "versions.yml:md5,f906fc3c61697a5598dbdf6d62572fe4"
                 ],
                 "h5ad": [
                     [
@@ -48,7 +48,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,f6c25be06bfb18cdf3e82e50985d9a9b"
+                    "versions.yml:md5,f906fc3c61697a5598dbdf6d62572fe4"
                 ]
             }
         ],

--- a/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
+++ b/modules/nf-core/scvitools/scar/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "Should run with default parameters": {
         "content": [
             [
-                "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+                "versions.yml:md5,b495dbf7249184fe0484e98f0e1d46b4"
             ],
             "test.h5ad"
         ],
@@ -15,7 +15,7 @@
     "Should run from X to X": {
         "content": [
             [
-                "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+                "versions.yml:md5,b495dbf7249184fe0484e98f0e1d46b4"
             ],
             "test.h5ad"
         ],
@@ -61,7 +61,7 @@
     "Should run with custom input and output layers": {
         "content": [
             [
-                "versions.yml:md5,295715b77d88ad6a0f3d4299311b7c3e"
+                "versions.yml:md5,b495dbf7249184fe0484e98f0e1d46b4"
             ],
             "test.h5ad"
         ],

--- a/modules/nf-core/scvitools/solo/templates/solo.py
+++ b/modules/nf-core/scvitools/solo/templates/solo.py
@@ -3,6 +3,8 @@
 import os
 
 os.environ["MPLCONFIGDIR"] = "./tmp"
+os.environ.setdefault("USER", "scvi")
+os.environ.setdefault("HOME", os.getcwd())
 
 import anndata as ad
 import scvi

--- a/modules/nf-core/scvitools/solo/templates/solo.py
+++ b/modules/nf-core/scvitools/solo/templates/solo.py
@@ -3,8 +3,7 @@
 import os
 
 os.environ["MPLCONFIGDIR"] = "./tmp"
-os.environ.setdefault("USER", "scvi")
-os.environ.setdefault("HOME", os.getcwd())
+os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", os.path.join(os.getcwd(), "torch_cache"))
 
 import anndata as ad
 import scvi


### PR DESCRIPTION
Follow up to https://github.com/nf-core/modules/pull/11648

Also updates scvi-tools for scar.
Further sets required environment variables. Otherwise, scvi-tools:py3.13-cu12-1.4.3- crashes inside `torch._dynamo` initialization when run with -u <uid>:<gid> and the UID isn't in /etc/passwd.
PyTorch 2.7's inductor cache-dir helper calls `getpass.getuser()`, which falls through to pwd.getpwuid() and raises KeyError for any UID not present in the container's passwd file. This is the default Docker/Singularity behaviour on most institutional setups (LDAP/AD-assigned UIDs).

We set the 
```python
os.environ.setdefault("TORCHINDUCTOR_CACHE_DIR", os.path.join(os.getcwd(), "torch_cache"))
```

to fix this.