### PR TITLE
Add HDL h2 module

### DIFF
--- a/modules/nf-core/hdl/h2/environment.yml
+++ b/modules/nf-core/hdl/h2/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+  - dnachun
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - conda-forge::r-data.table=1.15.4
+  - dnachun::r-hdl=1.4.0

--- a/modules/nf-core/hdl/h2/environment.yml
+++ b/modules/nf-core/hdl/h2/environment.yml
@@ -2,7 +2,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
-  - bioconda
   - dnachun
 dependencies:
   - conda-forge::r-base=4.3.1

--- a/modules/nf-core/hdl/h2/main.nf
+++ b/modules/nf-core/hdl/h2/main.nf
@@ -1,0 +1,35 @@
+process HDL_H2 {
+    tag "${meta.id}"
+    label 'process_medium'
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'oras://community.wave.seqera.io/library/r-base_r-data.table_r-hdl:a2553504418194cc'
+        : 'community.wave.seqera.io/library/r-base_r-data.table_r-hdl:cb9d70356e12d034'}"
+
+    input:
+    tuple val(meta), path(sumstats)
+    tuple val(meta2), path(hdl_ref_panel_dir)
+
+    output:
+    tuple val(meta), path("${meta.id}.h2.tsv"), emit: heritability_results
+    tuple val(meta), path("${meta.id}.hdl.log"), emit: h2_log
+    tuple val("${task.process}"), val("hdl"), val("1.4.0"), emit: versions_hdl, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    template('hdl_h2.R')
+
+    stub:
+    """
+    cat <<EOF_STUB > ${meta.id}.h2.tsv
+trait\th2\tse\tp\teigen_use
+${meta.id}\t0.2100\t0.0300\t0.00010\tautomatic
+EOF_STUB
+
+    cat <<EOF_STUB > ${meta.id}.hdl.log
+Stub HDL h2 run for ${meta.id}
+EOF_STUB
+    """
+}

--- a/modules/nf-core/hdl/h2/main.nf
+++ b/modules/nf-core/hdl/h2/main.nf
@@ -2,8 +2,8 @@ process HDL_H2 {
     tag "${meta.id}"
     label 'process_medium'
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/r-base_r-data.table_r-hdl:a2553504418194cc'
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/83/836e8894f4f631571ed765ceccf589173af16074703010898ec821e76f30479e/data'
         : 'community.wave.seqera.io/library/r-base_r-data.table_r-hdl:cb9d70356e12d034'}"
 
     input:

--- a/modules/nf-core/hdl/h2/meta.yml
+++ b/modules/nf-core/hdl/h2/meta.yml
@@ -19,6 +19,8 @@ input:
         type: file
         description: Canonicalized GWAS summary statistics for the trait in `meta.id`.
         pattern: "*.{tsv,txt}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
   - - meta2:
         type: map
         description: Metadata map for the HDL reference panel directory.
@@ -34,6 +36,8 @@ output:
           type: file
           description: Tab-delimited HDL heritability summary output.
           pattern: "*.h2.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475"
   h2_log:
     - - meta:
           type: map

--- a/modules/nf-core/hdl/h2/meta.yml
+++ b/modules/nf-core/hdl/h2/meta.yml
@@ -1,0 +1,64 @@
+name: hdl_h2
+description: Estimate SNP heritability from GWAS summary statistics using HDL.h2
+keywords:
+  - hdl
+  - heritability
+  - gwas
+tools:
+  - hdl:
+      description: High-definition likelihood method for genetic correlation and heritability from summary statistics
+      homepage: https://github.com/zhenin/HDL
+      documentation: https://github.com/zhenin/HDL/wiki
+input:
+  - - meta:
+        type: map
+        description: Metadata map for the trait input. The `meta.id` value is used to label output files.
+    - sumstats:
+        type: file
+        description: Canonicalized GWAS summary statistics for the trait in `meta.id`.
+  - - meta2:
+        type: map
+        description: Metadata map for the HDL reference panel directory.
+    - hdl_ref_panel_dir:
+        type: directory
+        description: Directory containing HDL LD reference panel files.
+output:
+  heritability_results:
+    - - meta:
+          type: map
+          description: Propagated trait metadata map.
+      - ${meta.id}.h2.tsv:
+          type: file
+          description: Tab-delimited HDL heritability summary output.
+  h2_log:
+    - - meta:
+          type: map
+          description: Propagated trait metadata map.
+      - ${meta.id}.hdl.log:
+          type: file
+          description: HDL heritability run log.
+  versions_hdl:
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - hdl:
+          type: string
+          description: Name of the tool
+      - 1.4.0:
+          type: string
+          description: Version of the HDL R package bundled for the module
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - hdl:
+          type: string
+          description: Name of the tool
+      - 1.4.0:
+          type: string
+          description: Version of the HDL R package bundled for the module
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/hdl/h2/meta.yml
+++ b/modules/nf-core/hdl/h2/meta.yml
@@ -46,6 +46,7 @@ output:
           type: file
           description: HDL heritability run log.
           pattern: "*.hdl.log"
