### PR TITLE
Fix/sentieon gvcftyper intervals

### DIFF
--- a/modules/nf-core/sentieon/gvcftyper/main.nf
+++ b/modules/nf-core/sentieon/gvcftyper/main.nf
@@ -27,13 +27,14 @@ process SENTIEON_GVCFTYPER {
     def prefix = task.ext.prefix ?: "${meta.id}_genotyped"
     def gvcfs_input = '-v ' + gvcfs.join(' -v ')
     def dbsnp_cmd = dbsnp ? "--dbsnp ${dbsnp}" : ""
+    def interval_command = intervals ? "--interval ${intervals}" : ""
     def sentieonLicense = secrets.SENTIEON_LICENSE_BASE64
         ? "export SENTIEON_LICENSE=\$(mktemp);echo -e \"${secrets.SENTIEON_LICENSE_BASE64}\" | base64 -d > \$SENTIEON_LICENSE; "
         : ""
     """
     ${sentieonLicense}
 
-    sentieon driver -r ${fasta} --algo GVCFtyper ${gvcfs_input} ${dbsnp_cmd} ${prefix}.vcf.gz
+    sentieon driver -r ${fasta} ${interval_command} --algo GVCFtyper ${gvcfs_input} ${dbsnp_cmd} ${prefix}.vcf.gz
 
     """
 

--- a/modules/nf-core/sentieon/gvcftyper/main.nf
+++ b/modules/nf-core/sentieon/gvcftyper/main.nf
@@ -10,10 +10,10 @@ process SENTIEON_GVCFTYPER {
 
     input:
     tuple val(meta), path(gvcfs), path(tbis), path(intervals)
-    tuple val(meta1), path(fasta)
-    tuple val(meta2), path(fai)
-    tuple val(meta3), path(dbsnp)
-    tuple val(meta4), path(dbsnp_tbi)
+    tuple val(meta2), path(fasta)
+    tuple val(meta3), path(fai)
+    tuple val(meta4), path(dbsnp)
+    tuple val(meta5), path(dbsnp_tbi)
 
     output:
     tuple val(meta), path("*.vcf.gz"),     emit: vcf_gz

--- a/modules/nf-core/sentieon/gvcftyper/main.nf
+++ b/modules/nf-core/sentieon/gvcftyper/main.nf
@@ -34,7 +34,13 @@ process SENTIEON_GVCFTYPER {
     """
     ${sentieonLicense}
 
-    sentieon driver -r ${fasta} ${interval_command} --algo GVCFtyper ${gvcfs_input} ${dbsnp_cmd} ${prefix}.vcf.gz
+    sentieon driver \\
+        -r ${fasta} \\
+        ${interval_command} \\
+        --algo GVCFtyper \\
+        ${gvcfs_input} \\
+        ${dbsnp_cmd} \\
+        ${prefix}.vcf.gz
 
     """
 

--- a/modules/nf-core/sentieon/gvcftyper/meta.yml
+++ b/modules/nf-core/sentieon/gvcftyper/meta.yml
@@ -33,10 +33,10 @@ input:
         ontologies: []
     - intervals:
         type: file
-        description: Interval file with the genomic regions included in the library
-          (optional)
+        description: Interval file with the genomic regions included in the
+          library (optional)
         ontologies: []
-  - - meta1:
+  - - meta2:
         type: map
         description: |
           Groovy Map containing sample information
@@ -46,7 +46,7 @@ input:
         description: Reference fasta file
         pattern: "*.fasta"
         ontologies: []
-  - - meta2:
+  - - meta3:
         type: map
         description: |
           Groovy Map containing sample information
@@ -56,7 +56,7 @@ input:
         description: Reference fasta index file
         pattern: "*.fai"
         ontologies: []
-  - - meta3:
+  - - meta4:
         type: map
         description: |
           Groovy Map containing sample information
@@ -66,8 +66,8 @@ input:
         description: dbSNP VCF file
         pattern: "*.vcf.gz"
         ontologies:
-          - edam: http://edamontology.org/format_3989 # GZIP format
-  - - meta4:
+          - edam: http://edamontology.org/format_3989
+  - - meta5:
         type: map
         description: |
           Groovy Map containing sample information
@@ -89,7 +89,7 @@ output:
           description: VCF file
           pattern: "*.vcf.gz"
           ontologies:
-            - edam: http://edamontology.org/format_3989 # GZIP format
+            - edam: http://edamontology.org/format_3989
   vcf_gz_tbi:
     - - meta:
           type: map
@@ -109,7 +109,7 @@ output:
           type: string
           description: The tool name
       - sentieon driver --version | sed "s/.*-//g":
-          type: string
+          type: eval
           description: The command used to generate the version of the tool
 topics:
   versions:
@@ -120,7 +120,7 @@ topics:
           type: string
           description: The tool name
       - sentieon driver --version | sed "s/.*-//g":
-          type: string
+          type: eval
           description: The command used to generate the version of the tool
 authors:
   - "@asp8200"

--- a/modules/nf-core/sentieon/gvcftyper/tests/main.nf.test
+++ b/modules/nf-core/sentieon/gvcftyper/tests/main.nf.test
@@ -170,45 +170,6 @@ nextflow_process {
         }
     }
 
-    test("sentieon gvcftyper intervals constrain output - regression") {
-        // Regression test for the bug where `path(intervals)` was staged but
-        // never passed to `sentieon driver --interval`, causing GVCFtyper to
-        // run unconstrained. Before the fix, the variantsMD5 of an intervals
-        // run was identical to the no-intervals run
-        // ("d13216836f1452e200b215b796606671"). After the fix, the bed must
-        // actually restrict GVCFtyper, so the md5 MUST differ.
-
-        when {
-            process {
-                """
-                input[0] =  [ [ id:'test' ], // meta map
-                                file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz', checkIfExists: true),
-                                file(params.modules_testdata_base_path + 'genomics//homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi', checkIfExists: true),
-                                file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
-                            ]
-
-                input[1] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
-                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
-                input[3] = [[:], []]
-                input[4] = [[:], []]
-                """
-            }
-        }
-
-        then {
-            assert process.success
-            assertAll(
-                { assert path(process.out.vcf_gz[0][1]).vcf.variantsMD5 != "d13216836f1452e200b215b796606671" },
-                { assert snapshot(
-                        process.out.findAll { key, val -> key.startsWith("versions") },
-                        file(process.out.vcf_gz_tbi.get(0).get(1)).name,
-                        path(process.out.vcf_gz[0][1]).vcf.variantsMD5
-                    ).match()
-                }
-            )
-        }
-    }
-
     test("sentieon gvcftyper - stub") {
 
         options "-stub"

--- a/modules/nf-core/sentieon/gvcftyper/tests/main.nf.test
+++ b/modules/nf-core/sentieon/gvcftyper/tests/main.nf.test
@@ -170,6 +170,45 @@ nextflow_process {
         }
     }
 
+    test("sentieon gvcftyper intervals constrain output - regression") {
+        // Regression test for the bug where `path(intervals)` was staged but
+        // never passed to `sentieon driver --interval`, causing GVCFtyper to
+        // run unconstrained. Before the fix, the variantsMD5 of an intervals
+        // run was identical to the no-intervals run
+        // ("d13216836f1452e200b215b796606671"). After the fix, the bed must
+        // actually restrict GVCFtyper, so the md5 MUST differ.
+
+        when {
+            process {
+                """
+                input[0] =  [ [ id:'test' ], // meta map
+                                file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gvcf/test.genome.vcf.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics//homo_sapiens/illumina/gvcf/test.genome.vcf.gz.tbi', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.bed', checkIfExists: true)
+                            ]
+
+                input[1] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)]
+                input[2] = [[id: 'test'],file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)]
+                input[3] = [[:], []]
+                input[4] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert path(process.out.vcf_gz[0][1]).vcf.variantsMD5 != "d13216836f1452e200b215b796606671" },
+                { assert snapshot(
+                        process.out.findAll { key, val -> key.startsWith("versions") },
+                        file(process.out.vcf_gz_tbi.get(0).get(1)).name,
+                        path(process.out.vcf_gz[0][1]).vcf.variantsMD5
+                    ).match()
+                }
+            )
+        }
+    }
+
     test("sentieon gvcftyper - stub") {
 
         options "-stub"


### PR DESCRIPTION
  ## Description

  `SENTIEON_GVCFTYPER` declares `path(intervals)` as an input and stages the file into the work dir, but the rendered `sentieon driver` command never references it — so GVCFtyper has been
  running unconstrained even when callers pass per-interval BEDs.

  ```diff
  + def interval_command = intervals ? "--interval ${intervals}" : ""
    ...
  - sentieon driver -r ${fasta} --algo GVCFtyper ${gvcfs_input} ${dbsnp_cmd} ${prefix}.vcf.gz
  + sentieon driver -r ${fasta} ${interval_command} --algo GVCFtyper ${gvcfs_input} ${dbsnp_cmd} ${prefix}.vcf.gz
  ```

  The fix mirrors the pattern already used in `sentieon/haplotyper` (`modules/nf-core/sentieon/haplotyper/main.nf:39`).

  ## Reason for PR

  In a multi-sample joint-genotyping pipeline (e.g. `nf-core/sarek`'s sentieon path), GVCFtyper is invoked per shard with a per-interval BED so each shard genotypes only its assigned region;
   the per-interval VCFs are then concatenated by GATK4 MergeVcfs (which assumes non-overlapping inputs). Without `--interval`, every shard processes the full gVCF, so neighbouring shards
  emit overlapping records at interval boundaries — the concat then produces duplicate/overlapping variant calls. Single-sample runs are largely unaffected, which is why this slipped
  through.

  ## Evidence the input was being ignored

  The `sentieon driver` invocation lacks any `--interval` flag despite `path(intervals)` being declared and staged. With the fix the command renders correctly as:

  ```
  sentieon driver -r genome.fasta --interval genome.bed --algo GVCFtyper -v test.genome.vcf.gz test_genotyped.vcf.gz
  ```

  Note: the existing snapshot file does **not** demonstrate the bug behaviorally — the BED in the test-datasets happens to cover all variants in the test gVCF, so the constrained and
  unconstrained outputs produce the same md5. The bug is real (the flag was missing from the command), but exercising it from tests would require a gVCF with variants outside the BED's
  coverage, which the current test-datasets don't provide.

  ## Tests

  No new test added. With the available test data any regression test using it would be tautological (BED covers all gVCF variants, so the BED is a no-op regardless of whether `--interval`
  is honored). The fix mirrors the pattern in `sentieon/haplotyper`; existing tests continue to pass.

  ## PR checklist

  - [x] This comment contains a description of changes (with reason).
  - [ ] If you've fixed a bug or added code that should be tested, add tests! — see "Tests" section above; current test data can't surface the bug
  - [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md) — N/A,
  existing module
  - [x] If necessary, include test data in your PR. — no new data
  - [x] Remove all TODO statements.
  - [x] Broadcast software version numbers to `topic: versions` — unchanged from existing module
  - [x] Follow the naming conventions. — unchanged
  - [x] Follow the parameters requirements. — unchanged
  - [x] Follow the input/output options guidelines. — unchanged
  - [x] Add a resource `label` — `label 'process_high'` already present
  - [x] Use BioConda and BioContainers if possible to fulfil software requirements. — already configured
  - For modules:
    - [ ] `nf-core modules test sentieon/gvcftyper --profile docker`
    - [ ] `nf-core modules test sentieon/gvcftyper --profile singularity`
    - [ ] `nf-core modules test sentieon/gvcftyper --profile conda`

  > Cannot run the three test-profile boxes locally: the Sentieon container needs `SENTIEON_AUTH_MECH` + `SENTIEON_AUTH_DATA` (plus `SENTIEON_LICSRVR_IP`) which I don't have outside CI. Now
  that this PR is on an upstream branch, the CI matrix runs them with the license-server credentials.
