### PR TITLE
Improve resource usage in `glimpse2`

### DIFF
--- a/modules/nf-core/glimpse2/chunk/main.nf
+++ b/modules/nf-core/glimpse2/chunk/main.nf
@@ -1,6 +1,6 @@
 process GLIMPSE2_CHUNK {
     tag "${meta.id}"
-    label 'process_low'
+    label 'process_single'
 
     beforeScript """
         if cat /proc/cpuinfo | grep avx2 -q

--- a/modules/nf-core/glimpse2/ligate/tests/main.nf.test
+++ b/modules/nf-core/glimpse2/ligate/tests/main.nf.test
@@ -43,6 +43,7 @@ nextflow_process {
                     .combine(ref_panel)
                     .combine(map_file)
                 input[1] = channel.of([[],[],[]]).collect()
+                input[2] = []
                 """
                 }
             }

--- a/modules/nf-core/glimpse2/phase/main.nf
+++ b/modules/nf-core/glimpse2/phase/main.nf
@@ -20,9 +20,10 @@ process GLIMPSE2_PHASE {
     input:
     tuple val(meta), path(input, arity: '1..*'), path(input_index), path(bamlist), path(samples_file), val(input_region), val(output_region), path(reference), path(reference_index), path(map)
     tuple val(meta2), path(fasta_reference), path(fasta_reference_index)
+    val(output_suffix)
 
     output:
-    tuple val(meta), path("*.{vcf,vcf.gz,bcf,bgen}"), emit: phased_variants
+    tuple val(meta), path("*.{vcf,vcf.gz,bcf,bcf.gz,bgen}"), emit: phased_variants
     tuple val(meta), path("*.txt.gz"), emit: stats_coverage, optional: true
     tuple val("${task.process}"), val('glimpse2'), eval("GLIMPSE2_phase --help | grep -oE 'v[0-9.]+' | cut -c2-"), topic: versions, emit: versions_glimpse2
 
@@ -33,7 +34,10 @@ process GLIMPSE2_PHASE {
     def region = input_region ? "${output_region.replace(":", "_")}" : "${reference}"
     def args = task.ext.args ?: ""
     def prefix = task.ext.prefix ?: "${meta.id}_${region}"
-    def suffix = task.ext.suffix ?: "vcf.gz"
+    def suffix = output_suffix ?: "vcf.gz"
+    if (!(suffix in ["vcf", "vcf.gz", "bcf", "bcf.gz", "bgen"])) {
+        error("Output suffix must be one of vcf, vcf.gz, bcf, bcf.gz, bgen. Found: ${suffix}")
+    }
 
     def map_command = map ? "--map ${map}" : ""
     def samples_file_command = samples_file ? "--samples-file ${samples_file}" : ""
@@ -100,7 +104,10 @@ process GLIMPSE2_PHASE {
     stub:
     def region = input_region ? "${output_region.replace(":", "_")}" : "${reference}"
     def prefix = task.ext.prefix ?: "${meta.id}_${region}"
-    def suffix = task.ext.suffix ?: "vcf.gz"
+    def suffix = output_suffix ?: "vcf.gz"
+    if (!(suffix in ["vcf", "vcf.gz", "bcf", "bcf.gz", "bgen"])) {
+        error("Output suffix must be one of vcf, vcf.gz, bcf, bcf.gz, bgen. Found: ${suffix}")
+    }
     def create_cmd = suffix.endsWith(".gz") ? "echo | gzip > ${prefix}.${suffix}" : "touch ${prefix}.${suffix}"
     """
     ${create_cmd}

--- a/modules/nf-core/glimpse2/phase/main.nf
+++ b/modules/nf-core/glimpse2/phase/main.nf
@@ -1,6 +1,6 @@
 process GLIMPSE2_PHASE {
     tag "${meta.id}"
-    label 'process_medium'
+    label 'process_single'
 
     beforeScript """
     if cat /proc/cpuinfo | grep avx2 -q

--- a/modules/nf-core/glimpse2/phase/main.nf
+++ b/modules/nf-core/glimpse2/phase/main.nf
@@ -23,7 +23,7 @@ process GLIMPSE2_PHASE {
     val(output_suffix)
 
     output:
-    tuple val(meta), path("*.{vcf,vcf.gz,bcf,bcf.gz,bgen}"), emit: phased_variants
+    tuple val(meta), path("*.{vcf,vcf.gz,bcf,bgen}"), emit: phased_variants
     tuple val(meta), path("*.txt.gz"), emit: stats_coverage, optional: true
     tuple val("${task.process}"), val('glimpse2'), eval("GLIMPSE2_phase --help | grep -oE 'v[0-9.]+' | cut -c2-"), topic: versions, emit: versions_glimpse2
 
@@ -35,8 +35,8 @@ process GLIMPSE2_PHASE {
     def args = task.ext.args ?: ""
     def prefix = task.ext.prefix ?: "${meta.id}_${region}"
     def suffix = output_suffix ?: "vcf.gz"
-    if (!(suffix in ["vcf", "vcf.gz", "bcf", "bcf.gz", "bgen"])) {
-        error("Output suffix must be one of vcf, vcf.gz, bcf, bcf.gz, bgen. Found: ${suffix}")
+    if (!(suffix in ["vcf", "vcf.gz", "bcf", "bgen"])) {
+        error("Output suffix must be one of vcf, vcf.gz, bcf, bgen. Found: ${suffix}")
     }
 
     def map_command = map ? "--map ${map}" : ""
@@ -105,8 +105,8 @@ process GLIMPSE2_PHASE {
     def region = input_region ? "${output_region.replace(":", "_")}" : "${reference}"
     def prefix = task.ext.prefix ?: "${meta.id}_${region}"
     def suffix = output_suffix ?: "vcf.gz"
-    if (!(suffix in ["vcf", "vcf.gz", "bcf", "bcf.gz", "bgen"])) {
-        error("Output suffix must be one of vcf, vcf.gz, bcf, bcf.gz, bgen. Found: ${suffix}")
+    if (!(suffix in ["vcf", "vcf.gz", "bcf", "bgen"])) {
+        error("Output suffix must be one of vcf, vcf.gz, bcf, bgen. Found: ${suffix}")
     }
     def create_cmd = suffix.endsWith(".gz") ? "echo | gzip > ${prefix}.${suffix}" : "touch ${prefix}.${suffix}"
     """

--- a/modules/nf-core/glimpse2/phase/meta.yml
+++ b/modules/nf-core/glimpse2/phase/meta.yml
@@ -101,6 +101,11 @@ input:
           Necessary for CRAM files.
         pattern: "*.fai"
         ontologies: []
+  - output_suffix:
+        type: string
+        description: |
+          Output file suffix used to choose the GLIMPSE2 output format. Defaults to `vcf.gz` when empty. Supported values: `vcf`, `vcf.gz`, `bcf`, `bcf.gz`, `bgen`.
+        pattern: "vcf|vcf.gz|bcf|bcf.gz|bgen"
 output:
   phased_variants:
     - - meta:
@@ -108,11 +113,11 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'test', single_end:false ]`
-      - "*.{vcf,vcf.gz,bcf,bgen}":
+      - "*.{vcf,vcf.gz,bcf,bcf.gz,bgen}":
           type: file
           description: |
-            Output VCF/BCF file containing genotype probabilities (GP field), imputed dosages (DS field), best guess genotypes (GT field), sampled haplotypes in the last (max 16) main iterations (HS field) and info-score.
-          pattern: "*.{vcf,bcf,vcf.gz,bcf.gz}"
+            Output VCF/BCF/BGEN file containing genotype probabilities (GP field), imputed dosages (DS field), best guess genotypes (GT field), sampled haplotypes in the last (max 16) main iterations (HS field) and info-score.
+          pattern: "*.{vcf,vcf.gz,bcf,bcf.gz,bgen}"
           ontologies: []
   stats_coverage:
     - - meta:

--- a/modules/nf-core/glimpse2/phase/meta.yml
+++ b/modules/nf-core/glimpse2/phase/meta.yml
@@ -104,8 +104,8 @@ input:
   - output_suffix:
         type: string
         description: |
-          Output file suffix used to choose the GLIMPSE2 output format. Defaults to `vcf.gz` when empty. Supported values: `vcf`, `vcf.gz`, `bcf`, `bcf.gz`, `bgen`.
-        pattern: "vcf|vcf.gz|bcf|bcf.gz|bgen"
+          Output file suffix used to choose the GLIMPSE2 output format. Defaults to `vcf.gz` when empty. Supported values: `vcf`, `vcf.gz`, `bcf`, `bgen`.
+        pattern: "vcf|vcf.gz|bcf|bgen"
 output:
   phased_variants:
     - - meta:
@@ -113,11 +113,11 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'test', single_end:false ]`
-      - "*.{vcf,vcf.gz,bcf,bcf.gz,bgen}":
+      - "*.{vcf,vcf.gz,bcf,bgen}":
           type: file
           description: |
             Output VCF/BCF/BGEN file containing genotype probabilities (GP field), imputed dosages (DS field), best guess genotypes (GT field), sampled haplotypes in the last (max 16) main iterations (HS field) and info-score.
-          pattern: "*.{vcf,vcf.gz,bcf,bcf.gz,bgen}"
+          pattern: "*.{vcf,vcf.gz,bcf,bgen}"
           ontologies: []
   stats_coverage:
     - - meta:

--- a/modules/nf-core/glimpse2/phase/tests/main.nf.test
+++ b/modules/nf-core/glimpse2/phase/tests/main.nf.test
@@ -352,7 +352,7 @@ nextflow_process {
         }
     }
 
-    test("homo_sapiens - vcf region - panel - bcf.gz output -- stub") {
+    test("homo_sapiens - vcf region - panel - bcf output -- stub") {
         options "-stub"
         when {
             process {
@@ -370,7 +370,7 @@ nextflow_process {
                 // [meta, vcf, index, sample_infos, regionin, regionout,ref, index, map] [meta, fasta, fai]
                 input[0] = input_vcf
                 input[1] = channel.of([[],[],[]])
-                input[2] = "bcf.gz"
+                input[2] = "bcf"
                 """
             }
         }

--- a/modules/nf-core/glimpse2/phase/tests/main.nf.test
+++ b/modules/nf-core/glimpse2/phase/tests/main.nf.test
@@ -38,6 +38,7 @@ nextflow_process {
                     .combine(ref_panel)
                     .combine(map_file)
                 input[1] = channel.of([[],[],[]])
+                input[2] = []
                 """
             }
         }
@@ -83,6 +84,7 @@ nextflow_process {
                     .combine(ref_panel)
                     .combine(map_file)
                 input[1] = channel.of([[],[],[]])
+                input[2] = []
                 """
             }
         }
@@ -155,6 +157,7 @@ nextflow_process {
                     .combine(ref_panel)
                     .combine(map_file)
                 input[1] = reference_genome
+                input[2] = []
                 """
                 }
         }
@@ -204,6 +207,7 @@ nextflow_process {
                     .combine(ref_panel)
                     .combine(map_file)
                 input[1] = channel.of([[],[],[]])
+                input[2] = []
                 """
                 }
         }
@@ -246,6 +250,7 @@ nextflow_process {
                 // [meta, vcf, index, sample_infos, regionin, regionout,ref, index, map] [meta, fasta, fai]
                 input[0] = input_bam
                 input[1] = channel.of([[],[],[]])
+                input[2] = []
                 """
                 }
         }
@@ -279,6 +284,7 @@ nextflow_process {
                 // [meta, vcf, index, sample_infos, regionin, regionout,ref, index, map] [meta, fasta, fai]
                 input[0] = input_bam
                 input[1] = channel.of([[],[],[]])
+                input[2] = []
                 """
                 }
         }
@@ -309,8 +315,8 @@ nextflow_process {
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/NA19401.chr21_22.1X.bam.bai", checkIfExists: true)
                     ],
                 ]).combine(bamlist)
-                .map{ map, bam, bai, bamlist -> [
-                    map, bam, bai, bamlist, [],
+                .map{ map, bam, bai, bamlist_file -> [
+                    map, bam, bai, bamlist_file, [],
                     "chr22:16600000-16800000",
                     "chr22:16650000-16750000",
                 ]}
@@ -326,6 +332,7 @@ nextflow_process {
                     .combine(ref_panel)
                     .combine(map_file)
                 input[1] = channel.of([[],[],[]])
+                input[2] = []
                 """
                 }
         }
@@ -345,7 +352,7 @@ nextflow_process {
         }
     }
 
-    test("homo_sapiens - vcf region - panel -- stub") {
+    test("homo_sapiens - vcf region - panel - bcf.gz output -- stub") {
         options "-stub"
         when {
             process {
@@ -363,6 +370,7 @@ nextflow_process {
                 // [meta, vcf, index, sample_infos, regionin, regionout,ref, index, map] [meta, fasta, fai]
                 input[0] = input_vcf
                 input[1] = channel.of([[],[],[]])
+                input[2] = "bcf.gz"
                 """
             }
         }

--- a/modules/nf-core/glimpse2/phase/tests/main.nf.test
+++ b/modules/nf-core/glimpse2/phase/tests/main.nf.test
@@ -315,8 +315,8 @@ nextflow_process {
                         file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/NA19401.chr21_22.1X.bam.bai", checkIfExists: true)
                     ],
                 ]).combine(bamlist)
