### PR TITLE
Add Zarr support to scanpy/filter

### DIFF
--- a/modules/nf-core/scanpy/filter/environment.yml
+++ b/modules/nf-core/scanpy/filter/environment.yml
@@ -6,4 +6,4 @@ channels:
 dependencies:
   - conda-forge::python=3.12.11
   - conda-forge::pyyaml=6.0.2
-  - conda-forge::scanpy=1.11.2
+  - conda-forge::scanpy=1.11.4

--- a/modules/nf-core/scanpy/filter/environment.yml
+++ b/modules/nf-core/scanpy/filter/environment.yml
@@ -4,6 +4,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::python=3.12.11
+  - conda-forge::python=3.14
   - conda-forge::pyyaml=6.0.2
   - conda-forge::scanpy=1.11.4

--- a/modules/nf-core/scanpy/filter/environment.yml
+++ b/modules/nf-core/scanpy/filter/environment.yml
@@ -4,6 +4,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::python=3.14
+  - conda-forge::python=3.14.5
   - conda-forge::pyyaml=6.0.2
   - conda-forge::scanpy=1.11.4

--- a/modules/nf-core/scanpy/filter/main.nf
+++ b/modules/nf-core/scanpy/filter/main.nf
@@ -4,8 +4,8 @@ process SCANPY_FILTER {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/16/168ecbbe27ccef766741ccbf937b0d2675be2e19b0565035e0719f1e9ea5ee95/data'
-        : 'community.wave.seqera.io/library/python_pyyaml_scanpy:b5509a698e9aae25'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/bd/bd4462356828eb975a9ae0a3073ec720d19f4918106b696e3c298a556f288480/data'
+        : 'community.wave.seqera.io/library/python_pyyaml_scanpy:ffeb5af98a9a5bde'}"
 
     input:
     tuple val(meta), path(h5ad)
