### PR TITLE
Update module amplify/predict

### DIFF
--- a/modules/nf-core/amplify/predict/environment.yml
+++ b/modules/nf-core/amplify/predict/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::amplify=2.0.0
+  - bioconda::amplify=2.0.1

--- a/modules/nf-core/amplify/predict/main.nf
+++ b/modules/nf-core/amplify/predict/main.nf
@@ -4,8 +4,8 @@ process AMPLIFY_PREDICT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/amplify:2.0.0--py36hdfd78af_1':
-        'quay.io/biocontainers/amplify:2.0.0--py36hdfd78af_1' }"
+        'https://depot.galaxyproject.org/singularity/amplify:2.0.1--py36hdfd78af_2':
+        'quay.io/biocontainers/amplify:2.0.1--py36hdfd78af_2' }"
 
     input:
     tuple val(meta), path(faa)

--- a/modules/nf-core/amplify/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/amplify/predict/tests/main.nf.test.snap
@@ -14,15 +14,15 @@
                     [
                         "AMPLIFY_PREDICT",
                         "AMPlify",
-                        "2.0.0"
+                        "2.0.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-06T14:54:38.829917615",
+        "timestamp": "2026-06-05T21:59:25.663902111",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.03.1"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
         }
     },
     "AMPlify predict (with Prodigal) - sarscov2 - contigs.fasta": {
@@ -33,22 +33,22 @@
                         {
                             "id": "test"
                         },
-                        "test.tsv:md5,1951084ce1d410028be86754997e5852"
+                        "test.tsv:md5,6028efe24bd8066fb934de7e9111f1a2"
                     ]
                 ],
                 "versions_amplify": [
                     [
                         "AMPLIFY_PREDICT",
                         "AMPlify",
-                        "2.0.0"
+                        "2.0.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-06T14:54:29.965957861",
+        "timestamp": "2026-06-05T21:59:20.161811514",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "26.03.1"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
         }
     }
 }

--- a/modules/nf-core/amplify/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/amplify/predict/tests/main.nf.test.snap
@@ -33,7 +33,7 @@
                         {
                             "id": "test"
                         },
-                        "test.tsv:md5,6028efe24bd8066fb934de7e9111f1a2"
+                        "test.tsv:md5,19c8d85daea7f5474e2c807d8c84ca10"
                     ]
                 ],
                 "versions_amplify": [


### PR DESCRIPTION
This updates amplify/predict 2.0.0 -> 2.0.1 (which brings a very relevant bugfix).

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
