### PR TITLE
Add HDL rg module

### DIFF
--- a/modules/nf-core/hdl/rg/environment.yml
+++ b/modules/nf-core/hdl/rg/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+  - dnachun
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - conda-forge::r-data.table=1.15.4
+  - dnachun::r-hdl=1.4.0

--- a/modules/nf-core/hdl/rg/environment.yml
+++ b/modules/nf-core/hdl/rg/environment.yml
@@ -2,7 +2,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
-  - bioconda
   - dnachun
 dependencies:
   - conda-forge::r-base=4.3.1

--- a/modules/nf-core/hdl/rg/main.nf
+++ b/modules/nf-core/hdl/rg/main.nf
@@ -2,8 +2,8 @@ process HDL_RG {
     tag "${meta.id}_${meta2.id}"
     label 'process_medium'
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/r-base_r-data.table_r-hdl:a2553504418194cc'
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/83/836e8894f4f631571ed765ceccf589173af16074703010898ec821e76f30479e/data'
         : 'community.wave.seqera.io/library/r-base_r-data.table_r-hdl:cb9d70356e12d034'}"
 
     input:

--- a/modules/nf-core/hdl/rg/main.nf
+++ b/modules/nf-core/hdl/rg/main.nf
@@ -1,0 +1,36 @@
+process HDL_RG {
+    tag "${meta.id}_${meta2.id}"
+    label 'process_medium'
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'oras://community.wave.seqera.io/library/r-base_r-data.table_r-hdl:a2553504418194cc'
+        : 'community.wave.seqera.io/library/r-base_r-data.table_r-hdl:cb9d70356e12d034'}"
+
+    input:
+    tuple val(meta), path(sumstats1)
+    tuple val(meta2), path(sumstats2)
+    tuple val(meta3), path(hdl_ref_panel_dir)
+
+    output:
+    tuple val(meta), val(meta2), path("${meta.id}.${meta2.id}.rg.tsv"), emit: correlation_results
+    tuple val(meta), val(meta2), path("${meta.id}.${meta2.id}.hdl.log"), emit: rg_log
+    tuple val("${task.process}"), val("hdl"), val("1.4.0"), emit: versions_hdl, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    template('hdl_rg.R')
+
+    stub:
+    """
+    cat <<EOF_STUB > ${meta.id}.${meta2.id}.rg.tsv
+trait1\ttrait2\trg\tse\tp\th2_trait1\th2_trait2\tcovariance\teigen_use
+${meta.id}\t${meta2.id}\t0.3500\t0.0700\t0.00001\t0.2000\t0.1800\t0.0600\tautomatic
+EOF_STUB
+
+    cat <<EOF_STUB > ${meta.id}.${meta2.id}.hdl.log
+Stub HDL rg run for ${meta.id} and ${meta2.id}
+EOF_STUB
+    """
+}

--- a/modules/nf-core/hdl/rg/meta.yml
+++ b/modules/nf-core/hdl/rg/meta.yml
@@ -1,0 +1,76 @@
+name: hdl_rg
+description: Estimate pairwise genetic correlation from GWAS summary statistics using HDL.rg
+keywords:
+  - hdl
+  - genetic correlation
+  - gwas
+tools:
+  - hdl:
+      description: High-definition likelihood method for genetic correlation and heritability from summary statistics
+      homepage: https://github.com/zhenin/HDL
+      documentation: https://github.com/zhenin/HDL/wiki
+input:
+  - - meta:
+        type: map
+        description: Metadata map for the first trait input. The `meta.id` value is used as the first trait label.
+    - sumstats1:
+        type: file
+        description: Canonicalized GWAS summary statistics for the first trait.
+  - - meta2:
+        type: map
+        description: Metadata map for the second trait input. The `meta2.id` value is used as the second trait label.
+    - sumstats2:
+        type: file
+        description: Canonicalized GWAS summary statistics for the second trait.
+  - - meta3:
+        type: map
+        description: Metadata map for the HDL reference panel directory.
+    - hdl_ref_panel_dir:
+        type: directory
+        description: Directory containing HDL LD reference panel files.
+output:
+  correlation_results:
+    - - meta:
+          type: map
+          description: Propagated first-trait metadata map.
+      - meta2:
+          type: map
+          description: Propagated second-trait metadata map.
+      - ${meta.id}.${meta2.id}.rg.tsv:
+          type: file
+          description: Tab-delimited HDL genetic correlation summary output.
+  rg_log:
+    - - meta:
+          type: map
+          description: Propagated first-trait metadata map.
+      - meta2:
+          type: map
+          description: Propagated second-trait metadata map.
+      - ${meta.id}.${meta2.id}.hdl.log:
+          type: file
+          description: HDL genetic-correlation run log.
+  versions_hdl:
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - hdl:
+          type: string
+          description: Name of the tool
+      - 1.4.0:
+          type: string
+          description: Version of the HDL R package bundled for the module
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - hdl:
+          type: string
+          description: Name of the tool
+      - 1.4.0:
+          type: string
+          description: Version of the HDL R package bundled for the module
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/hdl/rg/meta.yml
+++ b/modules/nf-core/hdl/rg/meta.yml
@@ -9,6 +9,8 @@ tools:
       description: High-definition likelihood method for genetic correlation and heritability from summary statistics
       homepage: https://github.com/zhenin/HDL
       documentation: https://github.com/zhenin/HDL/wiki
