### PR TITLE
Mifaser update for correct database file structure

### DIFF
--- a/modules/nf-core/mifaser/tests/main.nf.test
+++ b/modules/nf-core/mifaser/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
                 input[0] = Channel.of([
                     [],
                     file(
-                        'https://github.com/nickp60/test-datasets/raw/refs/heads/funcprofiler/data/database/mifaser/GS-24-all.tar.gz',
+                        'https://github.com/nf-core/test-datasets/raw/refs/heads/funcprofiler/data/database/mifaser/GS-24-all.tar.gz',
                         checkIfExists: true
                     )
                 ])

--- a/modules/nf-core/mifaser/tests/main.nf.test
+++ b/modules/nf-core/mifaser/tests/main.nf.test
@@ -16,7 +16,7 @@ nextflow_process {
                 input[0] = Channel.of([
                     [],
                     file(
-                        'https://github.com/nf-core/test-datasets/raw/refs/heads/funcprofiler/data/database/mifaser/GS-24-all.tar.gz',
+                        'https://github.com/nickp60/test-datasets/raw/refs/heads/funcprofiler/data/database/mifaser/GS-24-all.tar.gz',
                         checkIfExists: true
                     )
                 ])
@@ -33,7 +33,7 @@ nextflow_process {
                     [ id:'test', single_end:true ],
                     [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ]
-                input[1] = UNTAR.out.untar.map{ meta, dir -> dir.resolve("database/mifaser/GS-24-all") }
+                input[1] = UNTAR.out.untar.map { it[1] }
                 """
             }
         }


### PR DESCRIPTION
This PR removes a workaround needed for an improperly formatted database in `test-datasets`. When I compressed it initially I neglected to set the archive root, so when untarring it would include the local directory structure, preventing the actual tool from finding the database.  The tests previously relied on a workaround, this PR removes that. 

I have left the test data path pointing to my fork of `test-datasets`, pending acceptance of [this PR](https://github.com/nf-core/test-datasets/pull/2101).  Once accepted I will revert the path here and merge once approved.

 
## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [X] This comment contains a description of changes (with reason).
- [] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [X] If necessary, include test data in your PR.
- [X] Remove all TODO statements.
- [X] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [X] Add a resource `label`
- [X] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [X] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
