### PR TITLE
SHAPEIT5 Fix output instability by going to seqera container

### DIFF
--- a/modules/nf-core/shapeit5/ligate/main.nf
+++ b/modules/nf-core/shapeit5/ligate/main.nf
@@ -44,7 +44,7 @@ process SHAPEIT5_LIGATE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def suffix = suffix_ ?: "vcf.gz"
     assert suffix in ["vcf", "vcf.gz", "bcf", "bcf.gz"]
-    def create_cmd = suffix.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_cmd = suffix.endsWith(".gz") ? 'echo "" | gzip >' : "touch"
     """
     ${create_cmd} ${prefix}.${suffix}
     """

--- a/modules/nf-core/shapeit5/ligate/main.nf
+++ b/modules/nf-core/shapeit5/ligate/main.nf
@@ -4,8 +4,8 @@ process SHAPEIT5_LIGATE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/shapeit5:5.1.1--hb60d31d_0'
-        : 'quay.io/biocontainers/shapeit5:5.1.1--hb60d31d_0'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fa/fa06870e893f9045944461e5b674adffec6deec41e8496b63ec54d44a98d6134/data'
+        : 'community.wave.seqera.io/library/shapeit5:5.1.1--09a6cb254ece8f6e'}"
 
     input:
     tuple val(meta), path(input_list), path(input_list_index)

--- a/modules/nf-core/shapeit5/phasecommon/main.nf
+++ b/modules/nf-core/shapeit5/phasecommon/main.nf
@@ -4,8 +4,8 @@ process SHAPEIT5_PHASECOMMON {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/shapeit5:5.1.1--hb60d31d_0'
-        : 'quay.io/biocontainers/shapeit5:5.1.1--hb60d31d_0'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fa/fa06870e893f9045944461e5b674adffec6deec41e8496b63ec54d44a98d6134/data'
+        : 'community.wave.seqera.io/library/shapeit5:5.1.1--09a6cb254ece8f6e'}"
 
     input:
     tuple val(meta), path(input), path(input_index), path(pedigree), val(region), path(reference), path(reference_index), path(scaffold), path(scaffold_index), path(map)

--- a/modules/nf-core/shapeit5/phaserare/main.nf
+++ b/modules/nf-core/shapeit5/phaserare/main.nf
@@ -14,8 +14,8 @@ process SHAPEIT5_PHASERARE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/shapeit5:5.1.1--hb60d31d_0'
-        : 'quay.io/biocontainers/shapeit5:5.1.1--hb60d31d_0'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fa/fa06870e893f9045944461e5b674adffec6deec41e8496b63ec54d44a98d6134/data'
+        : 'community.wave.seqera.io/library/shapeit5:5.1.1--09a6cb254ece8f6e'}"
 
     input:
     tuple val(meta), path(input), path(input_index), path(pedigree), val(input_region), path(scaffold), path(scaffold_index), val(scaffold_region), path(map)

--- a/modules/nf-core/shapeit5/phaserare/main.nf
+++ b/modules/nf-core/shapeit5/phaserare/main.nf
@@ -60,7 +60,7 @@ process SHAPEIT5_PHASERARE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def suffix = output_suffix ?: "vcf.gz"
 
-    def create_cmd = suffix.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_cmd = suffix.endsWith(".gz") ? 'echo "" | gzip >' : "touch"
     """
     ${create_cmd} ${prefix}.${suffix}
     """

--- a/modules/nf-core/shapeit5/phaserare/meta.yml
+++ b/modules/nf-core/shapeit5/phaserare/meta.yml
@@ -31,8 +31,8 @@ input:
         ontologies: []
     - input_index:
         type: file
-        description: Index file of the input_plain VCF/BCF file containing genotype
-          likelihoods.
+        description: Index file of the input_plain VCF/BCF file containing
+          genotype likelihoods.
         pattern: "*.{vcf.gz.csi,bcf.gz.csi}"
         ontologies: []
     - pedigree:

--- a/modules/nf-core/shapeit5/switch/main.nf
+++ b/modules/nf-core/shapeit5/switch/main.nf
@@ -4,8 +4,8 @@ process SHAPEIT5_SWITCH {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/shapeit5:5.1.1--hb60d31d_0'
-        : 'quay.io/biocontainers/shapeit5:5.1.1--hb60d31d_0'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fa/fa06870e893f9045944461e5b674adffec6deec41e8496b63ec54d44a98d6134/data'
+        : 'community.wave.seqera.io/library/shapeit5:5.1.1--09a6cb254ece8f6e'}"
 
     input:
     tuple val(meta), path(estimate), path(estimate_index), val(region), path(pedigree), path(truth), path(truth_index), path(freq), path(freq_index)

--- a/modules/nf-core/shapeit5/switch/main.nf
+++ b/modules/nf-core/shapeit5/switch/main.nf
@@ -39,16 +39,15 @@ process SHAPEIT5_SWITCH {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
 
-    def create_cmd = "echo '' | gzip >"
     """
-    ${create_cmd} ${prefix}.block.switch.txt.gz
-    ${create_cmd} ${prefix}.calibration.switch.txt.gz
-    ${create_cmd} ${prefix}.flipsAndSwitches.txt.gz
-    ${create_cmd} ${prefix}.frequency.switch.txt.gz
-    ${create_cmd} ${prefix}.sample.switch.txt.gz
-    ${create_cmd} ${prefix}.sample.typing.txt.gz
-    ${create_cmd} ${prefix}.type.switch.txt.gz
-    ${create_cmd} ${prefix}.variant.switch.txt.gz
-    ${create_cmd} ${prefix}.variant.typing.txt.gz
+    echo "" | gzip > ${prefix}.block.switch.txt.gz
+    echo "" | gzip > ${prefix}.calibration.switch.txt.gz
+    echo "" | gzip > ${prefix}.flipsAndSwitches.txt.gz
+    echo "" | gzip > ${prefix}.frequency.switch.txt.gz
+    echo "" | gzip > ${prefix}.sample.switch.txt.gz
+    echo "" | gzip > ${prefix}.sample.typing.txt.gz
+    echo "" | gzip > ${prefix}.type.switch.txt.gz
+    echo "" | gzip > ${prefix}.variant.switch.txt.gz
+    echo "" | gzip > ${prefix}.variant.typing.txt.gz
     """
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

See https://nfcore.slack.com/archives/C04PPJLT1T3/p1781099185452859 for the explanation of this change

TLDR : singularity galaxy image gives unstable phasing when decompressing the output file (maybe a miss of a library somewhere).

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