@@ -17,22 +17,25 @@ process SCANPY_FILTER {
     val symbol_col
 
     output:
-    tuple val(meta), path("*.h5ad"), emit: h5ad
-    path "versions.yml"            , emit: versions
+    tuple val(meta), path("*.h5ad"), optional: true, emit: h5ad
+    path "versions.yml"            , emit: versions, topic: versions
+    tuple val(meta), path("*.zarr"), optional: true, emit: zarr
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     prefix     = task.ext.prefix ?: "${meta.id}_filtered"
-    if ("${prefix}.h5ad" == "${h5ad}") {
+    output_file = h5ad.name.endsWith(".zarr") ? "${prefix}.zarr" : "${prefix}.h5ad"
+    if (output_file == h5ad.name) {
         error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
     }
     template('filter.py')
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}_filtered"
-    if ("${prefix}.h5ad" == "${h5ad}") {
+    output_file = h5ad.name.endsWith(".zarr") ? "${prefix}.zarr" : "${prefix}.h5ad"
+    if (output_file == h5ad.name) {
         error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
     }
     """
@@ -41,7 +44,11 @@ process SCANPY_FILTER {
     export MPLCONFIGDIR=./tmp/mpl
     export NUMBA_CACHE_DIR=./tmp/numba
 
-    touch ${prefix}.h5ad
+    if [[ "${output_file}" == *.zarr ]]; then
+        mkdir -p "${output_file}"
+    else
+        touch "${output_file}"
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/scanpy/filter/main.nf
+++ b/modules/nf-core/scanpy/filter/main.nf
@@ -4,11 +4,11 @@ process SCANPY_FILTER {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/bd/bd4462356828eb975a9ae0a3073ec720d19f4918106b696e3c298a556f288480/data'
-        : 'community.wave.seqera.io/library/python_pyyaml_scanpy:ffeb5af98a9a5bde'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/81/8158c8824afb7a57da5327fbd188082d24d205e078103ca249d74e93cc1cd603/data'
+        : 'community.wave.seqera.io/library/python_pyyaml_scanpy:da8fc259e2b95ada'}"
 
     input:
-    tuple val(meta), path(h5ad)
+    tuple val(meta), path(anndata)
     val min_genes
     val min_cells
     val min_counts_gene
@@ -18,24 +18,24 @@ process SCANPY_FILTER {
 
     output:
     tuple val(meta), path("*.h5ad"), optional: true, emit: h5ad
-    path "versions.yml"            , emit: versions, topic: versions
     tuple val(meta), path("*.zarr"), optional: true, emit: zarr
+    path "versions.yml"            , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     prefix     = task.ext.prefix ?: "${meta.id}_filtered"
-    output_file = h5ad.name.endsWith(".zarr") ? "${prefix}.zarr" : "${prefix}.h5ad"
-    if (output_file == h5ad.name) {
+    output_file = anndata.name.endsWith(".zarr") ? "${prefix}.zarr" : "${prefix}.h5ad"
+    if (output_file == anndata.name) {
         error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
     }
     template('filter.py')
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}_filtered"
-    output_file = h5ad.name.endsWith(".zarr") ? "${prefix}.zarr" : "${prefix}.h5ad"
-    if (output_file == h5ad.name) {
+    output_file = anndata.name.endsWith(".zarr") ? "${prefix}.zarr" : "${prefix}.h5ad"
+    if (output_file == anndata.name) {
         error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
     }
     """

--- a/modules/nf-core/scanpy/filter/main.nf
+++ b/modules/nf-core/scanpy/filter/main.nf
@@ -18,7 +18,7 @@ process SCANPY_FILTER {
 
     output:
     tuple val(meta), path("*.{h5ad,zarr}"), emit: anndata
-    path "versions.yml"                     , emit: versions, topic: versions
+    path "versions.yml"                   , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/scanpy/filter/main.nf
+++ b/modules/nf-core/scanpy/filter/main.nf
@@ -17,9 +17,8 @@ process SCANPY_FILTER {
     val symbol_col
 
     output:
-    tuple val(meta), path("*.h5ad"), optional: true, emit: h5ad
-    tuple val(meta), path("*.zarr"), optional: true, emit: zarr
-    path "versions.yml"            , emit: versions, topic: versions
+    tuple val(meta), path("*.{h5ad,zarr}"), emit: anndata
+    path "versions.yml"                     , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/scanpy/filter/meta.yml
+++ b/modules/nf-core/scanpy/filter/meta.yml
@@ -51,29 +51,18 @@ input:
       description: Column name of the gene symbols in the `var` of the AnnData
         object. Use `index` if the gene symbols are the row names.
 output:
-  h5ad:
+  anndata:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
-      - "*.h5ad":
+      - "*.{h5ad,zarr}":
           type: file
-          description: Filtered AnnData object
-          pattern: "*.h5ad"
+          description: Filtered AnnData object in h5ad or zarr format
+          pattern: "*.{h5ad,zarr}"
           ontologies:
             - edam: "http://edamontology.org/format_3590"
-  zarr:
-    - - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test' ]
-      - "*.zarr":
-          type: directory
-          description: Filtered AnnData object
-          pattern: "*.zarr"
-          ontologies:
             - edam: "http://edamontology.org/format_3915"
   versions:
     - versions.yml:

--- a/modules/nf-core/scanpy/filter/meta.yml
+++ b/modules/nf-core/scanpy/filter/meta.yml
@@ -15,71 +15,81 @@ tools:
       documentation: https://scanpy.readthedocs.io/en/stable/api/generated/scanpy.pp.filter_cells.html
       tool_dev_url: https://github.com/scverse/scanpy
       doi: 10.1186/s13059-017-1382-0
-      licence: ["BSD-3-Clause"]
-
+      licence:
+        - "BSD-3-Clause"
+      identifier: biotools:scanpy
 input:
   - - meta:
         type: map
         description: |
           Groovy Map containing sample information
           e.g. [ id:'test' ]
-    - h5ad:
+    - anndata:
         type: file
         description: AnnData object in h5ad or zarr format
         pattern: "*.{h5ad,zarr}"
         ontologies:
-          - edam: "http://edamontology.org/format_3590" # HDF5 format
-          - edam: "http://edamontology.org/format_3915" # Zarr format
-  - - min_genes:
-        type: integer
-        description: Minimum number of genes expressed per cell
-  - - min_cells:
-        type: integer
-        description: Minimum number of cells expressing each gene
-  - - min_counts_gene:
-        type: integer
-        description: Minimum number of counts per gene
-  - - min_counts_cell:
-        type: integer
-        description: Minimum number of counts per cell
-  - - max_mito_percentage:
-        type: integer
-        description: Maximum percentage of mitochondrial genes per cell
-  - - symbol_col:
-        type: string
-        description: Column name of the gene symbols in the `var` of the AnnData object. Use `index` if the gene symbols are the row names.
-
+          - edam: "http://edamontology.org/format_3590"
+          - edam: "http://edamontology.org/format_3915"
+  - min_genes:
+      type: integer
+      description: Minimum number of genes expressed per cell
+  - min_cells:
+      type: integer
+      description: Minimum number of cells expressing each gene
+  - min_counts_gene:
+      type: integer
+      description: Minimum number of counts per gene
+  - min_counts_cell:
+      type: integer
+      description: Minimum number of counts per cell
+  - max_mito_percentage:
+      type: integer
+      description: Maximum percentage of mitochondrial genes per cell
+  - symbol_col:
+      type: string
+      description: Column name of the gene symbols in the `var` of the AnnData
+        object. Use `index` if the gene symbols are the row names.
 output:
   h5ad:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test' ]
-    - "*.h5ad":
-        type: file
-        description: Filtered AnnData object
-        pattern: "*.h5ad"
-        ontologies:
-          - edam: "http://edamontology.org/format_3590" # HDF5 format
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.h5ad":
+          type: file
+          description: Filtered AnnData object
+          pattern: "*.h5ad"
+          ontologies:
+            - edam: "http://edamontology.org/format_3590"
+  zarr:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.zarr":
+          type: directory
+          description: Filtered AnnData object
+          pattern: "*.zarr"
+          ontologies:
+            - edam: "http://edamontology.org/format_3915"
   versions:
     - versions.yml:
         type: file
         description: File containing software versions
         pattern: "versions.yml"
-  zarr:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test' ]
-    - "*.zarr":
-        type: directory
-        description: Filtered AnnData object
-        pattern: "*.zarr"
         ontologies:
-          - edam: "http://edamontology.org/format_3915" # Zarr format
-
+          - edam: http://edamontology.org/format_3750
+topics:
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750
 authors:
   - "@nictru"
 maintainers:

--- a/modules/nf-core/scanpy/filter/meta.yml
+++ b/modules/nf-core/scanpy/filter/meta.yml
@@ -25,10 +25,11 @@ input:
           e.g. [ id:'test' ]
     - h5ad:
         type: file
-        description: AnnData object in h5ad format
-        pattern: "*.{h5ad}"
+        description: AnnData object in h5ad or zarr format
+        pattern: "*.{h5ad,zarr}"
         ontologies:
           - edam: "http://edamontology.org/format_3590" # HDF5 format
+          - edam: "http://edamontology.org/format_3915" # Zarr format
   - - min_genes:
         type: integer
         description: Minimum number of genes expressed per cell
@@ -66,6 +67,18 @@ output:
         type: file
         description: File containing software versions
         pattern: "versions.yml"
+  zarr:
+    - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - "*.zarr":
+        type: directory
+        description: Filtered AnnData object
+        pattern: "*.zarr"
+        ontologies:
+          - edam: "http://edamontology.org/format_3915" # Zarr format
 
 authors:
   - "@nictru"

--- a/modules/nf-core/scanpy/filter/templates/filter.py
+++ b/modules/nf-core/scanpy/filter/templates/filter.py
@@ -21,13 +21,13 @@ sc.settings.n_jobs = int("${task.cpus}")
 input_file = "${anndata}"
 output_file = "${output_file}"
 
-match Path(input_file).suffix:
-    case ".h5ad":
-        adata = ad.read_h5ad(input_file)
-    case ".zarr":
-        adata = ad.read_zarr(input_file)
-    case other:
-        raise ValueError(f"Unsupported AnnData input format: {other}")
+input_suffix = Path(input_file).suffix
+if input_suffix == ".h5ad":
+    adata = ad.read_h5ad(input_file)
+elif input_suffix == ".zarr":
+    adata = ad.read_zarr(input_file)
+else:
+    raise ValueError(f"Unsupported AnnData input format: {input_suffix}")
 
 prefix = "${prefix}"
 symbol_col = "${symbol_col}"
@@ -48,13 +48,13 @@ sc.pp.filter_genes(adata, min_counts=int("${min_counts_gene}"))
 sc.pp.filter_cells(adata, min_genes=int("${min_genes}"))
 sc.pp.filter_genes(adata, min_cells=int("${min_cells}"))
 
-match Path(output_file).suffix:
-    case ".h5ad":
-        adata.write_h5ad(output_file)
-    case ".zarr":
-        adata.write_zarr(output_file)
-    case other:
-        raise ValueError(f"Unsupported AnnData output format: {other}")
+output_suffix = Path(output_file).suffix
+if output_suffix == ".h5ad":
+    adata.write_h5ad(output_file)
+elif output_suffix == ".zarr":
+    adata.write_zarr(output_file)
+else:
+    raise ValueError(f"Unsupported AnnData output format: {output_suffix}")
 
 # Versions
 

--- a/modules/nf-core/scanpy/filter/templates/filter.py
+++ b/modules/nf-core/scanpy/filter/templates/filter.py
@@ -8,6 +8,7 @@ os.environ["MPLCONFIGDIR"] = "./tmp/mpl"
 os.environ["NUMBA_CACHE_DIR"] = "./tmp/numba"
 
 import platform
+from pathlib import Path
 
 import anndata as ad
 import scanpy as sc
@@ -20,13 +21,13 @@ sc.settings.n_jobs = int("${task.cpus}")
 input_file = "${anndata}"
 output_file = "${output_file}"
 
-match input_file:
-    case _ if input_file.endswith(".h5ad"):
+match Path(input_file).suffix:
+    case ".h5ad":
         adata = ad.read_h5ad(input_file)
-    case _ if input_file.endswith(".zarr"):
+    case ".zarr":
         adata = ad.read_zarr(input_file)
-    case _:
-        raise ValueError(f"Unsupported AnnData input format: {input_file}")
+    case other:
+        raise ValueError(f"Unsupported AnnData input format: {other}")
 
 prefix = "${prefix}"
 symbol_col = "${symbol_col}"
@@ -47,13 +48,13 @@ sc.pp.filter_genes(adata, min_counts=int("${min_counts_gene}"))
 sc.pp.filter_cells(adata, min_genes=int("${min_genes}"))
 sc.pp.filter_genes(adata, min_cells=int("${min_cells}"))
 
-match output_file:
-    case _ if output_file.endswith(".h5ad"):
+match Path(output_file).suffix:
+    case ".h5ad":
         adata.write_h5ad(output_file)
-    case _ if output_file.endswith(".zarr"):
+    case ".zarr":
         adata.write_zarr(output_file)
-    case _:
-        raise ValueError(f"Unsupported AnnData output format: {output_file}")
+    case other:
+        raise ValueError(f"Unsupported AnnData output format: {other}")
 
 # Versions
 

--- a/modules/nf-core/scanpy/filter/templates/filter.py
+++ b/modules/nf-core/scanpy/filter/templates/filter.py
@@ -17,9 +17,17 @@ from threadpoolctl import threadpool_limits
 threadpool_limits(int("${task.cpus}"))
 sc.settings.n_jobs = int("${task.cpus}")
 
-input_file = "${h5ad}"
+input_file = "${anndata}"
 output_file = "${output_file}"
-adata = ad.read_zarr(input_file) if input_file.endswith(".zarr") else sc.read_h5ad(input_file)
+
+match input_file:
+    case _ if input_file.endswith(".h5ad"):
+        adata = ad.read_h5ad(input_file)
+    case _ if input_file.endswith(".zarr"):
+        adata = ad.read_zarr(input_file)
+    case _:
+        raise ValueError(f"Unsupported AnnData input format: {input_file}")
+
 prefix = "${prefix}"
 symbol_col = "${symbol_col}"
 
@@ -39,10 +47,13 @@ sc.pp.filter_genes(adata, min_counts=int("${min_counts_gene}"))
 sc.pp.filter_cells(adata, min_genes=int("${min_genes}"))
 sc.pp.filter_genes(adata, min_cells=int("${min_cells}"))
 
-if output_file.endswith(".zarr"):
-    adata.write_zarr(output_file)
-else:
-    adata.write_h5ad(output_file)
+match output_file:
+    case _ if output_file.endswith(".h5ad"):
+        adata.write_h5ad(output_file)
+    case _ if output_file.endswith(".zarr"):
+        adata.write_zarr(output_file)
+    case _:
+        raise ValueError(f"Unsupported AnnData output format: {output_file}")
 
 # Versions
 

--- a/modules/nf-core/scanpy/filter/templates/filter.py
+++ b/modules/nf-core/scanpy/filter/templates/filter.py
@@ -9,6 +9,7 @@ os.environ["NUMBA_CACHE_DIR"] = "./tmp/numba"
 
 import platform
 
+import anndata as ad
 import scanpy as sc
 import yaml
 from threadpoolctl import threadpool_limits
@@ -16,7 +17,9 @@ from threadpoolctl import threadpool_limits
 threadpool_limits(int("${task.cpus}"))
 sc.settings.n_jobs = int("${task.cpus}")
 
-adata = sc.read_h5ad("${h5ad}")
+input_file = "${h5ad}"
+output_file = "${output_file}"
+adata = ad.read_zarr(input_file) if input_file.endswith(".zarr") else sc.read_h5ad(input_file)
 prefix = "${prefix}"
 symbol_col = "${symbol_col}"
 
@@ -36,7 +39,10 @@ sc.pp.filter_genes(adata, min_counts=int("${min_counts_gene}"))
 sc.pp.filter_cells(adata, min_genes=int("${min_genes}"))
 sc.pp.filter_genes(adata, min_cells=int("${min_cells}"))
 
-adata.write_h5ad(f"{prefix}.h5ad")
+if output_file.endswith(".zarr"):
+    adata.write_zarr(output_file)
+else:
+    adata.write_h5ad(output_file)
 
 # Versions
 

--- a/modules/nf-core/scanpy/filter/tests/main.nf.test
+++ b/modules/nf-core/scanpy/filter/tests/main.nf.test
@@ -8,6 +8,92 @@ nextflow_process {
     tag "modules_nfcore"
     tag "scanpy"
     tag "scanpy/filter"
+    tag "untar"
+
+    test("Should emit zarr output for zarr input - stub") {
+
+        options '-stub'
+
+        setup {
+            run("UNTAR") {
+                config "./nextflow.config"
+                script "modules/nf-core/untar/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: 'test_zarr' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/zarr/test_zarr.zarr.tar.gz', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = UNTAR.out.untar.map { meta, zarr -> [ meta, zarr ] }
+                input[1] = 0
+                input[2] = 0
+                input[3] = 0
+                input[4] = 0
+                input[5] = 100
+                input[6] = 'index'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert process.out.zarr },
+            { assert file(process.out.zarr[0][1]).name == "test_zarr_filtered.zarr" }
+            )
+        }
+
+    }
+
+    test("Should run with zarr input") {
+
+        setup {
+            run("UNTAR") {
+                config "./nextflow.config"
+                script "modules/nf-core/untar/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id: 'test_zarr' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/scrnaseq/zarr/test_zarr.zarr.tar.gz', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = UNTAR.out.untar.map { meta, zarr -> [ meta, zarr ] }
+                input[1] = 0
+                input[2] = 0
+                input[3] = 0
+                input[4] = 0
+                input[5] = 100
+                input[6] = 'index'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert process.out.zarr },
+            { assert file(process.out.zarr[0][1]).name == "test_zarr_filtered.zarr" },
+            { assert file(process.out.zarr[0][1] + "/X/.zarray").exists() }
+            )
+        }
+
+    }
 
     test("Should run without failures") {
 

--- a/modules/nf-core/scanpy/filter/tests/main.nf.test
+++ b/modules/nf-core/scanpy/filter/tests/main.nf.test
@@ -46,8 +46,8 @@ nextflow_process {
         then {
             assertAll(
             { assert process.success },
-            { assert process.out.zarr },
-            { assert file(process.out.zarr[0][1]).name == "test_zarr_filtered.zarr" }
+            { assert process.out.anndata },
+            { assert file(process.out.anndata[0][1]).name == "test_zarr_filtered.zarr" }
             )
         }
 
@@ -87,9 +87,9 @@ nextflow_process {
         then {
             assertAll(
             { assert process.success },
-            { assert process.out.zarr },
-            { assert file(process.out.zarr[0][1]).name == "test_zarr_filtered.zarr" },
-            { assert file(process.out.zarr[0][1] + "/X/.zarray").exists() }
+            { assert process.out.anndata },
+            { assert file(process.out.anndata[0][1]).name == "test_zarr_filtered.zarr" },
+            { assert file(process.out.anndata[0][1] + "/X/.zarray").exists() }
             )
         }
 

--- a/modules/nf-core/scanpy/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/scanpy/filter/tests/main.nf.test.snap
@@ -11,10 +11,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,dae731033657c4bfd6d6b4fd8b226d89"
+
                 ],
                 "2": [
-
+                    "versions.yml:md5,ec563c0ab47a2c5035c8c1c85b9ae747"
                 ],
                 "h5ad": [
                     [
@@ -25,7 +25,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,dae731033657c4bfd6d6b4fd8b226d89"
+                    "versions.yml:md5,ec563c0ab47a2c5035c8c1c85b9ae747"
                 ],
                 "zarr": [
 
@@ -33,12 +33,12 @@
             },
             {
                 "SCANPY_FILTER": {
-                    "python": "3.12.11",
+                    "python": "3.14.5",
                     "scanpy": "1.11.4"
                 }
             }
         ],
-        "timestamp": "2026-05-24T21:24:19.783236",
+        "timestamp": "2026-05-25T11:37:58.067267",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -56,10 +56,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,cfc7cd776066a7c0a30603ddfe059923"
+
                 ],
                 "2": [
-
+                    "versions.yml:md5,c46264bf776aef9ae27fcff871c8f97e"
                 ],
                 "h5ad": [
                     [
@@ -70,7 +70,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,cfc7cd776066a7c0a30603ddfe059923"
+                    "versions.yml:md5,c46264bf776aef9ae27fcff871c8f97e"
                 ],
                 "zarr": [
 
@@ -78,12 +78,12 @@
             },
             {
                 "SCANPY_FILTER": {
-                    "python": "3.12.11",
+                    "python": "3.14.5",
                     "scanpy": "1.11.4"
                 }
             }
         ],
-        "timestamp": "2026-05-24T21:24:31.446031",
+        "timestamp": "2026-05-25T11:40:38.430505",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -101,10 +101,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,dae731033657c4bfd6d6b4fd8b226d89"
+
                 ],
                 "2": [
-
+                    "versions.yml:md5,ec563c0ab47a2c5035c8c1c85b9ae747"
                 ],
                 "h5ad": [
                     [
@@ -115,7 +115,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,dae731033657c4bfd6d6b4fd8b226d89"
+                    "versions.yml:md5,ec563c0ab47a2c5035c8c1c85b9ae747"
                 ],
                 "zarr": [
 
@@ -123,12 +123,12 @@
             },
             {
                 "SCANPY_FILTER": {
-                    "python": "3.12.11",
+                    "python": "3.14.5",
                     "scanpy": "1.11.4"
                 }
             }
         ],
-        "timestamp": "2026-05-24T21:24:11.273634",
+        "timestamp": "2026-05-25T11:35:08.637978",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/modules/nf-core/scanpy/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/scanpy/filter/tests/main.nf.test.snap
@@ -11,7 +11,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,a2e4b6b01deba3f07dce478c56acb14d"
+                    "versions.yml:md5,dae731033657c4bfd6d6b4fd8b226d89"
+                ],
+                "2": [
+
                 ],
                 "h5ad": [
                     [
@@ -22,21 +25,24 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a2e4b6b01deba3f07dce478c56acb14d"
+                    "versions.yml:md5,dae731033657c4bfd6d6b4fd8b226d89"
+                ],
+                "zarr": [
+
                 ]
             },
             {
                 "SCANPY_FILTER": {
                     "python": "3.12.11",
-                    "scanpy": "1.11.2"
+                    "scanpy": "1.11.4"
                 }
             }
         ],
+        "timestamp": "2026-05-24T21:24:19.783236",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
-        },
-        "timestamp": "2025-07-04T09:48:00.155846767"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
     "Should run without failures - stub": {
         "content": [
@@ -50,7 +56,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8bcc268104b7c43e2be4e678081d0596"
+                    "versions.yml:md5,cfc7cd776066a7c0a30603ddfe059923"
+                ],
+                "2": [
+
                 ],
                 "h5ad": [
                     [
@@ -61,21 +70,24 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,8bcc268104b7c43e2be4e678081d0596"
+                    "versions.yml:md5,cfc7cd776066a7c0a30603ddfe059923"
+                ],
+                "zarr": [
+
                 ]
             },
             {
                 "SCANPY_FILTER": {
                     "python": "3.12.11",
-                    "scanpy": "1.11.2"
+                    "scanpy": "1.11.4"
                 }
             }
         ],
