### PR TITLE
fix: sentieon varcal handles list elements with multiple --resource d…

### DIFF
--- a/modules/nf-core/sentieon/varcal/main.nf
+++ b/modules/nf-core/sentieon/varcal/main.nf
@@ -48,14 +48,18 @@ process SENTIEON_VARCAL {
         labels_command = processedResources.join(' ')
     }
     else if (labels_input instanceof List) {
-        // Process list input
-        def processedResources = labels_input.collect { label ->
-            def cleanedLabel = label.replaceFirst('^--resource:', '')
-            def items = cleanedLabel.split(' ', 2)
-            if (items.size() != 2) {
-                error("Expected the resource string '${cleanedLabel}' to contain two elements separated by a space.")
+        // Each list element may itself contain multiple `--resource:` directives
+        // (e.g. when params.known_indels_vqsr packs both `gatk` and `mills` into
+        // one string), so split each element on `--resource:` just like the
+        // String branch does, then process each individual resource.
+        def processedResources = labels_input.collectMany { label ->
+            label.split('--resource:').findAll().collect { resource_string ->
+                def items = resource_string.split(' ', 2)
+                if (items.size() != 2) {
+                    error("Expected the resource string '${resource_string}' to contain two elements separated by a space.")
+                }
+                "--resource ${items[1]} --resource_param ${items[0].replaceFirst('^--resource:', '')}"
             }
-            "--resource ${items[1]} --resource_param ${items[0].replaceFirst('^--resource:', '')}"
         }
         labels_command = processedResources.join(' ')
     }
@@ -69,7 +73,9 @@ process SENTIEON_VARCAL {
     """
     ${sentieonLicense}
 
-    sentieon driver -r ${fasta}  --algo VarCal \\
+    sentieon driver \\
+        -r ${fasta} \\
+        --algo VarCal \\
         -v ${vcf} \\
         --tranches_file ${prefix}.tranches \\
         ${labels_command} \\

--- a/modules/nf-core/sentieon/varcal/tests/main.nf.test
+++ b/modules/nf-core/sentieon/varcal/tests/main.nf.test
@@ -98,6 +98,61 @@ nextflow_process {
         }
     }
 
+    test("homo sapiens - list element packs multiple --resource directives") {
+        // Regression test: sarek's `params.known_indels_vqsr` (and other VQSR
+        // resource params in igenomes.config) packs several `--resource:`
+        // directives into a single string. Once such strings are `.mix().collect()`
+        // into a list, this module receives a List where ONE element contains
+        // multiple `--resource:` segments separated by spaces. Before the fix
+        // the List branch only stripped the leading `--resource:` and treated
+        // the rest as one file path, leaving an orphan `--resource:<label>,...`
+        // literal in the command which sentieon rejects with:
+        //   "VarCal: unrecognized option '--resource:<label>,...'"
+
+        when {
+            params {
+                module_args = '--var_type SNP --annotation QD --annotation MQ --annotation FS --annotation SOR'
+            }
+            process {
+                """
+                input[0] = [[id:'test'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz', checkIfExists:true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gatk/haplotypecaller_calls/test2_haplotc.ann.vcf.gz.tbi', checkIfExists:true)
+                    ]
+                input[1] = [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/hapmap_3.3.hg38.vcf.gz', checkIfExists:true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/1000G_omni2.5.hg38.vcf.gz', checkIfExists:true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz', checkIfExists:true)
+                    ]
+                input[2] = [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/hapmap_3.3.hg38.vcf.gz.tbi', checkIfExists:true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/1000G_omni2.5.hg38.vcf.gz.tbi', checkIfExists:true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/germlineresources/dbsnp_138.hg38.vcf.gz.tbi', checkIfExists:true)
+                    ]
+                // First element packs TWO --resource: directives, mirroring sarek's igenomes.config:68.
+                input[3] = [
+                    '--resource:hapmap,known=false,training=true,truth=true,prior=15.0 hapmap_3.3.hg38.vcf.gz --resource:omni,known=false,training=true,truth=false,prior=12.0 1000G_omni2.5.hg38.vcf.gz',
+                    '--resource:dbsnp,known=true,training=false,truth=false,prior=2.0 dbsnp_138.hg38.vcf.gz'
+                    ]
+                input[4] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists:true)
+                input[5] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists:true)
+                """
+            }
+        }
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    file(process.out.recal[0][1]).readLines()[0..5],
+                    file(process.out.idx[0][1]).name,
+                    process.out.tranches,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                    ).match()
+                }
+            )
+        }
+    }
+
     test("homo sapiens -- stub") {
         options '-stub'
         when {

--- a/modules/nf-core/sentieon/varcal/tests/main.nf.test
+++ b/modules/nf-core/sentieon/varcal/tests/main.nf.test
@@ -140,16 +140,12 @@ nextflow_process {
             }
         }
         then {
+            // Regression: under the buggy code, sentieon receives an orphan
+            // `--resource:omni,...` literal and exits non-zero with
+            // "VarCal: unrecognized option '--resource:omni,...'". So
+            // `process.success` alone is the regression signal — no snapshot
+            // needed.
             assert process.success
-            assertAll(
-                { assert snapshot(
-                    file(process.out.recal[0][1]).readLines()[0..5],
-                    file(process.out.idx[0][1]).name,
-                    process.out.tranches,
-                    process.out.findAll { key, val -> key.startsWith("versions") }
-                    ).match()
-                }
-            )
         }
     }
 


### PR DESCRIPTION
## Description

  The List branch of `SENTIEON_VARCAL`'s VQSR-resource translator only stripped one leading `--resource:` per list element, leaving any further `--resource:` directives in the same element
  as orphan literal arguments that sentieon rejects with:

  ```
  VarCal: unrecognized option '--resource:<label>,...'
  ```

  ```diff
  -        def processedResources = labels_input.collect { label ->
  -            def cleanedLabel = label.replaceFirst('^--resource:', '')
  -            def items = cleanedLabel.split(' ', 2)
  +        def processedResources = labels_input.collectMany { label ->
  +            label.split('--resource:').findAll().collect { resource_string ->
  +                def items = resource_string.split(' ', 2)
  ```

  The String branch already does this split correctly; the fix brings the List branch in line.

  ## Reason for PR

  `SENTIEON_VARCAL` is called from `nf-core/sarek`'s sentieon joint-germline path with `indels_resource_label = known_indels_vqsr.mix(dbsnp_vqsr).collect()`. For GRCh38
  (`conf/igenomes.config:68`), `known_indels_vqsr` packs two `--resource:` directives (`gatk` + `mills`) into a single string. After `.collect()`, the module receives a List where one
  element contains two directives. The old code:

  1. Strips the leading `--resource:` → leaves `gatk,...prior=10.0 Homo_sapiens_assembly38.known_indels.vcf.gz --resource:mills,...prior=10.0
  Mills_and_1000G_gold_standard.indels.hg38.vcf.gz`
  2. `split(' ', 2)` → `[label, "<file1> --resource:mills,... <file2>"]`
  3. Emits `--resource <file1> --resource:mills,... <file2> --resource_param gatk,...`

  The orphan `--resource:mills,...` literal is what sentieon chokes on.

  The SNP side of sarek's joint workflow happened to use single-resource strings (`1000G_omni2.5.hg38.vcf.gz` only) which the old List branch handled correctly — that's why this bug surfaces
   selectively on indel VQSR.

  ## Test added

  `homo sapiens - list element packs multiple --resource directives` mirrors sarek's actual usage: a list where the first element packs two `--resource:` directives. On the buggy code the
  rendered command contains an orphan `--resource:omni,...` literal, sentieon exits 1 with "unrecognized option", and `process.success` is false — i.e. the test fails loudly on regression.
  With the fix, the command is well-formed (3 paired `--resource` / `--resource_param` flags) and the test passes via snapshot.

A regression test (homo sapiens - list element packs multiple --resource directives) exercises sarek's actual usage: a list where the first element packs two --resource: directives.
  Under the buggy code, sentieon receives an orphan --resource:omni,… literal and exits non-zero ("VarCal: unrecognized option '--resource:omni,…'"), so assert process.success alone catches
  the regression — no snapshot assertion needed.
  ## PR checklist

  - [x] This comment contains a description of changes (with reason).
  - [x] If you've fixed a bug or added code that should be tested, add tests!
  - [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md) — N/A,
  existing module
  - [x] If necessary, include test data in your PR. — uses existing data from `nf-core/test-datasets`
  - [x] Remove all TODO statements.
  - [x] Broadcast software version numbers to `topic: versions` — unchanged from existing module
  - [x] Follow the naming conventions. — unchanged
  - [x] Follow the parameters requirements. — unchanged
  - [x] Follow the input/output options guidelines. — unchanged
  - [x] Add a resource `label` — `label 'process_low'` already present
  - [x] Use BioConda and BioContainers if possible to fulfil software requirements. — already configured
  - For modules:
    - [ ] `nf-core modules test sentieon/varcal --profile docker`
    - [ ] `nf-core modules test sentieon/varcal --profile singularity`
    - [ ] `nf-core modules test sentieon/varcal --profile conda`

  > Cannot run the test-profile boxes locally (Sentieon license-server credentials only available on CI from upstream branches). Lint is green locally. Relying on the CI matrix to validate.
