### PR TITLE
Add the finaletoolkit/adjustwps module

### DIFF
--- a/modules/nf-core/finaletoolkit/adjustwps/environment.yml
+++ b/modules/nf-core/finaletoolkit/adjustwps/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::finaletoolkit=0.11.1"

--- a/modules/nf-core/finaletoolkit/adjustwps/main.nf
+++ b/modules/nf-core/finaletoolkit/adjustwps/main.nf
@@ -1,0 +1,44 @@
+process FINALETOOLKIT_ADJUSTWPS {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/34/34f01d128ed135aedc33ddb62fced3911bef6d1a909694291b7184bf83719402/data'
+        : 'community.wave.seqera.io/library/finaletoolkit:0.11.1--8fe5ba6ec9e2ec95'}"
+
+    input:
+    tuple val(meta), path(wps_bigwig)
+    tuple val(meta2), path(site_bed)
+    tuple val(meta3), path(chromosome_sizes)
+
+    output:
+    tuple val(meta), path("${prefix}.bw"), emit: bigwig
+    tuple val("${task.process}"), val('finaletoolkit'), eval("finaletoolkit --version | sed 's/FinaleToolkit //g'"), topic: versions, emit: versions_finaletoolkit
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}_wps_adjusted"
+    """
+    finaletoolkit \\
+        adjust-wps \\
+        -w ${task.cpus} \\
+        ${wps_bigwig} \\
+        ${site_bed} \\
+        ${chromosome_sizes} \\
+        ${args} \\
+        -o "${prefix}.bw"
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}_wps_adjusted"
+    """
+    echo ${args}
+
+    touch "${prefix}.bw"
+    """
+}

--- a/modules/nf-core/finaletoolkit/adjustwps/meta.yml
+++ b/modules/nf-core/finaletoolkit/adjustwps/meta.yml
@@ -1,0 +1,93 @@
+name: "finaletoolkit_adjustwps"
+description: |
+  Adjusts raw Windowed Protection Score (WPS) by applying a median filter
+  and Savitsky-Golay filter.
+keywords:
+  - windowed_protection-score
+  - genomics
+  - fragmentomics
+tools:
+  - "finaletoolkit":
+      description: "Extract cfDNA fragmentation features from sequencing data."
+      homepage: "https://epifluidlab.github.io/FinaleToolkit/"
+      documentation: "https://epifluidlab.github.io/FinaleToolkit/documentation/index.html"
+      tool_dev_url: "https://github.com/epifluidlab/FinaleToolkit"
+      doi: "10.1093/bioadv/vbaf236"
+      licence:
+        - "MIT"
+      identifier: biotools:finaletoolkit
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - wps_bigwig:
+        type: file
+        description: BigWig file containing WPS scores for the observed sites
+        pattern: "*.bw"
+        ontologies:
+          - edam: "http://edamontology.org/format_3006"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - site_bed:
+        type: file
+        pattern: "*.bed"
+        description: |
+          BED file containing transcription start sites (TSS)
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - chromosome_sizes:
+        type: file
+        pattern: "*.sizes"
+        description: |
+          Two-column file containing the size for each chromosome
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+output:
+  bigwig:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "${prefix}.bw":
+          type: file
+          pattern: "*.bw"
+          description: |
+            BigWig file containing filtered WPS scores for the observed sites
+          ontologies:
+            - edam: "http://edamontology.org/format_3006"
+  versions_finaletoolkit:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - finaletoolkit:
+          type: string
+          description: The name of the tool
+      - finaletoolkit --version | sed 's/FinaleToolkit //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - finaletoolkit:
+          type: string
+          description: The name of the tool
+      - finaletoolkit --version | sed 's/FinaleToolkit //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@lbeltrame"
+maintainers:
+  - "@lbeltrame"

--- a/modules/nf-core/finaletoolkit/adjustwps/tests/main.nf.test
+++ b/modules/nf-core/finaletoolkit/adjustwps/tests/main.nf.test
@@ -1,0 +1,134 @@
+nextflow_process {
+
+    name "Test Process FINALETOOLKIT_ADJUSTWPS"
+    script "../main.nf"
+    process "FINALETOOLKIT_ADJUSTWPS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "finaletoolkit"
+    tag "finaletoolkit/wps"
+    tag "finaletoolkit/adjustwps"
+
+    test("homo_sapiens - bam") {
+
+        setup {
+
+            config "./nextflow.config"
+            run("FINALETOOLKIT_WPS") {
+                script("../../wps/main.nf")
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/NA12878.chr22.bam', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/NA12878.chr22.bam.bai', checkIfExists: true),
+                    ]
+                    input[1] = [
+                        [id: 'tss' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome_tss.bed', checkIfExists: true),
+                    ]
+                    input[2] = [
+                        [id: 'sizes' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.sizes', checkIfExists: true),
+                    ]
+                    """
+
+                }
+
+            }
+        }
+
+        when {
+
+            process {
+
+                config "./nextflow.config"
+
+                // HACK: finale writes the sizes of the TSS BED inside the bigwig
+                // Hence using the nf-core `genome.sizes` causes an out-of-bounds error
+                // and a crash, so we create a proper size file on the fly
+                """
+                input[0] = FINALETOOLKIT_WPS.out.bigwig
+                input[1] = [
+                    [id: 'tss' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome_tss.bed', checkIfExists: true),
+                ]
+                input[2] = Channel.of('chr22\t50818468')
+                    .collectFile(name: 'chr22.sizes', newLine: true)
+                    .map { sizes -> [[id: 'sizes' ], sizes] }
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match()  }
+            )
+
+        }
+
+    }
+
+    test("homo_sapiens - stub") {
+
+        options "-stub"
+
+        setup {
+
+            config "./nextflow.config"
+            run("FINALETOOLKIT_WPS") {
+                script("../../wps/main.nf")
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/NA12878.chr22.bam', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/NA12878.chr22.bam.bai', checkIfExists: true),
+                    ]
+                    input[1] = [
+                        [id: 'tss' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome_tss.bed', checkIfExists: true),
+                    ]
+                    input[2] = [
+                        [id: 'sizes' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.sizes', checkIfExists: true),
+                    ]
+                    """
+
+                }
+
+            }
+        }
+
+        when {
+
+            process {
+
+                config "./nextflow.config"
+
+                """
+                input[0] = FINALETOOLKIT_WPS.out.bigwig
+                input[1] = [
+                    [id: 'tss' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome_tss.bed', checkIfExists: true),
+                ]
+                input[2] = Channel.of('chr22\t50818468')
+                    .collectFile(name: 'chr22.sizes', newLine: true)
+                    .map { sizes -> [[id: 'sizes' ], sizes] }
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match()  }
+            )
+
+        }
+
+    }
+
+}

--- a/modules/nf-core/finaletoolkit/adjustwps/tests/main.nf.test.snap
+++ b/modules/nf-core/finaletoolkit/adjustwps/tests/main.nf.test.snap
@@ -1,0 +1,54 @@
+{
+    "homo_sapiens - stub": {
+        "content": [
+            {
+                "bigwig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_wps_adjusted.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_finaletoolkit": [
+                    [
+                        "FINALETOOLKIT_ADJUSTWPS",
+                        "finaletoolkit",
+                        "0.11.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-10T14:11:18.557484156"
+    },
+    "homo_sapiens - bam": {
+        "content": [
+            {
+                "bigwig": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_wps_adjusted.bw:md5,ed672baa79750af978f50a4e419a6c52"
+                    ]
+                ],
+                "versions_finaletoolkit": [
+                    [
+                        "FINALETOOLKIT_ADJUSTWPS",
+                        "finaletoolkit",
+                        "0.11.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-10T14:30:26.086594862"
+    }
+}

--- a/modules/nf-core/finaletoolkit/adjustwps/tests/nextflow.config
+++ b/modules/nf-core/finaletoolkit/adjustwps/tests/nextflow.config
@@ -1,0 +1,3 @@
+env {
+    MPLCONFIGDIR = './tmp'
+}


### PR DESCRIPTION
From the upstream documentation:

Adjusts raw Windowed Protection Score (WPS) by applying a median filter and Savitsky-Golay filter.

### Note

Using the nf-core test dataset for chromosome sizes causes a crash: debugging it (with the aid of GDB first and then a session with Codex) showed that it was actually an out-of-bounds error (the TSS sizes are written in the bigWig file, and there are no entries in the interval provided in nf-core `genome.sizes` dataset), so a custom size file is generated on the fly. I'm not too happy with the solution, so suggestions are welcome.

## PR checklist

References https://github.com/nf-core/modules/issues/11365

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
