### PR TITLE
feat(ribotish/predict): optional reference_gtf input + topics versions + 0.2.8

### DIFF
--- a/modules/nf-core/ribotish/predict/environment.yml
+++ b/modules/nf-core/ribotish/predict/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::ribotish=0.2.7
+  - bioconda::ribotish=0.2.8

--- a/modules/nf-core/ribotish/predict/main.nf
+++ b/modules/nf-core/ribotish/predict/main.nf
@@ -4,22 +4,23 @@ process RIBOTISH_PREDICT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/ribotish:0.2.7--pyhdfd78af_0':
-        'quay.io/biocontainers/ribotish:0.2.7--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/ribotish:0.2.8--pyhdfd78af_0':
+        'quay.io/biocontainers/ribotish:0.2.8--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(bam_ribo), path(bai_ribo)
     tuple val(meta2), path(bam_ti), path(bai_ti)
-    tuple val(meta3), path(fasta), path(gtf), path(reference_gtf, stageAs: 'secondary.gtf')
+    tuple val(meta3), path(fasta), path(gtf)
     tuple val(meta4), path(candidate_orfs)
     tuple val(meta5), path(para_ribo)
     tuple val(meta6), path(para_ti)
+    tuple val(meta7), path(reference_gtf, stageAs: 'secondary.gtf')
 
     output:
     tuple val(meta), path("*_pred.txt")        , emit: predictions
     tuple val(meta), path("*_all.txt")         , emit: all
     tuple val(meta), path("*_transprofile.py") , emit: transprofile
-    path "versions.yml"                        , emit: versions
+    tuple val("${task.process}"), val('ribotish'), eval("ribotish --version | sed 's/ribotish //'"), topic: versions, emit: versions_ribotish
 
     when:
     task.ext.when == null || task.ext.when