+      licence: ["GPL-3.0-or-later"]
+      identifier: ""
 input:
   - - meta:
         type: map
@@ -16,12 +18,14 @@ input:
     - sumstats1:
         type: file
         description: Canonicalized GWAS summary statistics for the first trait.
+        pattern: "*.{tsv,txt}"
   - - meta2:
         type: map
         description: Metadata map for the second trait input. The `meta2.id` value is used as the second trait label.
     - sumstats2:
         type: file
         description: Canonicalized GWAS summary statistics for the second trait.
+        pattern: "*.{tsv,txt}"
   - - meta3:
         type: map
         description: Metadata map for the HDL reference panel directory.
@@ -39,6 +43,7 @@ output:
       - ${meta.id}.${meta2.id}.rg.tsv:
           type: file
           description: Tab-delimited HDL genetic correlation summary output.
+          pattern: "*.rg.tsv"
   rg_log:
     - - meta:
           type: map
@@ -49,6 +54,7 @@ output:
       - ${meta.id}.${meta2.id}.hdl.log:
           type: file
           description: HDL genetic-correlation run log.
+          pattern: "*.hdl.log"
   versions_hdl:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/hdl/rg/meta.yml
+++ b/modules/nf-core/hdl/rg/meta.yml
@@ -19,6 +19,8 @@ input:
         type: file
         description: Canonicalized GWAS summary statistics for the first trait.
         pattern: "*.{tsv,txt}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
   - - meta2:
         type: map
         description: Metadata map for the second trait input. The `meta2.id` value is used as the second trait label.
@@ -26,6 +28,8 @@ input:
         type: file
         description: Canonicalized GWAS summary statistics for the second trait.
         pattern: "*.{tsv,txt}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
   - - meta3:
         type: map
         description: Metadata map for the HDL reference panel directory.
@@ -44,6 +48,8 @@ output:
           type: file
           description: Tab-delimited HDL genetic correlation summary output.
           pattern: "*.rg.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475"
   rg_log:
     - - meta:
           type: map

--- a/modules/nf-core/hdl/rg/meta.yml
+++ b/modules/nf-core/hdl/rg/meta.yml
@@ -61,6 +61,7 @@ output:
           type: file
           description: HDL genetic-correlation run log.
           pattern: "*.hdl.log"
+          ontologies: []
   versions_hdl:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/hdl/rg/templates/hdl_rg.R
