### PR TITLE
migrate leviosam2/index module to topic channels

### DIFF
--- a/modules/nf-core/leviosam2/index/main.nf
+++ b/modules/nf-core/leviosam2/index/main.nf
@@ -13,7 +13,7 @@ process LEVIOSAM2_INDEX {
 
     output:
     tuple val(meta), path("*.clft"), emit: clft
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('leviosam2'), eval("leviosam2 --version"), emit: versions_leviosam2, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,21 +27,11 @@ process LEVIOSAM2_INDEX {
         -c ${chain} \\
         -p ${prefix} \\
         -F ${fai}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        leviosam2: \$(leviosam2 --version)
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.clft
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        leviosam2: \$(leviosam2 --version)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/leviosam2/index/meta.yml
+++ b/modules/nf-core/leviosam2/index/meta.yml
@@ -9,7 +9,8 @@ tools:
       description: "Fast and accurate coordinate conversion between assemblies"
       homepage: "https://github.com/milkschen/leviosam2/blob/main/workflow/README.md"
       documentation: "https://github.com/milkschen/leviosam2/blob/main/workflow/README.md"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 input:
   - - meta:
@@ -27,7 +28,7 @@ input:
       description: Chain file to index.
       pattern: "*.{chain}"
       ontologies:
-        - edam: http://edamontology.org/format_3982 # CHAIN
+        - edam: http://edamontology.org/format_3982
 output:
   clft:
     - - meta:
@@ -40,13 +41,27 @@ output:
           description: Clft file of indexed chain
           pattern: "*.{clft}"
           ontologies: []
+  versions_leviosam2:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - "leviosam2":
+          type: string
+          description: The name of the tool
+      - leviosam2 --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - "leviosam2":
+          type: string
+          description: The name of the tool
+      - leviosam2 --version:
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@lgrochowalski"
 maintainers:

--- a/modules/nf-core/leviosam2/index/tests/main.nf.test.snap
+++ b/modules/nf-core/leviosam2/index/tests/main.nf.test.snap
@@ -11,7 +11,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,36cf8d4dceb8156f779cd6352eba61dc"
+                    [
+                        "LEVIOSAM2_INDEX",
+                        "leviosam2",
+                        "0.4.2"
+                    ]
                 ],
                 "clft": [
                     [
@@ -21,8 +25,12 @@
                         "test.clft:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,36cf8d4dceb8156f779cd6352eba61dc"
+                "versions_leviosam2": [
+                      [
+                        "LEVIOSAM2_INDEX",
+                        "leviosam2",
+                        "0.4.2"
+                    ]
                 ]
             }
         ],
@@ -44,7 +52,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,36cf8d4dceb8156f779cd6352eba61dc"
+                      [
+                        "LEVIOSAM2_INDEX",
+                        "leviosam2",
+                        "0.4.2"
+                    ]
                 ],
                 "clft": [
                     [
@@ -54,8 +66,12 @@
                         "test.clft:md5,f6ce975bfe33512114ac2cb8aefbffe2"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,36cf8d4dceb8156f779cd6352eba61dc"
+                "versions_leviosam2": [
+                      [
+                        "LEVIOSAM2_INDEX",
+                        "leviosam2",
+                        "0.4.2"
+                    ]
                 ]
             }
         ],
@@ -66,3 +82,4 @@
         "timestamp": "2024-03-20T11:20:40.461365"
     }
 }
+


### PR DESCRIPTION
## PR checklist

Closes #11906

This PR migrates the `leviosam2/index` module to topic channels by removing the old `versions.yml` output generation and broadcasting the software version to `topic: versions`.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the contribution docs
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions`.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`.
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.

Tests:
- [ ] `nf-core modules test leviosam2/index --profile docker`
- [ ] `nf-core modules test leviosam2/index --profile singularity`
- [ ] `nf-core modules test leviosam2/index --profile conda`