### PR TITLE
FIX: Remove leading 'v' from msisensorpro version topics

### DIFF
--- a/modules/nf-core/msisensorpro/msisomatic/main.nf
+++ b/modules/nf-core/msisensorpro/msisomatic/main.nf
@@ -17,7 +17,7 @@ process MSISENSORPRO_MSISOMATIC {
     tuple val(meta), path("${prefix}_dis")     , emit: output_dis
     tuple val(meta), path("${prefix}_germline"), emit: output_germline, optional: true
     tuple val(meta), path("${prefix}_somatic") , emit: output_somatic,  optional: true
-    tuple val("${task.process}"), val('msisensor-pro'), eval("msisensor-pro --version 2>&1 | sed -nE 's/Version:\\s*//p'") , emit: versions_msisensorpro, topic: versions
+    tuple val("${task.process}"), val('msisensor-pro'), eval("msisensor-pro --version 2>&1 | sed -nE 's/Version:\\s*v//p'") , emit: versions_msisensorpro, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/msisensorpro/msisomatic/meta.yml
+++ b/modules/nf-core/msisensorpro/msisomatic/meta.yml
@@ -114,7 +114,7 @@ output:
       - msisensor-pro:
           type: string
           description: The name of the tool
-      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*//p':
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*v//p':
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -125,7 +125,7 @@ topics:
       - msisensor-pro:
           type: string
           description: The name of the tool
-      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*//p':
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*v//p':
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/msisensorpro/msisomatic/tests/main.nf.test.snap
+++ b/modules/nf-core/msisensorpro/msisomatic/tests/main.nf.test.snap
@@ -28,7 +28,7 @@
                     [
                         "MSISENSORPRO_MSISOMATIC",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ],
                 "output_dis": [
@@ -57,16 +57,16 @@
                     [
                         "MSISENSORPRO_MSISOMATIC",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-02-18T17:25:19.660643827",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-02-18T17:25:19.660643827"
+        }
     },
     "homo_sapiens - cram - fasta - list -- stub": {
         "content": [
@@ -107,7 +107,7 @@
                     [
                         "MSISENSORPRO_MSISOMATIC",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ],
                 "output_dis": [
@@ -146,15 +146,15 @@
                     [
                         "MSISENSORPRO_MSISOMATIC",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-02-18T17:25:29.388003409",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-02-18T17:25:29.388003409"
+        }
     }
 }

--- a/modules/nf-core/msisensorpro/pro/main.nf
+++ b/modules/nf-core/msisensorpro/pro/main.nf
@@ -18,7 +18,7 @@ process MSISENSORPRO_PRO {
     tuple val(meta), path("${prefix}_all")      , emit: all_msi
     tuple val(meta), path("${prefix}_dis")      , emit: dis_msi
     tuple val(meta), path("${prefix}_unstable") , emit: unstable_msi
-    tuple val("${task.process}"), val('msisensor-pro'), eval("msisensor-pro --version 2>&1 | sed -nE 's/Version:\\s*//p'") , emit: versions_msisensorpro, topic: versions
+    tuple val("${task.process}"), val('msisensor-pro'), eval("msisensor-pro --version 2>&1 | sed -nE 's/Version:\\s*v//p'") , emit: versions_msisensorpro, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/msisensorpro/pro/meta.yml
+++ b/modules/nf-core/msisensorpro/pro/meta.yml
@@ -110,7 +110,7 @@ output:
       - msisensor-pro:
           type: string
           description: The name of the tool
-      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*//p':
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*v//p':
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -121,7 +121,7 @@ topics:
       - msisensor-pro:
           type: string
           description: The name of the tool
-      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*//p':
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*v//p':
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/msisensorpro/pro/tests/main.nf.test.snap
+++ b/modules/nf-core/msisensorpro/pro/tests/main.nf.test.snap
@@ -38,7 +38,7 @@
                     [
                         "MSISENSORPRO_PRO",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ],
                 "all_msi": [
@@ -77,16 +77,16 @@
                     [
                         "MSISENSORPRO_PRO",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-02-18T17:23:17.641576763",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-02-18T17:23:17.641576763"
+        }
     },
     "testdata - [test, input, index], list, fasta": {
         "content": [
@@ -127,7 +127,7 @@
                     [
                         "MSISENSORPRO_PRO",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ],
                 "all_msi": [
@@ -166,15 +166,15 @@
                     [
                         "MSISENSORPRO_PRO",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-02-18T17:23:03.333586135",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-02-18T17:23:03.333586135"
+        }
     }
 }

--- a/modules/nf-core/msisensorpro/scan/main.nf
+++ b/modules/nf-core/msisensorpro/scan/main.nf
@@ -12,7 +12,7 @@ process MSISENSORPRO_SCAN {
 
     output:
     tuple val(meta), path("*.list"), emit: list
-    tuple val("${task.process}"), val('msisensor-pro'), eval("msisensor-pro --version 2>&1 | sed -nE 's/Version:\\s*//p'") , emit: versions_msisensorpro, topic: versions
+    tuple val("${task.process}"), val('msisensor-pro'), eval("msisensor-pro --version 2>&1 | sed -nE 's/Version:\\s*v//p'") , emit: versions_msisensorpro, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/msisensorpro/scan/meta.yml
+++ b/modules/nf-core/msisensorpro/scan/meta.yml
@@ -48,7 +48,7 @@ output:
       - msisensor-pro:
           type: string
           description: The name of the tool
-      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*//p':
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*v//p':
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -59,7 +59,7 @@ topics:
       - msisensor-pro:
           type: string
           description: The name of the tool
-      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*//p':
+      - msisensor-pro --version 2>&1 | sed -nE 's/Version:\s*v//p':
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/msisensorpro/scan/tests/main.nf.test.snap
+++ b/modules/nf-core/msisensorpro/scan/tests/main.nf.test.snap
@@ -15,7 +15,7 @@
                     [
                         "MSISENSORPRO_SCAN",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ],
                 "list": [
@@ -31,16 +31,16 @@
                     [
                         "MSISENSORPRO_SCAN",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-02-18T17:28:09.342264184",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-02-18T17:28:09.342264184"
+        }
     },
     "test-msisensorpro-scan": {
         "content": [
@@ -58,7 +58,7 @@
                     [
                         "MSISENSORPRO_SCAN",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ],
                 "list": [
@@ -74,15 +74,15 @@
                     [
                         "MSISENSORPRO_SCAN",
                         "msisensor-pro",
-                        "v1.3.0"
+                        "1.3.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-02-18T17:27:57.182156379",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-02-18T17:27:57.182156379"
+        }
     }
 }


### PR DESCRIPTION
The `msisensor-pro --version` output includes a leading `v` in the version string (e.g. `v1.3.0`). The sed pattern used to extract it only strips the `Version: ` prefix, leaving the `v`. This PR updates the sed pattern to also strip the leading `v`, and updates the test snapshots and meta.yml documentation accordingly.

Changes:
- Updated sed pattern from `s/Version:\\s*//p` to `s/Version:\\s*v//p` in all 3 main.nf files
- Updated corresponding documentation in all 3 meta.yml files
- Updated test snapshots from `v1.3.0` to `1.3.0`