+++ b/modules/nf-core/hdl/rg/templates/hdl_rg.R
@@ -1,0 +1,66 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(data.table)
+})
+
+parse_hdl_ext_args <- function(raw_ext_args = "${task.ext.args ?: ''}") {
+  if (raw_ext_args %in% c("", "[]")) {
+    return(list())
+  }
+  tryCatch(
+    eval(parse(text = sprintf("list(%s)", raw_ext_args))),
+    error = function(e) stop(sprintf("Failed to parse task.ext.args as R named arguments: %s", conditionMessage(e)))
+  )
+}
+
+if (!requireNamespace("HDL", quietly = TRUE)) {
+  stop("R package 'HDL' is not installed. Install HDL in the runtime container/environment.")
+}
+
+gwas1 <- fread("${sumstats1}", data.table = FALSE)
+gwas2 <- fread("${sumstats2}", data.table = FALSE)
+hdl_ext_args <- parse_hdl_ext_args()
+
+call_args <- c(
+  list(
+    gwas1.df = gwas1,
+    gwas2.df = gwas2,
+    LD.path = "${hdl_ref_panel_dir}",
+    output.file = "${meta.id}.${meta2.id}.hdl.log"
+  ),
+  hdl_ext_args
+)
+
+result <- do.call(HDL::HDL.rg, call_args)
+
+h1 <- NA_real_
+h2 <- NA_real_
+gcov <- NA_real_
+if (!is.null(result[["estimates.df"]])) {
+  est <- result[["estimates.df"]]
+  if ("Heritability_1" %in% rownames(est)) {
+    h1 <- as.numeric(est["Heritability_1", "Estimate"])
+  }
+  if ("Heritability_2" %in% rownames(est)) {
+    h2 <- as.numeric(est["Heritability_2", "Estimate"])
+  }
+  if ("Genetic_Covariance" %in% rownames(est)) {
+    gcov <- as.numeric(est["Genetic_Covariance", "Estimate"])
+  }
+}
+
+out <- data.frame(
+  trait1 = "${meta.id}",
+  trait2 = "${meta2.id}",
+  rg = as.numeric(result[["rg"]]),
+  se = as.numeric(result[["rg.se"]]),
+  p = as.numeric(result[["P"]]),
+  h2_trait1 = h1,
+  h2_trait2 = h2,
+  covariance = gcov,
+  eigen_use = as.character(result[["eigen.use"]]),
+  stringsAsFactors = FALSE
+)
+
+fwrite(out, "${meta.id}.${meta2.id}.rg.tsv", sep = "\t", quote = FALSE, na = "NA")