+        "timestamp": "2026-05-24T21:24:31.446031",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
-        },
-        "timestamp": "2025-06-25T10:28:53.871079892"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     },
     "Should run without failures": {
         "content": [
@@ -89,7 +101,10 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,a2e4b6b01deba3f07dce478c56acb14d"
+                    "versions.yml:md5,dae731033657c4bfd6d6b4fd8b226d89"
+                ],
+                "2": [
+
                 ],
                 "h5ad": [
                     [
@@ -100,20 +115,23 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a2e4b6b01deba3f07dce478c56acb14d"
+                    "versions.yml:md5,dae731033657c4bfd6d6b4fd8b226d89"
+                ],
+                "zarr": [
+
                 ]
             },
             {
                 "SCANPY_FILTER": {
                     "python": "3.12.11",
-                    "scanpy": "1.11.2"
+                    "scanpy": "1.11.4"
                 }
             }
         ],
+        "timestamp": "2026-05-24T21:24:11.273634",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
-        },
-        "timestamp": "2025-07-04T09:47:51.215629629"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
     }
 }

--- a/modules/nf-core/scanpy/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/scanpy/filter/tests/main.nf.test.snap
@@ -11,12 +11,9 @@
                     ]
                 ],
                 "1": [
-
-                ],
-                "2": [
                     "versions.yml:md5,ec563c0ab47a2c5035c8c1c85b9ae747"
                 ],
