### PR TITLE
feat(custom/orfcountmatrix): add ORF x sample P-site count matrix builder

### DIFF
--- a/modules/nf-core/custom/orfcountmatrix/environment.yml
+++ b/modules/nf-core/custom/orfcountmatrix/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.11

--- a/modules/nf-core/custom/orfcountmatrix/environment.yml
+++ b/modules/nf-core/custom/orfcountmatrix/environment.yml
@@ -4,4 +4,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python=3.11
+  - pandas=2.2.3
+  - python=3.11.15
+  - pyyaml=6.0.2

--- a/modules/nf-core/custom/orfcountmatrix/main.nf
+++ b/modules/nf-core/custom/orfcountmatrix/main.nf
@@ -4,8 +4,8 @@ process CUSTOM_ORFCOUNTMATRIX {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/python:3.11' :
-        'quay.io/biocontainers/python:3.11' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7a/7a17ff642fb8c74fbf9feece8df823d78bcecca69f76770aa585e7468e6a9187/data' :
+        'community.wave.seqera.io/library/python_pandas_pyyaml:3ce680b21acf323f' }"
 
     input:
     tuple val(meta), path(per_sample_counts, stageAs: 'counts/*'), path(orf_catalogue_bed12)
@@ -22,7 +22,7 @@ process CUSTOM_ORFCOUNTMATRIX {
     template 'build_orf_count_matrix.py'
 
     stub:
-    def prefix = task.ext.prefix ?: "orf_psite_counts"
+    prefix = task.ext.prefix ?: "orf_psite_counts"
     """
     touch ${prefix}.tsv
 

--- a/modules/nf-core/custom/orfcountmatrix/main.nf
+++ b/modules/nf-core/custom/orfcountmatrix/main.nf
@@ -1,0 +1,34 @@
+process CUSTOM_ORFCOUNTMATRIX {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.11' :
+        'quay.io/biocontainers/python:3.11' }"
+
+    input:
+    tuple val(meta), path(per_sample_counts, stageAs: 'counts/*'), path(orf_catalogue_bed12)
+
+    output:
+    tuple val(meta), path("*.tsv"), emit: matrix
+    path "versions.yml"           , emit: versions_python, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    prefix = task.ext.prefix ?: "orf_psite_counts"
+    template 'build_orf_count_matrix.py'
+
+    stub:
+    def prefix = task.ext.prefix ?: "orf_psite_counts"
+    """
+    touch ${prefix}.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed -e "s/Python //g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/custom/orfcountmatrix/meta.yml
+++ b/modules/nf-core/custom/orfcountmatrix/meta.yml
@@ -1,0 +1,88 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "custom_orfcountmatrix"
+description: |
+  Pivot per-sample ORF P-site count TSVs into a single ORF x sample matrix.
+  Output rows follow the order of the supplied BED12 ORF catalogue and ORFs
+  with no observed counts in a given sample are zero-filled.
+keywords:
+  - riboseq
+  - orf
+  - psite
+  - counts
+  - matrix
+tools:
+  - "custom":
+      description: |
+        "Custom module that pivots per-sample ORF P-site count TSVs into a
+        single ORF x sample matrix, zero-filled for ORFs absent from a sample
+        and including every ORF in the catalogue regardless of observed
+        counts."
+      tool_dev_url: "https://github.com/nf-core/modules/blob/master/modules/nf-core/custom/orfcountmatrix/main.nf"
+      licence: ["MIT"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing dataset information
+          e.g. `[ id:'cohort' ]`
+    - per_sample_counts:
+        type: file
+        description: |
+          One TSV per sample with three columns (sample_id, orf_id, count).
+          Every row of a given file must carry the same sample_id; the
+          column order in the output matrix is the lexicographic sort of
+          the sample ids encountered.
+        pattern: "*.tsv"
+        ontologies:
+          - edam: http://edamontology.org/format_3475 # TSV
+    - orf_catalogue_bed12:
+        type: file
+        description: |
+          BED12 catalogue of ORFs. The 4th column is the canonical ORF id
+          and defines both the row order and the row membership of the
+          output matrix (ORFs missing from every sample appear as a row
+          of zeros).
+        pattern: "*.{bed,bed12}"
+        ontologies:
+          - edam: http://edamontology.org/format_3003 # BED
+
+output:
+  matrix:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing dataset information
+            e.g. `[ id:'cohort' ]`
+      - "*.tsv":
+          type: file
+          description: |
+            ORF x sample P-site count matrix, header
+            `orf_id<tab>sample1<tab>sample2...`, one row per catalogue
+            ORF in catalogue order, zeros for missing entries.
+          pattern: "*.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  versions_python:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+
+topics:
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+
+authors:
+  - "@pinin4fjords"
+maintainers:
+  - "@pinin4fjords"

--- a/modules/nf-core/custom/orfcountmatrix/templates/build_orf_count_matrix.py
+++ b/modules/nf-core/custom/orfcountmatrix/templates/build_orf_count_matrix.py
@@ -1,107 +1,36 @@
 #!/usr/bin/env python3
-"""Merge per-sample ORF P-site count TSVs into a single ORF x sample matrix.
+"""Pivot per-sample ORF P-site count TSVs into a single ORF x sample matrix.
 
-Input files: any number of per-sample TSVs with three columns:
-  sample_id  orf_id  count
-
-The sample_id is identical on every row of a given file (it is prepended
-upstream by the per-sample P-site counting step). The column order in the
-output matrix is the lexicographic sort of the sample ids encountered.
-
-Output: a single TSV with header `orf_id<tab>sample1<tab>sample2...` and
-one row per ORF in the catalogue. ORFs with no counts in a given sample
-are filled with 0; ORFs in the catalogue but absent from every sample
-appear as a row of zeros. This guarantees the matrix contains every ORF
-in the catalogue, not just the subset with non-zero counts in at least
-one sample.
+Per-sample input is `sample_id<TAB>orf_id<TAB>count` (sample_id is identical
+on every row, prepended upstream by the per-sample counter). Output rows
+follow the BED12 catalogue's 4th column in catalogue order; ORFs absent
+from a sample are zero-filled, and ORFs absent from every sample still
+appear as a row of zeros so the matrix is keyed on the catalogue.
 """
-import glob
+
 import platform
-import sys
+from pathlib import Path
 
+import pandas as pd
+import yaml
 
-def format_yaml_like(data, indent=0):
-    yaml_str = ""
-    for key, value in data.items():
-        spaces = "  " * indent
-        if isinstance(value, dict):
-            yaml_str += f"{spaces}{key}:\\n{format_yaml_like(value, indent + 1)}"
-        else:
-            yaml_str += f"{spaces}{key}: {value}\\n"
-    return yaml_str
+counts = pd.concat(
+    pd.read_csv(p, sep="\\t", names=["sample", "orf_id", "count"]) for p in sorted(Path("counts").iterdir())
+)
 
+catalogue_orfs = (
+    pd.read_csv("$orf_catalogue_bed12", sep="\\t", header=None, comment="#", usecols=[3])[3].drop_duplicates().tolist()
+)
 
-def read_orf_ids(path):
-    seen = set()
-    ordered = []
-    with open(path) as fh:
-        for line in fh:
-            if not line.strip() or line.startswith("#") or line.startswith("track") or line.startswith("browser"):
-                continue
-            parts = line.rstrip("\\n").split("\\t")
-            if len(parts) < 4:
-                continue
-            orf_id = parts[3]
-            if orf_id in seen:
-                continue
-            seen.add(orf_id)
-            ordered.append(orf_id)
-    return ordered
+matrix = (
+    counts.pivot_table(index="orf_id", columns="sample", values="count", aggfunc="sum", fill_value=0)
+    .reindex(catalogue_orfs, fill_value=0)
+    .astype(int)
+)
+matrix.to_csv("${prefix}.tsv", sep="\\t")
 
-
-def read_counts(path):
-    counts = {}
-    sample_id = None
-    with open(path) as fh:
-        for line in fh:
-            if not line.strip():
-                continue
-            parts = line.rstrip("\\n").split("\\t")
-            if len(parts) < 3:
-                continue
-            s, orf, c = parts[0], parts[1], parts[2]
-            if sample_id is None:
-                sample_id = s
-            elif sample_id != s:
-                raise ValueError(f"{path}: encountered sample id '{s}' after '{sample_id}'")
-            try:
-                counts[orf] = counts.get(orf, 0) + int(c)
-            except ValueError:
-                counts[orf] = counts.get(orf, 0) + int(float(c))
-    return sample_id, counts
-
-
-def build_matrix(count_files, orf_list, output_path):
-    orf_ids = read_orf_ids(orf_list)
-    per_sample = {}
-    for path in count_files:
-        sample, counts = read_counts(path)
-        if sample is None:
-            stem = path.split("/")[-1].split(".")[0]
-            sample = stem
-            counts = {}
-        per_sample[sample] = counts
-
-    samples = sorted(per_sample.keys())
-    with open(output_path, "w") as out:
-        out.write("orf_id\\t" + "\\t".join(samples) + "\\n")
-        for orf in orf_ids:
-            row = [orf]
-            for s in samples:
-                row.append(str(per_sample[s].get(orf, 0)))
-            out.write("\\t".join(row) + "\\n")
-
-
-if __name__ == "__main__":
-    count_files = sorted(glob.glob("counts/*"))
-    if not count_files:
-        sys.stderr.write("No per-sample count files found in counts/\\n")
-        sys.exit(1)
-
-    prefix = "$prefix" if "$prefix" != "null" else "orf_psite_counts"
-    build_matrix(count_files, "$orf_catalogue_bed12", f"{prefix}.tsv")
-
-    versions_this_module = {}
-    versions_this_module["${task.process}"] = {"python": platform.python_version()}
-    with open("versions.yml", "w") as f:
-        f.write(format_yaml_like(versions_this_module))
+with open("versions.yml", "w") as f:
+    yaml.safe_dump(
+        {"${task.process}": {"python": platform.python_version(), "pandas": pd.__version__}},
+        f,
+    )

--- a/modules/nf-core/custom/orfcountmatrix/templates/build_orf_count_matrix.py
+++ b/modules/nf-core/custom/orfcountmatrix/templates/build_orf_count_matrix.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Merge per-sample ORF P-site count TSVs into a single ORF x sample matrix.
+
+Input files: any number of per-sample TSVs with three columns:
+  sample_id  orf_id  count
+
+The sample_id is identical on every row of a given file (it is prepended
+upstream by the per-sample P-site counting step). The column order in the
+output matrix is the lexicographic sort of the sample ids encountered.
+
+Output: a single TSV with header `orf_id<tab>sample1<tab>sample2...` and
+one row per ORF in the catalogue. ORFs with no counts in a given sample
+are filled with 0; ORFs in the catalogue but absent from every sample
+appear as a row of zeros. This guarantees the matrix contains every ORF
+in the catalogue, not just the subset with non-zero counts in at least
+one sample.
+"""
+import glob
+import platform
+import sys
+
+
+def format_yaml_like(data, indent=0):
+    yaml_str = ""
+    for key, value in data.items():
+        spaces = "  " * indent
+        if isinstance(value, dict):
+            yaml_str += f"{spaces}{key}:\\n{format_yaml_like(value, indent + 1)}"
+        else:
+            yaml_str += f"{spaces}{key}: {value}\\n"
+    return yaml_str
+
+
+def read_orf_ids(path):
+    seen = set()
+    ordered = []
+    with open(path) as fh:
+        for line in fh:
+            if not line.strip() or line.startswith("#") or line.startswith("track") or line.startswith("browser"):
+                continue
+            parts = line.rstrip("\\n").split("\\t")
+            if len(parts) < 4:
+                continue
+            orf_id = parts[3]
+            if orf_id in seen:
+                continue
+            seen.add(orf_id)
+            ordered.append(orf_id)
+    return ordered
+
+
+def read_counts(path):
+    counts = {}
+    sample_id = None
+    with open(path) as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            parts = line.rstrip("\\n").split("\\t")
+            if len(parts) < 3:
+                continue
+            s, orf, c = parts[0], parts[1], parts[2]
+            if sample_id is None:
+                sample_id = s
+            elif sample_id != s:
+                raise ValueError(f"{path}: encountered sample id '{s}' after '{sample_id}'")
+            try:
+                counts[orf] = counts.get(orf, 0) + int(c)
+            except ValueError:
+                counts[orf] = counts.get(orf, 0) + int(float(c))
+    return sample_id, counts
+
+
+def build_matrix(count_files, orf_list, output_path):
+    orf_ids = read_orf_ids(orf_list)
+    per_sample = {}
+    for path in count_files:
+        sample, counts = read_counts(path)
+        if sample is None:
+            stem = path.split("/")[-1].split(".")[0]
+            sample = stem
+            counts = {}
+        per_sample[sample] = counts
+
+    samples = sorted(per_sample.keys())
+    with open(output_path, "w") as out:
+        out.write("orf_id\\t" + "\\t".join(samples) + "\\n")
+        for orf in orf_ids:
+            row = [orf]
+            for s in samples:
+                row.append(str(per_sample[s].get(orf, 0)))
+            out.write("\\t".join(row) + "\\n")
+
+
+if __name__ == "__main__":
+    count_files = sorted(glob.glob("counts/*"))
+    if not count_files:
+        sys.stderr.write("No per-sample count files found in counts/\\n")
+        sys.exit(1)
+
+    prefix = "$prefix" if "$prefix" != "null" else "orf_psite_counts"
+    build_matrix(count_files, "$orf_catalogue_bed12", f"{prefix}.tsv")
+
+    versions_this_module = {}
+    versions_this_module["${task.process}"] = {"python": platform.python_version()}
+    with open("versions.yml", "w") as f:
+        f.write(format_yaml_like(versions_this_module))

--- a/modules/nf-core/custom/orfcountmatrix/tests/main.nf.test
+++ b/modules/nf-core/custom/orfcountmatrix/tests/main.nf.test
@@ -1,0 +1,69 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_ORFCOUNTMATRIX"
+    script "../main.nf"
+    process "CUSTOM_ORFCOUNTMATRIX"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "custom/orfcountmatrix"
+
+    test("homo_sapiens - orf psite counts - bed12") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    [
+                        file("https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orfcountmatrix-test-data/data/genomics/homo_sapiens/riboseq_expression/orfcountmatrix/samples/sample1.orf_psite_counts.tsv", checkIfExists: true),
+                        file("https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orfcountmatrix-test-data/data/genomics/homo_sapiens/riboseq_expression/orfcountmatrix/samples/sample2.orf_psite_counts.tsv", checkIfExists: true)
+                    ],
+                    file("https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orfcountmatrix-test-data/data/genomics/homo_sapiens/riboseq_expression/orfcountmatrix/orf_catalogue.bed12", checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.matrix,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - orf psite counts - bed12 - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    [
+                        file("https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orfcountmatrix-test-data/data/genomics/homo_sapiens/riboseq_expression/orfcountmatrix/samples/sample1.orf_psite_counts.tsv", checkIfExists: true),
+                        file("https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orfcountmatrix-test-data/data/genomics/homo_sapiens/riboseq_expression/orfcountmatrix/samples/sample2.orf_psite_counts.tsv", checkIfExists: true)
+                    ],
+                    file("https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orfcountmatrix-test-data/data/genomics/homo_sapiens/riboseq_expression/orfcountmatrix/orf_catalogue.bed12", checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/custom/orfcountmatrix/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/orfcountmatrix/tests/main.nf.test.snap
@@ -1,0 +1,62 @@
+{
+    "homo_sapiens - orf psite counts - bed12": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "orf_psite_counts.tsv:md5,238f1f36821b8dbfd1441c958f836b41"
+                ]
+            ],
+            {
+                "versions_python": [
+                    "versions.yml:md5,ce42c3a2de4a1aeefa0418cec14939c4"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-20T11:58:31.357861"
+    },
+    "homo_sapiens - orf psite counts - bed12 - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "orf_psite_counts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,ebb54155189228ea17cde26d5b66bbbb"
+                ],
+                "matrix": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "orf_psite_counts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_python": [
+                    "versions.yml:md5,ebb54155189228ea17cde26d5b66bbbb"
+                ]
+            },
+            {
+                "versions_python": [
+                    "versions.yml:md5,ebb54155189228ea17cde26d5b66bbbb"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-20T11:58:36.47235"
+    }
+}

--- a/modules/nf-core/custom/orfcountmatrix/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/orfcountmatrix/tests/main.nf.test.snap
@@ -11,15 +11,15 @@
             ],
             {
                 "versions_python": [
-                    "versions.yml:md5,ce42c3a2de4a1aeefa0418cec14939c4"
+                    "versions.yml:md5,6fbdfa2480d8ec5f1a2c28314d61dc9c"
                 ]
             }
         ],
