### PR TITLE
Add stub and stub tests for bbmap/clumpify

### DIFF
--- a/modules/nf-core/bbmap/clumpify/main.nf
+++ b/modules/nf-core/bbmap/clumpify/main.nf
@@ -31,4 +31,14 @@ process BBMAP_CLUMPIFY {
         $args \\
         &> ${prefix}.clumpify.log
     """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def output_command = meta.single_end ?
+        "echo '' | gzip > ${prefix}.clumped.fastq.gz" :
+        "echo '' | gzip > ${prefix}_1.clumped.fastq.gz ; echo '' | gzip > ${prefix}_2.clumped.fastq.gz"
+    """
+    touch ${prefix}.clumpify.log
+    $output_command
+    """
 }

--- a/modules/nf-core/bbmap/clumpify/tests/main.nf.test
+++ b/modules/nf-core/bbmap/clumpify/tests/main.nf.test
@@ -29,12 +29,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-					process.out.reads,
-					file(process.out.log[0][1]).name,
-					process.out.findAll { key, val -> key.startsWith('versions') }
-					).match()
-				}
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
             )
         }
     }
@@ -59,12 +54,60 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-					process.out.reads,
-					file(process.out.log[0][1]).name,
-					process.out.findAll { key, val -> key.startsWith('versions') }
-					).match()
-				}
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
+            )
+        }
+    }
+
+    test("test-bbmap-clumpify-single-end - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+				    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                    ]
+				]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("test-bbmap-clumpify-paired-end - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+				    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+				        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+				]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/bbmap/clumpify/tests/main.nf.test.snap
+++ b/modules/nf-core/bbmap/clumpify/tests/main.nf.test.snap
@@ -1,20 +1,28 @@
 {
     "test-bbmap-clumpify-paired-end": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": false
-                    },
-                    [
-                        "test_1.clumped.fastq.gz:md5,27e51643262c1ef3905c4be184c3814c",
-                        "test_2.clumped.fastq.gz:md5,c70ab7bbd44d6b6fadd6a1a79ef1648f"
-                    ]
-                ]
-            ],
-            "test.clumpify.log",
             {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.clumpify.log"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.clumped.fastq.gz:md5,27e51643262c1ef3905c4be184c3814c",
+                            "test_2.clumped.fastq.gz:md5,c70ab7bbd44d6b6fadd6a1a79ef1648f"
+                        ]
+                    ]
+                ],
                 "versions_bbmap": [
                     [
                         "BBMAP_CLUMPIFY",
@@ -24,25 +32,33 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-11T13:50:50.67389917",
+        "timestamp": "2026-06-12T13:45:10.280022778",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     },
     "test-bbmap-clumpify-single-end": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "test.clumped.fastq.gz:md5,27e51643262c1ef3905c4be184c3814c"
-                ]
-            ],
-            "test.clumpify.log",
             {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.clumpify.log"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.clumped.fastq.gz:md5,27e51643262c1ef3905c4be184c3814c"
+                    ]
+                ],
                 "versions_bbmap": [
                     [
                         "BBMAP_CLUMPIFY",
@@ -52,10 +68,85 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-11T13:50:43.591887248",
+        "timestamp": "2026-06-12T13:45:03.743249724",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "test-bbmap-clumpify-single-end - stub": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.clumpify.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.clumped.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bbmap": [
+                    [
+                        "BBMAP_CLUMPIFY",
+                        "bbmap",
+                        "39.18"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-12T13:45:15.652095723",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "test-bbmap-clumpify-paired-end - stub": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.clumpify.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.clumped.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test_2.clumped.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "versions_bbmap": [
+                    [
+                        "BBMAP_CLUMPIFY",
+                        "bbmap",
+                        "39.18"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-12T13:45:20.572814339",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
         }
     }
 }


### PR DESCRIPTION
Add stub section to `BBMAP_CLUMPIFY` process and stub tests for single-end and paired-end modes. Uses `sanitizeOutput` with `unstableKeys: [log]` for non-stub tests.