### PR TITLE
feat: support task.ext.args in sentieon/gvcftyper

### DIFF
--- a/modules/nf-core/sentieon/gvcftyper/main.nf
+++ b/modules/nf-core/sentieon/gvcftyper/main.nf
@@ -24,6 +24,7 @@ process SENTIEON_GVCFTYPER {
     task.ext.when == null || task.ext.when
 
     script:
+    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}_genotyped"
     def gvcfs_input = '-v ' + gvcfs.join(' -v ')
     def dbsnp_cmd = dbsnp ? "--dbsnp ${dbsnp}" : ""
@@ -38,6 +39,7 @@ process SENTIEON_GVCFTYPER {
         -r ${fasta} \\
         ${interval_command} \\
         --algo GVCFtyper \\
+        ${args} \\
         ${gvcfs_input} \\
         ${dbsnp_cmd} \\
         ${prefix}.vcf.gz


### PR DESCRIPTION
  ## Description

  Add `task.ext.args` support to `SENTIEON_GVCFTYPER`, matching the convention already used by sibling sentieon modules (`haplotyper`, `varcal`, `applyvarcal`,
  `dnascope`, `applyvarcal`, etc.).

  ```diff
  + def args = task.ext.args ?: ''
    ...
    sentieon driver \
        -r ${fasta} \
        ${interval_command} \
        --algo GVCFtyper \
  +     ${args} \
        ${gvcfs_input} \
        ${dbsnp_cmd} \
        ${prefix}.vcf.gz
  ```

  `${args}` is injected after `--algo GVCFtyper`, so callers pass algorithm-level options (`--emit_mode`, `--call_conf`,
  `--allow-old-rms-mapping-quality-annotation-data`, etc.). Driver-level flags (`-t`, `--interval`) remain managed by the module since they relate to inputs the
  module already owns.

  ## Reason for PR

  `nf-core/sarek`'s joint-germline path needs to call GVCFtyper in two distinct modes for very large cohorts:

  - **SHARD** (per interval, per sample-batch): `--emit_mode all_samples` to produce batch-aggregated intermediates
  - **REDUCE** (per interval, over batch intermediates): default emit mode for the final joint VCF

  Without `ext.args` support, sarek currently has to ship a local fork of the module (`modules/local/sentieon/gvcftyper/`) that's identical to the upstream module
  except for these two lines. This PR removes that need.

  ## Tests

  No new tests added — the change is a no-op when `task.ext.args` is unset (the default), which is what every existing test exercises. They continue to pass
  unchanged.

  ## PR checklist

  - [x] This comment contains a description of changes (with reason).
  - [x] If you've fixed a bug or added code that should be tested, add tests! — existing tests cover the empty-args path; non-empty args is pass-through
  - [x] If you've added a new tool - have you followed the module conventions in the [contribution
  docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md) — N/A, existing module
  - [x] If necessary, include test data in your PR. — no new data
  - [x] Remove all TODO statements.
  - [x] Broadcast software version numbers to `topic: versions` — unchanged
  - [x] Follow the naming conventions. — unchanged
  - [x] Follow the parameters requirements. — unchanged
  - [x] Follow the input/output options guidelines. — unchanged
  - [x] Add a resource `label` — `label 'process_high'` already present
  - [x] Use BioConda and BioContainers if possible to fulfil software requirements. — already configured
  - For modules:
    - [ ] `nf-core modules test sentieon/gvcftyper --profile docker`
    - [ ] `nf-core modules test sentieon/gvcftyper --profile singularity`
    - [ ] `nf-core modules test sentieon/gvcftyper --profile conda`

  > Relying on the CI matrix (license-server credentials only available from upstream branches).
