### PR TITLE
fix(pypolca): support gzipped and uncompressed assemblies

### DIFF
--- a/modules/nf-core/pypolca/run/main.nf
+++ b/modules/nf-core/pypolca/run/main.nf
@@ -26,7 +26,12 @@ process PYPOLCA_RUN {
     def read_files    = reads instanceof List ? reads : [reads]
     def read_file_arg = read_files.size() > 1 ? "-1 ${read_files[0]} -2 ${read_files[1]}" : "-1 ${read_files[0]}"
     """
-    gzip -cdf $contigs > contigs_uncompressed
+
+    if [[ "${contigs}" == *.gz ]]; then
+        gzip -cdf ${contigs} > contigs_uncompressed
+    else
+        cp ${contigs} contigs_uncompressed
+    fi
 
     pypolca \
         run \


### PR DESCRIPTION
## Description

PyPOLCA currently assumes the assembly input is gzipped and always runs:

gzip -cdf $contigs > contigs_uncompressed

This fails when an uncompressed assembly is provided.

This PR updates the module to:
- decompress gzipped assemblies when the input ends with .gz
- copy uncompressed assemblies directly otherwise

This allows the module to support both compressed and uncompressed assembly inputs.