### PR TITLE
Use sanitized snapshots for gcta/makegrmpart tests

### DIFF
--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test
@@ -38,18 +38,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.grm_files.size() == 1 },
-                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm' },
-                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(1).size() == 3 },
-                { assert process.out.grm_files.get(0).get(2) == 2 },
-                { assert process.out.grm_files.get(0).get(3) == 1 },
-                {
-                    assert snapshot(
-                        process.out.grm_files,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -83,18 +72,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.grm_files.size() == 1 },
-                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed' },
-                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(1).size() == 3 },
-                { assert process.out.grm_files.get(0).get(2) == 2 },
-                { assert process.out.grm_files.get(0).get(3) == 1 },
-                {
-                    assert snapshot(
-                        process.out.grm_files,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -135,18 +113,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.grm_files.size() == 1 },
-                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed_extract' },
-                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(1).size() == 3 },
-                { assert process.out.grm_files.get(0).get(2) == 2 },
-                { assert process.out.grm_files.get(0).get(3) == 1 },
-                {
-                    assert snapshot(
-                        process.out.grm_files,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -180,24 +147,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.grm_files.size() == 1 },
-                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed_default' },
-                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(1).size() == 3 },
-                {
-                    assert process.out.grm_files.get(0).get(1).collect { it.toString().tokenize('/').last() }.toSet() == [
-                        'gcta_grm_bed_default.part_1_1.grm.id',
-                        'gcta_grm_bed_default.part_1_1.grm.bin',
-                        'gcta_grm_bed_default.part_1_1.grm.N.bin'
-                    ] as Set
-                },
-                { assert process.out.grm_files.get(0).get(2) == null },
-                { assert process.out.grm_files.get(0).get(3) == null },
-                {
-                    assert snapshot(
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -233,7 +183,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/makegrmpart/tests/main.nf.test.snap
@@ -1,124 +1,103 @@
 {
     "homo_sapiens popgen - plink2": {
         "content": [
-            [
-                [
-                    {
-                        "id": "gcta_grm"
-                    },
-                    [
-                        "gcta_grm.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
-                        "gcta_grm.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
-                        "gcta_grm.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
-                    ],
-                    2,
-                    1
-                ]
-            ],
             {
-                "versions_gcta": [
-                    [
-                        "GCTA_MAKEGRMPART",
-                        "gcta",
-                        "1.94.1"
-                    ]
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-14T14:40:46.422832109"
-    },
-    "homo_sapiens popgen - plink1": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "gcta_grm_bed"
-                    },
-                    [
-                        "gcta_grm_bed.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
-                        "gcta_grm_bed.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
-                        "gcta_grm_bed.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
-                    ],
-                    2,
-                    1
-                ]
-            ],
-            {
-                "versions_gcta": [
-                    [
-                        "GCTA_MAKEGRMPART",
-                        "gcta",
-                        "1.94.1"
-                    ]
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-14T14:41:32.425143203"
-    },
-    "homo_sapiens popgen - plink1 - extract snp group": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "gcta_grm_bed_extract"
-                    },
-                    [
-                        "gcta_grm_bed_extract.part_2_1.grm.N.bin:md5,6b38fd68fa01357c900ba502c1d17f24",
-                        "gcta_grm_bed_extract.part_2_1.grm.bin:md5,9ec73c76840e9dce7ffe30d66d6d427d",
-                        "gcta_grm_bed_extract.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
-                    ],
-                    2,
-                    1
-                ]
-            ],
-            {
-                "versions_gcta": [
-                    [
-                        "GCTA_MAKEGRMPART",
-                        "gcta",
-                        "1.94.1"
-                    ]
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-14T14:42:17.337260978"
-    },
-    "homo_sapiens popgen - plink1 - stub": {
-        "content": [
-            {
-                "0": [
+                "grm_files": [
                     [
                         {
-                            "id": "gcta_grm_bed"
+                            "id": "gcta_grm"
                         },
                         [
-                            "gcta_grm_bed.part_2_1.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "gcta_grm_bed.part_2_1.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "gcta_grm_bed.part_2_1.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            "gcta_grm.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
+                            "gcta_grm.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
+                            "gcta_grm.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
                         ],
                         2,
                         1
                     ]
                 ],
-                "1": [
+                "versions_gcta": [
                     [
                         "GCTA_MAKEGRMPART",
                         "gcta",
                         "1.94.1"
                     ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-26T21:44:03.619639049"
+    },
+    "homo_sapiens popgen - plink1": {
+        "content": [
+            {
+                "grm_files": [
+                    [
+                        {
+                            "id": "gcta_grm_bed"
+                        },
+                        [
+                            "gcta_grm_bed.part_2_1.grm.N.bin:md5,0dcc3200354c243fca2de4c023352e66",
+                            "gcta_grm_bed.part_2_1.grm.bin:md5,b683a1daa96406174c02156527da1f19",
+                            "gcta_grm_bed.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
+                        ],
+                        2,
+                        1
+                    ]
                 ],
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRMPART",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-26T21:44:12.435159573"
+    },
+    "homo_sapiens popgen - plink1 - extract snp group": {
+        "content": [
+            {
+                "grm_files": [
+                    [
+                        {
+                            "id": "gcta_grm_bed_extract"
+                        },
+                        [
+                            "gcta_grm_bed_extract.part_2_1.grm.N.bin:md5,6b38fd68fa01357c900ba502c1d17f24",
+                            "gcta_grm_bed_extract.part_2_1.grm.bin:md5,9ec73c76840e9dce7ffe30d66d6d427d",
+                            "gcta_grm_bed_extract.part_2_1.grm.id:md5,9c193413bbf336213da941abeee78718"
+                        ],
+                        2,
+                        1
+                    ]
+                ],
+                "versions_gcta": [
+                    [
+                        "GCTA_MAKEGRMPART",
+                        "gcta",
+                        "1.94.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-26T21:44:26.156923172"
+    },
+    "homo_sapiens popgen - plink1 - stub": {
+        "content": [
+            {
                 "grm_files": [
                     [
                         {
@@ -146,11 +125,25 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-14T14:43:49.194574681"
+        "timestamp": "2026-05-26T21:44:59.541876791"
     },
     "homo_sapiens popgen - plink1 - default partition values": {
         "content": [
             {
+                "grm_files": [
+                    [
+                        {
+                            "id": "gcta_grm_bed_default"
+                        },
+                        [
+                            "gcta_grm_bed_default.part_1_1.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4",
+                            "gcta_grm_bed_default.part_1_1.grm.bin:md5,45f8dff14bda17d50009a21050572228",
+                            "gcta_grm_bed_default.part_1_1.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9"
+                        ],
+                        null,
+                        null
+                    ]
+                ],
                 "versions_gcta": [
                     [
                         "GCTA_MAKEGRMPART",
@@ -164,6 +157,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-15T20:37:03.862317452"
+        "timestamp": "2026-05-26T21:44:43.991622741"
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://nf-co.re/docs/contributing/modules)?
- [x] If necessary, also make a PR on the nf-core/test-datasets repository.
- [x] Make sure your code lints (`nf-core modules lint gcta/makegrmpart`).
- [x] Ensure the test works with either Docker / Singularity. Conda CI tests can be quite slow; please only use them if you need them.

This updates the `gcta/makegrmpart` nf-test assertions to snapshot the sanitized full `process.out` object instead of manually snapshotting selected channels and versions. The updated snapshots now cover the complete emitted output contract for each successful test while keeping the tests simpler.

Tested with:

- [x] `nf-test test modules/nf-core/gcta/makegrmpart/tests/main.nf.test --profile=docker --update-snapshot --verbose`
