### PR TITLE
Add new module: pridepy/downloadfile

### DIFF
--- a/modules/nf-core/pridepy/downloadfile/environment.yml
+++ b/modules/nf-core/pridepy/downloadfile/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::pridepy=0.0.15"

--- a/modules/nf-core/pridepy/downloadfile/main.nf
+++ b/modules/nf-core/pridepy/downloadfile/main.nf
@@ -1,0 +1,37 @@
+process PRIDEPY_DOWNLOADFILE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/pridepy:0.0.15--pyhdfd78af_0':
+        'quay.io/biocontainers/pridepy:0.0.15--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), val(file_name), val(pride_accession)
+
+    output:
+    tuple val(meta), path("${file_name}"), emit: file
+    tuple val("${task.process}"), val('pridepy'), eval('python -c "from importlib.metadata import version; print(version(\'pridepy\'))"'), topic: versions, emit: versions_pridepy
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    pridepy download-file-by-name \\
+        -a "${pride_accession}" \\
+        -f "${file_name}" \\
+        -o . \\
+        ${args}
+
+    # pridepy exits 0 even when the download fails, so fail explicitly on an empty file
+    [ -s "${file_name}" ] || { echo "ERROR: Downloaded file ${file_name} is empty" >&2; exit 1; }
+    """
+
+    stub:
+    """
+    touch "${file_name}"
+    """
+}

--- a/modules/nf-core/pridepy/downloadfile/meta.yml
+++ b/modules/nf-core/pridepy/downloadfile/meta.yml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "pridepy_downloadfile"
+description: Download a single file from the PRIDE Archive by name using pridepy.
+keywords:
+  - pride
+  - download
+  - proteomics
+  - mass spectrometry
+tools:
+  - "pridepy":
+      description: |
+        Python client library and command-line tool to access PRIDE Archive data
+        programmatically, including downloading files from public proteomics datasets.
+      homepage: "https://github.com/PRIDE-Archive/pridepy"
+      documentation: "https://github.com/PRIDE-Archive/pridepy"
+      tool_dev_url: "https://github.com/PRIDE-Archive/pridepy"
+      licence: ["Apache-2.0"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - file_name:
+        type: string
+        description: Name of the file to download from the PRIDE Archive dataset
+    - pride_accession:
+        type: string
+        description: PRIDE Archive project accession (e.g. PXD000001) identifying the dataset
+
+output:
+  file:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "${file_name}":
+          type: file
+          description: The file downloaded from the PRIDE Archive
+          pattern: "*"
+  versions_pridepy:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "pridepy":
+          type: string
+          description: The name of the tool
+      - 'python -c "from importlib.metadata import version; print(version(''pridepy''))"':
+          type: string
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pridepy:
+          type: string
+          description: The name of the tool
+      - 'python -c "from importlib.metadata import version; print(version(''pridepy''))"':
+          type: string
+          description: The expression to obtain the version of the tool
+authors:
+  - "@jonasscheid"
+maintainers:
+  - "@jonasscheid"

--- a/modules/nf-core/pridepy/downloadfile/tests/main.nf.test
+++ b/modules/nf-core/pridepy/downloadfile/tests/main.nf.test
@@ -1,0 +1,61 @@
+nextflow_process {
+
+    name "Test Process PRIDEPY_DOWNLOADFILE"
+    script "../main.nf"
+    process "PRIDEPY_DOWNLOADFILE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "pridepy"
+    tag "pridepy/downloadfile"
+
+    test("pride - PXD004684 - sdrf.tsv") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    'sdrf.tsv',
+                    'PXD004684'
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.file[0][1]).text.contains('Source Name') },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("pride - PXD004684 - sdrf.tsv - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    'sdrf.tsv',
+                    'PXD004684'
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/pridepy/downloadfile/tests/main.nf.test.snap
+++ b/modules/nf-core/pridepy/downloadfile/tests/main.nf.test.snap
@@ -1,0 +1,54 @@
+{
+    "pride - PXD004684 - sdrf.tsv - stub": {
+        "content": [
+            {
+                "file": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "sdrf.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_pridepy": [
+                    [
+                        "PRIDEPY_DOWNLOADFILE",
+                        "pridepy",
+                        "0.0.15"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-22T17:07:48.191545249",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "pride - PXD004684 - sdrf.tsv": {
+        "content": [
+            {
+                "file": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "sdrf.tsv:md5,a8a2aa91d85adb241110fe3a7ce8f372"
+                    ]
+                ],
+                "versions_pridepy": [
+                    [
+                        "PRIDEPY_DOWNLOADFILE",
+                        "pridepy",
+                        "0.0.15"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-05-22T17:07:37.525258608",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
## PR checklist

New module `pridepy/downloadfile` — downloads a single file from the PRIDE Archive by name using pridepy.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`