-                "h5ad": [
+                "anndata": [
                     [
                         {
                             "id": "test"
@@ -26,9 +23,6 @@
                 ],
                 "versions": [
                     "versions.yml:md5,ec563c0ab47a2c5035c8c1c85b9ae747"
-                ],
-                "zarr": [
-
                 ]
             },
             {
@@ -38,7 +32,7 @@
                 }
             }
         ],
-        "timestamp": "2026-05-25T11:37:58.067267",
+        "timestamp": "2026-05-27T17:53:35.665579",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -56,12 +50,9 @@
                     ]
                 ],
                 "1": [
-
-                ],
-                "2": [
                     "versions.yml:md5,c46264bf776aef9ae27fcff871c8f97e"
                 ],
-                "h5ad": [
+                "anndata": [
                     [
                         {
                             "id": "test"
@@ -71,9 +62,6 @@
                 ],
                 "versions": [
                     "versions.yml:md5,c46264bf776aef9ae27fcff871c8f97e"
-                ],
-                "zarr": [
-
                 ]
             },
             {
@@ -83,7 +71,7 @@
                 }
             }
         ],
-        "timestamp": "2026-05-25T11:40:38.430505",
+        "timestamp": "2026-05-27T17:53:55.584953",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
@@ -101,12 +89,9 @@
                     ]
                 ],
                 "1": [
-
-                ],
-                "2": [
                     "versions.yml:md5,ec563c0ab47a2c5035c8c1c85b9ae747"
                 ],
