### PR TITLE
Fix `STITCH` to use chunks

### DIFF
--- a/modules/nf-core/stitch/main.nf
+++ b/modules/nf-core/stitch/main.nf
@@ -8,7 +8,7 @@ process STITCH {
         : 'quay.io/biocontainers/r-stitch:1.7.3--r44h64f727c_0'}"
 
     input:
-    tuple val(meta), path(collected_crams), path(collected_crais), path(cramlist), path(samplename), path(posfile), path(input, stageAs: "input"), path(genetic_map), path(rdata, stageAs: "RData_in"), val(chromosome_name), val(start), val(end), val(K), val(nGen)
+    tuple val(meta), path(collected_crams), path(collected_crais), path(cramlist), path(samplename), path(posfile), path(input, stageAs: "input"), path(genetic_map), path(rdata, stageAs: "RData_in"), val(chromosome_name), val(start), val(end), val(buffer), val(K), val(nGen)
     tuple val(meta2), path(fasta), path(fasta_fai)
     val seed
 
@@ -44,13 +44,15 @@ process STITCH {
     def bamlist_cmd          = cramlist && reads_ext == ["bam" ] ? "--bamlist ${cramlist}"            : ""
 
     def reference_cmd        = fasta                       ? "--reference ${fasta}"                                            : ""
-    def original_region_name = start && end ? "${chromosome_name}.${start}.${end}" : "${chromosome_name}"
+    def has_region           = start != null && start != [] && end != null && end != []
+    def has_buffer           = buffer != null && buffer != [] && buffer.toString() != ""
+    def original_region_name = has_region ? "${chromosome_name}.${start}.${end}" : "${chromosome_name}"
     def regenerate_input_cmd = input && rdata && !cramlist ? "--regenerateInput FALSE --originalRegionName ${original_region_name}" : ""
     def samplename_cmd       = samplename                  ? "--sampleNames_file ${samplename}"                                : ""
     def genetic_map_command  = genetic_map                 ? "--genetic_map_file=${genetic_map}"                               : ""
-    def start_command        = start && end ? "--regionStart ${start}"                       : ""
-    def end_command          = start && end ? "--regionEnd ${end}"                           : ""
-    def buffer_command       = start && end ? "--buffer 0"                                  : ""
+    def start_command        = has_region                  ? "--regionStart ${start}"                                       : ""
+    def end_command          = has_region                  ? "--regionEnd ${end}"                                           : ""
+    def buffer_command       = has_region && has_buffer    ? "--buffer ${buffer}"                                           : ""
 
     // Rsync and Stitch command to copy RData from previous run if available
     def rsync_cmd            = rdata ? "rsync -rL ${rdata}/ RData" : ""

--- a/modules/nf-core/stitch/main.nf
+++ b/modules/nf-core/stitch/main.nf
@@ -44,9 +44,13 @@ process STITCH {
     def bamlist_cmd          = cramlist && reads_ext == ["bam" ] ? "--bamlist ${cramlist}"            : ""
 
     def reference_cmd        = fasta                       ? "--reference ${fasta}"                                            : ""
-    def regenerate_input_cmd = input && rdata && !cramlist ? "--regenerateInput FALSE --originalRegionName ${chromosome_name}" : ""
+    def original_region_name = start && end ? "${chromosome_name}.${start}.${end}" : "${chromosome_name}"
+    def regenerate_input_cmd = input && rdata && !cramlist ? "--regenerateInput FALSE --originalRegionName ${original_region_name}" : ""
     def samplename_cmd       = samplename                  ? "--sampleNames_file ${samplename}"                                : ""
     def genetic_map_command  = genetic_map                 ? "--genetic_map_file=${genetic_map}"                               : ""
+    def start_command        = start && end ? "--regionStart ${start}"                       : ""
+    def end_command          = start && end ? "--regionEnd ${end}"                           : ""
+    def buffer_command       = start && end ? "--buffer 0"                                  : ""
 
     // Rsync and Stitch command to copy RData from previous run if available
     def rsync_cmd            = rdata ? "rsync -rL ${rdata}/ RData" : ""
@@ -68,6 +72,9 @@ process STITCH {
         ${regenerate_input_cmd} \\
         ${samplename_cmd} \\
         ${genetic_map_command} \\
+        ${start_command} \\
+        ${end_command} \\
+        ${buffer_command} \\
         --output_filename ${prefix}.${suffix} \\
         ${args2}
     """

--- a/modules/nf-core/stitch/meta.yml
+++ b/modules/nf-core/stitch/meta.yml
@@ -85,6 +85,9 @@ input:
     - end:
         type: integer
         description: End position of the region to impute.
+    - buffer:
+        type: integer
+        description: Buffer, in base pairs, around the region to impute.
     - K:
         type: integer
         description: Number of ancestral haplotypes to use for imputation. Refer

--- a/modules/nf-core/stitch/tests/main.nf.test
+++ b/modules/nf-core/stitch/tests/main.nf.test
@@ -31,7 +31,7 @@ def ch_params = """Channel.of([
     ${pathgenome}dbsnp_138.hg38.first_10_biallelic_sites.tsv', checkIfExists: true),
     [],
     ${pathgenome}genome.GRCh38.stitch.chr21.txt.gz', checkIfExists: true),
-    [], 'chr21', 8522360, 8522670, 2, 1
+    [], 'chr21', 8522360, 8522670, 0, 2, 1
 ])"""
 
 // reference genome
@@ -170,8 +170,8 @@ nextflow_process {
                     .join ( STITCH_GENERATE_INPUTS.out.rdata )
                     .combine( $ch_params )
                     .map {
-                        meta, target, rdata, positions, _emptytarget, genetic_map, _emptyrdata, chr, start, end, k, nGen  ->
-                        [ meta, [], [], [], [], positions, target, genetic_map, rdata, chr, start, end, k, nGen ]
+                        meta, target, rdata, positions, _emptytarget, genetic_map, _emptyrdata, chr, start, end, buffer, k, nGen  ->
+                        [ meta, [], [], [], [], positions, target, genetic_map, rdata, chr, start, end, buffer, k, nGen ]
                     }
                 input[1] = [[id: null], [], []]
                 input[2] = $seed

--- a/modules/nf-core/stitch/tests/main.nf.test.snap
+++ b/modules/nf-core/stitch/tests/main.nf.test.snap
@@ -3,29 +3,30 @@
         "content": [
             [
                 [
-                    "sample.1.input.chr21.RData",
-                    "sample.2.input.chr21.RData"
+                    "sample.1.input.chr21.8522360.8522670.RData",
+                    "sample.2.input.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "EM.all.chr21.RData",
-                    "end.chr21.RData",
-                    "endEM.chr21.RData",
-                    "sampleNames.chr21.RData",
-                    "start.chr21.RData",
-                    "startEM.chr21.RData"
+                    "EM.all.chr21.8522360.8522670.RData",
+                    "EM.all.chr21.8522360.8522670.withBuffer.RData",
+                    "end.chr21.8522360.8522670.RData",
+                    "endEM.chr21.8522360.8522670.RData",
+                    "sampleNames.chr21.8522360.8522670.RData",
+                    "start.chr21.8522360.8522670.RData",
+                    "startEM.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "alphaMat.chr21.all.s.1.png",
-                    "alphaMat.chr21.normalized.s.1.png",
-                    "hapSum.chr21.s.1.png",
-                    "hapSum_log.chr21.s.1.png",
-                    "metricsForPostImputationQC.chr21.sample.jpg",
-                    "metricsForPostImputationQCChromosomeWide.chr21.sample.jpg",
-                    "r2.chr21.goodonly.jpg"
+                    "alphaMat.chr21.8522360.8522670.all.s.1.png",
+                    "alphaMat.chr21.8522360.8522670.normalized.s.1.png",
+                    "hapSum.chr21.8522360.8522670.s.1.png",
+                    "hapSum_log.chr21.8522360.8522670.s.1.png",
+                    "metricsForPostImputationQC.chr21.8522360.8522670.sample.jpg",
+                    "metricsForPostImputationQCChromosomeWide.chr21.8522360.8522670.sample.jpg",
+                    "r2.chr21.8522360.8522670.goodonly.jpg"
                 ]
             ],
             [
@@ -66,39 +67,40 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-17T14:56:20.837393824",
+        "timestamp": "2026-05-24T18:17:16.272903408",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "test_no_seed": {
         "content": [
             [
                 [
-                    "sample.1.input.chr21.RData",
-                    "sample.2.input.chr21.RData"
+                    "sample.1.input.chr21.8522360.8522670.RData",
+                    "sample.2.input.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "EM.all.chr21.RData",
-                    "end.chr21.RData",
-                    "endEM.chr21.RData",
-                    "sampleNames.chr21.RData",
-                    "start.chr21.RData",
-                    "startEM.chr21.RData"
+                    "EM.all.chr21.8522360.8522670.RData",
+                    "EM.all.chr21.8522360.8522670.withBuffer.RData",
+                    "end.chr21.8522360.8522670.RData",
+                    "endEM.chr21.8522360.8522670.RData",
+                    "sampleNames.chr21.8522360.8522670.RData",
+                    "start.chr21.8522360.8522670.RData",
+                    "startEM.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "alphaMat.chr21.all.s.1.png",
-                    "alphaMat.chr21.normalized.s.1.png",
-                    "hapSum.chr21.s.1.png",
-                    "hapSum_log.chr21.s.1.png",
-                    "metricsForPostImputationQC.chr21.sample.jpg",
-                    "metricsForPostImputationQCChromosomeWide.chr21.sample.jpg",
-                    "r2.chr21.goodonly.jpg"
+                    "alphaMat.chr21.8522360.8522670.all.s.1.png",
+                    "alphaMat.chr21.8522360.8522670.normalized.s.1.png",
+                    "hapSum.chr21.8522360.8522670.s.1.png",
+                    "hapSum_log.chr21.8522360.8522670.s.1.png",
+                    "metricsForPostImputationQC.chr21.8522360.8522670.sample.jpg",
+                    "metricsForPostImputationQCChromosomeWide.chr21.8522360.8522670.sample.jpg",
+                    "r2.chr21.8522360.8522670.goodonly.jpg"
                 ]
             ],
             [
@@ -138,10 +140,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-17T14:55:13.02376413",
+        "timestamp": "2026-05-24T18:16:26.01783424",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "test_with_bam - bgen - stub": {
@@ -232,29 +234,30 @@
         "content": [
             [
                 [
-                    "sample.1.input.chr21.RData",
-                    "sample.2.input.chr21.RData"
+                    "sample.1.input.chr21.8522360.8522670.RData",
+                    "sample.2.input.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "EM.all.chr21.RData",
-                    "end.chr21.RData",
-                    "endEM.chr21.RData",
-                    "sampleNames.chr21.RData",
-                    "start.chr21.RData",
-                    "startEM.chr21.RData"
+                    "EM.all.chr21.8522360.8522670.RData",
+                    "EM.all.chr21.8522360.8522670.withBuffer.RData",
+                    "end.chr21.8522360.8522670.RData",
+                    "endEM.chr21.8522360.8522670.RData",
+                    "sampleNames.chr21.8522360.8522670.RData",
+                    "start.chr21.8522360.8522670.RData",
+                    "startEM.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "alphaMat.chr21.all.s.1.png",
-                    "alphaMat.chr21.normalized.s.1.png",
-                    "hapSum.chr21.s.1.png",
-                    "hapSum_log.chr21.s.1.png",
-                    "metricsForPostImputationQC.chr21.sample.jpg",
-                    "metricsForPostImputationQCChromosomeWide.chr21.sample.jpg",
-                    "r2.chr21.goodonly.jpg"
+                    "alphaMat.chr21.8522360.8522670.all.s.1.png",
+                    "alphaMat.chr21.8522360.8522670.normalized.s.1.png",
+                    "hapSum.chr21.8522360.8522670.s.1.png",
+                    "hapSum_log.chr21.8522360.8522670.s.1.png",
+                    "metricsForPostImputationQC.chr21.8522360.8522670.sample.jpg",
+                    "metricsForPostImputationQCChromosomeWide.chr21.8522360.8522670.sample.jpg",
+                    "r2.chr21.8522360.8522670.goodonly.jpg"
                 ]
             ],
             [
@@ -295,10 +298,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-17T14:55:59.119322982",
+        "timestamp": "2026-05-24T18:16:59.46583024",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "test_with_bam - vcf - stub": {
@@ -389,29 +392,30 @@
         "content": [
             [
                 [
-                    "sample.1.input.chr21.RData",
-                    "sample.2.input.chr21.RData"
+                    "sample.1.input.chr21.8522360.8522670.RData",
+                    "sample.2.input.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "EM.all.chr21.RData",
-                    "end.chr21.RData",
-                    "endEM.chr21.RData",
-                    "sampleNames.chr21.RData",
-                    "start.chr21.RData",
-                    "startEM.chr21.RData"
+                    "EM.all.chr21.8522360.8522670.RData",
+                    "EM.all.chr21.8522360.8522670.withBuffer.RData",
+                    "end.chr21.8522360.8522670.RData",
+                    "endEM.chr21.8522360.8522670.RData",
+                    "sampleNames.chr21.8522360.8522670.RData",
+                    "start.chr21.8522360.8522670.RData",
+                    "startEM.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "alphaMat.chr21.all.s.1.png",
-                    "alphaMat.chr21.normalized.s.1.png",
-                    "hapSum.chr21.s.1.png",
-                    "hapSum_log.chr21.s.1.png",
-                    "metricsForPostImputationQC.chr21.sample.jpg",
-                    "metricsForPostImputationQCChromosomeWide.chr21.sample.jpg",
-                    "r2.chr21.goodonly.jpg"
+                    "alphaMat.chr21.8522360.8522670.all.s.1.png",
+                    "alphaMat.chr21.8522360.8522670.normalized.s.1.png",
+                    "hapSum.chr21.8522360.8522670.s.1.png",
+                    "hapSum_log.chr21.8522360.8522670.s.1.png",
+                    "metricsForPostImputationQC.chr21.8522360.8522670.sample.jpg",
+                    "metricsForPostImputationQCChromosomeWide.chr21.8522360.8522670.sample.jpg",
+                    "r2.chr21.8522360.8522670.goodonly.jpg"
                 ]
             ],
             [
@@ -452,39 +456,40 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-17T14:56:39.256710433",
+        "timestamp": "2026-05-24T18:17:30.351170027",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "test_with_seed": {
         "content": [
             [
                 [
-                    "sample.1.input.chr21.RData",
-                    "sample.2.input.chr21.RData"
+                    "sample.1.input.chr21.8522360.8522670.RData",
+                    "sample.2.input.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "EM.all.chr21.RData",
-                    "end.chr21.RData",
-                    "endEM.chr21.RData",
-                    "sampleNames.chr21.RData",
-                    "start.chr21.RData",
-                    "startEM.chr21.RData"
+                    "EM.all.chr21.8522360.8522670.RData",
+                    "EM.all.chr21.8522360.8522670.withBuffer.RData",
+                    "end.chr21.8522360.8522670.RData",
+                    "endEM.chr21.8522360.8522670.RData",
+                    "sampleNames.chr21.8522360.8522670.RData",
+                    "start.chr21.8522360.8522670.RData",
+                    "startEM.chr21.8522360.8522670.RData"
                 ]
             ],
             [
                 [
-                    "alphaMat.chr21.all.s.1.png",
-                    "alphaMat.chr21.normalized.s.1.png",
-                    "hapSum.chr21.s.1.png",
-                    "hapSum_log.chr21.s.1.png",
-                    "metricsForPostImputationQC.chr21.sample.jpg",
-                    "metricsForPostImputationQCChromosomeWide.chr21.sample.jpg",
-                    "r2.chr21.goodonly.jpg"
+                    "alphaMat.chr21.8522360.8522670.all.s.1.png",
+                    "alphaMat.chr21.8522360.8522670.normalized.s.1.png",
+                    "hapSum.chr21.8522360.8522670.s.1.png",
+                    "hapSum_log.chr21.8522360.8522670.s.1.png",
+                    "metricsForPostImputationQC.chr21.8522360.8522670.sample.jpg",
+                    "metricsForPostImputationQCChromosomeWide.chr21.8522360.8522670.sample.jpg",
+                    "r2.chr21.8522360.8522670.goodonly.jpg"
                 ]
             ],
             [
@@ -514,10 +519,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-17T14:55:33.575611285",
+        "timestamp": "2026-05-24T18:16:41.157554537",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/subworkflows/nf-core/bam_impute_stitch/main.nf
+++ b/subworkflows/nf-core/bam_impute_stitch/main.nf
@@ -12,6 +12,7 @@ workflow BAM_IMPUTE_STITCH {
     ch_fasta // channel (optional) :   [ [genome], fa, fai ]
     k_val // integer:   k value for STITCH
     n_gen // integer:   number of generations for STITCH
+    buffer // integer:   Buffer size around each chunk for STITCH
     seed // value  :   seed for random number generator
 
     main:
@@ -48,6 +49,7 @@ workflow BAM_IMPUTE_STITCH {
                 chr,
                 start,
                 end,
+                buffer,
                 k_val,
                 n_gen,
             ]

--- a/subworkflows/nf-core/bam_impute_stitch/meta.yml
+++ b/subworkflows/nf-core/bam_impute_stitch/meta.yml
@@ -94,6 +94,9 @@ input:
   - n_gen:
       type: integer
       description: Number of generations for STITCH imputation
+  - buffer:
+      type: integer
+      description: Buffer size around each chunk for STITCH imputation
   - seed:
       type: integer
       description: Random seed for STITCH imputation

--- a/subworkflows/nf-core/bam_impute_stitch/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_impute_stitch/tests/main.nf.test
@@ -37,7 +37,8 @@ nextflow_workflow {
                 input[4] = channel.of([ [id: "GRCh38"], [], [] ]).collect()
                 input[5] = 2
                 input[6] = 100
-                input[7] = 1
+                input[7] = 0
+                input[8] = 1
                 """
             }
         }
@@ -105,7 +106,8 @@ nextflow_workflow {
                 input[4] = channel.of([ [id: "GRCh38"], [], [] ]).collect()
                 input[5] = 2
                 input[6] = 100
-                input[7] = 1
+                input[7] = 0
+                input[8] = 1
                 """
             }
         }
@@ -156,7 +158,8 @@ nextflow_workflow {
                 input[4] = channel.of([ [id: "GRCh38"], [], [] ]).collect()
                 input[5] = 2
                 input[6] = 100
-                input[7] = 1
+                input[7] = 0
+                input[8] = 1
                 """
             }
         }