-                .map{ map, bam, bai, bamlist_file -> [
-                    map, bam, bai, bamlist_file, [],
+                .map{ map, bam, bai, bamlist -> [
+                    map, bam, bai, bamlist, [],
                     "chr22:16600000-16800000",
                     "chr22:16650000-16750000",
                 ]}

--- a/modules/nf-core/glimpse2/phase/tests/main.nf.test.snap
+++ b/modules/nf-core/glimpse2/phase/tests/main.nf.test.snap
@@ -174,7 +174,7 @@
         },
         "timestamp": "2026-02-06T09:43:18.729861703"
     },
-    "homo_sapiens - vcf region - panel - bcf.gz output -- stub": {
+    "homo_sapiens - vcf region - panel - bcf output -- stub": {
         "content": [
             {
                 "phased_variants": [
@@ -182,7 +182,7 @@
                         {
                             "id": "input"
                         },
-                        "input_chr22_16650000-16750000.bcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "input_chr22_16650000-16750000.bcf:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "stats_coverage": [

--- a/modules/nf-core/glimpse2/phase/tests/main.nf.test.snap
+++ b/modules/nf-core/glimpse2/phase/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                     {
                         "id": "input"
                     },
-                    "input_chr22_16650000-16750000.vcf",
+                    "input_chr22_16650000-16750000.vcf.gz",
                     "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=266, phased=true, phasedAutodetect=false]",
                     "23026b2111d5b93194ebbb5de09d654d"
                 ]
@@ -42,7 +42,7 @@
                     {
                         "id": "input"
                     },
-                    "input_chr22_16650000-16750000.vcf",
+                    "input_chr22_16650000-16750000.vcf.gz",
                     "VcfFile [chromosomes=[chr22], sampleCount=2, variantCount=266, phased=true, phasedAutodetect=false]",
                     "f06d12e3c16a8edc313ad564836008"
                 ]
@@ -78,7 +78,7 @@
                     {
                         "id": "input"
                     },
-                    "input_chr22_16650000-16750000.vcf",
+                    "input_chr22_16650000-16750000.vcf.gz",
                     "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=266, phased=true, phasedAutodetect=false]",
                     "d8e9e1ec4d9d229536a23f2f69a469de"
                 ]
@@ -109,7 +109,7 @@
                     {
                         "id": "input"
                     },
-                    "input_chr22_16650000-16750000.vcf",
+                    "input_chr22_16650000-16750000.vcf.gz",
                     "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=266, phased=true, phasedAutodetect=false]",
                     "d8e9e1ec4d9d229536a23f2f69a469de"
                 ]
@@ -145,7 +145,7 @@
                     {
                         "id": "input"
                     },
-                    "input_chr22_16650000-16750000.vcf",
+                    "input_chr22_16650000-16750000.vcf.gz",
                     "VcfFile [chromosomes=[chr22], sampleCount=2, variantCount=266, phased=true, phasedAutodetect=false]",
                     "f2aff70c52df2f69d9bc1f4bf63fcb5c"
                 ]
@@ -174,7 +174,7 @@
         },
         "timestamp": "2026-02-06T09:43:18.729861703"
     },
