### PR TITLE
New module `savana/to` 

### DIFF
--- a/modules/nf-core/savana/to/environment.yml
+++ b/modules/nf-core/savana/to/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::savana=1.3.7"

--- a/modules/nf-core/savana/to/environment.yml
+++ b/modules/nf-core/savana/to/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::savana=1.3.7"
+  - "bioconda::savana=1.3.8"

--- a/modules/nf-core/savana/to/main.nf
+++ b/modules/nf-core/savana/to/main.nf
@@ -1,19 +1,18 @@
 process SAVANA_TO {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/savana:1.3.8--pyhdfd78af_0' :
-        'quay.io/biocontainers/savana:1.3.8--pyhdfd78af_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/savana:1.3.8--pyhdfd78af_0'
+        : 'quay.io/biocontainers/savana:1.3.8--pyhdfd78af_0'}"
 
     input:
     tuple val(meta), path(tumour), path(tumour_index), path(snp_vcf), path(allele_counts_het_snps), path(breakpoints)
     tuple val(meta2), path(ref), path(ref_index)
-    path(contigs)
-    path(blacklist)
-    val(g1000_vcf)
-
+    path contigs
+    path blacklist
+    val g1000_vcf
 
     output:
     tuple val(meta), path("${prefix}.sv_breakpoints.vcf"), emit: sv_breakpoints_vcf // savana run
