### PR TITLE
Update: ANGSD/GL

### DIFF
--- a/modules/nf-core/angsd/gl/main.nf
+++ b/modules/nf-core/angsd/gl/main.nf
@@ -8,8 +8,8 @@ process ANGSD_GL {
         'quay.io/biocontainers/angsd:0.940--hce60e53_2' }"
 
     input:
-    tuple val(meta),  path(bam)
-    tuple val(meta2), path(fasta)      //Optionally
+    tuple val(meta), path(bam), path(bai)
+    tuple val(meta2), path(fasta), path(fai) //Optionally. 
     tuple val(meta3), path(error_file) //Optionally. Used for SYK model only.
 
     output:

--- a/modules/nf-core/angsd/gl/main.nf
+++ b/modules/nf-core/angsd/gl/main.nf
@@ -32,7 +32,7 @@ process ANGSD_GL {
 
     if (GL_model != 3 && GL_model != 4) {
         """
-        ls -1 *.bam > bamlist.txt
+        printf '%s\n' ${bam} > bamlist.txt
 
         angsd \\
             -nThreads ${task.cpus} \\
@@ -46,7 +46,7 @@ process ANGSD_GL {
         // No args for this part.
         // GL is hardcoded to 3 here to avoid passing all other arguments to the calibration step
         """
-        ls -1 *.bam > bamlist.txt
+        printf '%s\n' ${bam} > bamlist.txt
 
         ## SOAPsnp model
         ## First get the calibration matrix. minQ MUST be 0 for this step. Will create the directory angsd_tmpdir/ with the required files for the next step.
@@ -69,7 +69,7 @@ process ANGSD_GL {
         """
     } else if (GL_model == 4) {
         """
-        ls -1 *.bam > bamlist.txt
+        printf '%s\n' ${bam} > bamlist.txt
 
         ## SYK model
         angsd \\

--- a/modules/nf-core/angsd/gl/main.nf
+++ b/modules/nf-core/angsd/gl/main.nf
@@ -9,7 +9,7 @@ process ANGSD_GL {
 
     input:
     tuple val(meta), path(bam), path(bai)
-    tuple val(meta2), path(fasta), path(fai) //Optionally. 
+    tuple val(meta2), path(fasta), path(fai) //Optionally.
     tuple val(meta3), path(error_file) //Optionally. Used for SYK model only.
 
     output:
@@ -25,13 +25,15 @@ process ANGSD_GL {
 
     def GL_model = args.contains("-GL 1") ? 1 : args.contains("-GL 2") ? 2 : args.contains("-GL 3") ? 3 : args.contains("-GL 4") ? 4 : 0
 
-    def ref         = fasta                   ? "-ref ${fasta}"         : ''         // Use reference fasta if provided
-    def errors      = error_file              ? "-errors ${error_file}" : ''         // Only applies to SYK model
-    def output_mode = args.contains("-doGlf") ? ""                      : '-doGlf 1' // Default to outputting binary glf (10 log likelihoods) if not set in args
+    def ref         = fasta                   ? "-ref ${fasta}"            : ''         // Use reference fasta if provided
+    def touch       = fai                     ? "sleep 1 && touch ${fai}"  : ''         // Touch fai to ensure timestamp is newer than fasta
+    def errors      = error_file              ? "-errors ${error_file}"    : ''         // Only applies to SYK model
+    def output_mode = args.contains("-doGlf") ? ""                         : '-doGlf 1' // Default to outputting binary glf (10 log likelihoods) if not set in args
     // NOTE: GL is specified within args, so is not provided as a separate argument
 
     if (GL_model != 3 && GL_model != 4) {
         """
+        ${touch}
         printf '%s\n' ${bam} > bamlist.txt
 
         angsd \\
@@ -46,6 +48,7 @@ process ANGSD_GL {
         // No args for this part.
         // GL is hardcoded to 3 here to avoid passing all other arguments to the calibration step
         """
+        ${touch}
         printf '%s\n' ${bam} > bamlist.txt
 
         ## SOAPsnp model
@@ -69,6 +72,7 @@ process ANGSD_GL {
         """
     } else if (GL_model == 4) {
         """
+        ${touch}
         printf '%s\n' ${bam} > bamlist.txt
 
         ## SYK model

--- a/modules/nf-core/angsd/gl/meta.yml
+++ b/modules/nf-core/angsd/gl/meta.yml
@@ -27,6 +27,13 @@ input:
         ontologies:
           - edam: "http://edamontology.org/format_2572" # BAM
           - edam: "http://edamontology.org/format_3462" # CRAM
+    - bai:
+        type: file
+        description: A list of BAM or CRAM indices
+        pattern: "*.{bam.bai,cram.crai}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3327" # BAI
+          - edam: "http://edamontology.org/format_3462" # CRAM (no dedicated CRAI term in EDAM)
   - - meta2:
         type: map
         description: |
@@ -38,6 +45,12 @@ input:
         pattern: "*.fasta"
         ontologies:
           - edam: "http://edamontology.org/format_1929" # FASTA
+    - fai:
+        type: file
+        description: Index of the reference genome FASTA file
+        pattern: "*.{fasta,fa}.fai"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929" # FASTA (no dedicated FAI term in EDAM)
   - - meta3:
         type: map
         description: |
@@ -87,3 +100,5 @@ authors:
 maintainers:
   - "@apeltzer"
   - "@TCLamnidis"
+contributors:
+  - "@ASendellPrice"

--- a/modules/nf-core/angsd/gl/tests/main.nf.test
+++ b/modules/nf-core/angsd/gl/tests/main.nf.test
@@ -22,10 +22,12 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'test_fa' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
                 """
@@ -54,10 +56,12 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'test_fa' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
                 """
@@ -86,10 +90,12 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'test_fa' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
                 """
@@ -117,10 +123,12 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'test_fa' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
                 """
@@ -146,10 +154,12 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'test_fa' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
                 """
@@ -175,10 +185,12 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'test_fa' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
                 """
@@ -204,10 +216,12 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'test_fa' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
                 """
@@ -233,10 +247,12 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.markduplicates.sorted.bam.bai', checkIfExists: true)
                 ]
                 input[1] = [
                     [ id:'test_fa' ],
-                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr21/sequence/genome.fasta.fai', checkIfExists: true)
                 ]
                 input[2] = [ [], [] ]
                 """

--- a/modules/nf-core/angsd/gl/tests/main.nf.test.snap
+++ b/modules/nf-core/angsd/gl/tests/main.nf.test.snap
@@ -19,10 +19,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-14T15:19:09.875837084",
+        "timestamp": "2026-06-08T21:05:43.376008",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     },
     "angsd - gl_gatk - bam - stub": {
@@ -45,10 +45,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-14T15:21:46.042933441",
+        "timestamp": "2026-06-08T21:23:09.642802",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     },
     "angsd - gl_samtools - bam - stub": {
@@ -71,10 +71,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-14T15:21:30.188418306",
+        "timestamp": "2026-06-08T21:23:04.847122",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     },
     "angsd - gl_soapsnp - bam": {
@@ -97,10 +97,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-14T15:20:33.262475217",
+        "timestamp": "2026-06-08T21:06:20.613177",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     },
     "angsd - gl_syk - bam - stub": {
@@ -123,10 +123,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-14T15:22:17.401913409",
+        "timestamp": "2026-06-08T21:23:19.179511",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     },
     "angsd - gl_syk - bam": {
@@ -149,10 +149,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-14T15:21:14.237292216",
+        "timestamp": "2026-06-08T21:06:43.086787",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     },
     "angsd - gl_soapsnp - bam - stub": {
@@ -175,10 +175,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-14T15:22:01.658344669",
+        "timestamp": "2026-06-08T21:23:14.394079",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     },
     "angsd - gl_gatk - bam": {
@@ -201,10 +201,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-14T15:19:31.828513267",
+        "timestamp": "2026-06-08T21:05:53.222746",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     }
 }


### PR DESCRIPTION
This PR addresses several issues with the `angsd/gl` module I have identified while working on a pipeline. The BAM input has been updated to include the BAI index (path(bam), path(bai)), and the FASTA input now includes the FAI index (path(fasta), path(fai)), resolving errors when using `-r` (region restriction) and `-ref` respectively. 

The bamlist is now generated using `printf '%s\n' ${bam}` rather than `ls -1 *.bam`, ensuring deterministic sample ordering consistent with the input channel. A `touch` on the FAI file is performed at runtime to resolve timestamp issues when files are staged as symlinks. Tests, test data, and snapshots have been updated accordingly.

## PR checklist

Closes #11897 

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [X] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [X] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [X] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