-    "homo_sapiens - vcf region - panel -- stub": {
+    "homo_sapiens - vcf region - panel - bcf.gz output -- stub": {
         "content": [
             {
                 "phased_variants": [
@@ -182,7 +182,7 @@
                         {
                             "id": "input"
                         },
-                        "input_chr22_16650000-16750000.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "input_chr22_16650000-16750000.bcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "stats_coverage": [

--- a/modules/nf-core/glimpse2/phase/tests/nextflow.config
+++ b/modules/nf-core/glimpse2/phase/tests/nextflow.config
@@ -2,7 +2,6 @@ process {
     withName: GLIMPSE2_PHASE {
         cpus       = 1 // needed for deterministic output
         ext.args   = "--seed 1"
-        ext.suffix = "vcf"
     }
     withName: SAMTOOLS_VIEW {
         ext.args  = "--output-fmt cram"

--- a/subworkflows/nf-core/bam_vcf_impute_glimpse2/main.nf
+++ b/subworkflows/nf-core/bam_vcf_impute_glimpse2/main.nf
@@ -111,7 +111,7 @@ workflow BAM_VCF_IMPUTE_GLIMPSE2 {
         }
 
     // Impute with Glimpse2
-    GLIMPSE2_PHASE(ch_phase_input, ch_fasta, [])
+    GLIMPSE2_PHASE(ch_phase_input, ch_fasta, "bcf")
 
     // Index phased file
     BCFTOOLS_INDEX_PHASE(GLIMPSE2_PHASE.out.phased_variants)

--- a/subworkflows/nf-core/bam_vcf_impute_glimpse2/main.nf
+++ b/subworkflows/nf-core/bam_vcf_impute_glimpse2/main.nf
@@ -111,7 +111,7 @@ workflow BAM_VCF_IMPUTE_GLIMPSE2 {
         }
 
     // Impute with Glimpse2
-    GLIMPSE2_PHASE(ch_phase_input, ch_fasta)
+    GLIMPSE2_PHASE(ch_phase_input, ch_fasta, [])
 
     // Index phased file
     BCFTOOLS_INDEX_PHASE(GLIMPSE2_PHASE.out.phased_variants)


### PR DESCRIPTION
The `test_full` of phaseimpute show that these two modules receive a lot of unnecessary resources:
- `GLIMPSE2_CHUNK` shows only ~200–400 MB of RAM used and moderate CPU utilisation. 
- `GLIMPSE_PHASE` the job peaks at only one or two cores with <1 GB RAM.
Therefore, I am updating the labels to `process_single`. 

Additionally, the subworkflow `BAM_VCF_IMPUTE_GLIMPSE2` is improved by using BCF intermediate outputs. The ligation process uses less resources if the input files are BCF: 
- With `vcf.gz` `GLIMPSE2_LIGATE` used 301.2 MB peak RSS, 527.3 MB peak vmem, duration 1.6s.
- With `bcf` `GLIMPSE2_LIGATE` used 13.3 MB peak RSS, 23.3 MB peak vmem, duration 626ms.

Also, this fixes a linting error: "Invalid 'ext' keys detected: ext.suffix ".