### PR TITLE
Add plink_gwas_regenie subworkflow

### DIFF
--- a/modules/nf-core/regenie/runl1/environment.yml
+++ b/modules/nf-core/regenie/runl1/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::regenie=4.1.2"

--- a/modules/nf-core/regenie/runl1/main.nf
+++ b/modules/nf-core/regenie/runl1/main.nf
@@ -3,7 +3,7 @@ process REGENIE_RUNL1 {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7a/7a05bf71ea09adc5ebf9f0c656c9b326c0f16ba8e4966914972e58313469a466/data'
         : 'community.wave.seqera.io/library/regenie:4.1.2--5d361f9fcb2f85cf'}"
 

--- a/modules/nf-core/regenie/runl1/main.nf
+++ b/modules/nf-core/regenie/runl1/main.nf
@@ -45,13 +45,10 @@ process REGENIE_RUNL1 {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def input_prefix = plink_genotype_file.baseName
     def prefix = task.ext.prefix ?: input_prefix
-    def pheno_match = args =~ /--phenoColList\s+(\S+)/
-    def pheno_name = pheno_match.find() ? pheno_match.group(1) : 'Y1'
     """
-    echo "${pheno_name} ${prefix}_1.loco.gz" > ${prefix}_pred.list
+    echo "Y1 ${prefix}_1.loco.gz" > ${prefix}_pred.list
     echo "" | gzip > ${prefix}_1.loco.gz
     touch ${prefix}.log
     """

--- a/modules/nf-core/regenie/runl1/main.nf
+++ b/modules/nf-core/regenie/runl1/main.nf
@@ -1,0 +1,58 @@
+process REGENIE_RUNL1 {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7a/7a05bf71ea09adc5ebf9f0c656c9b326c0f16ba8e4966914972e58313469a466/data'
+        : 'community.wave.seqera.io/library/regenie:4.1.2--5d361f9fcb2f85cf'}"
+
+    input:
+    tuple val(meta), path(plink_genotype_file), path(plink_variant_file), path(plink_sample_file)
+    tuple val(meta2), path(master), path(snplists), path(l0_predictions)
+    tuple val(meta3), path(pheno)
+    tuple val(meta4), path(covar)
+    val bsize
+
+    output:
+    tuple val(meta), path("*_pred.list"), emit: predictions
+    tuple val(meta), path("*.loco.gz"), emit: loco
+    tuple val(meta), path("*.log"), emit: log
+    tuple val("${task.process}"), val('regenie'), eval('regenie --version 2>&1 | sed -n "1{s/^v//;s/\\.gz$//;p}"'), topic: versions, emit: versions_regenie
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def input_prefix = plink_genotype_file.baseName
+    def prefix = task.ext.prefix ?: input_prefix
+    def genotype_flag = plink_genotype_file.name.endsWith('.pgen') ? '--pgen' : '--bed'
+    def covar_arg = covar ? "--covarFile ${covar}" : ''
+    def bsize_arg = bsize ?: 1000
+    """
+    regenie \\
+        --step 1 \\
+        ${genotype_flag} ${input_prefix} \\
+        --phenoFile ${pheno} \\
+        ${covar_arg} \\
+        --bsize ${bsize_arg} \\
+        --gz \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        --out ${prefix} \\
+        --run-l1 ${master}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def input_prefix = plink_genotype_file.baseName
+    def prefix = task.ext.prefix ?: input_prefix
+    def pheno_match = args =~ /--phenoColList\s+(\S+)/
+    def pheno_name = pheno_match.find() ? pheno_match.group(1) : 'Y1'
+    """
+    echo "${pheno_name} ${prefix}_1.loco.gz" > ${prefix}_pred.list
+    echo "" | gzip > ${prefix}_1.loco.gz
+    touch ${prefix}.log
+    """
+}

--- a/modules/nf-core/regenie/runl1/meta.yml
+++ b/modules/nf-core/regenie/runl1/meta.yml
@@ -1,0 +1,174 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "regenie_runl1"
+description: Finish REGENIE step 1 from split level-0 prediction files
+keywords:
+  - regenie
+  - gwas
+  - association
+  - genomics
+  - parallel
+tools:
+  - "regenie":
+      description: "Regenie is a C++ program for whole genome regression modelling of large genome-wide association studies (GWAS)."
+      homepage: "https://rgcgithub.github.io/regenie/"
+      documentation: "https://rgcgithub.github.io/regenie/options/"
+      tool_dev_url: "https://github.com/rgcgithub/regenie"
+      doi: "10.1038/s41588-021-00870-7"
+      licence: ["MIT"]
+      identifier: "biotools:regenie"
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing genotype information
+          Keep only the genotype analysis identifier in this map
+          REGENIE consumes the staged basename of `plink_genotype_file` as the `--bed` or `--pgen` prefix, so the `.bed/.bim/.fam` or `.pgen/.pvar/.psam` files must share one basename
+          e.g. `[ id:'cohort' ]`
+    - plink_genotype_file:
+        type: file
+        description: PLINK primary genotype file in BED or PGEN format
+        pattern: "*.{bed,pgen}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+    - plink_variant_file:
+        type: file
+        description: PLINK variant metadata file in BIM or PVAR format
+        pattern: "*.{bim,pvar,zst}"
+        ontologies: []
+    - plink_sample_file:
+        type: file
+        description: PLINK sample metadata file in FAM or PSAM format
+        pattern: "*.{fam,psam}"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing split level-0 output information
+          e.g. `[ id:'plink_simulated' ]`
+    - master:
+        type: file
+        description: REGENIE split level-0 master file from `regenie/splitl0`
+        pattern: "*.master"
+        ontologies:
+          - edam: "http://edamontology.org/format_2330" # Text
+    - snplists:
+        type: file
+        description: All per-job variant list files referenced by the master file, staged so `--run-l1` can resolve them
+        pattern: "*_job*.snplist"
+        ontologies:
+          - edam: "http://edamontology.org/format_2330" # Text
+    - l0_predictions:
+        type: file
+        description: All level-0 prediction files referenced by the master file, staged so `--run-l1` can resolve them
+        pattern: "*_l0_Y*"
+        ontologies: []
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing genotype/sample information associated with the phenotype file input
+          Use the same phenotype file and phenotype-selection arguments for all `regenie/splitl0`, `regenie/runl0`, and `regenie/runl1` jobs in the same chunked step 1 analysis
+          e.g. `[ id:'plink_simulated' ]`
+    - pheno:
+        type: file
+        description: Phenotype file passed to `--phenoFile`
+        pattern: "*.{phe,pheno,txt,tsv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing genotype/sample information associated with the covariate input
+          Use compatible covariate inputs for all stages in the same chunked step 1 analysis
+          e.g. `[ id:'plink_simulated' ]`
+    - covar:
+        type: file
+        optional: true
+        description: Optional covariate file passed to `--covarFile`; provide `[]` when absent
+        pattern: "*.{covar,cov,txt,tsv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+  - bsize:
+      type: integer
+      description: Optional block size passed to `--bsize`; pass `[]` to use the module default of `1000`
+
+output:
+  predictions:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing genotype/sample information
+            e.g. `[ id:'plink_simulated' ]`
+      - "*_pred.list":
+          type: file
+          description: REGENIE prediction list file
+          pattern: "*_pred.list"
+          ontologies: []
+  loco:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing genotype/sample information
+            e.g. `[ id:'plink_simulated' ]`
+      - "*.loco.gz":
+          type: file
+          description: REGENIE LOCO prediction files
+          pattern: "*.loco.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_3987" # GZIP
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing genotype information
+            e.g. `[ id:'plink_simulated' ]`
+      - "*.log":
+          type: file
+          description: REGENIE run level-1 log file
+          pattern: "*.log"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330" # Text
+  versions_regenie:
+    - - "${task.process}":
+          type: string
+          description: The process the versions were collected from
+      - "regenie":
+          type: string
+          description: The tool name
+      - 'regenie --version 2>&1 | sed -n "1{s/^v//;s/\.gz$//;p}"':
+          type: eval
+          description: The command used to generate the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - regenie:
+          type: string
+          description: The tool name
+      - 'regenie --version 2>&1 | sed -n "1{s/^v//;s/\.gz$//;p}"':
+          type: eval
+          description: The command used to generate the version of the tool
+
+notes: |
+  `task.ext.args` is passed directly to REGENIE and can be used for stage-consistent options such as `--phenoColList`, `--bt`, `--loocv`, `--keep-l0`, or `--l1-phenoList`.
+  The same phenotype file, phenotype-selection arguments, trait mode arguments such as `--bt`, and compatible genotype/covariate inputs must be used across `regenie/splitl0`, every matching `regenie/runl0` job, and `regenie/runl1`.
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"
+containers:
+  conda:
+    linux_amd64:
+      lock_file: "modules/nf-core/regenie/runl1/.conda-lock/linux_amd64-bd-5d361f9fcb2f85cf_1.txt"
+  docker:
+    linux_amd64:
+      build_id: "bd-5d361f9fcb2f85cf_1"
+      name: "community.wave.seqera.io/library/regenie:4.1.2--5d361f9fcb2f85cf"
+      scanId: "sc-cc9eb5ed5eb381dd_2"
+  singularity:
+    linux_amd64:
+      build_id: "bd-7c121fb4ecd57890_1"
+      name: "oras://community.wave.seqera.io/library/regenie:4.1.2--7c121fb4ecd57890"
+      https: "https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7a/7a05bf71ea09adc5ebf9f0c656c9b326c0f16ba8e4966914972e58313469a466/data"

--- a/modules/nf-core/regenie/runl1/meta.yml
+++ b/modules/nf-core/regenie/runl1/meta.yml
@@ -160,13 +160,16 @@ authors:
 maintainers:
   - "@lyh970817"
 containers:
+  conda:
+    linux/amd64:
+      lock_file: "modules/nf-core/regenie/runl1/.conda-lock/linux_amd64-bd-5d361f9fcb2f85cf_1.txt"
   docker:
-    linux_amd64:
+    linux/amd64:
       build_id: "bd-5d361f9fcb2f85cf_1"
       name: "community.wave.seqera.io/library/regenie:4.1.2--5d361f9fcb2f85cf"
-      scanId: "sc-cc9eb5ed5eb381dd_2"
+      scan_id: "sc-cc9eb5ed5eb381dd_2"
   singularity:
-    linux_amd64:
+    linux/amd64:
       build_id: "bd-7c121fb4ecd57890_1"
       name: "oras://community.wave.seqera.io/library/regenie:4.1.2--7c121fb4ecd57890"
       https: "https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7a/7a05bf71ea09adc5ebf9f0c656c9b326c0f16ba8e4966914972e58313469a466/data"

--- a/modules/nf-core/regenie/runl1/meta.yml
+++ b/modules/nf-core/regenie/runl1/meta.yml
@@ -4,6 +4,7 @@ description: Finish REGENIE step 1 from split level-0 prediction files
 keywords:
   - regenie
   - gwas
+  - genome-wide association study
   - association
   - genomics
   - parallel
@@ -159,9 +160,6 @@ authors:
 maintainers:
   - "@lyh970817"
 containers:
-  conda:
-    linux_amd64:
-      lock_file: "modules/nf-core/regenie/runl1/.conda-lock/linux_amd64-bd-5d361f9fcb2f85cf_1.txt"
   docker:
     linux_amd64:
       build_id: "bd-5d361f9fcb2f85cf_1"

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test
@@ -1,0 +1,243 @@
+nextflow_process {
+
+    name "Test Process REGENIE_RUNL1"
+    config "./nextflow.config"
+    script "../main.nf"
+    process "REGENIE_RUNL1"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "regenie"
+    tag "regenie/splitl0"
+    tag "regenie/runl0"
+    tag "regenie/runl1"
+
+    setup {
+        run("REGENIE_SPLITL0") {
+            script "../../splitl0/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+
+                input[1] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ]
+
+                input[2] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ]
+
+                input[3] = 100
+                input[4] = 2
+                """
+            }
+        }
+
+        run("REGENIE_RUNL0") {
+            script "../../runl0/main.nf"
+            process {
+                """
+                input[0] = Channel.of(
+                    [
+                        [ id:'plink_simulated' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'plink_simulated' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                )
+
+                input[1] = REGENIE_SPLITL0.out.master
+                    .combine(REGENIE_SPLITL0.out.snplists)
+                    .flatMap { master_meta, master, snplist_meta, snplists ->
+                        (1..2).collect { job ->
+                            [
+                                master_meta,
+                                master,
+                                snplists.find { snplist -> snplist.getFileName().toString().contains('_job' + job + '.snplist') },
+                                job
+                            ]
+                        }
+                    }
+
+                input[2] = Channel.of(
+                    [
+                        [ id:'plink_simulated' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'plink_simulated' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                    ]
+                )
+
+                input[3] = Channel.of(
+                    [
+                        [ id:'plink_simulated' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'plink_simulated' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                    ]
+                )
+
+                input[4] = Channel.of(100, 100)
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens popgen - quantitative plink1 with covariates") {
+
+        when {
+            params {
+                module_args = '--phenoColList QuantitativeTrait'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+
+                input[1] = REGENIE_SPLITL0.out.master
+                    .combine(REGENIE_SPLITL0.out.snplists)
+                    .combine(REGENIE_RUNL0.out.l0_predictions.map { it[1] }.collect())
+                    .map { values ->
+                        [ values[0], values[1], values[3], values.drop(4).flatten() ]
+                    }
+
+                input[2] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ]
+
+                input[3] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ]
+
+                input[4] = 100
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.predictions.size() == 1 },
+                { assert process.out.loco.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                { assert process.out.predictions.get(0).get(0).id == 'plink_simulated' },
+                { assert process.out.loco.get(0).get(0).id == 'plink_simulated' },
+                { assert process.out.log.get(0).get(0).id == 'plink_simulated' },
+                { assert path(process.out.log.get(0).get(1)).exists() },
+                {
+                    def predList = path(process.out.predictions.get(0).get(1))
+                    def locoFile = path(process.out.loco.get(0).get(1))
+                    def predListLines = predList.text.readLines().findAll { it }
+                    assert predList.exists()
+                    assert predListLines.size() == 1
+                    def predListFields = predListLines[0].split(/\s+/)
+                    assert predListFields.size() == 2
+                    assert predListFields[0] == 'QuantitativeTrait'
+                    assert predListFields[1] == locoFile.toString()
+                },
+                {
+                    def stablePredictions = process.out.predictions.collect { prediction ->
+                        [prediction[0], path(prediction[1]).getFileName().toString()]
+                    }
+                    def stableLoco = process.out.loco.collect { loco ->
+                        [loco[0], path(loco[1]).getFileName().toString()]
+                    }
+                    assert snapshot(
+                        stablePredictions,
+                        stableLoco,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("homo_sapiens popgen - plink1 - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = '--phenoColList QuantitativeTrait'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+
+                input[1] = REGENIE_SPLITL0.out.master
+                    .combine(REGENIE_SPLITL0.out.snplists)
+                    .combine(REGENIE_RUNL0.out.l0_predictions.map { it[1] }.collect())
+                    .map { values ->
+                        [ values[0], values[1], values[3], values.drop(4).flatten() ]
+                    }
+
+                input[2] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ]
+
+                input[3] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ]
+
+                input[4] = 100
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                {
+                    def stablePredictions = process.out.predictions.collect { prediction ->
+                        [prediction[0], path(prediction[1]).getFileName().toString()]
+                    }
+                    def stableLoco = process.out.loco.collect { loco ->
+                        [loco[0], path(loco[1]).getFileName().toString()]
+                    }
+                    def stableLogs = process.out.log.collect { log ->
+                        [log[0], path(log[1]).getFileName().toString()]
+                    }
+                    assert snapshot(
+                        stablePredictions,
+                        stableLoco,
+                        stableLogs,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test
@@ -1,9 +1,9 @@
 nextflow_process {
 
     name "Test Process REGENIE_RUNL1"
-    config "./nextflow.config"
     script "../main.nf"
     process "REGENIE_RUNL1"
+    config "./nextflow.config"
 
     tag "modules"
     tag "modules_nfcore"
@@ -63,12 +63,7 @@ nextflow_process {
                     .combine(REGENIE_SPLITL0.out.snplists)
                     .flatMap { master_meta, master, snplist_meta, snplists ->
                         (1..2).collect { job ->
-                            [
-                                master_meta,
-                                master,
-                                snplists.find { snplist -> snplist.getFileName().toString().contains('_job' + job + '.snplist') },
-                                job
-                            ]
+                            [master_meta, master, snplists, job]
                         }
                     }
 
@@ -98,13 +93,64 @@ nextflow_process {
                 """
             }
         }
