### PR TITLE
add deprecation field to the meta.yml of deprecated modules

### DIFF
--- a/modules/meta-schema.json
+++ b/modules/meta-schema.json
@@ -12,6 +12,10 @@
             "type": "string",
             "description": "Description of the module"
         },
+        "deprecated": {
+            "type": "boolean",
+            "description": "Whether the module is deprecated and should not be used in new pipelines"
+        },
         "keywords": {
             "type": "array",
             "description": "Keywords for the module",

--- a/modules/nf-core/ampcombi/meta.yml
+++ b/modules/nf-core/ampcombi/meta.yml
@@ -1,6 +1,7 @@
 name: "ampcombi"
 description: A tool to parse and summarise results from antimicrobial peptides tools
   and present functional classification.
+deprecated: true
 keywords:
   - antimicrobial peptides
   - amps

--- a/modules/nf-core/amulety/antiberta2/meta.yml
+++ b/modules/nf-core/amulety/antiberta2/meta.yml
@@ -2,6 +2,7 @@
 name: "amulety_antiberta2"
 description: A module to create antiberta2 embeddings of antibody (BCR) amino acid
   sequences using amulety.
+deprecated: true
 keywords:
   - embeddings
   - BCR

--- a/modules/nf-core/amulety/antiberty/meta.yml
+++ b/modules/nf-core/amulety/antiberty/meta.yml
@@ -2,6 +2,7 @@
 name: "amulety_antiberty"
 description: A module to create antiberty embeddings of antibody (BCR) amino acid
   sequences using amulety.
+deprecated: true
 keywords:
   - embeddings
   - BCR

--- a/modules/nf-core/amulety/balmpaired/meta.yml
+++ b/modules/nf-core/amulety/balmpaired/meta.yml
@@ -2,6 +2,7 @@
 name: "amulety_balmpaired"
 description: A module to create BALM paired embeddings of antibody (BCR) amino acid
   sequences using amulety.
+deprecated: true
 keywords:
   - embeddings
   - BCR

--- a/modules/nf-core/amulety/esm2/meta.yml
+++ b/modules/nf-core/amulety/esm2/meta.yml
@@ -2,6 +2,7 @@
 name: "amulety_esm2"
 description: A module to create esm2 embeddings of antibody (BCR) amino acid sequences
   using amulety.
+deprecated: true
 keywords:
   - embeddings
   - BCR

--- a/modules/nf-core/antismash/antismashlite/meta.yml
+++ b/modules/nf-core/antismash/antismashlite/meta.yml
@@ -2,6 +2,7 @@ name: antismash_antismashlite
 description: |
   antiSMASH allows the rapid genome-wide identification, annotation
   and analysis of secondary metabolite biosynthesis gene clusters.
+deprecated: true
 keywords:
   - secondary metabolites
   - BGC

--- a/modules/nf-core/antismash/antismashlitedownloaddatabases/meta.yml
+++ b/modules/nf-core/antismash/antismashlitedownloaddatabases/meta.yml
@@ -2,6 +2,7 @@ name: antismash_antismashlitedownloaddatabases
 description: antiSMASH allows the rapid genome-wide identification, annotation and
   analysis of secondary metabolite biosynthesis gene clusters. This module downloads
   the antiSMASH databases for conda and docker/singularity runs.
+deprecated: true
 keywords:
   - secondary metabolites
   - BGC

--- a/modules/nf-core/bam2fastx/bam2fastq/meta.yml
+++ b/modules/nf-core/bam2fastx/bam2fastq/meta.yml
@@ -1,6 +1,7 @@
 name: "bam2fastx_bam2fastq"
 description: Conversion of PacBio BAM files into gzipped fastq files, including
   splitting of barcoded data
+deprecated: true
 keywords:
   - bam2fastx
   - bam2fastq

--- a/modules/nf-core/cat/cat/meta.yml
+++ b/modules/nf-core/cat/cat/meta.yml
@@ -1,5 +1,6 @@
 name: cat_cat
 description: A module for concatenation of gzipped or uncompressed files
+deprecated: true
 keywords:
   - concatenate
   - gzip

--- a/modules/nf-core/custom/dumpsoftwareversions/meta.yml
+++ b/modules/nf-core/custom/dumpsoftwareversions/meta.yml
@@ -2,6 +2,7 @@
 name: custom_dumpsoftwareversions
 description: Custom module used to dump software versions within the nf-core pipeline
   template
+deprecated: true
 keywords:
   - custom
   - dump

--- a/modules/nf-core/custom/getchromsizes/meta.yml
+++ b/modules/nf-core/custom/getchromsizes/meta.yml
@@ -1,5 +1,6 @@
 name: custom_getchromsizes
 description: Generates a FASTA file of chromosome sizes and a fasta index file
+deprecated: true
 keywords:
   - fasta
   - chromosome

--- a/modules/nf-core/dastool/scaffolds2bin/meta.yml
+++ b/modules/nf-core/dastool/scaffolds2bin/meta.yml
@@ -1,6 +1,7 @@
 name: dastool_scaffolds2bin
 description: Helper script to convert a set of bins in fasta format to tabular scaffolds2bin
   format
+deprecated: true
 keywords:
   - binning
   - das tool

--- a/modules/nf-core/deepvariant/meta.yml
+++ b/modules/nf-core/deepvariant/meta.yml
@@ -2,6 +2,7 @@ name: deepvariant
 description: (DEPRECATED - see main.nf) DeepVariant is an analysis pipeline that uses
   a deep neural network to call genetic variants from next-generation DNA sequencing
   data
+deprecated: true
 keywords:
   - variant calling
   - machine learning

--- a/modules/nf-core/fastavalidator/meta.yml
+++ b/modules/nf-core/fastavalidator/meta.yml
@@ -3,6 +3,7 @@ name: "fastavalidator"
 description: |
   "Python C-extension for a simple validator for fasta files. The module emits the validated file or an
   error log upon validation failure."
+deprecated: true
 keywords:
   - fasta
   - validation

--- a/modules/nf-core/fcs/fcsgx/meta.yml
+++ b/modules/nf-core/fcs/fcsgx/meta.yml
@@ -1,6 +1,7 @@
 name: "fcs_fcsgx"
 description: Run FCS-GX on assembled genomes. The contigs of the assembly are
   searched against a reference database excluding the given taxid.
+deprecated: true
 keywords:
   - assembly
   - genomics

--- a/modules/nf-core/kat/hist/meta.yml
+++ b/modules/nf-core/kat/hist/meta.yml
@@ -1,5 +1,6 @@
 name: "kat_hist"
 description: Creates a histogram of the number of distinct k-mers having a given frequency.
+deprecated: true
 keywords:
   - k-mer
   - histogram

--- a/modules/nf-core/krona/kronadb/meta.yml
+++ b/modules/nf-core/krona/kronadb/meta.yml
@@ -1,5 +1,6 @@
 name: krona_kronadb
 description: KronaTools Update Taxonomy downloads a taxonomy database
+deprecated: true
 keywords:
   - database
   - taxonomy

--- a/modules/nf-core/mcstaging/imc2mc/meta.yml
+++ b/modules/nf-core/mcstaging/imc2mc/meta.yml
@@ -2,6 +2,7 @@
 name: "mcstaging_imc2mc"
 description: Staging module for MCMICRO transforming Imaging Mass Cytometry .txt files
   to .tif files with OME-XML metadata. Includes optional hot pixel removal.
+deprecated: true
 keywords:
   - imaging
   - ome-tif

--- a/modules/nf-core/mcstaging/phenoimager2mc/meta.yml
+++ b/modules/nf-core/mcstaging/phenoimager2mc/meta.yml
@@ -1,6 +1,7 @@
 name: "mcstaging_phenoimager2mc"
 description: Staging module for MCMICRO transforming PhenoImager .tif files into
   stacked and normalized ome-tif files per cycle, compatible as ASHLAR input.
+deprecated: true
 keywords:
   - imaging
   - registration

--- a/modules/nf-core/msisensor/msi/meta.yml
+++ b/modules/nf-core/msisensor/msi/meta.yml
@@ -1,6 +1,7 @@
 name: msisensor_msi
 description: Evaluate microsattelite instability (MSI) using paired tumor-normal sequencing
   data
+deprecated: true
 keywords:
   - homoploymer
   - microsatellite

--- a/modules/nf-core/msisensor/scan/meta.yml
+++ b/modules/nf-core/msisensor/scan/meta.yml
@@ -1,5 +1,6 @@
 name: msisensor_scan
 description: Scan a reference genome to get microsatellite & homopolymer information
+deprecated: true
 keywords:
   - homoploymer
   - microsatellite

--- a/modules/nf-core/openms/idmassaccuracy/meta.yml
+++ b/modules/nf-core/openms/idmassaccuracy/meta.yml
@@ -1,6 +1,7 @@
 name: "openms_idmassaccuracy"
 description: Calculates a distribution of the mass error from given mass spectra and
   IDs.
+deprecated: true
 keywords:
   - mass_error
   - openms

--- a/modules/nf-core/pbbam/pbmerge/meta.yml
+++ b/modules/nf-core/pbbam/pbmerge/meta.yml
@@ -2,6 +2,7 @@ name: pbbam_pbmerge
 description: The pbbam software package provides components to create, query, & edit
   PacBio BAM files and associated indices. These components include a core C++ library,
   bindings for additional languages, and command-line utilities.
+deprecated: true
 keywords:
   - pbbam
   - pbmerge

--- a/modules/nf-core/samtools/getrg/meta.yml
+++ b/modules/nf-core/samtools/getrg/meta.yml
@@ -1,5 +1,6 @@
 name: samtools_getrg
 description: filter/convert SAM/BAM/CRAM file
+deprecated: true
 keywords:
   - view
   - bam

--- a/modules/nf-core/untarfiles/meta.yml
+++ b/modules/nf-core/untarfiles/meta.yml
@@ -1,5 +1,6 @@
 name: untarfiles
 description: Extract files.
+deprecated: true
 keywords:
   - untar
   - uncompress

--- a/modules/nf-core/vcf2zarr/convert/meta.yml
+++ b/modules/nf-core/vcf2zarr/convert/meta.yml
@@ -2,6 +2,7 @@
 name: "vcf2zarr_convert"
 description: Convert VCF data to the VCF Zarr specification reliably, in
   parallel or distributed over a cluster
+deprecated: true
 keywords:
   - vcf
   - zarr

--- a/modules/nf-core/vcf2zarr/explode/meta.yml
+++ b/modules/nf-core/vcf2zarr/explode/meta.yml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "vcf2zarr_explode"
 description: Convert VCF(s) to intermediate columnar format
+deprecated: true
 keywords:
   - vcf
   - icf


### PR DESCRIPTION
This makes it more apparent and will make it easier to show a warning for this on the website and in the CLI.

Docs update in https://github.com/nf-core/website/pull/4223:  https://deploy-preview-4223--nf-core-docs.netlify.app/docs/developing/components/deprecating-components