+          ontologies: []
   versions_hdl:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/hdl/h2/meta.yml
+++ b/modules/nf-core/hdl/h2/meta.yml
@@ -9,6 +9,8 @@ tools:
       description: High-definition likelihood method for genetic correlation and heritability from summary statistics
       homepage: https://github.com/zhenin/HDL
       documentation: https://github.com/zhenin/HDL/wiki
+      licence: ["GPL-3.0-or-later"]
+      identifier: ""
 input:
   - - meta:
         type: map
@@ -16,6 +18,7 @@ input:
     - sumstats:
         type: file
         description: Canonicalized GWAS summary statistics for the trait in `meta.id`.
+        pattern: "*.{tsv,txt}"
   - - meta2:
         type: map
         description: Metadata map for the HDL reference panel directory.
@@ -30,6 +33,7 @@ output:
       - ${meta.id}.h2.tsv:
           type: file
           description: Tab-delimited HDL heritability summary output.
+          pattern: "*.h2.tsv"
   h2_log:
     - - meta:
           type: map
@@ -37,6 +41,7 @@ output:
       - ${meta.id}.hdl.log:
           type: file
           description: HDL heritability run log.
+          pattern: "*.hdl.log"
   versions_hdl:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/hdl/h2/templates/hdl_h2.R
+++ b/modules/nf-core/hdl/h2/templates/hdl_h2.R
@@ -1,0 +1,44 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(data.table)
+})
+
+parse_hdl_ext_args <- function(raw_ext_args = "${task.ext.args ?: ''}") {
+  if (raw_ext_args %in% c("", "[]")) {
+    return(list())
+  }
+  tryCatch(
+    eval(parse(text = sprintf("list(%s)", raw_ext_args))),
+    error = function(e) stop(sprintf("Failed to parse task.ext.args as R named arguments: %s", conditionMessage(e)))
+  )
+}
+
+if (!requireNamespace("HDL", quietly = TRUE)) {
+  stop("R package 'HDL' is not installed. Install HDL in the runtime container/environment.")
+}
+
+gwas <- fread("${sumstats}", data.table = FALSE)
+hdl_ext_args <- parse_hdl_ext_args()
+
+call_args <- c(
+  list(
+    gwas.df = gwas,
+    LD.path = "${hdl_ref_panel_dir}",
+    output.file = "${meta.id}.hdl.log"
+  ),
+  hdl_ext_args
+)
+
+result <- do.call(HDL::HDL.h2, call_args)
+
+out <- data.frame(
+  trait = "${meta.id}",
+  h2 = as.numeric(result[["h2"]]),
+  se = as.numeric(result[["h2.se"]]),
+  p = as.numeric(result[["P"]]),
+  eigen_use = as.character(result[["eigen.use"]]),
+  stringsAsFactors = FALSE
+)
+
+fwrite(out, "${meta.id}.h2.tsv", sep = "\t", quote = FALSE, na = "NA")

