### PR TITLE
feat(ribocode): pre-build pyfasta indexes + prefix-scoped outputs

### DIFF
--- a/modules/nf-core/ribocode/prepare/main.nf
+++ b/modules/nf-core/ribocode/prepare/main.nf
@@ -27,6 +27,18 @@ process RIBOCODE_PREPARE {
         -f ${fasta} \\
         -o annotation \\
         $args
+
+    # Pre-build pyfasta .gdx/.flat with RiboCode's key_fn so consumers don't write to staged inputs.
+    python - <<'PYTHON'
+from pyfasta import Fasta
+def key_fn(name):
+    if ' ' in name:
+        return name.split()[0]
+    if '|' in name:
+        return name.split('|')
+    return name
+Fasta('annotation/transcripts_sequence.fa', key_fn=key_fn)
+PYTHON
     """
 
     stub:
@@ -36,6 +48,8 @@ process RIBOCODE_PREPARE {
 
     touch annotation/transcripts_cds.txt
     touch annotation/transcripts_sequence.fa
+    touch annotation/transcripts_sequence.fa.gdx
+    touch annotation/transcripts_sequence.fa.flat
     touch annotation/transcripts.pickle
     """
 }

--- a/modules/nf-core/ribocode/prepare/main.nf
+++ b/modules/nf-core/ribocode/prepare/main.nf
@@ -28,7 +28,9 @@ process RIBOCODE_PREPARE {
         -o annotation \\
         $args
 
-    # Pre-build pyfasta .gdx/.flat with RiboCode's key_fn so consumers don't write to staged inputs.
+    # Pre-build the pyfasta .gdx/.flat sidecars for transcripts_sequence.fa using RiboCode's
+    # own key_fn (RiboCode.prepare_transcripts.get_chrom), so the published annotation directory
+    # is complete and downstream readers don't trigger pyfasta's lazy first-read index write.
     python - <<'PYTHON'
 from pyfasta import Fasta
 def key_fn(name):

--- a/modules/nf-core/ribocode/prepare/main.nf
+++ b/modules/nf-core/ribocode/prepare/main.nf
@@ -28,19 +28,10 @@ process RIBOCODE_PREPARE {
         -o annotation \\
         $args
 
-    # Pre-build the pyfasta .gdx/.flat sidecars for transcripts_sequence.fa using RiboCode's
-    # own key_fn (RiboCode.prepare_transcripts.get_chrom), so the published annotation directory
-    # is complete and downstream readers don't trigger pyfasta's lazy first-read index write.
-    python - <<'PYTHON'
-from pyfasta import Fasta
-def key_fn(name):
-    if ' ' in name:
-        return name.split()[0]
-    if '|' in name:
-        return name.split('|')
-    return name
-Fasta('annotation/transcripts_sequence.fa', key_fn=key_fn)
-PYTHON
+    # Pre-build the pyfasta .gdx/.flat sidecars by instantiating RiboCode's own GenomeSeq -
+    # so the published annotation is complete and downstream readers don't trigger pyfasta's
+    # lazy first-read index write.
+    python -c "from RiboCode.prepare_transcripts import GenomeSeq; GenomeSeq('annotation/transcripts_sequence.fa')"
     """
 
     stub:

--- a/modules/nf-core/ribocode/prepare/tests/main.nf.test.snap
+++ b/modules/nf-core/ribocode/prepare/tests/main.nf.test.snap
@@ -28,7 +28,9 @@
                         [
                             "transcripts.pickle:md5,b83be7910166b56d09c4879d38223883",
                             "transcripts_cds.txt:md5,6fae20439cbe378eb4db60a8bdf6a6af",
-                            "transcripts_sequence.fa:md5,b0401ee625d655ea116528507b038c33"
+                            "transcripts_sequence.fa:md5,b0401ee625d655ea116528507b038c33",
+                            "transcripts_sequence.fa.flat:md5,e99a891bd574545ef72d40334b383c23",
+                            "transcripts_sequence.fa.gdx:md5,4981ecea133628891d475215d48b9fa3"
                         ]
                     ]
                 ],
@@ -47,7 +49,9 @@
                         [
                             "transcripts.pickle:md5,b83be7910166b56d09c4879d38223883",
                             "transcripts_cds.txt:md5,6fae20439cbe378eb4db60a8bdf6a6af",
-                            "transcripts_sequence.fa:md5,b0401ee625d655ea116528507b038c33"
+                            "transcripts_sequence.fa:md5,b0401ee625d655ea116528507b038c33",
+                            "transcripts_sequence.fa.flat:md5,e99a891bd574545ef72d40334b383c23",
+                            "transcripts_sequence.fa.gdx:md5,4981ecea133628891d475215d48b9fa3"
                         ]
                     ]
                 ],

--- a/modules/nf-core/ribocode/ribocode/main.nf
+++ b/modules/nf-core/ribocode/ribocode/main.nf
@@ -14,8 +14,8 @@ process RIBOCODE_RIBOCODE {
 
     output:
 
-    tuple val(meta), path("*.txt")                                                  , emit: orf_txt
-    tuple val(meta), path("*_collapsed.txt")                                        , emit: orf_txt_collapsed
+    tuple val(meta), path("${prefix}.txt")                                          , emit: orf_txt
+    tuple val(meta), path("${prefix}_collapsed.txt")                                , emit: orf_txt_collapsed
     tuple val(meta), path("*_ORFs_category.pdf")                                    , emit: orf_pdf, optional: true
     tuple val(meta), path("*_psites.hd5")                                           , emit: psites_hd5, optional: true
     tuple val("${task.process}"), val('ribocode'), eval('RiboCode --version  2>&1') , emit: versions_ribocode, topic: versions
@@ -25,7 +25,7 @@ process RIBOCODE_RIBOCODE {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
     # Run RiboCode and capture output to check for errors
     RiboCode \\
@@ -45,7 +45,7 @@ process RIBOCODE_RIBOCODE {
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
 
     """
     touch ${prefix}.txt

--- a/modules/nf-core/ribocode/ribocode/meta.yml
+++ b/modules/nf-core/ribocode/ribocode/meta.yml
@@ -55,7 +55,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*.txt":
+      - ${prefix}.txt:
           type: file
           description: Text file containing all detected ORFs with detailed information
           pattern: "*.txt"
@@ -66,7 +66,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - "*_collapsed.txt":
+      - ${prefix}_collapsed.txt:
           type: file
           description: Text file containing collapsed ORFs (merged isoforms)
           pattern: "*_collapsed.txt"

--- a/modules/nf-core/ribocode/ribocode/tests/main.nf.test
+++ b/modules/nf-core/ribocode/ribocode/tests/main.nf.test
@@ -85,7 +85,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.orf_txt[0][1][0].toString().endsWith('.txt') },
+                { assert process.out.orf_txt[0][1].toString().endsWith('.txt') },
                 { assert process.out.orf_txt_collapsed[0][1].toString().endsWith('_collapsed.txt') },
                 { assert process.out.orf_pdf[0][1].toString().endsWith('.pdf') },
                 { assert process.out.psites_hd5[0][1].toString().endsWith('.hd5') }

--- a/modules/nf-core/ribocode/ribocode/tests/main.nf.test.snap
+++ b/modules/nf-core/ribocode/ribocode/tests/main.nf.test.snap
@@ -7,10 +7,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    [
-                        "test.txt:md5,3c6c1f3ffff5f9c4f4e59fd4f52c56f4",
-                        "test_collapsed.txt:md5,d1e13bb728ad0b0e79b9326c75c6e47a"
-                    ]
+                    "test.txt:md5,3c6c1f3ffff5f9c4f4e59fd4f52c56f4"
                 ]
             ],
             [


### PR DESCRIPTION
Two related changes carried in nf-core/riboseq#174.

### ribocode/prepare

After `prepare_transcripts` runs, pre-build the pyfasta `.gdx`/`.flat` sidecars for `annotation/transcripts_sequence.fa` by instantiating `RiboCode.prepare_transcripts.GenomeSeq` directly.

Why: RiboCode's downstream `detectORF.py` opens `transcripts_sequence.fa` via pyfasta, which lazily writes `.gdx`/`.flat` next to the FASTA on first read. Under Nextflow's default symlink staging those writes go through the symlink and land in the upstream `RIBOCODE_PREPARE` task's work dir; parallel consumers then race on the same sidecar paths, with last-writer-wins behaviour on shared/network storage. Building the sidecars in the producing task makes them part of the published annotation directory and removes the lazy-write path entirely - same pattern as `samtools/faidx` shipping `.fai` alongside its FASTA.

### ribocode/ribocode

Switch `orf_txt` and `orf_txt_collapsed` from `*.txt` / `*_collapsed.txt` to `${prefix}.txt` / `${prefix}_collapsed.txt`. The previous globs matched both files into the same emit. The `prefix` binding is promoted out of `def` in both `script:` and `stub:` so it resolves at the output-glob stage; the Nextflow 26 strict parser rejects re-declaring the same local across the two blocks. Existing stub assertion adjusted from `process.out.orf_txt[0][1][0]` to `process.out.orf_txt[0][1]`.

### Snapshot deltas

- `ribocode/prepare`: gains two new file md5s (`.flat`, `.gdx`); existing md5s unchanged.
- `ribocode/ribocode`: drops the duplicate `test_collapsed.txt` entry the old `*.txt` glob double-counted.

Source: nf-core/riboseq#174. Supersedes the ribocode half of nf-core/modules#11684.