### PR TITLE
Remove `estimator-multiple-cpu` from cellbender/removebackground

### DIFF
--- a/modules/nf-core/cellbender/removebackground/main.nf
+++ b/modules/nf-core/cellbender/removebackground/main.nf
@@ -34,7 +34,6 @@ process CELLBENDER_REMOVEBACKGROUND {
         TMPDIR=. cellbender remove-background \
             ${args} \
             --cpu-threads ${task.cpus} \
-            --estimator-multiple-cpu \
             ${use_gpu} \
             --input ${h5ad} \
             --output ${prefix}.h5


### PR DESCRIPTION
This helps prevent [this issue](https://github.com/broadinstitute/CellBender/issues/362). Can still be enabled via `ext.args`