### PR TITLE
feat(ribocode,ribotish): pyfasta indexes, prefix-scoped outputs, optional ribotish -a

### DIFF
--- a/modules/nf-core/ribocode/prepare/main.nf
+++ b/modules/nf-core/ribocode/prepare/main.nf
@@ -27,6 +27,18 @@ process RIBOCODE_PREPARE {
         -f ${fasta} \\
         -o annotation \\
         $args
+
+    # Pre-build pyfasta .gdx/.flat with RiboCode's key_fn so consumers don't write to staged inputs.
+    python - <<'PYTHON'
+from pyfasta import Fasta
+def key_fn(name):
+    if ' ' in name:
+        return name.split()[0]
+    if '|' in name:
+        return name.split('|')
+    return name
+Fasta('annotation/transcripts_sequence.fa', key_fn=key_fn)
+PYTHON
     """
 
     stub:
@@ -36,6 +48,8 @@ process RIBOCODE_PREPARE {
 
     touch annotation/transcripts_cds.txt
     touch annotation/transcripts_sequence.fa
+    touch annotation/transcripts_sequence.fa.gdx
+    touch annotation/transcripts_sequence.fa.flat
     touch annotation/transcripts.pickle
     """
 }

--- a/modules/nf-core/ribocode/prepare/tests/main.nf.test.snap
+++ b/modules/nf-core/ribocode/prepare/tests/main.nf.test.snap
@@ -28,7 +28,9 @@
                         [
                             "transcripts.pickle:md5,b83be7910166b56d09c4879d38223883",
                             "transcripts_cds.txt:md5,6fae20439cbe378eb4db60a8bdf6a6af",
-                            "transcripts_sequence.fa:md5,b0401ee625d655ea116528507b038c33"
+                            "transcripts_sequence.fa:md5,b0401ee625d655ea116528507b038c33",
+                            "transcripts_sequence.fa.flat:md5,e99a891bd574545ef72d40334b383c23",
+                            "transcripts_sequence.fa.gdx:md5,4981ecea133628891d475215d48b9fa3"
                         ]
                     ]
                 ],
@@ -47,7 +49,9 @@
                         [
                             "transcripts.pickle:md5,b83be7910166b56d09c4879d38223883",
                             "transcripts_cds.txt:md5,6fae20439cbe378eb4db60a8bdf6a6af",
-                            "transcripts_sequence.fa:md5,b0401ee625d655ea116528507b038c33"
+                            "transcripts_sequence.fa:md5,b0401ee625d655ea116528507b038c33",
+                            "transcripts_sequence.fa.flat:md5,e99a891bd574545ef72d40334b383c23",
+                            "transcripts_sequence.fa.gdx:md5,4981ecea133628891d475215d48b9fa3"
                         ]
                     ]
                 ],