@@ -55,11 +56,6 @@ process RIBOTISH_PREDICT {
         --transprofile ${prefix}_transprofile.py \\
         -p $task.cpus \\
         $args
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ribotish: \$(ribotish --version | sed 's/ribotish //')
-    END_VERSIONS
     """
 
     stub:
@@ -68,10 +64,5 @@ process RIBOTISH_PREDICT {
     touch ${prefix}_pred.txt
     touch ${prefix}_all.txt
     touch ${prefix}_transprofile.py
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ribotish: \$(ribotish --version | sed 's/ribotish //')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/ribotish/predict/main.nf
+++ b/modules/nf-core/ribotish/predict/main.nf
@@ -10,7 +10,7 @@ process RIBOTISH_PREDICT {
     input:
     tuple val(meta), path(bam_ribo), path(bai_ribo)
     tuple val(meta2), path(bam_ti), path(bai_ti)
-    tuple val(meta3), path(fasta), path(gtf)
+    tuple val(meta3), path(fasta), path(gtf), path(reference_gtf, stageAs: 'secondary.gtf')
     tuple val(meta4), path(candidate_orfs)
     tuple val(meta5), path(para_ribo)
     tuple val(meta6), path(para_ti)
@@ -27,6 +27,7 @@ process RIBOTISH_PREDICT {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference_gtf_arg = reference_gtf ? "-a ${reference_gtf}" : ''
 
     ribo_bam_cmd = ''
     ti_bam_cmd = ''
@@ -48,6 +49,7 @@ process RIBOTISH_PREDICT {
         $ti_bam_cmd \\
         -f $fasta \\
         -g $gtf \\
+        $reference_gtf_arg \\
         -o ${prefix}_pred.txt \\
         --allresult ${prefix}_all.txt \\
         --transprofile ${prefix}_transprofile.py \\

--- a/modules/nf-core/ribotish/predict/meta.yml
+++ b/modules/nf-core/ribotish/predict/meta.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "ribotish_predict"
 description: Quality control of riboseq bam data
 keywords:
@@ -13,9 +12,9 @@ tools:
       documentation: "https://github.com/zhpn1024/ribotish"
       tool_dev_url: "https://github.com/zhpn1024/ribotish"
       doi: "10.1038/s41467-017-01981-8"
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: ""
-
 input:
   - - meta:
         type: map
@@ -64,13 +63,6 @@ input:
           GTF-format annotation file for reference sequences used in the bam file
         pattern: "*.gtf"
         ontologies: []
-    - reference_gtf:
-        type: file
-        description: |
-          Optional secondary GTF annotation passed to ribotish as `-a` (e.g. a
-          MANE/RefSeq overlay). Pass `[]` to omit.
-        pattern: "*.gtf"
-        ontologies: []
   - - meta4:
         type: map
         description: |
@@ -92,7 +84,7 @@ input:
           Input P-site offset parameter files for riboseq bam files
         pattern: "*.py"
         ontologies:
-          - edam: http://edamontology.org/format_3996 # Python script
+          - edam: http://edamontology.org/format_3996
   - - meta6:
         type: map
         description: |
@@ -104,7 +96,20 @@ input:
           Input P-site offset parameter files for TI-seq bam files
         pattern: "*.py"
         ontologies:
-          - edam: http://edamontology.org/format_3996 # Python script
+          - edam: http://edamontology.org/format_3996
+  - - meta7:
+        type: map
+        description: |
+          Groovy Map containing reference information for the secondary
+          annotation file
+    - reference_gtf:
+        type: file
+        description: |
+          Optional secondary GTF annotation passed to ribotish as
+          `-a <reference-annotation>` (e.g. a MANE/RefSeq overlay applied on
+          top of the primary GTF). Pass `[]` to omit.
+        pattern: "*.gtf"
+        ontologies: []
 output:
   predictions:
     - - meta:
@@ -144,14 +149,28 @@ output:
             positions on transcript.
           pattern: "*.{py}"
           ontologies:
-            - edam: http://edamontology.org/format_3996 # Python script
+            - edam: http://edamontology.org/format_3996
+  versions_ribotish:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ribotish:
+          type: string
+          description: The name of the tool
+      - ribotish --version | sed 's/ribotish //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ribotish:
+          type: string
+          description: The name of the tool
+      - ribotish --version | sed 's/ribotish //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@pinin4fjords"
 maintainers:

--- a/modules/nf-core/ribotish/predict/meta.yml
+++ b/modules/nf-core/ribotish/predict/meta.yml
@@ -64,6 +64,13 @@ input:
           GTF-format annotation file for reference sequences used in the bam file
         pattern: "*.gtf"
         ontologies: []
+    - reference_gtf:
+        type: file
+        description: |
+          Optional secondary GTF annotation passed to ribotish as `-a` (e.g. a
+          MANE/RefSeq overlay). Pass `[]` to omit.
+        pattern: "*.gtf"
+        ontologies: []
   - - meta4:
         type: map
         description: |

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test
@@ -38,12 +38,12 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
-                    []
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
                 input[5] = Channel.of([[],[]])
+                input[6] = Channel.of([[],[]])
                 """
             }
         }
@@ -54,7 +54,7 @@ nextflow_process {
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert snapshot(process.out.transprofile).match("transprofile_single_end_single_ribo_bam") },
-                { assert snapshot(process.out.versions).match("versions_single_end_single_ribo_bam") }
+                { assert snapshot(process.out.versions_ribotish).match("versions_ribotish_single_end_single_ribo_bam") }
             )
         }
     }
@@ -75,12 +75,12 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
-                    []
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
                 input[5] = Channel.of([[],[]])