--- a/modules/nf-core/hdl/h2/tests/main.nf.test
+++ b/modules/nf-core/hdl/h2/tests/main.nf.test
@@ -1,0 +1,81 @@
+nextflow_process {
+
+    name "Test Process HDL_H2"
+    script "../main.nf"
+    process "HDL_H2"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "hdl"
+    tag "hdl/h2"
+
+    test("trait1 - real") {
+        when {
+            process {
+                """
+                input[0] = tuple(
+                    [id: "trait1"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait1_canonical.tsv", checkIfExists: true)
+                )
+                input[1] = Channel.of([
+                    [id: "hdl_reference"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.rda", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.rda", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_counter.RData", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_list.RData", checkIfExists: true)
+                ])
+                .map { meta, files ->
+                    def reference_dir = file("${workDir}/hdl_reference")
+                    reference_dir.mkdirs()
+                    files.each { it.copyTo(file("${reference_dir}/${it.name}")) }
+                    [meta, reference_dir]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["h2_log"])).match() }
+            )
+        }
+    }
+
+    test("trait1 - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = tuple(
+                    [id: "trait1"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait1_canonical.tsv", checkIfExists: true)
+                )
+                input[1] = Channel.of([
+                    [id: "hdl_reference"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.rda", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.rda", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_counter.RData", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_list.RData", checkIfExists: true)
+                ])
+                .map { meta, files ->
+                    def reference_dir = file("${workDir}/hdl_reference")
+                    reference_dir.mkdirs()
+                    files.each { it.copyTo(file("${reference_dir}/${it.name}")) }
+                    [meta, reference_dir]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/hdl/h2/tests/main.nf.test
+++ b/modules/nf-core/hdl/h2/tests/main.nf.test
@@ -2,6 +2,7 @@ nextflow_process {
 
     name "Test Process HDL_H2"
     script "../main.nf"
+    config "./nextflow.config"
     process "HDL_H2"
     tag "modules"
     tag "modules_nfcore"
@@ -16,21 +17,22 @@ nextflow_process {
                     [id: "trait1"],
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait1_canonical.tsv", checkIfExists: true)
                 )
-                input[1] = Channel.of([
-                    [id: "hdl_reference"],
+                def reference_dir = file("${workDir}/hdl_reference")
+                reference_dir.mkdirs()
+                for (f in [
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.rda", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.rda", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_counter.RData", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_list.RData", checkIfExists: true)
-                ])
-                .map { meta, files ->
-                    def reference_dir = file("${workDir}/hdl_reference")
-                    reference_dir.mkdirs()
-                    files.each { it.copyTo(file("${reference_dir}/${it.name}")) }
-                    [meta, reference_dir]
+                ]) {
+                    f.copyTo(reference_dir.resolve(f.name))
                 }
+                input[1] = tuple(
+                    [id: "hdl_reference"],
+                    reference_dir
+                )
                 """
             }
         }
@@ -52,21 +54,22 @@ nextflow_process {
                     [id: "trait1"],
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait1_canonical.tsv", checkIfExists: true)
                 )
-                input[1] = Channel.of([
-                    [id: "hdl_reference"],
+                def reference_dir = file("${workDir}/hdl_reference")
+                reference_dir.mkdirs()
+                for (f in [
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.rda", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.rda", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_counter.RData", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_list.RData", checkIfExists: true)
-                ])
-                .map { meta, files ->
-                    def reference_dir = file("${workDir}/hdl_reference")
-                    reference_dir.mkdirs()
-                    files.each { it.copyTo(file("${reference_dir}/${it.name}")) }
-                    [meta, reference_dir]
+                ]) {
+                    f.copyTo(reference_dir.resolve(f.name))
                 }
+                input[1] = tuple(
+                    [id: "hdl_reference"],
+                    reference_dir
+                )
                 """
             }
         }

--- a/modules/nf-core/hdl/h2/tests/main.nf.test.snap
+++ b/modules/nf-core/hdl/h2/tests/main.nf.test.snap
@@ -1,0 +1,70 @@
+{
+    "trait1 - stub": {
+        "content": [
+            {
+                "h2_log": [
+                    [
+                        {
+                            "id": "trait1"
+                        },
+                        "trait1.hdl.log:md5,a13a7344736e93264a761c4ee98c7ede"
+                    ]
+                ],
+                "heritability_results": [
+                    [
+                        {
+                            "id": "trait1"
+                        },
+                        "trait1.h2.tsv:md5,ce00dd50cc23b53da1e226dcffcd55e4"
+                    ]
+                ],
+                "versions_hdl": [
+                    [
+                        "HDL_H2",
+                        "hdl",
+                        "1.4.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-11T01:01:10.97011229"
+    },
+    "trait1 - real": {
+        "content": [
+            {
+                "h2_log": [
+                    [
+                        {
+                            "id": "trait1"
+                        },
+                        "trait1.hdl.log"
+                    ]
+                ],
+                "heritability_results": [
+                    [
+                        {
+                            "id": "trait1"
+                        },
+                        "trait1.h2.tsv:md5,55e85c234116e695451a39de1f55ecd2"
+                    ]
+                ],
+                "versions_hdl": [
+                    [
+                        "HDL_H2",
+                        "hdl",
+                        "1.4.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-11T01:01:06.2985062"
+    }
+}

--- a/modules/nf-core/hdl/h2/tests/main.nf.test.snap
+++ b/modules/nf-core/hdl/h2/tests/main.nf.test.snap
@@ -49,7 +49,7 @@
                         {
                             "id": "trait1"
                         },
-                        "trait1.h2.tsv:md5,55e85c234116e695451a39de1f55ecd2"
+                        "trait1.h2.tsv:md5,2810cd29bb8bba55041a2c72f16cd3b7"
                     ]
                 ],
                 "versions_hdl": [
@@ -65,6 +65,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-06-11T01:01:06.2985062"
+        "timestamp": "2026-07-08T12:28:53.633462878"
     }
 }

--- a/modules/nf-core/hdl/h2/tests/nextflow.config
+++ b/modules/nf-core/hdl/h2/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'HDL_H2' {
+        ext.args = 'eigen.cut = 0.5'
+    }
+}


### PR DESCRIPTION
HDL estimates SNP heritability and pairwise genetic correlation from GWAS summary statistics. This PR upstreams `hdl/h2`, which estimates SNP heritability from canonicalized GWAS summary statistics with an HDL LD reference panel.

The HDL fixtures used by these tests are available on the merged `nf-core/test-datasets` `modules` branch from https://github.com/nf-core/test-datasets/pull/1932.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test hdl/h2 --profile docker`
    - [x] `nf-core modules test hdl/h2 --profile singularity`
    - [x] `nf-core modules test hdl/h2 --profile conda`