@@ -75,7 +74,8 @@ process SAVANA_TO {
 
     stub:
     prefix = task.ext.prefix ?: "${meta.id}"
-    def cna_outputs = (snp_vcf || g1000_vcf || allele_counts_het_snps) ? """
+    def cna_outputs = snp_vcf || g1000_vcf || allele_counts_het_snps
+        ? """
     touch ${prefix}_raw_read_counts.tsv
     touch ${prefix}_read_counts_self_log2r_segmented.tsv
     touch ${prefix}_ranked_solutions.tsv
@@ -83,7 +83,8 @@ process SAVANA_TO {
     touch ${prefix}_segmented_absolute_copy_number.tsv
     touch ${prefix}_allele_counts_hetSNPs.bed
     touch 10kbp_bin_ref_all_${prefix}_with_SV_breakpoints.bed
-    """ : ""
+    """
+        : ""
 
     """
     touch ${prefix}.sv_breakpoints.vcf

--- a/modules/nf-core/savana/to/main.nf
+++ b/modules/nf-core/savana/to/main.nf
@@ -1,0 +1,99 @@
+process SAVANA_TO {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/savana:1.3.7--pyhdfd78af_0' :
+        'quay.io/biocontainers/savana:1.3.7--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(tumour), path(tumour_index), path(snp_vcf), path(allele_counts_het_snps), path(breakpoints)
+    tuple val(meta2), path(ref), path(ref_index)
+    path(contigs)
+    path(blacklist)
+    val(g1000_vcf)
+
+
+    output:
+    tuple val(meta), path("${prefix}.sv_breakpoints.vcf"), emit: sv_breakpoints_vcf // savana run
+    tuple val(meta), path("${prefix}.sv_breakpoints.bedpe"), emit: sv_breakpoints_bedpe // savana run
+    tuple val(meta), path("${prefix}.sv_breakpoints_read_support.tsv"), emit: sv_breakpoints_read_support // savana run
+    tuple val(meta), path("${prefix}.inserted_sequences.fa"), emit: inserted_sequences // savana run
+    tuple val(meta), path("${prefix}.classified.vcf"), emit: classified_vcf // savana classify
+    tuple val(meta), path("${prefix}.classified.somatic.vcf"), emit: somatic_vcf, optional: true // savana classify
+    tuple val(meta), path("${prefix}.classified.somatic.bedpe"), emit: somatic_bedpe, optional: true // savana classify
+    tuple val(meta), path("${prefix}.classified.germline.vcf"), emit: germline_vcf, optional: true // savana classify
+    tuple val(meta), path("${prefix}.classified.{strict,lenient}.vcf"), emit: legacy_vcfs, optional: true // savana classify
+    tuple val(meta), path("${prefix}.classified*.cna_rescue.vcf"), emit: cna_rescue_vcfs, optional: true
+    tuple val(meta), path("${prefix}.somatic.labelled.vcf"), emit: labelled_vcf, optional: true // savana evaluate
+    tuple val(meta), path("${prefix}.somatic.evaluation.stats"), emit: evaluation_stats, optional: true // savana evaluate
+    tuple val(meta), path("${prefix}_allele_counts_hetSNPs.bed"), emit: allele_counts, optional: true
+    tuple val(meta), path("${prefix}_raw_read_counts.tsv"), emit: raw_read_counts, optional: true
+    tuple val(meta), path("${prefix}_read_counts_*_segmented.tsv"), emit: segmented_log2r, optional: true
+    tuple val(meta), path("${prefix}_ranked_solutions.tsv"), emit: ranked_solutions, optional: true
+    tuple val(meta), path("${prefix}_fitted_purity_ploidy.tsv"), emit: fitted_purity_ploidy, optional: true
+    tuple val(meta), path("${prefix}_segmented_absolute_copy_number.tsv"), emit: cna, optional: true
+    tuple val(meta), path("*kbp_bin_ref_*_${prefix}*.bed"), emit: binned_ref, optional: true
+    tuple val("${task.process}"), val('savana'), eval("python -c \"import importlib.metadata as m; print(m.version('savana'))\""), emit: versions_savana, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def contigs_arg = contigs ? "--contigs ${contigs}" : ""
+    def allele_arg = snp_vcf
+        ? "--snp_vcf ${snp_vcf}"
+        : g1000_vcf
+            ? "--g1000_vcf ${g1000_vcf}"
+            : allele_counts_het_snps ? "--allele_counts_het_snps ${allele_counts_het_snps}" : ""
+    def blacklist_arg = blacklist ? "--blacklist ${blacklist}" : ""
+    def ref_index_arg = ref_index ? "--ref_index ${ref_index}" : ""
+    def breakpoints_arg = breakpoints ? "--breakpoints ${breakpoints}" : ""
+
+    """
+    savana to \\
+        --tumour ${tumour} \\
+        --ref ${ref} \\
+        ${ref_index_arg} \\
+        --outdir "./outdir" \\
+        --sample ${prefix} \\
+        --threads ${task.cpus} \\
+        --cna_threads ${task.cpus} \\
+        ${contigs_arg} \\
+        ${blacklist_arg} \\
+        ${allele_arg} \\
+        ${breakpoints_arg} \\
+        ${args}
+
+    mv ./outdir/* .
+    rmdir ./outdir
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def cna_outputs = (snp_vcf || g1000_vcf || allele_counts_het_snps) ? """
+    touch ${prefix}_raw_read_counts.tsv
+    touch ${prefix}_read_counts_self_log2r_segmented.tsv
+    touch ${prefix}_ranked_solutions.tsv
+    touch ${prefix}_fitted_purity_ploidy.tsv
+    touch ${prefix}_segmented_absolute_copy_number.tsv
+    touch ${prefix}_allele_counts_hetSNPs.bed
+    touch 10kbp_bin_ref_all_${prefix}_with_SV_breakpoints.bed
+    """ : ""
+
+    """
+    touch ${prefix}.sv_breakpoints.vcf
+    touch ${prefix}.sv_breakpoints.bedpe
+    touch ${prefix}.sv_breakpoints_read_support.tsv
+    touch ${prefix}.inserted_sequences.fa
+    touch ${prefix}.classified.vcf
+    touch ${prefix}.classified.somatic.vcf
+    touch ${prefix}.classified.somatic.bedpe
+    touch ${prefix}.classified.strict.vcf
+    touch ${prefix}.classified.lenient.vcf
+    ${cna_outputs}
+    """
+}

--- a/modules/nf-core/savana/to/main.nf
+++ b/modules/nf-core/savana/to/main.nf
@@ -10,9 +10,9 @@ process SAVANA_TO {
     input:
     tuple val(meta), path(tumour), path(tumour_index), path(snp_vcf), path(allele_counts_het_snps), path(breakpoints)
     tuple val(meta2), path(ref), path(ref_index)
-    path contigs
-    path blacklist
-    val g1000_vcf
+    tuple val(meta3), path(contigs)
+    tuple val(meta4), path(blacklist)
+    tuple val(meta5), val(g1000_vcf)
 
     output:
     tuple val(meta), path("${prefix}.sv_breakpoints.vcf"), emit: sv_breakpoints_vcf // savana run

--- a/modules/nf-core/savana/to/main.nf
+++ b/modules/nf-core/savana/to/main.nf
@@ -4,8 +4,8 @@ process SAVANA_TO {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/savana:1.3.7--pyhdfd78af_0' :
-        'quay.io/biocontainers/savana:1.3.7--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/savana:1.3.8--pyhdfd78af_0' :
+        'quay.io/biocontainers/savana:1.3.8--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(tumour), path(tumour_index), path(snp_vcf), path(allele_counts_het_snps), path(breakpoints)
@@ -30,11 +30,12 @@ process SAVANA_TO {
     tuple val(meta), path("${prefix}.somatic.evaluation.stats"), emit: evaluation_stats, optional: true // savana evaluate
     tuple val(meta), path("${prefix}_allele_counts_hetSNPs.bed"), emit: allele_counts, optional: true
     tuple val(meta), path("${prefix}_raw_read_counts.tsv"), emit: raw_read_counts, optional: true
-    tuple val(meta), path("${prefix}_read_counts_*_segmented.tsv"), emit: segmented_log2r, optional: true
+    tuple val(meta), path("${prefix}_read_counts_*_log2r_segmented.tsv"), emit: segmented_log2r, optional: true
     tuple val(meta), path("${prefix}_ranked_solutions.tsv"), emit: ranked_solutions, optional: true
     tuple val(meta), path("${prefix}_fitted_purity_ploidy.tsv"), emit: fitted_purity_ploidy, optional: true
     tuple val(meta), path("${prefix}_segmented_absolute_copy_number.tsv"), emit: cna, optional: true
     tuple val(meta), path("*kbp_bin_ref_*_${prefix}*.bed"), emit: binned_ref, optional: true
+    tuple val(meta), path("No_fit_found_PARAMS.tsv"), emit: no_fit, optional: true
     tuple val("${task.process}"), val('savana'), eval("python -c \"import importlib.metadata as m; print(m.version('savana'))\""), emit: versions_savana, topic: versions
 
     when:

--- a/modules/nf-core/savana/to/meta.yml
+++ b/modules/nf-core/savana/to/meta.yml
@@ -248,11 +248,11 @@ output:
     - - meta:
           type: map
           description: Sample information
-      - ${prefix}_read_counts_*_segmented.tsv:
+      - ${prefix}_read_counts_*_log2r_segmented.tsv:
           type: file
           optional: true
           description: Segmented log2R copy numbers
-          pattern: "*_read_counts_*_segmented.tsv"
+          pattern: "*_read_counts_*_log2r_segmented.tsv"
           ontologies:
             - edam: "http://edamontology.org/format_3475" # TSV
   ranked_solutions:
@@ -299,6 +299,17 @@ output:
           pattern: "*kbp_bin_ref_*_*.bed"
           ontologies:
             - edam: "http://edamontology.org/format_3003" # BED
+  no_fit:
+    - - meta:
+          type: map
+          description: Sample information
+      - No_fit_found_PARAMS.tsv:
+          type: file
+          optional: true
+          description: Report containing rejected candidate purity/ploidy solutions if no fit is found
+          pattern: "No_fit_found_PARAMS.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
   versions_savana:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/savana/to/meta.yml
+++ b/modules/nf-core/savana/to/meta.yml
@@ -1,0 +1,328 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "savana_to"
+description: "Tumour-only somatic SV calling with optional copy-number analysis in SAVANA"
+keywords:
+  - structural variants
+  - somatic variants
+  - copy number analysis
+  - long-read sequencing
+  - genomics
+tools:
+  - "savana":
+      description: "SAVANA: a somatic structural variant and copy-number caller for
+        long-read data."
+      homepage: "https://github.com/cortes-ciriano-lab/savana"
+      documentation: "https://github.com/cortes-ciriano-lab/savana"
+      tool_dev_url: "https://github.com/cortes-ciriano-lab/savana"
+      doi: "10.1038/s41592-025-02708-0"
+      licence:
+        - "Apache-2.0"
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - tumour:
+        type: file
+        description: Tumour BAM/CRAM file
+        pattern: "*.{bam,cram}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+    - tumour_index:
+        type: file
+        description: Tumour BAM/CRAM index
+        pattern: "*.{bai,crai}"
+    - snp_vcf:
+        type: file
+        description: Optional SNP VCF for allele counting (mutually exclusive with g1000_vcf and allele_counts_het_snps)
+        pattern: "*.{vcf,vcf.gz}"
+        optional: true
+        ontologies:
+          - edam: "http://edamontology.org/format_3016" # VCF
+          - edam: "http://edamontology.org/format_3615" # BGZIP
+    - allele_counts_het_snps:
+        type: file
+        description: Optional precomputed allele counts of heterozygous SNPs
+        pattern: "*.bed"
+        optional: true
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+    - breakpoints:
+        type: file
+        description: SAVANA breakpoints VCF to be included in CNA analysis
+        pattern: "*.{vcf,vcf.gz}"
+        optional: true
+        ontologies:
+          - edam: "http://edamontology.org/format_3016" # VCF
+          - edam: "http://edamontology.org/format_3615" # BGZIP
+  - - meta2:
+        type: map
+        description: Groovy Map containing reference information
+          e.g. `[ id:'GRCh38' ]`
+    - ref:
+        type: file
+        description: Reference FASTA
+        pattern: "*.{fa,fasta,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929" # FASTA
+    - ref_index:
+        type: file
+        description: Reference FASTA index
+        pattern: "*.fai"
+        optional: true
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+  - contigs:
+      type: file
+      description: Optional contigs list file for SAVANA to restrict analysis to specific contigs
+      pattern: "*.txt"
+      optional: true
+      ontologies:
+        - edam: "http://edamontology.org/format_2330" # TXT
+  - blacklist:
+      type: file
+      description: Optional blacklist BED for CNA analysis
+      pattern: "*.bed"
+      optional: true
+      ontologies:
+        - edam: "http://edamontology.org/format_3003" # BED
+  - g1000_vcf:
+      type: string
+      description: Optional 1000G preset for allele counting (mutually exclusive with snp_vcf and allele_counts_het_snps)
+      optional: true
+
+output:
+  sv_breakpoints_vcf:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.sv_breakpoints.vcf:
+          type: file
+          description: VCF file containing raw SV breakpoints
+          pattern: "*.sv_breakpoints.vcf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3016" # VCF
+  sv_breakpoints_bedpe:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.sv_breakpoints.bedpe:
+          type: file
+          description: Raw SV breakpoints BEDPE
+          pattern: "*.sv_breakpoints.bedpe"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003" # BED
+  sv_breakpoints_read_support:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.sv_breakpoints_read_support.tsv:
+          type: file
+          description: TSV file containing read support information for each SV breakpoint
+          pattern: "*.sv_breakpoints_read_support.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  inserted_sequences:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.inserted_sequences.fa:
+          type: file
+          description: FASTA file containing inserted sequences
+          pattern: "*.inserted_sequences.fa"
+          ontologies:
+            - edam: "http://edamontology.org/format_1929" # FASTA
+  classified_vcf:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.classified.vcf:
+          type: file
+          description: VCF containing information about variant classification in the INFO field
+          pattern: "*.classified.vcf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3016" # VCF
+  somatic_vcf:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.classified.somatic.vcf:
+          type: file
+          optional: true
+          description: VCF containing variants classified as somatic
+          pattern: "*.classified.somatic.vcf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3016" # VCF
+  somatic_bedpe:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.classified.somatic.bedpe:
+          type: file
+          optional: true
+          description: Somatic BEDPE
+          pattern: "*.classified.somatic.bedpe"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003" # BED
+  germline_vcf:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.classified.germline.vcf:
+          type: file
+          optional: true
+          description: VCF containing variants classified as germline
+          pattern: "*.classified.germline.vcf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3016" # VCF
+  legacy_vcfs:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.classified.{strict,lenient}.vcf:
+          type: file
+          optional: true
+          description: Legacy strict/lenient VCFs
+          pattern: "*.classified.{strict,lenient}.vcf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3016" # VCF
+  cna_rescue_vcfs:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.classified*.cna_rescue.vcf:
+          type: file
+          optional: true
+          description: CNA rescue VCFs
+          pattern: "*.cna_rescue.vcf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3016" # VCF
+  labelled_vcf:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.somatic.labelled.vcf:
+          type: file
+          optional: true
+          description: Labelled VCF from evaluation
+          pattern: "*.somatic.labelled.vcf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3016" # VCF
+  evaluation_stats:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}.somatic.evaluation.stats:
+          type: file
+          optional: true
+          description: Summary of the SAVANA evaluation results
+          pattern: "*.somatic.evaluation.stats"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330" # TXT
+  allele_counts:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}_allele_counts_hetSNPs.bed:
+          type: file
+          optional: true
+          description: Allele counts for heterozygous SNPs (optional)
+          pattern: "*_allele_counts_hetSNPs.bed"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003" # BED
+  raw_read_counts:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}_raw_read_counts.tsv:
+          type: file
+          optional: true
+          description: Raw binned read counts
+          pattern: "*_raw_read_counts.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  segmented_log2r:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}_read_counts_*_segmented.tsv:
+          type: file
+          optional: true
+          description: Segmented log2R copy numbers
+          pattern: "*_read_counts_*_segmented.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  ranked_solutions:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}_ranked_solutions.tsv:
+          type: file
+          optional: true
+          description: Ranked purity/ploidy solutions
+          pattern: "*_ranked_solutions.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  fitted_purity_ploidy:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}_fitted_purity_ploidy.tsv:
+          type: file
+          optional: true
+          description: Final purity/ploidy fit
+          pattern: "*_fitted_purity_ploidy.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  cna:
+    - - meta:
+          type: map
+          description: Sample information
+      - ${prefix}_segmented_absolute_copy_number.tsv:
+          type: file
+          optional: true
+          description: Segmented absolute copy numbers
+          pattern: "*_segmented_absolute_copy_number.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  binned_ref:
+    - - meta:
+          type: map
+          description: Sample information
+      - "*kbp_bin_ref_*_${prefix}*.bed":
+          type: file
+          optional: true
+          description: Binned reference BED (with or without SV breakpoint integration)
+          pattern: "*kbp_bin_ref_*_*.bed"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003" # BED
+  versions_savana:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - savana:
+          type: string
+          description: The name of the tool
+      - python -c "import importlib.metadata as m; print(m.version('savana'))":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - savana:
+          type: string
+          description: The name of the tool
+      - python -c "import importlib.metadata as m; print(m.version('savana'))":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@manascripts"
+maintainers:
+  - "@manascripts"

--- a/modules/nf-core/savana/to/meta.yml
+++ b/modules/nf-core/savana/to/meta.yml
@@ -75,24 +75,39 @@ input:
         optional: true
         ontologies:
           - edam: "http://edamontology.org/format_3475" # TSV
-  - contigs:
-      type: file
-      description: Optional contigs list file for SAVANA to restrict analysis to specific contigs
-      pattern: "*.txt"
-      optional: true
-      ontologies:
-        - edam: "http://edamontology.org/format_2330" # TXT
-  - blacklist:
-      type: file
-      description: Optional blacklist BED for CNA analysis
-      pattern: "*.bed"
-      optional: true
-      ontologies:
-        - edam: "http://edamontology.org/format_3003" # BED
-  - g1000_vcf:
-      type: string
-      description: Optional 1000G preset for allele counting (mutually exclusive with snp_vcf and allele_counts_het_snps)
-      optional: true
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing contigs file information
+          e.g. `[ id:'contigs' ]`
+    - contigs:
+        type: file
+        description: Optional contigs list file for SAVANA to restrict analysis to specific contigs
+        pattern: "*.txt"
+        optional: true
+        ontologies:
+          - edam: "http://edamontology.org/format_2330" # TXT
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing blacklist file information
+          e.g. `[ id:'blacklist' ]`
+    - blacklist:
+        type: file
+        description: Optional blacklist BED for CNA analysis
+        pattern: "*.bed"
+        optional: true
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+  - - meta5:
+        type: map
+        description: |
+          Groovy Map containing 1000G preset information
+          e.g. `[ id:'1000g_hg38' ]`
+    - g1000_vcf:
+        type: string
+        description: Optional 1000G preset for allele counting (mutually exclusive with snp_vcf and allele_counts_het_snps)
+        optional: true
 
 output:
   sv_breakpoints_vcf:

--- a/modules/nf-core/savana/to/tests/main.nf.test
+++ b/modules/nf-core/savana/to/tests/main.nf.test
@@ -10,7 +10,7 @@ nextflow_process {
     tag "savana"
     tag "savana/to"
 
-    test("homo_sapiens - nanopore_HG002_ont_telomere - g1000") {
+    test("homo_sapiens - nanopore_HG002_ont_telomere") {
         when {
             params {
                 module_args = '--chromosomes 1 2 --allele_min_reads 1 --overwrite --min_support 1 --length 5'
@@ -84,7 +84,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/savana/to/tests/main.nf.test
+++ b/modules/nf-core/savana/to/tests/main.nf.test
@@ -1,0 +1,81 @@
+nextflow_process {
+
+    name "Test Process SAVANA_TO"
+    script "../main.nf"
+    process "SAVANA_TO"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "savana"
+    tag "savana/to"
+
+    test("homo_sapiens - nanopore_HG002_ont_telomere - g1000") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub.bam.bai', checkIfExists: true),
+                    [],
+                    [],
+                    []
+                ]
+                input[1] = [
+                    [ id:'ref' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub_ref.fa', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub_ref.fa.fai', checkIfExists: true)
+                ]
+                input[2] = []
+                input[3] = []
+                input[4] = "1000g_hg38"
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - nanopore_HG002_ont_telomere - g1000 - stub") {
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub.bam.bai', checkIfExists: true),
+                    [],
+                    [],
+                    []
+                ]
+                input[1] = [
+                    [ id:'ref' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub_ref.fa', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub_ref.fa.fai', checkIfExists: true)
+                ]
+                input[2] = []
+                input[3] = []
+                input[4] = "1000g_hg38"
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/savana/to/tests/main.nf.test
+++ b/modules/nf-core/savana/to/tests/main.nf.test
@@ -10,7 +10,7 @@ nextflow_process {
     tag "savana"
     tag "savana/to"
 
-    test("homo_sapiens - nanopore_HG002_ont_telomere") {
+    test("homo_sapiens - nanopore - bam") {
         when {
             params {
                 module_args = '--overrule_cellularity 1 --chromosomes 22 --overwrite'
@@ -19,20 +19,29 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub.bam', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub.bam.bai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/savana/colo829.PAU61426.sup.chr22.subset.0.05.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/savana/colo829.PAU61426.sup.chr22.subset.0.05.bam.bai', checkIfExists: true),
                     [],
                     [],
                     []
                 ]
                 input[1] = [
                     [ id:'ref' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub_ref.fa', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub_ref.fa.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr22/sequence/hg38.chr22.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr22/sequence/hg38.chr22.fasta.fai', checkIfExists: true),
                 ]
-                input[2] = []
-                input[3] = []
-                input[4] = []
+                input[2] = [
+                    [ id:'contigs' ],
+                    []
+                ]
+                input[3] = [
+                    [ id:'blacklist' ],
+                    []
+                ]
+                input[4] = [
+                    [ id:'g1000_vcf' ],
+                    ''
+                ]
                 """
             }
         }
@@ -72,11 +81,20 @@ nextflow_process {
                 input[1] = [
                     [ id:'ref' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr22/sequence/hg38.chr22.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr22/sequence/hg38.chr22.fasta.fai', checkIfExists: true),
+                ]
+                input[2] = [
+                    [ id:'contigs' ],
                     []
                 ]
-                input[2] = []
-                input[3] = []
-                input[4] = []
+                input[3] = [
+                    [ id:'blacklist' ],
+                    []
+                ]
+                input[4] = [
+                    [ id:'g1000_vcf' ],
+                    ''
+                ]
                 """
             }
         }

--- a/modules/nf-core/savana/to/tests/main.nf.test
+++ b/modules/nf-core/savana/to/tests/main.nf.test
@@ -13,7 +13,7 @@ nextflow_process {
     test("homo_sapiens - nanopore_HG002_ont_telomere") {
         when {
             params {
-                module_args = '--chromosomes 1 2 --allele_min_reads 1 --overwrite --min_support 1 --length 5'
+                module_args = '--overrule_cellularity 1 --chromosomes 22 --overwrite'
             }
             process {
                 """
@@ -52,31 +52,31 @@ nextflow_process {
         }
     }
 
-    test("homo_sapiens - nanopore_HG002_ont_telomere - g1000 - stub") {
+    test("homo_sapiens - nanopore - stub") {
         options "-stub"
 
         when {
             params {
-                module_args = '--chromosomes 1 2 --allele_min_reads 1 --overwrite --min_support 1 --length 5'
+                module_args = '--overrule_cellularity 1 --chromosomes 22 --overwrite'
             }
             process {
                 """
                 input[0] = [
                     [ id:'test' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub.bam', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub.bam.bai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/savana/colo829.PAU61426.sup.chr22.subset.0.05.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/savana/colo829.PAU61426.sup.chr22.subset.0.05.bam.bai', checkIfExists: true),
                     [],
                     [],
                     []
                 ]
                 input[1] = [
                     [ id:'ref' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub_ref.fa', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/nanopore/bam/HG002_ont_telomere/HG002_ont_tel_sub_ref.fa.fai', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr22/sequence/hg38.chr22.fasta', checkIfExists: true),
+                    []
                 ]
                 input[2] = []
                 input[3] = []
-                input[4] = "1000g_hg38"
+                input[4] = []
                 """
             }
         }

--- a/modules/nf-core/savana/to/tests/main.nf.test
+++ b/modules/nf-core/savana/to/tests/main.nf.test
@@ -12,6 +12,9 @@ nextflow_process {
 
     test("homo_sapiens - nanopore_HG002_ont_telomere - g1000") {
         when {
+            params {
+                module_args = '--chromosomes 1 2 --allele_min_reads 1 --overwrite --min_support 1 --length 5'
+            }
             process {
                 """
                 input[0] = [
@@ -29,7 +32,7 @@ nextflow_process {
                 ]
                 input[2] = []
                 input[3] = []
-                input[4] = "1000g_hg38"
+                input[4] = []
                 """
             }
         }
@@ -38,7 +41,11 @@ nextflow_process {
             assert process.success
             assertAll(
                 { assert snapshot(
-                    process.out,
+                    path(process.out.sv_breakpoints_vcf.get(0).get(1)).vcf.summary,
+                    file(process.out.sv_breakpoints_bedpe.get(0).get(1)).name,
+                    file(process.out.sv_breakpoints_read_support.get(0).get(1)).readLines().size(),
+                    file(process.out.inserted_sequences.get(0).get(1)).name,
+                    path(process.out.classified_vcf.get(0).get(1)).vcf.summary,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -49,6 +56,9 @@ nextflow_process {
         options "-stub"
 
         when {
+            params {
+                module_args = '--chromosomes 1 2 --allele_min_reads 1 --overwrite --min_support 1 --length 5'
+            }
             process {
                 """
                 input[0] = [

--- a/modules/nf-core/savana/to/tests/main.nf.test.snap
+++ b/modules/nf-core/savana/to/tests/main.nf.test.snap
@@ -1,0 +1,320 @@
+{
+    "homo_sapiens - nanopore_HG002_ont_telomere - g1000 - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sv_breakpoints.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sv_breakpoints.bedpe:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "10": [
+                    
+                ],
+                "11": [
+                    
+                ],
+                "12": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_allele_counts_hetSNPs.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "13": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_raw_read_counts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "14": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_read_counts_self_log2r_segmented.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "15": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_ranked_solutions.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "16": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_fitted_purity_ploidy.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "17": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_segmented_absolute_copy_number.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "18": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "10kbp_bin_ref_all_test_with_SV_breakpoints.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "19": [
+                    [
+                        "SAVANA_TO",
+                        "savana",
+                        "1.3.7"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sv_breakpoints_read_support.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.inserted_sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.classified.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.classified.somatic.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.classified.somatic.bedpe:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "7": [
+                    
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.classified.lenient.vcf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.classified.strict.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "9": [
+                    
+                ],
+                "allele_counts": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_allele_counts_hetSNPs.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "binned_ref": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "10kbp_bin_ref_all_test_with_SV_breakpoints.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "classified_vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.classified.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cna": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_segmented_absolute_copy_number.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "cna_rescue_vcfs": [
+                    
+                ],
+                "evaluation_stats": [
+                    
+                ],
+                "fitted_purity_ploidy": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_fitted_purity_ploidy.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "germline_vcf": [
+                    
+                ],
+                "inserted_sequences": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.inserted_sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "labelled_vcf": [
+                    
+                ],
+                "legacy_vcfs": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.classified.lenient.vcf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.classified.strict.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "ranked_solutions": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_ranked_solutions.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "raw_read_counts": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_raw_read_counts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "segmented_log2r": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_read_counts_self_log2r_segmented.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "somatic_bedpe": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.classified.somatic.bedpe:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "somatic_vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.classified.somatic.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "sv_breakpoints_bedpe": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sv_breakpoints.bedpe:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "sv_breakpoints_read_support": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sv_breakpoints_read_support.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "sv_breakpoints_vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sv_breakpoints.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_savana": [
+                    [
+                        "SAVANA_TO",
+                        "savana",
+                        "1.3.7"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-03T15:13:17.760247132",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "homo_sapiens - nanopore_HG002_ont_telomere - g1000": {
+        "content": [
+            "VcfFile [chromosomes=[], sampleCount=1, variantCount=0, phased=true, phasedAutodetect=true]",
+            "test.sv_breakpoints.bedpe",
+            1,
+            "test.inserted_sequences.fa",
+            "VcfFile [chromosomes=[], sampleCount=1, variantCount=0, phased=true, phasedAutodetect=true]",
+            {
+                "versions_savana": [
+                    [
+                        "SAVANA_TO",
+                        "savana",
+                        "1.3.7"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-03T15:13:04.571379655",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/savana/to/tests/main.nf.test.snap
+++ b/modules/nf-core/savana/to/tests/main.nf.test.snap
@@ -2,148 +2,6 @@
     "homo_sapiens - nanopore_HG002_ont_telomere - g1000 - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sv_breakpoints.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sv_breakpoints.bedpe:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "10": [
-                    
-                ],
-                "11": [
-                    
-                ],
-                "12": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_allele_counts_hetSNPs.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "13": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_raw_read_counts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "14": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_read_counts_self_log2r_segmented.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "15": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_ranked_solutions.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "16": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_fitted_purity_ploidy.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "17": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_segmented_absolute_copy_number.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "18": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "10kbp_bin_ref_all_test_with_SV_breakpoints.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "19": [
-                    [
-                        "SAVANA_TO",
-                        "savana",
-                        "1.3.7"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sv_breakpoints_read_support.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.inserted_sequences.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.classified.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.classified.somatic.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.classified.somatic.bedpe:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "7": [
-                    
-                ],
-                "8": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "test.classified.lenient.vcf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "test.classified.strict.vcf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "9": [
-                    
-                ],
                 "allele_counts": [
                     [
                         {
@@ -288,13 +146,13 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-03T15:13:17.760247132",
+        "timestamp": "2026-06-08T14:05:13.195819423",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
         }
     },
-    "homo_sapiens - nanopore_HG002_ont_telomere - g1000": {
+    "homo_sapiens - nanopore_HG002_ont_telomere": {
         "content": [
             "VcfFile [chromosomes=[], sampleCount=1, variantCount=0, phased=true, phasedAutodetect=true]",
             "test.sv_breakpoints.bedpe",
@@ -311,7 +169,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-03T15:13:04.571379655",
+        "timestamp": "2026-06-08T14:04:58.800279569",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/savana/to/tests/main.nf.test.snap
+++ b/modules/nf-core/savana/to/tests/main.nf.test.snap
@@ -1,22 +1,12 @@
 {
-    "homo_sapiens - nanopore_HG002_ont_telomere - g1000 - stub": {
+    "homo_sapiens - nanopore - stub": {
         "content": [
             {
                 "allele_counts": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_allele_counts_hetSNPs.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "binned_ref": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "10kbp_bin_ref_all_test_with_SV_breakpoints.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "classified_vcf": [
                     [
@@ -27,12 +17,7 @@
                     ]
                 ],
                 "cna": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_segmented_absolute_copy_number.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "cna_rescue_vcfs": [
                     
@@ -41,12 +26,7 @@
                     
                 ],
                 "fitted_purity_ploidy": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_fitted_purity_ploidy.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "germline_vcf": [
                     
@@ -73,29 +53,17 @@
                         ]
                     ]
                 ],
+                "no_fit": [
+                    
+                ],
                 "ranked_solutions": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_ranked_solutions.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "raw_read_counts": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_raw_read_counts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "segmented_log2r": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test_read_counts_self_log2r_segmented.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "somatic_bedpe": [
                     [
@@ -141,12 +109,12 @@
                     [
                         "SAVANA_TO",
                         "savana",
-                        "1.3.7"
+                        "1.3.8"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-08T14:05:13.195819423",
+        "timestamp": "2026-07-02T11:51:13.813163693",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -164,12 +132,12 @@
                     [
                         "SAVANA_TO",
                         "savana",
-                        "1.3.7"
+                        "1.3.8"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-08T14:04:58.800279569",
+        "timestamp": "2026-07-02T11:51:03.741358927",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/savana/to/tests/main.nf.test.snap
+++ b/modules/nf-core/savana/to/tests/main.nf.test.snap
@@ -1,4 +1,27 @@
 {
+    "homo_sapiens - nanopore - bam": {
+        "content": [
+            "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=3, phased=false, phasedAutodetect=false]",
+            "test.sv_breakpoints.bedpe",
+            3,
+            "test.inserted_sequences.fa",
+            "VcfFile [chromosomes=[chr22], sampleCount=1, variantCount=3, phased=false, phasedAutodetect=false]",
+            {
+                "versions_savana": [
+                    [
+                        "SAVANA_TO",
+                        "savana",
+                        "1.3.8"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T12:21:29.824157309",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
     "homo_sapiens - nanopore - stub": {
         "content": [
             {
@@ -114,30 +137,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-02T11:51:13.813163693",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
-        }
-    },
-    "homo_sapiens - nanopore_HG002_ont_telomere": {
-        "content": [
-            "VcfFile [chromosomes=[], sampleCount=1, variantCount=0, phased=true, phasedAutodetect=true]",
-            "test.sv_breakpoints.bedpe",
-            1,
-            "test.inserted_sequences.fa",
-            "VcfFile [chromosomes=[], sampleCount=1, variantCount=0, phased=true, phasedAutodetect=true]",
-            {
-                "versions_savana": [
-                    [
-                        "SAVANA_TO",
-                        "savana",
-                        "1.3.8"
-                    ]
-                ]
-            }
-        ],
-        "timestamp": "2026-07-02T11:51:03.741358927",
+        "timestamp": "2026-07-02T12:21:38.662293865",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/savana/to/tests/nextflow.config
+++ b/modules/nf-core/savana/to/tests/nextflow.config
@@ -1,5 +1,5 @@
 process {
   withName: 'SAVANA_TO' {
-    ext.args = "--chromosomes 1 2 --allele_min_reads 1 --overwrite --min_support 1 --length 5"
+    ext.args = { params.module_args ?: '' }
   }
 }

--- a/modules/nf-core/savana/to/tests/nextflow.config
+++ b/modules/nf-core/savana/to/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+  withName: 'SAVANA_TO' {
+    ext.args = "--chromosomes 1 2 --allele_min_reads 1 --overwrite --min_support 1 --length 5"
+  }
+}


### PR DESCRIPTION
This PR adds a new module` savana/to`. 
Because `cna` part of `savana to` requires an adequately large test dataset for copy number fitting [@cortés‑ciriano‑lab/savana#110](https://github.com/cortes-ciriano-lab/savana/issues/110), snapshotting of copy‑number outputs has been deliberately excluded.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