+                input[6] = Channel.of([[],[]])
                 """
             }
         }
@@ -91,7 +91,7 @@ nextflow_process {
                 { assert snapshot(process.out.predictions).match("predictions_single_end_single_ribo_bam_stub") },
                 { assert snapshot(process.out.all).match("all_single_end_single_ribo_bam_stub") },
                 { assert snapshot(process.out.transprofile).match("transprofile_single_end_single_ribo_bam_stub") },
-                { assert snapshot(process.out.versions).match("versions_single_end_single_ribo_bam_stub") }
+                { assert snapshot(process.out.versions_ribotish).match("versions_ribotish_single_end_single_ribo_bam_stub") }
             )
         }
     }
@@ -116,12 +116,12 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
-                    []
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
                 input[5] = Channel.of([[],[]])
+                input[6] = Channel.of([[],[]])
                 """
             }
         }
@@ -132,7 +132,7 @@ nextflow_process {
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert snapshot(process.out.transprofile).match("transprofile_single_end_multi_ribo_bam") },
-                { assert snapshot(process.out.versions).match("versions_single_end_multi_ribo_bam") }
+                { assert snapshot(process.out.versions_ribotish).match("versions_ribotish_single_end_multi_ribo_bam") }
             )
         }
     }
@@ -159,12 +159,12 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
-                    []
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
                 input[5] = Channel.of([[],[]])
