### PR TITLE
Fix centrifuger output naming to avoid filename collisions in taxprof…

### DIFF
--- a/modules/nf-core/centrifuger/centrifuger/meta.yml
+++ b/modules/nf-core/centrifuger/centrifuger/meta.yml
@@ -60,7 +60,7 @@ output:
           type: file
           description: |
             File containing classification results
-          pattern: "${prefix}.tsv"
+          pattern: "*.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 #TSV
   fastq_classified:

--- a/modules/nf-core/centrifuger/quantification/main.nf
+++ b/modules/nf-core/centrifuger/quantification/main.nf
@@ -15,7 +15,7 @@ process CENTRIFUGER_QUANTIFICATION {
     path size_table
 
     output:
-    tuple val(meta), path("${meta.id}.tsv"), emit: report_file
+    tuple val(meta), path("*.tsv"), emit: report_file
     tuple val("${task.process}"), val('centrifuger'), eval("centrifuger -v 2>&1 | sed 's/Centrifuger v//'"), emit: versions_centrifuger,  topic: versions
 
     when:

--- a/modules/nf-core/centrifuger/quantification/meta.yml
+++ b/modules/nf-core/centrifuger/quantification/meta.yml
@@ -49,11 +49,11 @@ output:
           type: map
           description: Groovy Map containing sample information. e.g. `[
             id:'sample1' ]`
-      - "${meta.id}.tsv":
+      - "*.tsv":
           type: file
           description: |
             File containing taxonomic profiling results
-          pattern: "${prefix}.tsv"
+          pattern: "*.tsv"
   versions_centrifuger:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/centrifuger/quantification/tests/main.nf.test
+++ b/modules/nf-core/centrifuger/quantification/tests/main.nf.test
@@ -43,7 +43,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = CENTRIFUGER_CENTRIFUGER.out.classification_file
+                input[0] = CENTRIFUGER_CENTRIFUGER.out.classification_file.map { meta, file -> [[id: 'quant'], file] }
                 input[1] = UNTAR.out.untar.map{ meta, db -> [ [id:'sarscov2'], db] }
                 input[2] = []
                 input[3] = []
@@ -72,7 +72,7 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = CENTRIFUGER_CENTRIFUGER.out.classification_file
+                input[0] = CENTRIFUGER_CENTRIFUGER.out.classification_file.map { meta, file -> [[id: 'quant'], file] }
                 input[1] = UNTAR.out.untar.map{ meta, db -> [ [id:'sarscov2'], db] }
                 input[2] = []
                 input[3] = []

--- a/modules/nf-core/centrifuger/quantification/tests/main.nf.test.snap
+++ b/modules/nf-core/centrifuger/quantification/tests/main.nf.test.snap
@@ -5,10 +5,9 @@
                 "0": [
                     [
                         {
-                            "id": "test",
-                            "single_end": true
+                            "id": "quant"
                         },
-                        "test.tsv:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "quant.tsv:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "1": [
@@ -21,10 +20,9 @@
                 "report_file": [
                     [
                         {
-                            "id": "test",
-                            "single_end": true
+                            "id": "quant"
                         },
-                        "test.tsv:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "quant.tsv:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "versions_centrifuger": [
@@ -36,15 +34,15 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-30T12:13:07.817497",
+        "timestamp": "2026-06-15T17:27:16.601991",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "sarscov2 - fastq_se": {
         "content": [
-            "test.tsv",
+            "quant.tsv",
             {
                 "versions_centrifuger": [
                     [
@@ -55,10 +53,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-22T12:08:55.368311",
+        "timestamp": "2026-06-15T17:27:08.763745",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }


### PR DESCRIPTION
Updates the output filenames of centrifuger/centrifuger and centrifuger/quantification to be distinct, so they don't collide when used in the same pipeline (e.g., nf-core/taxprofiler).

Changes:
centrifuger/centrifuger: output pattern changed from *.tsv to *.classification.tsv (script and stub updated accordingly)
centrifuger/quantification: Output pattern changed from hardcoded ${meta.id}.tsv to glob *.report.tsv so custom ext.prefix works correctly.

Both modules previously emitted ${prefix}.tsv, causing filename collisions when both were used together in a pipeline (e.g., centrifuger classification + quantification in nf-core/taxprofiler).