@@ -198,7 +201,8 @@ nextflow_workflow {
                 input[4] = channel.of([ [id: "GRCh38"], [], [] ]).collect()
                 input[5] = 2
                 input[6] = 100
-                input[7] = 1
+                input[7] = 0
+                input[8] = 1
                 """
             }
         }
@@ -229,7 +233,8 @@ nextflow_workflow {
                 input[4] = channel.of([ [id: "GRCh38"], [], [] ]).collect()
                 input[5] = 2
                 input[6] = 100
-                input[7] = 1
+                input[7] = 0
+                input[8] = 1
                 """
             }
         }

--- a/subworkflows/nf-core/bam_impute_stitch/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_impute_stitch/tests/main.nf.test.snap
@@ -63,7 +63,7 @@
                         "MySample1",
                         "MySample2"
                     ],
-                    "1604c8f19d69344cc6f8fe8f17a209d7"
+                    "5020babc4d74a3c528d473ebea611d9d"
                 ],
                 [
                     "allid_chr22.ligate.vcf.gz",
@@ -73,7 +73,7 @@
                         "MySample1",
                         "MySample2"
                     ],
-                    "ac38db1b020d33a9ca1fa5e75858b51"
+                    "f4cb31f431cca963ad0de4d5e5754a72"
                 ]
             ]
         ],


### PR DESCRIPTION
The subworkflow was passing chunks to the module, but the module did not have any parameter to use regionStart and regionEnd, therefore, it was processing the whole chromosome. The changes here fix that. 