-                "h5ad": [
+                "anndata": [
                     [
                         {
                             "id": "test"
@@ -116,9 +101,6 @@
                 ],
                 "versions": [
                     "versions.yml:md5,ec563c0ab47a2c5035c8c1c85b9ae747"
-                ],
-                "zarr": [
-
                 ]
             },
             {
@@ -128,7 +110,7 @@
                 }
             }
         ],
-        "timestamp": "2026-05-25T11:35:08.637978",
+        "timestamp": "2026-05-27T17:53:24.108261",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/modules/nf-core/scanpy/filter/tests/nextflow.config
+++ b/modules/nf-core/scanpy/filter/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: UNTAR {
+        ext.prefix = "test_zarr.zarr"
+    }
+}


### PR DESCRIPTION
## PR checklist

Related to #11559

This PR adds Zarr input/output support to `scanpy/filter`, following the same pattern as the `scanpy/pca` Zarr work.

Changes:
- Accept `.h5ad` and `.zarr` AnnData inputs.
- Emit `.h5ad` or `.zarr` outputs to match the input format.
- Use `anndata.read_zarr()` / `write_zarr()` for Zarr-backed AnnData.
- Bump `scanpy` from `1.11.2` to `1.11.4` and use the matching Wave container because the previous image did not include `zarr`.
- Add nf-test coverage using the AnnData Zarr fixture from `nf-core/test-datasets`, unpacked with `UNTAR`.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR. The fixture is already in `nf-core/test-datasets` from nf-core/test-datasets#2076.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.

Local testing:
- [x] `conda run -n nfcore-topic nf-core modules lint scanpy/filter --local --plain-text`
- [x] `conda run -n nfcore-topic prek run --files <changed files>`
- [x] `conda run -n nfcore-topic nf-test test modules/nf-core/scanpy/filter/tests/main.nf.test --profile docker --filter process --verbose`
- [x] `git diff --check`
- [ ] `nf-core modules test scanpy/filter --profile singularity`
- [ ] `nf-core modules test scanpy/filter --profile conda`