--- a/modules/nf-core/ribocode/ribocode/main.nf
+++ b/modules/nf-core/ribocode/ribocode/main.nf
@@ -14,8 +14,8 @@ process RIBOCODE_RIBOCODE {
 
     output:
 
-    tuple val(meta), path("*.txt")                                                  , emit: orf_txt
-    tuple val(meta), path("*_collapsed.txt")                                        , emit: orf_txt_collapsed
+    tuple val(meta), path("${prefix}.txt")                                          , emit: orf_txt
+    tuple val(meta), path("${prefix}_collapsed.txt")                                , emit: orf_txt_collapsed
     tuple val(meta), path("*_ORFs_category.pdf")                                    , emit: orf_pdf, optional: true
     tuple val(meta), path("*_psites.hd5")                                           , emit: psites_hd5, optional: true
     tuple val("${task.process}"), val('ribocode'), eval('RiboCode --version  2>&1') , emit: versions_ribocode, topic: versions
@@ -25,7 +25,7 @@ process RIBOCODE_RIBOCODE {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
     # Run RiboCode and capture output to check for errors
     RiboCode \\
@@ -45,7 +45,7 @@ process RIBOCODE_RIBOCODE {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
 
     """
     touch ${prefix}.txt

--- a/modules/nf-core/ribocode/ribocode/meta.yml
+++ b/modules/nf-core/ribocode/ribocode/meta.yml
@@ -55,7 +55,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*.txt":
+      - ${prefix}.txt:
           type: file
           description: Text file containing all detected ORFs with detailed information
           pattern: "*.txt"
@@ -66,7 +66,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*_collapsed.txt":
+      - ${prefix}_collapsed.txt:
           type: file
           description: Text file containing collapsed ORFs (merged isoforms)
           pattern: "*_collapsed.txt"

--- a/modules/nf-core/ribocode/ribocode/tests/main.nf.test
+++ b/modules/nf-core/ribocode/ribocode/tests/main.nf.test
@@ -85,7 +85,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.orf_txt[0][1][0].toString().endsWith('.txt') },
+                { assert process.out.orf_txt[0][1].toString().endsWith('.txt') },
                 { assert process.out.orf_txt_collapsed[0][1].toString().endsWith('_collapsed.txt') },
                 { assert process.out.orf_pdf[0][1].toString().endsWith('.pdf') },
                 { assert process.out.psites_hd5[0][1].toString().endsWith('.hd5') }

--- a/modules/nf-core/ribocode/ribocode/tests/main.nf.test.snap
+++ b/modules/nf-core/ribocode/ribocode/tests/main.nf.test.snap
@@ -7,10 +7,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    [
-                        "test.txt:md5,3c6c1f3ffff5f9c4f4e59fd4f52c56f4",
-                        "test_collapsed.txt:md5,d1e13bb728ad0b0e79b9326c75c6e47a"
-                    ]
+                    "test.txt:md5,3c6c1f3ffff5f9c4f4e59fd4f52c56f4"
                 ]
             ],
             [

--- a/modules/nf-core/ribotish/predict/main.nf
+++ b/modules/nf-core/ribotish/predict/main.nf
@@ -10,7 +10,7 @@ process RIBOTISH_PREDICT {
     input:
     tuple val(meta), path(bam_ribo), path(bai_ribo)
     tuple val(meta2), path(bam_ti), path(bai_ti)
-    tuple val(meta3), path(fasta), path(gtf)
+    tuple val(meta3), path(fasta), path(gtf), path(reference_gtf, stageAs: 'secondary.gtf')
     tuple val(meta4), path(candidate_orfs)
     tuple val(meta5), path(para_ribo)
     tuple val(meta6), path(para_ti)
@@ -27,6 +27,7 @@ process RIBOTISH_PREDICT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference_gtf_arg = reference_gtf ? "-a ${reference_gtf}" : ''
 
     ribo_bam_cmd = ''
     ti_bam_cmd = ''
@@ -48,6 +49,7 @@ process RIBOTISH_PREDICT {
         $ti_bam_cmd \\
         -f $fasta \\
         -g $gtf \\
+        $reference_gtf_arg \\
         -o ${prefix}_pred.txt \\
         --allresult ${prefix}_all.txt \\
         --transprofile ${prefix}_transprofile.py \\

--- a/modules/nf-core/ribotish/predict/meta.yml
+++ b/modules/nf-core/ribotish/predict/meta.yml
@@ -64,6 +64,13 @@ input:
           GTF-format annotation file for reference sequences used in the bam file
         pattern: "*.gtf"
         ontologies: []
+    - reference_gtf:
+        type: file
+        description: |
+          Optional secondary GTF annotation passed to ribotish as `-a` (e.g. a
+          MANE/RefSeq overlay). Pass `[]` to omit.
+        pattern: "*.gtf"
+        ontologies: []
   - - meta4:
         type: map
         description: |

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test
@@ -38,7 +38,8 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
+                    []
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
@@ -74,7 +75,8 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
+                    []
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
@@ -114,7 +116,8 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
+                    []
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
@@ -156,7 +159,8 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
+                    []
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])


### PR DESCRIPTION
Bundles three in-place module changes carried in nf-core/riboseq#174. Each is self-contained and addresses a different pain point we hit running RiboCode / Ribo-TISH at scale.

### ribocode/prepare

Pre-build the pyfasta `.gdx`/`.flat` indexes for `annotation/transcripts_sequence.fa` immediately after `prepare_transcripts`, using the same `key_fn` RiboCode applies internally (split on first space, otherwise split on `|`). The stub also touches the two new sidecars.

Why: downstream RiboCode steps open the FASTA with pyfasta, which lazily writes `.gdx`/`.flat` next to the input on first read. Under Fusion staging those writes land back at the upstream task's S3 prefix and silently corrupt the staged copy on retries. Building the indexes inside the producing task fixes it.

### ribocode/ribocode

Switch the `orf_txt` and `orf_txt_collapsed` output globs from `*.txt` / `*_collapsed.txt` to `${prefix}.txt` / `${prefix}_collapsed.txt` so multi-instance publication is unambiguous (`*.txt` previously matched both the all-ORFs and collapsed files into the same emit). The `prefix` binding is promoted out of `def` in both `script:` and `stub:` so it resolves at the output-glob stage; the Nextflow 26 strict parser rejects re-declaring the same local with `def` across the two blocks.

The existing stub assertion that indexed `process.out.orf_txt[0][1][0]` is corrected to the new single-file shape (`process.out.orf_txt[0][1]`).

### ribotish/predict

**Breaking signature change.** The third input tuple gains an optional fourth element, `reference_gtf`, plumbed through to `ribotish predict` as `-a <gtf>` when populated:

```groovy
tuple val(meta3), path(fasta), path(gtf), path(reference_gtf, stageAs: 'secondary.gtf')
```

Callers must supply a fourth element on every emit. Pass `[]` for the no-op case (no secondary annotation). The existing test cases in this PR are migrated that way; positive-coverage tests for the populated path will land in a follow-up.

Why: Ribo-TISH's `-a` argument is the documented hook for layering a secondary annotation (e.g. MANE/RefSeq) on top of the primary GTF, and we want to expose it from the module without a second optional input tuple.

### Test plan

All three modules pass under Docker on a `c5.9xlarge` VM with `nf-core 4.0.2` / `nextflow 26.04.1` / `nf-test 0.9.5`:

```
nf-core modules test --profile docker ribocode/prepare
nf-core modules test --profile docker ribocode/ribocode
nf-core modules test --profile docker ribotish/predict
```

Snapshot deltas:

- `ribocode/prepare`: non-stub snapshot gains the two new file md5s (`transcripts_sequence.fa.flat`, `transcripts_sequence.fa.gdx`); existing files' md5s unchanged.
- `ribocode/ribocode`: `orf_outputs` snapshot drops the duplicate `test_collapsed.txt` entry that the old `*.txt` glob had pulled into `orf_txt`; everything else unchanged.
- `ribotish/predict`: no snapshot change (the `[]` migration is a no-op at runtime).

Source: nf-core/riboseq#174