### PR TITLE
 Updates controlfreec containers hdbdd923_0 to hde5307d_3

### DIFF
--- a/modules/nf-core/controlfreec/assesssignificance/main.nf
+++ b/modules/nf-core/controlfreec/assesssignificance/main.nf
@@ -4,8 +4,8 @@ process CONTROLFREEC_ASSESSSIGNIFICANCE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hdbdd923_0'
-        : 'quay.io/biocontainers/control-freec:11.6b--hdbdd923_0'}"
+        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hde5307d_3'
+        : 'quay.io/biocontainers/control-freec:11.6b--hde5307d_3'}"
 
     input:
     tuple val(meta), path(cnvs), path(ratio)

--- a/modules/nf-core/controlfreec/freec/main.nf
+++ b/modules/nf-core/controlfreec/freec/main.nf
@@ -4,8 +4,8 @@ process CONTROLFREEC_FREEC {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hdbdd923_0'
-        : 'quay.io/biocontainers/control-freec:11.6b--hdbdd923_0'}"
+        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hde5307d_3'
+        : 'quay.io/biocontainers/control-freec:11.6b--hde5307d_3'}"
 
     input:
     tuple val(meta), path(mpileup_normal), path(mpileup_tumor), path(cpn_normal), path(cpn_tumor), path(minipileup_normal), path(minipileup_tumor)

--- a/modules/nf-core/controlfreec/freec2bed/main.nf
+++ b/modules/nf-core/controlfreec/freec2bed/main.nf
@@ -4,8 +4,8 @@ process CONTROLFREEC_FREEC2BED {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hdbdd923_0'
-        : 'quay.io/biocontainers/control-freec:11.6b--hdbdd923_0'}"
+        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hde5307d_3'
+        : 'quay.io/biocontainers/control-freec:11.6b--hde5307d_3'}"
 
     input:
     tuple val(meta), path(ratio)

--- a/modules/nf-core/controlfreec/freec2circos/main.nf
+++ b/modules/nf-core/controlfreec/freec2circos/main.nf
@@ -4,8 +4,8 @@ process CONTROLFREEC_FREEC2CIRCOS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hdbdd923_0'
-        : 'quay.io/biocontainers/control-freec:11.6b--hdbdd923_0'}"
+        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hde5307d_3'
+        : 'quay.io/biocontainers/control-freec:11.6b--hde5307d_3'}"
 
     input:
     tuple val(meta), path(ratio)

--- a/modules/nf-core/controlfreec/makegraph/main.nf
+++ b/modules/nf-core/controlfreec/makegraph/main.nf
@@ -4,8 +4,8 @@ process CONTROLFREEC_MAKEGRAPH {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hdbdd923_0'
-        : 'quay.io/biocontainers/control-freec:11.6b--hdbdd923_0'}"
+        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hde5307d_3'
+        : 'quay.io/biocontainers/control-freec:11.6b--hde5307d_3'}"
 
     input:
     tuple val(meta), path(ratio), path(baf), val(ploidy)

--- a/modules/nf-core/controlfreec/makegraph2/main.nf
+++ b/modules/nf-core/controlfreec/makegraph2/main.nf
@@ -4,8 +4,8 @@ process CONTROLFREEC_MAKEGRAPH2 {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hdbdd923_0'
-        : 'quay.io/biocontainers/control-freec:11.6b--hdbdd923_0'}"
+        ? 'https://depot.galaxyproject.org/singularity/control-freec:11.6b--hde5307d_3'
+        : 'quay.io/biocontainers/control-freec:11.6b--hde5307d_3'}"
 
     input:
     tuple val(meta), path(ratio), path(baf)


### PR DESCRIPTION
hde5307d_3 fixes the SeekSubclones.cpp segfault in controlfreec (see bioconda/bioconda-recipes#63245)


  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
