### PR TITLE
Use sanitized snapshots for gcta/makegrm tests

### DIFF
--- a/modules/nf-core/gcta/makegrm/tests/main.nf.test
+++ b/modules/nf-core/gcta/makegrm/tests/main.nf.test
@@ -35,25 +35,9 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.grm_files.size() == 1 },
-                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm' },
-                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(1).size() == 3 },
-                {
-                    assert process.out.grm_files.get(0).get(1).collect { file(it).name }.toSet() == [
-                        'gcta_grm.grm.id',
-                        'gcta_grm.grm.bin',
-                        'gcta_grm.grm.N.bin'
-                    ] as Set
-                },
                 { assert file(path(process.out.grm_files.get(0).get(1)[0]).parent.toString() + '/.command.sh').text.contains('--make-grm') },
                 { assert file(path(process.out.grm_files.get(0).get(1)[0]).parent.toString() + '/.command.sh').text.contains('--mpfile') },
-                {
-                    assert snapshot(
-                        process.out.grm_files,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -84,25 +68,9 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.grm_files.size() == 1 },
-                { assert process.out.grm_files.get(0).get(0).id == 'gcta_grm_bed' },
-                { assert process.out.grm_files.get(0).get(0).keySet() == ['id'] as Set },
-                { assert process.out.grm_files.get(0).get(1).size() == 3 },
-                {
-                    assert process.out.grm_files.get(0).get(1).collect { file(it).name }.toSet() == [
-                        'gcta_grm_bed.grm.id',
-                        'gcta_grm_bed.grm.bin',
-                        'gcta_grm_bed.grm.N.bin'
-                    ] as Set
-                },
                 { assert file(path(process.out.grm_files.get(0).get(1)[0]).parent.toString() + '/.command.sh').text.contains('--make-grm') },
                 { assert file(path(process.out.grm_files.get(0).get(1)[0]).parent.toString() + '/.command.sh').text.contains('--mbfile') },
-                {
-                    assert snapshot(
-                        process.out.grm_files,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -135,7 +103,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/gcta/makegrm/tests/main.nf.test.snap
+++ b/modules/nf-core/gcta/makegrm/tests/main.nf.test.snap
@@ -1,19 +1,19 @@
 {
     "homo_sapiens popgen - plink2": {
         "content": [
-            [
-                [
-                    {
-                        "id": "gcta_grm"
-                    },
-                    [
-                        "gcta_grm.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4",
-                        "gcta_grm.grm.bin:md5,45f8dff14bda17d50009a21050572228",
-                        "gcta_grm.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9"
-                    ]
-                ]
-            ],
             {
+                "grm_files": [
+                    [
+                        {
+                            "id": "gcta_grm"
+                        },
+                        [
+                            "gcta_grm.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4",
+                            "gcta_grm.grm.bin:md5,45f8dff14bda17d50009a21050572228",
+                            "gcta_grm.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9"
+                        ]
+                    ]
+                ],
                 "versions_gcta": [
                     [
                         "GCTA_MAKEGRM",
@@ -27,60 +27,41 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-15T21:08:43.209734458"
+        "timestamp": "2026-05-26T21:43:59.883031834"
     },
     "homo_sapiens popgen - plink1": {
         "content": [
-            [
-                [
-                    {
-                        "id": "gcta_grm_bed"
-                    },
-                    [
-                        "gcta_grm_bed.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4",
-                        "gcta_grm_bed.grm.bin:md5,45f8dff14bda17d50009a21050572228",
-                        "gcta_grm_bed.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9"
-                    ]
-                ]
-            ],
             {
-                "versions_gcta": [
-                    [
-                        "GCTA_MAKEGRM",
-                        "gcta",
-                        "1.94.1"
-                    ]
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-05-15T21:09:34.058651287"
-    },
-    "homo_sapiens popgen - plink1 - stub": {
-        "content": [
-            {
-                "0": [
+                "grm_files": [
                     [
                         {
                             "id": "gcta_grm_bed"
                         },
                         [
-                            "gcta_grm_bed.grm.N.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "gcta_grm_bed.grm.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "gcta_grm_bed.grm.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            "gcta_grm_bed.grm.N.bin:md5,acaa43bbbf2253d392537a178ecf09a4",
+                            "gcta_grm_bed.grm.bin:md5,45f8dff14bda17d50009a21050572228",
+                            "gcta_grm_bed.grm.id:md5,4f9aa36c44a417ff6d7caa9841e66ad9"
                         ]
                     ]
                 ],
-                "1": [
+                "versions_gcta": [
                     [
                         "GCTA_MAKEGRM",
                         "gcta",
                         "1.94.1"
                     ]
-                ],
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-26T21:44:08.158125889"
+    },
+    "homo_sapiens popgen - plink1 - stub": {
+        "content": [
+            {
                 "grm_files": [
                     [
                         {
@@ -106,6 +87,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-15T21:10:21.024687128"
+        "timestamp": "2026-05-26T21:44:19.878280249"
     }
 }


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://nf-co.re/docs/contributing/modules)?
- [x] If necessary, also make a PR on the nf-core/test-datasets repository.
- [x] Make sure your code lints (`nf-core modules lint gcta/makegrm`).
- [x] Ensure the test works with either Docker / Singularity. Conda CI tests can be quite slow; please only use them if you need them.

This updates the `gcta/makegrm` nf-test assertions to snapshot the sanitized full `process.out` object instead of manually snapshotting selected channels and versions. The updated snapshots now cover the complete emitted output contract for each successful test while preserving the targeted command-line checks.

Tested with:

- [x] `nix-shell /home/andongni/Yandex.Disk/Projects/Research/nf-core/modules/shell.nix --run 'nf-test test modules/nf-core/gcta/makegrm/tests/main.nf.test --profile=docker --update-snapshot --verbose'`
- [x] `nix-shell /home/andongni/Yandex.Disk/Projects/Research/nf-core/modules/shell.nix --run 'nf-test test modules/nf-core/gcta/makegrm/tests/main.nf.test --profile=docker --verbose'`