+                input[6] = Channel.of([[],[]])
                 """
             }
         }
@@ -175,7 +175,7 @@ nextflow_process {
                 { assert snapshot(process.out.predictions).match("predictions_single_end_multi_ribo_bam_stub") },
                 { assert snapshot(process.out.all).match("all_single_end_multi_ribo_bam_stub") },
                 { assert snapshot(process.out.transprofile).match("transprofile_single_end_multi_ribo_bam_stub") },
-                { assert snapshot(process.out.versions).match("versions_single_end_multi_ribo_bam_stub") }
+                { assert snapshot(process.out.versions_ribotish).match("versions_ribotish_single_end_multi_ribo_bam_stub") }
             )
         }
     }

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test
@@ -53,8 +53,10 @@ nextflow_process {
                 { assert process.success },
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
-                { assert snapshot(process.out.transprofile).match("transprofile_single_end_single_ribo_bam") },
-                { assert snapshot(process.out.versions_ribotish).match("versions_ribotish_single_end_single_ribo_bam") }
+                { assert snapshot(
+                    process.out.transprofile,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
     }
@@ -88,10 +90,12 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.predictions).match("predictions_single_end_single_ribo_bam_stub") },
-                { assert snapshot(process.out.all).match("all_single_end_single_ribo_bam_stub") },
-                { assert snapshot(process.out.transprofile).match("transprofile_single_end_single_ribo_bam_stub") },
-                { assert snapshot(process.out.versions_ribotish).match("versions_ribotish_single_end_single_ribo_bam_stub") }
+                { assert snapshot(
+                    process.out.predictions,
+                    process.out.all,
+                    process.out.transprofile,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
     }
@@ -131,8 +135,10 @@ nextflow_process {
                 { assert process.success },
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
-                { assert snapshot(process.out.transprofile).match("transprofile_single_end_multi_ribo_bam") },
-                { assert snapshot(process.out.versions_ribotish).match("versions_ribotish_single_end_multi_ribo_bam") }
+                { assert snapshot(
+                    process.out.transprofile,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
     }
@@ -172,10 +178,12 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.predictions).match("predictions_single_end_multi_ribo_bam_stub") },
-                { assert snapshot(process.out.all).match("all_single_end_multi_ribo_bam_stub") },
-                { assert snapshot(process.out.transprofile).match("transprofile_single_end_multi_ribo_bam_stub") },
-                { assert snapshot(process.out.versions_ribotish).match("versions_ribotish_single_end_multi_ribo_bam_stub") }
+                { assert snapshot(
+                    process.out.predictions,
+                    process.out.all,
+                    process.out.transprofile,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
     }

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test
@@ -38,7 +38,8 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
+                    []
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
@@ -74,7 +75,8 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
+                    []
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
@@ -114,7 +116,8 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
+                    []
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])
@@ -156,7 +159,8 @@ nextflow_process {
                 input[2] = GUNZIP.out.gunzip.map{[
                     [id:'homo_sapiens_chr20'],
                     it[1],
-                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true)
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf", checkIfExists: true),
+                    []
                 ]}
                 input[3] = Channel.of([[],[]])
                 input[4] = Channel.of([[],[]])

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "transprofile_single_end_single_ribo_bam_stub": {
+    "sarscov2 [bam] - single_end - single ribo bam - stub": {
         "content": [
             [
                 [
@@ -8,34 +8,9 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test_pred.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
-            ]
-        ],
-        "timestamp": "2024-03-04T11:27:04.019058",
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        }
-    },
-    "versions_ribotish_single_end_multi_ribo_bam": {
-        "content": [
-            [
-                [
-                    "RIBOTISH_PREDICT",
-                    "ribotish",
-                    "0.2.8"
-                ]
-            ]
-        ],
-        "timestamp": "2026-05-18T16:42:56.345570295",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
-        }
-    },
-    "all_single_end_multi_ribo_bam_stub": {
-        "content": [
+            ],
             [
                 [
                     {
@@ -45,15 +20,82 @@
                     },
                     "test_all.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
-            ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "forward"
+                    },
+                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            {
+                "versions_ribotish": [
+                    [
+                        "RIBOTISH_PREDICT",
+                        "ribotish",
+                        "0.2.8"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2024-03-04T11:28:24.849804",
+        "timestamp": "2026-05-19T10:03:51.7008198",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     },
-    "transprofile_single_end_multi_ribo_bam": {
+    "sarscov2 [bam] - single_end - multi ribo bam - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "forward"
+                    },
+                    "test_pred.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "forward"
+                    },
+                    "test_all.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "forward"
+                    },
+                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            {
+                "versions_ribotish": [
+                    [
+                        "RIBOTISH_PREDICT",
+                        "ribotish",
+                        "0.2.8"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-19T10:04:37.952263709",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "sarscov2 [bam] - single_end - multi ribo bam": {
         "content": [
             [
                 [
@@ -64,88 +106,24 @@
                     },
                     "test_transprofile.py:md5,202a5b5983806e8d9f242c6157736357"
                 ]
-            ]
-        ],
-        "timestamp": "2024-03-14T12:26:32.447969",
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        }
-    },
-    "predictions_single_end_multi_ribo_bam_stub": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "forward"
-                    },
-                    "test_pred.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+            ],
+            {
+                "versions_ribotish": [
+                    [
+                        "RIBOTISH_PREDICT",
+                        "ribotish",
+                        "0.2.8"
+                    ]
                 ]
-            ]
+            }
         ],
-        "timestamp": "2024-03-04T11:28:24.825927",
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        }
-    },
-    "transprofile_single_end_multi_ribo_bam_stub": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "forward"
-                    },
-                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ]
-        ],
-        "timestamp": "2024-03-04T11:28:24.874123",
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        }
-    },
-    "all_single_end_single_ribo_bam_stub": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "forward"
-                    },
-                    "test_all.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ]
-        ],
-        "timestamp": "2024-03-04T11:27:04.007006",
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        }
-    },
-    "versions_ribotish_single_end_multi_ribo_bam_stub": {
-        "content": [
-            [
-                [
-                    "RIBOTISH_PREDICT",
-                    "ribotish",
-                    "0.2.8"
-                ]
-            ]
-        ],
-        "timestamp": "2026-05-18T16:43:04.293934651",
+        "timestamp": "2026-05-19T10:04:30.097163994",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
         }
     },
-    "transprofile_single_end_single_ribo_bam": {
+    "sarscov2 [bam] - single_end - single ribo bam": {
         "content": [
             [
                 [
@@ -156,63 +134,21 @@
                     },
                     "test_transprofile.py:md5,3e6aaa9ec9f3346ae8c838da2d415924"
                 ]
-            ]
-        ],
-        "timestamp": "2024-03-14T12:20:15.166081",
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        }
-    },
-    "versions_ribotish_single_end_single_ribo_bam": {
-        "content": [
-            [
-                [
-                    "RIBOTISH_PREDICT",
-                    "ribotish",
-                    "0.2.8"
+            ],
+            {
+                "versions_ribotish": [
+                    [
+                        "RIBOTISH_PREDICT",
+                        "ribotish",
+                        "0.2.8"
+                    ]
                 ]
-            ]
+            }
         ],
-        "timestamp": "2026-05-18T16:42:09.742242601",
+        "timestamp": "2026-05-19T10:03:43.377664597",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
-        }
-    },
-    "versions_ribotish_single_end_single_ribo_bam_stub": {
-        "content": [
-            [
-                [
-                    "RIBOTISH_PREDICT",
-                    "ribotish",
-                    "0.2.8"
-                ]
-            ]
-        ],
-        "timestamp": "2026-05-18T16:42:17.695252803",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
-        }
-    },
-    "predictions_single_end_single_ribo_bam_stub": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "forward"
-                    },
-                    "test_pred.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ]
-        ],
-        "timestamp": "2024-03-04T11:27:03.99362",
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
         }
     }
 }

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
@@ -1,16 +1,4 @@
 {
-    "versions_single_end_multi_ribo_bam_stub": {
-        "content": [
-            [
-                "versions.yml:md5,48e727a11954fb4c3de5a0eb2576951c"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T11:28:24.897805"
-    },
     "transprofile_single_end_single_ribo_bam_stub": {
         "content": [
             [
@@ -24,92 +12,27 @@
                 ]
             ]
         ],
+        "timestamp": "2024-03-04T11:27:04.019058",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T11:27:04.019058"
+        }
     },
-    "transprofile_single_end_multi_ribo_bam_stub": {
+    "versions_ribotish_single_end_multi_ribo_bam": {
         "content": [
             [
                 [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "forward"
-                    },
-                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "RIBOTISH_PREDICT",
+                    "ribotish",
+                    "0.2.8"
                 ]
             ]
         ],
+        "timestamp": "2026-05-18T16:42:56.345570295",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T11:28:24.874123"
-    },
-    "all_single_end_single_ribo_bam_stub": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "forward"
-                    },
-                    "test_all.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T11:27:04.007006"
-    },
-    "versions_single_end_single_ribo_bam_stub": {
-        "content": [
-            [
-                "versions.yml:md5,48e727a11954fb4c3de5a0eb2576951c"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T11:27:04.031448"
-    },
-    "versions_single_end_multi_ribo_bam": {
-        "content": [
-            [
-                "versions.yml:md5,48e727a11954fb4c3de5a0eb2576951c"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T09:47:34.863391"
-    },
-    "transprofile_single_end_single_ribo_bam": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true,
-                        "strandedness": "forward"
-                    },
-                    "test_transprofile.py:md5,3e6aaa9ec9f3346ae8c838da2d415924"
-                ]
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-14T12:20:15.166081"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
     "all_single_end_multi_ribo_bam_stub": {
         "content": [
@@ -124,23 +47,11 @@
                 ]
             ]
         ],
+        "timestamp": "2024-03-04T11:28:24.849804",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T11:28:24.849804"
-    },
-    "versions_single_end_single_ribo_bam": {
-        "content": [
-            [
-                "versions.yml:md5,48e727a11954fb4c3de5a0eb2576951c"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T09:46:34.409406"
+        }
     },
     "transprofile_single_end_multi_ribo_bam": {
         "content": [
@@ -155,11 +66,11 @@
                 ]
             ]
         ],
+        "timestamp": "2024-03-14T12:26:32.447969",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-14T12:26:32.447969"
+        }
     },
     "predictions_single_end_multi_ribo_bam_stub": {
         "content": [
@@ -174,11 +85,116 @@
                 ]
             ]
         ],
+        "timestamp": "2024-03-04T11:28:24.825927",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T11:28:24.825927"
+        }
+    },
+    "transprofile_single_end_multi_ribo_bam_stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "forward"
+                    },
+                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ]
+        ],
+        "timestamp": "2024-03-04T11:28:24.874123",
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        }
+    },
+    "all_single_end_single_ribo_bam_stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "forward"
+                    },
+                    "test_all.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ]
+        ],
+        "timestamp": "2024-03-04T11:27:04.007006",
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        }
+    },
+    "versions_ribotish_single_end_multi_ribo_bam_stub": {
+        "content": [
+            [
+                [
+                    "RIBOTISH_PREDICT",
+                    "ribotish",
+                    "0.2.8"
+                ]
+            ]
+        ],
+        "timestamp": "2026-05-18T16:43:04.293934651",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "transprofile_single_end_single_ribo_bam": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "strandedness": "forward"
+                    },
+                    "test_transprofile.py:md5,3e6aaa9ec9f3346ae8c838da2d415924"
+                ]
+            ]
+        ],
+        "timestamp": "2024-03-14T12:20:15.166081",
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        }
+    },
+    "versions_ribotish_single_end_single_ribo_bam": {
+        "content": [
+            [
+                [
+                    "RIBOTISH_PREDICT",
+                    "ribotish",
+                    "0.2.8"
+                ]
+            ]
+        ],
+        "timestamp": "2026-05-18T16:42:09.742242601",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "versions_ribotish_single_end_single_ribo_bam_stub": {
+        "content": [
+            [
+                [
+                    "RIBOTISH_PREDICT",
+                    "ribotish",
+                    "0.2.8"
+                ]
+            ]
+        ],
+        "timestamp": "2026-05-18T16:42:17.695252803",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
     "predictions_single_end_single_ribo_bam_stub": {
         "content": [
@@ -193,10 +209,10 @@
                 ]
             ]
         ],
+        "timestamp": "2024-03-04T11:27:03.99362",
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
-        },
-        "timestamp": "2024-03-04T11:27:03.99362"
+        }
     }
 }


### PR DESCRIPTION
Adds an optional secondary GTF input to `ribotish predict` (so callers can supply a MANE/RefSeq-style overlay via `-a` while keeping the primary GTF on `-g`), and brings the module up to current nf-core conventions.

### Changes

- **New optional input**: `tuple val(meta7), path(reference_gtf, stageAs: 'secondary.gtf')`. When populated, plumbed through as `-a <reference_gtf>` on the ribotish command line. Lives in its own tuple - matches the pattern this module already uses for `bam_ti`, `candidate_orfs`, `para_ribo`, `para_ti`. Existing `(meta3, fasta, gtf)` signature is preserved, so consumers add a single new input channel rather than restructuring an existing tuple.
- **Topic-based versions**: legacy `path "versions.yml"` emit + `cat <<-END_VERSIONS` heredoc replaced with `tuple val("${task.process}"), val('ribotish'), eval("ribotish --version | sed 's/ribotish //'"), topic: versions, emit: versions_ribotish`. `meta.yml` regenerated via `nf-core modules lint --fix` (adds the `topics:` block and reshapes the `versions_ribotish` output entry).
- **Bump ribotish 0.2.7 → 0.2.8** (bioconda; same build hash, container URLs and `environment.yml` updated).

### Test plan

`nf-core modules test --profile docker ribotish/predict` runs all four cases green (single/multi ribo bam × main/stub). Snapshot regenerated:

- `versions_*` keys renamed to `versions_ribotish_*` (matching the new emit name).
- Version string `0.2.7` → `0.2.8`.
- Prediction-table assertions unchanged - 0.2.8 is a patch release.

### Caller migration

Existing callers must add a 7th input slot. Pass `Channel.of([[], []])` (or `[[id:'reference'], []]`) for the no-op case; pass a populated `[meta, gtf_path]` to use `-a`.

Source: nf-core/riboseq#174. Supersedes the ribotish half of nf-core/modules#11684.