+
+        run("REGENIE_SPLITL0", alias: "REGENIE_SPLITL0_PLINK2") {
+            script "../../splitl0/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'plink_simulated_plink2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ]
+
+                input[1] = [
+                    [ id:'plink_simulated_plink2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ]
+
+                input[2] = [[:], []]
+                input[3] = []
+                input[4] = 2
+                """
+            }
+        }
+
+        run("REGENIE_RUNL0", alias: "REGENIE_RUNL0_PLINK2") {
+            script "../../runl0/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'plink_simulated_plink2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ]
+
+                input[1] = REGENIE_SPLITL0_PLINK2.out.master
+                    .combine(REGENIE_SPLITL0_PLINK2.out.snplists)
+                    .map { master_meta, master, snplist_meta, snplists ->
+                        [master_meta, master, snplists, 1]
+                    }
+
+                input[2] = [
+                    [ id:'plink_simulated_plink2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                input[4] = []
+                """
+            }
+        }
     }
 
     test("homo_sapiens popgen - quantitative plink1 with covariates") {
 
         when {
             params {
-                module_args = '--phenoColList QuantitativeTrait'
+                module_args = "--phenoColList QuantitativeTrait"
             }
             process {
                 """
@@ -148,6 +194,21 @@ nextflow_process {
                 { assert process.out.log.get(0).get(0).id == 'plink_simulated' },
                 { assert path(process.out.log.get(0).get(1)).exists() },
                 {
+                    def workDir = path(process.out.predictions.get(0).get(1)).parent
+                    def command = workDir.resolve('.command.sh').text
+                    def stagedNames = workDir.toFile().listFiles().collect { it.name }
+
+                    assert command.contains('--run-l1 plink_simulated.master')
+                    assert command.contains('--bed plink_simulated')
+                    assert command.contains('--covarFile plink_simulated_covariates.txt')
+                    assert command.contains('--bsize 100')
+                    assert !command.contains('--pgen')
+                    assert stagedNames.contains('plink_simulated.bed')
+                    assert stagedNames.contains('plink_simulated.bim')
+                    assert stagedNames.contains('plink_simulated.fam')
+                    assert stagedNames.contains('plink_simulated.master')
+                },
+                {
                     def predList = path(process.out.predictions.get(0).get(1))
                     def locoFile = path(process.out.loco.get(0).get(1))
                     def predListLines = predList.text.readLines().findAll { it }
@@ -165,9 +226,99 @@ nextflow_process {
                     def stableLoco = process.out.loco.collect { loco ->
                         [loco[0], path(loco[1]).getFileName().toString()]
                     }
+                    def stableLogs = process.out.log.collect { log ->
+                        [log[0], path(log[1]).getFileName().toString()]
+                    }
                     assert snapshot(
                         stablePredictions,
                         stableLoco,
+                        stableLogs,
+                        process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("homo_sapiens popgen - quantitative plink2 without covariates") {
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+                module_prefix = "plink_simulated_plink2"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'plink_simulated_plink2' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ]
+
+                input[1] = REGENIE_SPLITL0_PLINK2.out.master
+                    .combine(REGENIE_SPLITL0_PLINK2.out.snplists)
+                    .combine(REGENIE_RUNL0_PLINK2.out.l0_predictions.map { it[1] }.collect())
+                    .map { values ->
+                        [ values[0], values[1], values[3], values.drop(4).flatten() ]
+                    }
+
+                input[2] = [
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ]
+
+                input[3] = [
+                    [ id:'plink_simulated' ],
+                    []
+                ]
+
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.predictions.size() == 1 },
+                { assert process.out.loco.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                { assert process.out.predictions.get(0).get(0).id == 'plink_simulated_plink2' },
+                { assert process.out.loco.get(0).get(0).id == 'plink_simulated_plink2' },
+                { assert process.out.log.get(0).get(0).id == 'plink_simulated_plink2' },
+                {
+                    def workDir = path(process.out.predictions.get(0).get(1)).parent
+                    def command = workDir.resolve('.command.sh').text
+                    def stagedNames = workDir.toFile().listFiles().collect { it.name }
+
+                    assert command.contains('--run-l1 plink_simulated_plink2.master')
+                    assert command.contains('--pgen plink_simulated')
+                    assert command.contains('--bsize 1000')
+                    assert command.contains('--out plink_simulated_plink2')
+                    assert !command.contains('--bed')
+                    assert !command.contains('--covarFile')
+                    assert command.contains('--phenoColList QuantitativeTrait')
+                    assert stagedNames.contains('plink_simulated.pgen')
+                    assert stagedNames.contains('plink_simulated.psam')
+                    assert stagedNames.contains('plink_simulated.pvar')
+                    assert stagedNames.contains('plink_simulated_plink2.master')
+                },
+                {
+                    def stablePredictions = process.out.predictions.collect { prediction ->
+                        [prediction[0], path(prediction[1]).getFileName().toString()]
+                    }
+                    def stableLoco = process.out.loco.collect { loco ->
+                        [loco[0], path(loco[1]).getFileName().toString()]
+                    }
+                    def stableLogs = process.out.log.collect { log ->
+                        [log[0], path(log[1]).getFileName().toString()]
+                    }
+                    assert snapshot(
+                        stablePredictions,
+                        stableLoco,
+                        stableLogs,
                         process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 }
@@ -181,9 +332,6 @@ nextflow_process {
         options "-stub"
 
         when {
-            params {
-                module_args = '--phenoColList QuantitativeTrait'
-            }
             process {
                 """
                 input[0] = [

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test
@@ -99,14 +99,14 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'plink_simulated_plink2' ],
+                    [ id:'plink_simulated' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
                 ]
 
                 input[1] = [
-                    [ id:'plink_simulated_plink2' ],
+                    [ id:'plink_simulated' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
                 ]
 
@@ -122,7 +122,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'plink_simulated_plink2' ],
+                    [ id:'plink_simulated' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
@@ -135,7 +135,7 @@ nextflow_process {
                     }
 
                 input[2] = [
-                    [ id:'plink_simulated_plink2' ],
+                    [ id:'plink_simulated' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
                 ]
 
@@ -194,19 +194,12 @@ nextflow_process {
                 { assert process.out.log.get(0).get(0).id == 'plink_simulated' },
                 { assert path(process.out.log.get(0).get(1)).exists() },
                 {
-                    def workDir = path(process.out.predictions.get(0).get(1)).parent
-                    def command = workDir.resolve('.command.sh').text
-                    def stagedNames = workDir.toFile().listFiles().collect { it.name }
-
+                    def command = path(process.out.predictions.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
                     assert command.contains('--run-l1 plink_simulated.master')
                     assert command.contains('--bed plink_simulated')
                     assert command.contains('--covarFile plink_simulated_covariates.txt')
                     assert command.contains('--bsize 100')
                     assert !command.contains('--pgen')
-                    assert stagedNames.contains('plink_simulated.bed')
-                    assert stagedNames.contains('plink_simulated.bim')
-                    assert stagedNames.contains('plink_simulated.fam')
-                    assert stagedNames.contains('plink_simulated.master')
                 },
                 {
                     def predList = path(process.out.predictions.get(0).get(1))
@@ -229,12 +222,12 @@ nextflow_process {
                     def stableLogs = process.out.log.collect { log ->
                         [log[0], path(log[1]).getFileName().toString()]
                     }
-                    assert snapshot(
-                        stablePredictions,
-                        stableLoco,
-                        stableLogs,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
+                    assert snapshot([
+                        predictions: stablePredictions,
+                        loco: stableLoco,
+                        log: stableLogs,
+                        versions_regenie: process.out.versions_regenie
+                    ]).match()
                 }
             )
         }
@@ -251,7 +244,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'plink_simulated_plink2' ],
+                    [ id:'plink_simulated' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
@@ -285,14 +278,11 @@ nextflow_process {
                 { assert process.out.predictions.size() == 1 },
                 { assert process.out.loco.size() == 1 },
                 { assert process.out.log.size() == 1 },
-                { assert process.out.predictions.get(0).get(0).id == 'plink_simulated_plink2' },
-                { assert process.out.loco.get(0).get(0).id == 'plink_simulated_plink2' },
-                { assert process.out.log.get(0).get(0).id == 'plink_simulated_plink2' },
+                { assert process.out.predictions.get(0).get(0).id == 'plink_simulated' },
+                { assert process.out.loco.get(0).get(0).id == 'plink_simulated' },
+                { assert process.out.log.get(0).get(0).id == 'plink_simulated' },
                 {
-                    def workDir = path(process.out.predictions.get(0).get(1)).parent
-                    def command = workDir.resolve('.command.sh').text
-                    def stagedNames = workDir.toFile().listFiles().collect { it.name }
-
+                    def command = path(process.out.predictions.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
                     assert command.contains('--run-l1 plink_simulated_plink2.master')
                     assert command.contains('--pgen plink_simulated')
                     assert command.contains('--bsize 1000')
@@ -300,10 +290,6 @@ nextflow_process {
                     assert !command.contains('--bed')
                     assert !command.contains('--covarFile')
                     assert command.contains('--phenoColList QuantitativeTrait')
-                    assert stagedNames.contains('plink_simulated.pgen')
-                    assert stagedNames.contains('plink_simulated.psam')
-                    assert stagedNames.contains('plink_simulated.pvar')
-                    assert stagedNames.contains('plink_simulated_plink2.master')
                 },
                 {
                     def stablePredictions = process.out.predictions.collect { prediction ->
@@ -315,12 +301,12 @@ nextflow_process {
                     def stableLogs = process.out.log.collect { log ->
                         [log[0], path(log[1]).getFileName().toString()]
                     }
-                    assert snapshot(
-                        stablePredictions,
-                        stableLoco,
-                        stableLogs,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
+                    assert snapshot([
+                        predictions: stablePredictions,
+                        loco: stableLoco,
+                        log: stableLogs,
+                        versions_regenie: process.out.versions_regenie
+                    ]).match()
                 }
             )
         }
@@ -376,12 +362,12 @@ nextflow_process {
                     def stableLogs = process.out.log.collect { log ->
                         [log[0], path(log[1]).getFileName().toString()]
                     }
-                    assert snapshot(
-                        stablePredictions,
-                        stableLoco,
-                        stableLogs,
-                        process.out.findAll { key, val -> key.startsWith('versions') }
-                    ).match()
+                    assert snapshot([
+                        predictions: stablePredictions,
+                        loco: stableLoco,
+                        log: stableLogs,
+                        versions_regenie: process.out.versions_regenie
+                    ]).match()
                 }
             )
         }

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test
@@ -239,7 +239,6 @@ nextflow_process {
         when {
             params {
                 module_args = "--phenoColList QuantitativeTrait"
-                module_prefix = "plink_simulated_plink2"
             }
             process {
                 """
@@ -283,7 +282,7 @@ nextflow_process {
                 { assert process.out.log.get(0).get(0).id == 'plink_simulated' },
                 {
                     def command = path(process.out.predictions.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
-                    assert command.contains('--run-l1 plink_simulated_plink2.master')
+                    assert command.contains('--run-l1 plink_simulated.master')
                     assert command.contains('--pgen plink_simulated')
                     assert command.contains('--bsize 1000')
                     assert command.contains('--out plink_simulated')

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test
@@ -296,7 +296,7 @@ nextflow_process {
                     assert command.contains('--run-l1 plink_simulated_plink2.master')
                     assert command.contains('--pgen plink_simulated')
                     assert command.contains('--bsize 1000')
-                    assert command.contains('--out plink_simulated_plink2')
+                    assert command.contains('--out plink_simulated')
                     assert !command.contains('--bed')
                     assert !command.contains('--covarFile')
                     assert command.contains('--phenoColList QuantitativeTrait')

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test.snap
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test.snap
@@ -17,6 +17,14 @@
                     "plink_simulated_1.loco.gz"
                 ]
             ],
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated.log"
+                ]
+            ],
             {
                 "versions_regenie": [
                     [
@@ -31,7 +39,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-21T22:36:12.351327082"
+        "timestamp": "2026-05-27T19:57:18.939854903"
     },
     "homo_sapiens popgen - plink1 - stub": {
         "content": [
@@ -73,6 +81,48 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-21T22:37:19.177658994"
+        "timestamp": "2026-05-27T18:59:13.646476959"
+    },
+    "homo_sapiens popgen - quantitative plink2 without covariates": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated_plink2"
+                    },
+                    "plink_simulated_plink2_pred.list"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "plink_simulated_plink2"
+                    },
+                    "plink_simulated_plink2_1.loco.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "plink_simulated_plink2"
+                    },
+                    "plink_simulated_plink2.log"
+                ]
+            ],
+            {
+                "versions_regenie": [
+                    [
+                        "REGENIE_RUNL1",
+                        "regenie",
+                        "4.1.2"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-27T19:57:40.719017173"
     }
 }

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test.snap
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test.snap
@@ -90,7 +90,7 @@
                     {
                         "id": "plink_simulated_plink2"
                     },
-                    "plink_simulated_plink2_pred.list"
+                    "plink_simulated_pred.list"
                 ]
             ],
             [
@@ -98,7 +98,7 @@
                     {
                         "id": "plink_simulated_plink2"
                     },
-                    "plink_simulated_plink2_1.loco.gz"
+                    "plink_simulated_1.loco.gz"
                 ]
             ],
             [
@@ -106,7 +106,7 @@
                     {
                         "id": "plink_simulated_plink2"
                     },
-                    "plink_simulated_plink2.log"
+                    "plink_simulated.log"
                 ]
             ],
             {

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test.snap
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test.snap
@@ -1,0 +1,78 @@
+{
+    "homo_sapiens popgen - quantitative plink1 with covariates": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated_pred.list"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated_1.loco.gz"
+                ]
+            ],
+            {
+                "versions_regenie": [
+                    [
+                        "REGENIE_RUNL1",
+                        "regenie",
+                        "4.1.2"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-21T22:36:12.351327082"
+    },
+    "homo_sapiens popgen - plink1 - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated_pred.list"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated_1.loco.gz"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated.log"
+                ]
+            ],
+            {
+                "versions_regenie": [
+                    [
+                        "REGENIE_RUNL1",
+                        "regenie",
+                        "4.1.2"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-05-21T22:37:19.177658994"
+    }
+}

--- a/modules/nf-core/regenie/runl1/tests/main.nf.test.snap
+++ b/modules/nf-core/regenie/runl1/tests/main.nf.test.snap
@@ -1,31 +1,31 @@
 {
     "homo_sapiens popgen - quantitative plink1 with covariates": {
         "content": [
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated_pred.list"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated_1.loco.gz"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated.log"
-                ]
-            ],
             {
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
                 "versions_regenie": [
                     [
                         "REGENIE_RUNL1",
@@ -39,35 +39,35 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-27T19:57:18.939854903"
+        "timestamp": "2026-06-08T00:58:56.144945786"
     },
     "homo_sapiens popgen - plink1 - stub": {
         "content": [
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated_pred.list"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated_1.loco.gz"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "plink_simulated"
-                    },
-                    "plink_simulated.log"
-                ]
-            ],
             {
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
                 "versions_regenie": [
                     [
                         "REGENIE_RUNL1",
@@ -85,31 +85,31 @@
     },
     "homo_sapiens popgen - quantitative plink2 without covariates": {
         "content": [
-            [
-                [
-                    {
-                        "id": "plink_simulated_plink2"
-                    },
-                    "plink_simulated_pred.list"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "plink_simulated_plink2"
-                    },
-                    "plink_simulated_1.loco.gz"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "plink_simulated_plink2"
-                    },
-                    "plink_simulated.log"
-                ]
-            ],
             {
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
                 "versions_regenie": [
                     [
                         "REGENIE_RUNL1",
@@ -123,6 +123,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-05-27T19:57:40.719017173"
+        "timestamp": "2026-06-08T00:59:23.869025925"
     }
 }

--- a/modules/nf-core/regenie/runl1/tests/nextflow.config
+++ b/modules/nf-core/regenie/runl1/tests/nextflow.config
@@ -1,0 +1,11 @@
+process {
+    withName: REGENIE_SPLITL0 {
+        ext.args = params.module_args
+    }
+    withName: REGENIE_RUNL0 {
+        ext.args = params.module_args
+    }
+    withName: REGENIE_RUNL1 {
+        ext.args = params.module_args
+    }
+}

--- a/modules/nf-core/regenie/runl1/tests/nextflow.config
+++ b/modules/nf-core/regenie/runl1/tests/nextflow.config
@@ -7,7 +7,7 @@ process {
     withName: "REGENIE_SPLITL0|REGENIE_RUNL0|REGENIE_RUNL1|REGENIE_SPLITL0_PLINK2|REGENIE_RUNL0_PLINK2" {
         ext.args = { params.module_args ?: "" }
     }
-    withName: "REGENIE_SPLITL0_PLINK2|REGENIE_RUNL0_PLINK2|REGENIE_RUNL1" {
+    withName: "REGENIE_SPLITL0_PLINK2|REGENIE_RUNL0_PLINK2" {
         ext.prefix = { params.module_prefix }
     }
 }

--- a/modules/nf-core/regenie/runl1/tests/nextflow.config
+++ b/modules/nf-core/regenie/runl1/tests/nextflow.config
@@ -1,13 +1,9 @@
 params {
     module_args = ""
-    module_prefix = null
 }
 
 process {
     withName: "REGENIE_SPLITL0|REGENIE_RUNL0|REGENIE_RUNL1|REGENIE_SPLITL0_PLINK2|REGENIE_RUNL0_PLINK2" {
         ext.args = { params.module_args ?: "" }
-    }
-    withName: "REGENIE_SPLITL0_PLINK2|REGENIE_RUNL0_PLINK2" {
-        ext.prefix = { params.module_prefix }
     }
 }

--- a/modules/nf-core/regenie/runl1/tests/nextflow.config
+++ b/modules/nf-core/regenie/runl1/tests/nextflow.config
@@ -1,11 +1,13 @@
+params {
+    module_args = ""
+    module_prefix = null
+}
+
 process {
-    withName: REGENIE_SPLITL0 {
-        ext.args = params.module_args
+    withName: "REGENIE_SPLITL0|REGENIE_RUNL0|REGENIE_RUNL1|REGENIE_SPLITL0_PLINK2|REGENIE_RUNL0_PLINK2" {
+        ext.args = { params.module_args ?: "" }
     }
-    withName: REGENIE_RUNL0 {
-        ext.args = params.module_args
-    }
-    withName: REGENIE_RUNL1 {
-        ext.args = params.module_args
+    withName: "REGENIE_SPLITL0_PLINK2|REGENIE_RUNL0_PLINK2|REGENIE_RUNL1" {
+        ext.prefix = { params.module_prefix }
     }
 }

--- a/subworkflows/nf-core/plink_fit_regenie/main.nf
+++ b/subworkflows/nf-core/plink_fit_regenie/main.nf
@@ -1,0 +1,143 @@
+//
+// Fit REGENIE Step 1 whole-genome regression models from PLINK-format genotype files
+//
+
+include { REGENIE_STEP1   } from '../../../modules/nf-core/regenie/step1/main'
+include { REGENIE_SPLITL0 } from '../../../modules/nf-core/regenie/splitl0/main'
+include { REGENIE_RUNL0   } from '../../../modules/nf-core/regenie/runl0/main'
+include { REGENIE_RUNL1   } from '../../../modules/nf-core/regenie/runl1/main'
+
+workflow PLINK_FIT_REGENIE {
+    take:
+    ch_genotypes // channel: [ val(meta), path(genotype_file), path(variant_file), path(sample_file) ]
+    ch_pheno // channel: [ val(meta), path(pheno) ]
+    ch_covar // channel: [ val(meta), path(covar) ], use [] when absent
+    val_bsize // value: Step 1 block size, use [] to keep module default
+    val_step1_mode // value: 'standard' or 'chunked'
+    val_n_l0_jobs // value: number of L0 jobs for chunked mode, use [] for standard mode
+
+    main:
+    ch_versions = channel.empty()
+
+    if (!['standard', 'chunked'].contains(val_step1_mode)) {
+        error("PLINK_FIT_REGENIE: val_step1_mode must be 'standard' or 'chunked', got '${val_step1_mode}'")
+    }
+
+    if (val_step1_mode == 'standard') {
+        if (!is_empty_value(val_n_l0_jobs)) {
+            error("PLINK_FIT_REGENIE: val_n_l0_jobs must be empty when val_step1_mode is 'standard'")
+        }
+
+        REGENIE_STEP1(
+            ch_genotypes,
+            ch_pheno,
+            ch_covar,
+            val_bsize,
+        )
+
+        ch_predictions = REGENIE_STEP1.out.predictions
+        ch_loco = REGENIE_STEP1.out.loco
+        ch_log = REGENIE_STEP1.out.log
+    }
+    else {
+        n_l0_jobs = require_positive_integer(
+            val_n_l0_jobs,
+            "PLINK_FIT_REGENIE: val_n_l0_jobs must be a positive integer when val_step1_mode is 'chunked'",
+        )
+
+        REGENIE_SPLITL0(
+            ch_genotypes,
+            ch_pheno,
+            ch_covar,
+            val_bsize,
+            n_l0_jobs,
+        )
+
+        ch_l0_jobs = REGENIE_SPLITL0.out.master
+            .join(REGENIE_SPLITL0.out.snplists, by: [0])
+            .flatMap { meta, master, snplists ->
+                (1..n_l0_jobs).collect { job_number ->
+                    [meta, master, snplists, job_number]
+                }
+            }
+
+        ch_runl0_inputs = ch_genotypes
+            .combine(ch_l0_jobs, by: [0])
+            .combine(ch_pheno, by: [0])
+            .combine(ch_covar, by: [0])
+
+        REGENIE_RUNL0(
+            ch_runl0_inputs.map { values ->
+                [values[0], values[1], values[2], values[3]]
+            },
+            ch_runl0_inputs.map { values ->
+                [values[0], values[4], values[5], values[6]]
+            },
+            ch_runl0_inputs.map { values ->
+                [values[0], values[7]]
+            },
+            ch_runl0_inputs.map { values ->
+                [values[0], values[8]]
+            },
+            val_bsize,
+        )
+
+        ch_l0_predictions = REGENIE_RUNL0.out.l0_predictions
+            .groupTuple(by: [0])
+            .map { meta, l0_predictions ->
+                [meta, l0_predictions.flatten()]
+            }
+
+        ch_runl1_split_inputs = REGENIE_SPLITL0.out.master
+            .join(REGENIE_SPLITL0.out.snplists, by: [0])
+            .join(ch_l0_predictions, by: [0])
+
+        ch_runl1_inputs = ch_genotypes
+            .combine(ch_runl1_split_inputs, by: [0])
+            .combine(ch_pheno, by: [0])
+            .combine(ch_covar, by: [0])
+
+        REGENIE_RUNL1(
+            ch_runl1_inputs.map { values ->
+                [values[0], values[1], values[2], values[3]]
+            },
+            ch_runl1_inputs.map { values ->
+                [values[0], values[4], values[5], values[6]]
+            },
+            ch_runl1_inputs.map { values ->
+                [values[0], values[7]]
+            },
+            ch_runl1_inputs.map { values ->
+                [values[0], values[8]]
+            },
+            val_bsize,
+        )
+
+        ch_predictions = REGENIE_RUNL1.out.predictions
+        ch_loco = REGENIE_RUNL1.out.loco
+        ch_log = REGENIE_SPLITL0.out.log.mix(REGENIE_RUNL0.out.log, REGENIE_RUNL1.out.log)
+    }
+
+    emit:
+    predictions = ch_predictions
+    loco        = ch_loco
+    logs        = ch_log
+    versions    = ch_versions
+}
+
+def is_empty_value(value) {
+    value == null || value == [] || value == ''
+}
+
+def require_positive_integer(value, message) {
+    try {
+        def integer_value = value as Integer
+        if (integer_value < 1) {
+            error(message)
+        }
+        return integer_value
+    }
+    catch (_ignored) {
+        error(message)
+    }
+}

--- a/subworkflows/nf-core/plink_fit_regenie/meta.yml
+++ b/subworkflows/nf-core/plink_fit_regenie/meta.yml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: plink_fit_regenie
+description: Fit REGENIE Step 1 prediction models from PLINK-format genotype bundles
+keywords:
+  - regenie
+  - gwas
+  - plink
+  - step1
+  - genotype
+components:
+  - regenie/step1
+  - regenie/splitl0
+  - regenie/runl0
+  - regenie/runl1
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - genotype_file:
+      type: file
+      description: PLINK-format genotype file, either PLINK 1 BED or PLINK 2 PGEN
+      pattern: "*.{bed,pgen}"
+  - variant_file:
+      type: file
+      description: PLINK-format variant file matching the genotype file
+      pattern: "*.{bim,pvar}"
+  - sample_file:
+      type: file
+      description: PLINK-format sample file matching the genotype file
+      pattern: "*.{fam,psam}"
+  - pheno:
+      type: file
+      description: REGENIE phenotype file
+      pattern: "*"
+  - covar:
+      type: file
+      description: Optional REGENIE covariate file. Use [] when absent.
+      pattern: "*"
+  - bsize:
+      type: integer
+      description: Step 1 block size. Use [] to keep the module default.
+  - step1_mode:
+      type: string
+      description: Step 1 execution mode. Must be "standard" or "chunked".
+  - n_l0_jobs:
+      type: integer
+      description: Number of L0 jobs for chunked mode. Use [] for standard mode.
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - predictions:
+      type: file
+      description: REGENIE Step 1 prediction list
+      pattern: "*_pred.list"
+  - loco:
+      type: file
+      description: REGENIE Step 1 leave-one-chromosome-out predictions
+      pattern: "*.loco.gz"
+  - logs:
+      type: file
+      description: REGENIE log files from the selected Step 1 execution path
+      pattern: "*.log"
+  - versions:
+      type: file
+      description: Compatibility versions channel. REGENIE module versions are published via topic channels.
+      pattern: "versions.yml"
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/subworkflows/nf-core/plink_fit_regenie/tests/main.nf.test
+++ b/subworkflows/nf-core/plink_fit_regenie/tests/main.nf.test
@@ -1,0 +1,376 @@
+nextflow_workflow {
+
+    name "Test Workflow PLINK_FIT_REGENIE"
+    script "../main.nf"
+    workflow "PLINK_FIT_REGENIE"
+    config "./nextflow.config"
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/plink_fit_regenie"
+    tag "plink_fit_regenie"
+    tag "regenie"
+    tag "regenie/step1"
+    tag "regenie/splitl0"
+    tag "regenie/runl0"
+    tag "regenie/runl1"
+
+    test("homo_sapiens popgen - standard quantitative plink1 with covariates") {
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[3] = []
+                input[4] = 'standard'
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.predictions.size() == 1 },
+                { assert workflow.out.loco.size() == 1 },
+                { assert workflow.out.logs.size() == 1 },
+                { assert workflow.out.versions.size() == 0 },
+                { assert workflow.out.predictions.get(0).get(0).id == 'plink_simulated' },
+                { assert workflow.out.loco.get(0).get(0).id == 'plink_simulated' },
+                { assert workflow.out.logs.get(0).get(0).id == 'plink_simulated' },
+                { assert path(workflow.out.logs.get(0).get(1)).exists() },
+                {
+                    def predList = path(workflow.out.predictions.get(0).get(1))
+                    def locoFile = path(workflow.out.loco.get(0).get(1))
+                    def predListFields = predList.text.readLines().find { it }.split(/\s+/)
+                    assert predListFields[0] == 'QuantitativeTrait'
+                    assert predListFields[1] == locoFile.toString()
+                },
+                {
+                    def command = path(workflow.out.predictions.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
+                    assert command.contains('--bed plink_simulated')
+                    assert command.contains('--covarFile plink_simulated_covariates.txt')
+                    assert command.contains('--bsize 1000')
+                    assert command.contains('--phenoColList QuantitativeTrait')
+                    assert !command.contains('--pgen plink_simulated')
+                },
+                {
+                    assert snapshot([
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - chunked quantitative plink1 with covariates") {
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[3] = 100
+                input[4] = 'chunked'
+                input[5] = 2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.predictions.size() == 1 },
+                { assert workflow.out.loco.size() == 1 },
+                { assert workflow.out.logs.size() == 4 },
+                { assert workflow.out.versions.size() == 0 },
+                { assert workflow.out.predictions.get(0).get(0).id == 'plink_simulated' },
+                {
+                    def command = path(workflow.out.predictions.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
+                    assert command.contains('--run-l1 plink_simulated.master')
+                    assert command.contains('--bed plink_simulated')
+                    assert command.contains('--covarFile plink_simulated_covariates.txt')
+                    assert command.contains('--bsize 100')
+                    assert command.contains('--phenoColList QuantitativeTrait')
+                },
+                {
+                    def logNames = workflow.out.logs.collect { path(it[1]).fileName.toString() }.sort()
+                    assert logNames == ['plink_simulated.log', 'plink_simulated_job1.log', 'plink_simulated_job2.log', 'plink_simulated.log'].sort()
+                },
+                {
+                    assert snapshot([
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] }.sort { a, b -> a[1] <=> b[1] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - standard quantitative plink2 without covariates") {
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    []
+                ])
+
+                input[3] = 256
+                input[4] = 'standard'
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.predictions.size() == 1 },
+                { assert workflow.out.loco.size() == 1 },
+                { assert workflow.out.logs.size() == 1 },
+                {
+                    def command = path(workflow.out.predictions.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
+                    assert command.contains('--pgen plink_simulated')
+                    assert command.contains('--bsize 256')
+                    assert command.contains('--phenoColList QuantitativeTrait')
+                    assert !command.contains('--bed plink_simulated')
+                    assert !command.contains('--covarFile')
+                },
+                {
+                    assert snapshot([
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - standard plink1 - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[3] = []
+                input[4] = 'standard'
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                {
+                    assert snapshot([
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - chunked plink1 - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[3] = 100
+                input[4] = 'chunked'
+                input[5] = 2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                {
+                    assert snapshot([
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] }.sort { a, b -> a[1] <=> b[1] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("invalid step1 mode fails") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.empty()
+                input[1] = Channel.empty()
+                input[2] = Channel.empty()
+                input[3] = []
+                input[4] = 'invalid'
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.failed },
+                { assert workflow.errorReport.contains("val_step1_mode must be 'standard' or 'chunked'") }
+            )
+        }
+    }
+
+    test("chunked mode without n_l0_jobs fails") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.empty()
+                input[1] = Channel.empty()
+                input[2] = Channel.empty()
+                input[3] = []
+                input[4] = 'chunked'
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.failed },
+                { assert workflow.errorReport.contains("val_n_l0_jobs must be a positive integer") }
+            )
+        }
+    }
+
+    test("standard mode with n_l0_jobs fails") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.empty()
+                input[1] = Channel.empty()
+                input[2] = Channel.empty()
+                input[3] = []
+                input[4] = 'standard'
+                input[5] = 2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.failed },
+                { assert workflow.errorReport.contains("val_n_l0_jobs must be empty") }
+            )
+        }
+    }
+}

--- a/subworkflows/nf-core/plink_fit_regenie/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/plink_fit_regenie/tests/main.nf.test.snap
@@ -1,0 +1,228 @@
+{
+    "homo_sapiens popgen - chunked quantitative plink1 with covariates": {
+        "content": [
+            {
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_job1.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_job2.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:15:16.391666605"
+    },
+    "homo_sapiens popgen - standard plink1 - stub": {
+        "content": [
+            {
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:15:26.589742926"
+    },
+    "homo_sapiens popgen - standard quantitative plink2 without covariates": {
+        "content": [
+            {
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:15:21.502142966"
+    },
+    "homo_sapiens popgen - chunked plink1 - stub": {
+        "content": [
+            {
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_job1.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_job2.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:15:33.035665725"
+    },
+    "homo_sapiens popgen - standard quantitative plink1 with covariates": {
+        "content": [
+            {
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:15:10.02065748"
+    }
+}

--- a/subworkflows/nf-core/plink_fit_regenie/tests/nextflow.config
+++ b/subworkflows/nf-core/plink_fit_regenie/tests/nextflow.config
@@ -1,0 +1,9 @@
+process {
+    withName: '.*REGENIE_(STEP1|SPLITL0|RUNL0|RUNL1)' {
+        ext.args = { params.module_args ?: "" }
+    }
+}
+
+params {
+    module_args = ""
+}

--- a/subworkflows/nf-core/plink_gwas_regenie/main.nf
+++ b/subworkflows/nf-core/plink_gwas_regenie/main.nf
@@ -1,0 +1,103 @@
+//
+// Run REGENIE Step 1 fitting and Step 2 association testing from PLINK-format genotype files
+//
+
+include { PLINK_FIT_REGENIE } from '../plink_fit_regenie/main'
+include { REGENIE_STEP2     } from '../../../modules/nf-core/regenie/step2/main'
+
+workflow PLINK_GWAS_REGENIE {
+    take:
+    ch_step1_genotypes // channel: [ val(meta), path(genotype_file), path(variant_file), path(sample_file) ]
+    ch_step2_genotypes // channel: [ val(meta), path(genotype_file), path(variant_file), path(sample_file) ]
+    ch_pheno // channel: [ val(meta), path(pheno) ]
+    ch_covar // channel: [ val(meta), path(covar) ], use [] when absent
+    val_step1_bsize // value: Step 1 block size, use [] to keep module default
+    val_step2_bsize // value: Step 2 block size
+    val_step1_mode // value: 'standard' or 'chunked'
+    val_n_l0_jobs // value: number of L0 jobs for chunked mode, use [] for standard mode
+
+    main:
+    ch_versions = channel.empty()
+
+    PLINK_FIT_REGENIE(
+        ch_step1_genotypes,
+        ch_pheno,
+        ch_covar,
+        val_step1_bsize,
+        val_step1_mode,
+        val_n_l0_jobs,
+    )
+
+    ch_step1_predictions = PLINK_FIT_REGENIE.out.predictions.map { meta, predictions ->
+        [meta_id(meta, 'ch_step1_genotypes'), meta, predictions]
+    }
+
+    ch_step1_loco = PLINK_FIT_REGENIE.out.loco.map { meta, loco ->
+        [meta_id(meta, 'ch_step1_genotypes'), meta, loco]
+    }
+
+    ch_step1_pred_loco = ch_step1_predictions
+        .join(ch_step1_loco, by: [0])
+        .ifEmpty {
+            error("PLINK_GWAS_REGENIE: no matching Step 1 predictions and LOCO files were available for REGENIE_STEP2")
+        }
+        .map { values ->
+            [values[0], values[1], values[2], values[4]]
+        }
+
+    ch_keyed_step2_genotypes = ch_step2_genotypes.map { meta, genotype_file, variant_file, sample_file ->
+        [meta_id(meta, 'ch_step2_genotypes'), meta, genotype_file, variant_file, sample_file]
+    }
+
+    ch_keyed_pheno = ch_pheno.map { meta, pheno ->
+        [meta_id(meta, 'ch_pheno'), meta, pheno]
+    }
+
+    ch_keyed_covar = ch_covar.map { meta, covar ->
+        [meta_id(meta, 'ch_covar'), meta, covar]
+    }
+
+    ch_step2_inputs = ch_keyed_step2_genotypes
+        .combine(ch_step1_pred_loco, by: [0])
+        .ifEmpty {
+            error("PLINK_GWAS_REGENIE: no Step 2 genotype records matched Step 1 predictions by meta.id")
+        }
+        .combine(ch_keyed_pheno, by: [0])
+        .ifEmpty {
+            error("PLINK_GWAS_REGENIE: no Step 2 records matched phenotype records by meta.id")
+        }
+        .combine(ch_keyed_covar, by: [0])
+        .ifEmpty {
+            error("PLINK_GWAS_REGENIE: no Step 2 records matched covariate records by meta.id")
+        }
+
+    REGENIE_STEP2(
+        ch_step2_inputs.map { values ->
+            [values[1], values[2], values[3], values[4]]
+        },
+        ch_step2_inputs.map { values ->
+            [values[5], values[6], values[7]]
+        },
+        ch_step2_inputs.map { values ->
+            [values[8], values[9]]
+        },
+        ch_step2_inputs.map { values ->
+            [values[10], values[11]]
+        },
+        val_step2_bsize,
+    )
+
+    emit:
+    results     = REGENIE_STEP2.out.results
+    logs        = PLINK_FIT_REGENIE.out.logs.mix(REGENIE_STEP2.out.log)
+    predictions = PLINK_FIT_REGENIE.out.predictions
+    loco        = PLINK_FIT_REGENIE.out.loco
+    versions    = ch_versions
+}
+
+def meta_id(meta, channel_name) {
+    if (!meta?.id) {
+        error("PLINK_GWAS_REGENIE: ${channel_name} records must include meta.id")
+    }
+    meta.id
+}

--- a/subworkflows/nf-core/plink_gwas_regenie/meta.yml
+++ b/subworkflows/nf-core/plink_gwas_regenie/meta.yml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: plink_gwas_regenie
+description: Run REGENIE Step 1 fitting and Step 2 GWAS from PLINK-format genotype bundles
+keywords:
+  - regenie
+  - gwas
+  - plink
+  - association
+  - genotype
+components:
+  - plink_fit_regenie
+  - regenie/step2
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]. Step 2 genotype records may include additional shard metadata while sharing meta.id.
+  - step1_genotype_file:
+      type: file
+      description: PLINK-format genotype file used for Step 1 fitting, either PLINK 1 BED or PLINK 2 PGEN
+      pattern: "*.{bed,pgen}"
+  - step1_variant_file:
+      type: file
+      description: PLINK-format variant file matching the Step 1 genotype file
+      pattern: "*.{bim,pvar}"
+  - step1_sample_file:
+      type: file
+      description: PLINK-format sample file matching the Step 1 genotype file
+      pattern: "*.{fam,psam}"
+  - step2_genotype_file:
+      type: file
+      description: PLINK-format genotype file used for Step 2 association testing, either PLINK 1 BED or PLINK 2 PGEN
+      pattern: "*.{bed,pgen}"
+  - step2_variant_file:
+      type: file
+      description: PLINK-format variant file matching the Step 2 genotype file
+      pattern: "*.{bim,pvar}"
+  - step2_sample_file:
+      type: file
+      description: PLINK-format sample file matching the Step 2 genotype file
+      pattern: "*.{fam,psam}"
+  - pheno:
+      type: file
+      description: REGENIE phenotype file
+      pattern: "*"
+  - covar:
+      type: file
+      description: Optional REGENIE covariate file. Use [] when absent.
+      pattern: "*"
+  - step1_bsize:
+      type: integer
+      description: Step 1 block size. Use [] to keep the module default.
+  - step2_bsize:
+      type: integer
+      description: Step 2 block size.
+  - step1_mode:
+      type: string
+      description: Step 1 execution mode. Must be "standard" or "chunked".
+  - n_l0_jobs:
+      type: integer
+      description: Number of L0 jobs for chunked Step 1 mode. Use [] for standard mode.
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - results:
+      type: file
+      description: REGENIE Step 2 association results
+      pattern: "*.regenie.gz"
+  - logs:
+      type: file
+      description: REGENIE log files from Step 1 fitting and Step 2 association testing
+      pattern: "*.log"
+  - predictions:
+      type: file
+      description: REGENIE Step 1 prediction list
+      pattern: "*_pred.list"
+  - loco:
+      type: file
+      description: REGENIE Step 1 leave-one-chromosome-out predictions
+      pattern: "*.loco.gz"
+  - versions:
+      type: file
+      description: Compatibility versions channel. REGENIE module versions are published via topic channels.
+      pattern: "versions.yml"
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/subworkflows/nf-core/plink_gwas_regenie/tests/main.nf.test
+++ b/subworkflows/nf-core/plink_gwas_regenie/tests/main.nf.test
@@ -1,0 +1,417 @@
+nextflow_workflow {
+
+    name "Test Workflow PLINK_GWAS_REGENIE"
+    script "../main.nf"
+    workflow "PLINK_GWAS_REGENIE"
+    config "./nextflow.config"
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/plink_gwas_regenie"
+    tag "plink_gwas_regenie"
+    tag "subworkflows/plink_fit_regenie"
+    tag "plink_fit_regenie"
+    tag "regenie"
+    tag "regenie/step1"
+    tag "regenie/splitl0"
+    tag "regenie/runl0"
+    tag "regenie/runl1"
+    tag "regenie/step2"
+
+    test("homo_sapiens popgen - standard quantitative plink1 with covariates and two step2 shards") {
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of(
+                    [
+                        [ id:'plink_simulated', shard:'a' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ],
+                    [
+                        [ id:'plink_simulated', shard:'b' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                    ]
+                )
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[3] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[4] = []
+                input[5] = 400
+                input[6] = 'standard'
+                input[7] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.results.size() == 2 },
+                { assert workflow.out.predictions.size() == 1 },
+                { assert workflow.out.loco.size() == 1 },
+                { assert workflow.out.logs.size() == 3 },
+                { assert workflow.out.versions.size() == 0 },
+                { assert workflow.out.results.collect { it[0].shard }.sort() == ['a', 'b'] },
+                {
+                    workflow.out.results.each { result ->
+                        def workDir = path(result[1]).parent
+                        def command = workDir.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
+                        assert path(result[1]).fileName.toString() == 'plink_simulated_QuantitativeTrait.regenie.gz'
+                        assert command.contains('--bed plink_simulated')
+                        assert command.contains('--pred plink_simulated_pred.list')
+                        assert command.contains('--covarFile plink_simulated_covariates.txt')
+                        assert command.contains('--bsize 400')
+                        assert command.contains('--phenoColList QuantitativeTrait')
+                        assert !command.contains('--pgen plink_simulated')
+                    }
+                },
+                {
+                    assert snapshot([
+                        results: workflow.out.results.collect { [it[0], path(it[1]).fileName.toString()] }.sort { a, b -> a[0].shard <=> b[0].shard },
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] }.sort { a, b -> a[1] <=> b[1] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - chunked quantitative plink1 with covariates") {
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[3] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[4] = 100
+                input[5] = 400
+                input[6] = 'chunked'
+                input[7] = 2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.results.size() == 1 },
+                { assert workflow.out.logs.size() == 5 },
+                {
+                    def command = path(workflow.out.results.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
+                    assert command.contains('--bed plink_simulated')
+                    assert command.contains('--pred plink_simulated_pred.list')
+                    assert command.contains('--covarFile plink_simulated_covariates.txt')
+                    assert command.contains('--bsize 400')
+                    assert command.contains('--phenoColList QuantitativeTrait')
+                },
+                {
+                    assert snapshot([
+                        results: workflow.out.results.collect { [it[0], path(it[1]).fileName.toString()] },
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] }.sort { a, b -> a[1] <=> b[1] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - binary plink1 with covariates") {
+
+        when {
+            params {
+                module_args = "--phenoColList BinaryTrait --bt"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_binary_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[3] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[4] = []
+                input[5] = 400
+                input[6] = 'standard'
+                input[7] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.results.size() == 1 },
+                { assert path(workflow.out.results.get(0).get(1)).fileName.toString() == 'plink_simulated_BinaryTrait.regenie.gz' },
+                {
+                    def command = path(workflow.out.results.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
+                    assert command.contains('--bed plink_simulated')
+                    assert command.contains('--pred plink_simulated_pred.list')
+                    assert command.contains('--covarFile plink_simulated_covariates.txt')
+                    assert command.contains('--phenoColList BinaryTrait')
+                    assert command.contains('--bt')
+                },
+                {
+                    assert snapshot([
+                        results: workflow.out.results.collect { [it[0], path(it[1]).fileName.toString()] },
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - standard quantitative plink2 without covariates") {
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[3] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    []
+                ])
+
+                input[4] = 256
+                input[5] = 400
+                input[6] = 'standard'
+                input[7] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.results.size() == 1 },
+                {
+                    def command = path(workflow.out.results.get(0).get(1)).parent.resolve('.command.sh').text.replaceAll(/\s+/, ' ')
+                    assert command.contains('--pgen plink_simulated')
+                    assert command.contains('--pred plink_simulated_pred.list')
+                    assert command.contains('--bsize 400')
+                    assert command.contains('--phenoColList QuantitativeTrait')
+                    assert !command.contains('--bed plink_simulated')
+                    assert !command.contains('--covarFile')
+                },
+                {
+                    assert snapshot([
+                        results: workflow.out.results.collect { [it[0], path(it[1]).fileName.toString()] },
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - standard plink1 - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[3] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[4] = []
+                input[5] = 400
+                input[6] = 'standard'
+                input[7] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                {
+                    assert snapshot([
+                        results: workflow.out.results.collect { [it[0], path(it[1]).fileName.toString()] },
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - chunked plink1 - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = "--phenoColList QuantitativeTrait"
+            }
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[1] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ])
+
+                input[2] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe', checkIfExists: true)
+                ])
+
+                input[3] = Channel.of([
+                    [ id:'plink_simulated' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated_covariates.txt', checkIfExists: true)
+                ])
+
+                input[4] = 100
+                input[5] = 400
+                input[6] = 'chunked'
+                input[7] = 2
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                {
+                    assert snapshot([
+                        results: workflow.out.results.collect { [it[0], path(it[1]).fileName.toString()] },
+                        predictions: workflow.out.predictions.collect { [it[0], path(it[1]).fileName.toString()] },
+                        loco: workflow.out.loco.collect { [it[0], path(it[1]).fileName.toString()] },
+                        logs: workflow.out.logs.collect { [it[0], path(it[1]).fileName.toString()] }.sort { a, b -> a[1] <=> b[1] },
+                        versions: workflow.out.versions
+                    ]).match()
+                }
+            )
+        }
+    }
+}

--- a/subworkflows/nf-core/plink_gwas_regenie/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/plink_gwas_regenie/tests/main.nf.test.snap
@@ -1,0 +1,366 @@
+{
+    "homo_sapiens popgen - chunked quantitative plink1 with covariates": {
+        "content": [
+            {
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_QuantitativeTrait.regenie.gz"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_job1.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_job2.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:22:54.670599828"
+    },
+    "homo_sapiens popgen - standard plink1 - stub": {
+        "content": [
+            {
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_QuantitativeTrait.regenie.gz"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:23:11.770343139"
+    },
+    "homo_sapiens popgen - standard quantitative plink2 without covariates": {
+        "content": [
+            {
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_QuantitativeTrait.regenie.gz"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:23:05.802517965"
+    },
+    "homo_sapiens popgen - standard quantitative plink1 with covariates and two step2 shards": {
+        "content": [
+            {
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated",
+                            "shard": "a"
+                        },
+                        "plink_simulated_QuantitativeTrait.regenie.gz"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated",
+                            "shard": "b"
+                        },
+                        "plink_simulated_QuantitativeTrait.regenie.gz"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated",
+                            "shard": "a"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated",
+                            "shard": "b"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:22:48.108164103"
+    },
+    "homo_sapiens popgen - chunked plink1 - stub": {
+        "content": [
+            {
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_QuantitativeTrait.regenie.gz"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_job1.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_job2.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:23:18.55091441"
+    },
+    "homo_sapiens popgen - binary plink1 with covariates": {
+        "content": [
+            {
+                "results": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_BinaryTrait.regenie.gz"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_pred.list"
+                    ]
+                ],
+                "loco": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated_1.loco.gz"
+                    ]
+                ],
+                "logs": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ],
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.log"
+                    ]
+                ],
+                "versions": [
+                    
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-09T18:23:00.297813013"
+    }
+}

--- a/subworkflows/nf-core/plink_gwas_regenie/tests/nextflow.config
+++ b/subworkflows/nf-core/plink_gwas_regenie/tests/nextflow.config
@@ -1,0 +1,9 @@
+process {
+    withName: '.*REGENIE_(STEP1|SPLITL0|RUNL0|RUNL1|STEP2)' {
+        ext.args = { params.module_args ?: "" }
+    }
+}
+
+params {
+    module_args = ""
+}


### PR DESCRIPTION
## Description

Adds the `plink_gwas_regenie` subworkflow to run REGENIE Step 1 model fitting followed by Step 2 association testing from PLINK-format genotype bundles.

This subworkflow composes `plink_fit_regenie` with `regenie/step2`, supports standard and chunked Step 1 execution, and supports multiple Step 2 genotype shards sharing the same analysis `meta.id`.

Draft dependencies: this PR depends on #11768 for `regenie/runl1` and #11937 for `plink_fit_regenie`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For subworkflows:
    - [x] `nf-core subworkflows test plink_gwas_regenie --profile docker --dir .`
    - [ ] `nf-core subworkflows test plink_gwas_regenie --profile singularity`
    - [ ] `nf-core subworkflows test plink_gwas_regenie --profile conda`