+        "timestamp": "2026-05-20T12:10:56.421206144",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-20T11:58:31.357861"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
     "homo_sapiens - orf psite counts - bed12 - stub": {
         "content": [
@@ -33,7 +33,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,ebb54155189228ea17cde26d5b66bbbb"
+                    "versions.yml:md5,f30f3591db9468afc9a12be22fb99bf9"
                 ],
                 "matrix": [
                     [
@@ -44,19 +44,19 @@
                     ]
                 ],
                 "versions_python": [
-                    "versions.yml:md5,ebb54155189228ea17cde26d5b66bbbb"
+                    "versions.yml:md5,f30f3591db9468afc9a12be22fb99bf9"
                 ]
             },
             {
                 "versions_python": [
-                    "versions.yml:md5,ebb54155189228ea17cde26d5b66bbbb"
+                    "versions.yml:md5,f30f3591db9468afc9a12be22fb99bf9"
                 ]
             }
         ],
+        "timestamp": "2026-05-20T12:11:00.714343406",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-20T11:58:36.47235"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds `custom/orfcountmatrix`, a stdlib-only Python module that pivots per-sample ORF P-site count TSVs into a single ORF x sample matrix.

- Input shape: `tuple val(meta), path(per_sample_counts, stageAs: 'counts/*'), path(orf_catalogue_bed12)`. Per-sample TSVs are `sample_id<TAB>orf_id<TAB>count` (every row of a given file shares the same sample_id). The BED12 catalogue's 4th column defines the canonical ORF id list.
- Output: a single TSV with header `orf_id<TAB>sample1<TAB>sample2...`, one row per catalogue ORF in catalogue order, columns in lexicographic sample-id order.
- Zero-fill semantics: ORFs absent from a sample get `0` in that column; ORFs in the catalogue but absent from every sample appear as a row of zeros. This guarantees the matrix is keyed on the catalogue rather than just the union of observed ORFs.

Under `custom/` rather than as a tool-specific module because the pivot is a generic transform over the `(sample_id, orf_id, count)` input shape produced upstream by P-site counters such as Plastid, Ribotricer, or riboWaltz.

Source: extracted from `modules/local/orf/count_matrix/` in nf-core/riboseq#174.

## Paired test-datasets PR

nf-core/test-datasets#2065 adds the hand-crafted synthetic fixtures used by the test. The test currently fetches them from `raw.githubusercontent.com/pinin4fjords/test-datasets/add-orfcountmatrix-test-data/...` - **the URLs will be flipped to `nf-core/test-datasets/modules` once #2065 merges.**

## Test plan

- [x] Real test (non-stub) runs and produces the expected zero-filled, catalogue-ordered matrix.
- [x] Stub test passes.
- [x] Snapshot stable across two consecutive `nf-core modules test` invocations.
- [x] `nf-core modules lint`: 51 passed, 0 warnings, 0 failures.