--- a/modules/nf-core/hdl/rg/tests/main.nf.test
+++ b/modules/nf-core/hdl/rg/tests/main.nf.test
@@ -1,0 +1,90 @@
+nextflow_process {
+
+    name "Test Process HDL_RG"
+    script "../main.nf"
+    config "./nextflow.config"
+    process "HDL_RG"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "hdl"
+    tag "hdl/rg"
+
+    test("trait1 trait2 - real") {
+        when {
+            process {
+                """
+                input[0] = tuple(
+                    [id: "trait1"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait1_canonical.tsv", checkIfExists: true)
+                )
+                input[1] = tuple(
+                    [id: "trait2"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait2_canonical.tsv", checkIfExists: true)
+                )
+                input[2] = Channel.of([
+                    [id: "hdl_reference"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.rda", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.rda", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_counter.RData", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_list.RData", checkIfExists: true)
+                ])
+                .map { meta, files ->
+                    def reference_dir = file("${workDir}/hdl_reference")
+                    reference_dir.mkdirs()
+                    files.each { it.copyTo(file("${reference_dir}/${it.name}")) }
+                    [meta, reference_dir]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["rg_log"])).match() }
+            )
+        }
+    }
+
+    test("trait1 trait2 - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = tuple(
+                    [id: "trait1"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait1_canonical.tsv", checkIfExists: true)
+                )
+                input[1] = tuple(
+                    [id: "trait2"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait2_canonical.tsv", checkIfExists: true)
+                )
+                input[2] = Channel.of([
+                    [id: "hdl_reference"],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.rda", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.rda", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_counter.RData", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_list.RData", checkIfExists: true)
+                ])
+                .map { meta, files ->
+                    def reference_dir = file("${workDir}/hdl_reference")
+                    reference_dir.mkdirs()
+                    files.each { it.copyTo(file("${reference_dir}/${it.name}")) }
+                    [meta, reference_dir]
+                }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/hdl/rg/tests/main.nf.test
+++ b/modules/nf-core/hdl/rg/tests/main.nf.test
@@ -21,21 +21,22 @@ nextflow_process {
                     [id: "trait2"],
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait2_canonical.tsv", checkIfExists: true)
                 )
-                input[2] = Channel.of([
-                    [id: "hdl_reference"],
+                def reference_dir = file("${workDir}/hdl_reference")
+                reference_dir.mkdirs()
+                for (f in [
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.rda", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.rda", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_counter.RData", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_list.RData", checkIfExists: true)
-                ])
-                .map { meta, files ->
-                    def reference_dir = file("${workDir}/hdl_reference")
-                    reference_dir.mkdirs()
-                    files.each { it.copyTo(file("${reference_dir}/${it.name}")) }
-                    [meta, reference_dir]
+                ]) {
+                    f.copyTo(reference_dir.resolve(f.name))
                 }
+                input[2] = tuple(
+                    [id: "hdl_reference"],
+                    reference_dir
+                )
                 """
             }
         }
@@ -61,21 +62,22 @@ nextflow_process {
                     [id: "trait2"],
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/sumstats/trait2_canonical.tsv", checkIfExists: true)
                 )
-                input[2] = Channel.of([
-                    [id: "hdl_reference"],
+                def reference_dir = file("${workDir}/hdl_reference")
+                reference_dir.mkdirs()
+                for (f in [
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.1_toy.rda", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/chr1.2_toy.rda", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_counter.RData", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/hdl/reference/toy_snp_list.RData", checkIfExists: true)
-                ])
-                .map { meta, files ->
-                    def reference_dir = file("${workDir}/hdl_reference")
-                    reference_dir.mkdirs()
-                    files.each { it.copyTo(file("${reference_dir}/${it.name}")) }
-                    [meta, reference_dir]
+                ]) {
+                    f.copyTo(reference_dir.resolve(f.name))
                 }
+                input[2] = tuple(
+                    [id: "hdl_reference"],
+                    reference_dir
+                )
                 """
             }
         }

--- a/modules/nf-core/hdl/rg/tests/main.nf.test.snap
+++ b/modules/nf-core/hdl/rg/tests/main.nf.test.snap
@@ -1,0 +1,82 @@
+{
+    "trait1 trait2 - real": {
+        "content": [
+            {
+                "correlation_results": [
+                    [
+                        {
+                            "id": "trait1"
+                        },
+                        {
+                            "id": "trait2"
+                        },
+                        "trait1.trait2.rg.tsv:md5,8e8faed4043a6db37fbad2225619144d"
+                    ]
+                ],
+                "rg_log": [
+                    [
+                        {
+                            "id": "trait1"
+                        },
+                        {
+                            "id": "trait2"
+                        },
+                        "trait1.trait2.hdl.log"
+                    ]
+                ],
+                "versions_hdl": [
+                    [
+                        "HDL_RG",
+                        "hdl",
+                        "1.4.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-11T01:05:09.523408627"
+    },
+    "trait1 trait2 - stub": {
+        "content": [
+            {
+                "correlation_results": [
+                    [
+                        {
+                            "id": "trait1"
+                        },
+                        {
+                            "id": "trait2"
+                        },
+                        "trait1.trait2.rg.tsv:md5,54f49eb2799f74af3b4e4c2a037bf59e"
+                    ]
+                ],
+                "rg_log": [
+                    [
+                        {
+                            "id": "trait1"
+                        },
+                        {
+                            "id": "trait2"
+                        },
+                        "trait1.trait2.hdl.log:md5,b18469b6e53bfa3e2519771bb436347d"
+                    ]
+                ],
+                "versions_hdl": [
+                    [
+                        "HDL_RG",
+                        "hdl",
+                        "1.4.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-06-11T01:05:14.871223294"
+    }
+}

--- a/modules/nf-core/hdl/rg/tests/nextflow.config
+++ b/modules/nf-core/hdl/rg/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'HDL_RG' {
+        ext.args = 'N0 = 0'
+    }
+}


### PR DESCRIPTION
HDL estimates SNP heritability and pairwise genetic correlation from GWAS summary statistics. This PR upstreams `hdl/rg`, which estimates pairwise genetic correlation from two canonicalized GWAS summary statistics files with an HDL LD reference panel.

The HDL fixtures used by these tests are available on the merged `nf-core/test-datasets` `modules` branch from https://github.com/nf-core/test-datasets/pull/1932.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test hdl/rg --profile docker`
    - [x] `nf-core modules test hdl/rg --profile singularity`
    - [x] `nf-core modules test hdl/rg --profile conda`