### PR TITLE
feat(orftable_fasta_gtf_buildorfcatalogue): collapse small ORFs by amino-acid identity

### DIFF
--- a/modules/nf-core/custom/orfcollapse/environment.yml
+++ b/modules/nf-core/custom/orfcollapse/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::pandas=2.3.0
+  - conda-forge::python=3.12.11
+  - conda-forge::pyyaml=6.0.2

--- a/modules/nf-core/custom/orfcollapse/main.nf
+++ b/modules/nf-core/custom/orfcollapse/main.nf
@@ -34,6 +34,7 @@ process CUSTOM_ORFCOLLAPSE {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version 2>&1 | sed 's/Python //')
+        pyyaml: \$(python -c "import yaml; print(yaml.__version__)")
     END_VERSIONS
     """
 }

--- a/modules/nf-core/custom/orfcollapse/main.nf
+++ b/modules/nf-core/custom/orfcollapse/main.nf
@@ -1,0 +1,39 @@
+process CUSTOM_ORFCOLLAPSE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f1019bd22c111267bcb670fdb128829776f0ca6adfa7b0e2d126f91577d08e3/data' :
+        'community.wave.seqera.io/library/python_pandas_pyyaml:75514f9f977be607' }"
+
+    input:
+    tuple val(meta), path(bed12, stageAs: 'input/*'), path(catalogue_tsv, stageAs: 'input/*'), path(orf_to_gene_tsv, stageAs: 'input/*'), path(aa_fasta, stageAs: 'input/*'), path(cluster_tsv, stageAs: 'input/*')
+
+    output:
+    tuple val(meta), path("${prefix}.bed12")           , emit: bed12
+    tuple val(meta), path("${prefix}.tsv")             , emit: catalogue_tsv
+    tuple val(meta), path("${prefix}.orf_to_gene.tsv") , emit: orf_to_gene_tsv
+    tuple val(meta), path("${prefix}.mqc.tsv")         , emit: multiqc
+    tuple val(meta), path("${prefix}.fasta")           , emit: aa_fasta
+    path "versions.yml"                                , emit: versions, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    prefix = task.ext.prefix ?: "${meta.id}.catalogue"
+    args   = task.ext.args ?: ''
+    template 'orfcollapse.py'
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}.catalogue"
+    """
+    touch ${prefix}.bed12 ${prefix}.tsv ${prefix}.orf_to_gene.tsv ${prefix}.mqc.tsv ${prefix}.fasta
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version 2>&1 | sed 's/Python //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/custom/orfcollapse/meta.yml
+++ b/modules/nf-core/custom/orfcollapse/meta.yml
@@ -9,10 +9,14 @@ description: |
   The coordinate-based merge in `custom/orfmerge` only groups ORFs that overlap
   on the genome, so the same micropeptide encoded at several distinct,
   non-overlapping loci (typically repetitive regions) survives as separate rows.
-  Following the GENCODE Ribo-seq ORF catalogue convention (Mudge et al. 2022,
-  Nat Biotechnol, doi:10.1038/s41587-022-01369-0), small ORFs (orf_class
-  "smORF", i.e. aa_length <= 100) are clustered by amino-acid identity upstream
-  and this module folds each multi-member cluster down to one representative.
+  This adopts the peptide-level deduplication and 0.9 amino-acid-similarity
+  threshold of the GENCODE Ribo-seq ORF consolidation (Mudge et al. 2022,
+  Nat Biotechnol, doi:10.1038/s41587-022-01369-0; gencode-riboseqORFs
+  collapse_cutoff 0.9), implemented here with MMseqs2 sequence-identity
+  clustering rather than that tool's longest-shared-string / P-site-overlap
+  metric. Small ORFs (orf_class "smORF", i.e. aa_length <= 100) are clustered by
+  amino-acid identity upstream and this module folds each multi-member cluster
+  down to one representative.
 
   Only smORF rows are collapsed; larger ORFs and transcript-anchored classes are
   passed through untouched. Among the smORF members of a cluster the

--- a/modules/nf-core/custom/orfcollapse/meta.yml
+++ b/modules/nf-core/custom/orfcollapse/meta.yml
@@ -1,0 +1,144 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "custom_orfcollapse"
+description: |
+  Collapse small ORFs that share an amino-acid sequence cluster into a single
+  catalogue entry. Pair with `custom/orfmerge` (coordinate-based catalogue),
+  `bedtools/getfasta` + `seqkit/translate` (AA FASTA keyed by orf_id), and
+  `mmseqs/easycluster` (AA clusters) upstream.
+
+  The coordinate-based merge in `custom/orfmerge` only groups ORFs that overlap
+  on the genome, so the same micropeptide encoded at several distinct,
+  non-overlapping loci (typically repetitive regions) survives as separate rows.
+  Following the GENCODE Ribo-seq ORF catalogue convention (Mudge et al. 2022,
+  Nat Biotechnol, doi:10.1038/s41587-022-01369-0), small ORFs (orf_class
+  "smORF", i.e. aa_length <= 100) are clustered by amino-acid identity upstream
+  and this module folds each multi-member cluster down to one representative.
+
+  Only smORF rows are collapsed; larger ORFs and transcript-anchored classes are
+  passed through untouched. Among the smORF members of a cluster the
+  representative is chosen by longest aa_length (ties broken by orf_id), so the
+  result does not depend on which sequence MMseqs2 labelled the cluster
+  representative. Catalogue row order is preserved; dropped members fold their
+  `called_by_<caller>` / `score_<caller>` evidence, `n_samples` / `samples`
+  recurrence and gene mappings into the survivor.
+keywords:
+  - orf
+  - ribo-seq
+  - catalogue
+  - smorf
+  - deduplication
+tools:
+  - "orfcollapse":
+      description: |
+        Python helper that folds small-ORF catalogue rows sharing an MMseqs2
+        amino-acid cluster into a single representative, merging cross-caller
+        provenance, cross-sample recurrence and gene mappings.
+      tool_dev_url: "https://github.com/nf-core/modules/blob/master/modules/nf-core/custom/orfcollapse/main.nf"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map. Typically a cohort-level `[ id: 'cohort' ]`.
+    - bed12:
+        type: file
+        description: Merged ORF catalogue BED12 (output of `custom/orfmerge`).
+        pattern: "*.bed12"
+        ontologies:
+          - edam: http://edamontology.org/format_3586 # BED
+    - catalogue_tsv:
+        type: file
+        description: Merged ORF catalogue TSV (output of `custom/orfmerge`).
+        pattern: "*.tsv"
+        ontologies:
+          - edam: http://edamontology.org/format_3475 # TSV
+    - orf_to_gene_tsv:
+        type: file
+        description: ORF-to-gene mapping TSV (output of `custom/orfmerge`).
+        pattern: "*.orf_to_gene.tsv"
+        ontologies:
+          - edam: http://edamontology.org/format_3475 # TSV
+    - aa_fasta:
+        type: file
+        description: |
+          Catalogue amino-acid FASTA keyed by orf_id (output of
+          `bedtools/getfasta -split -s -nameOnly` then `seqkit/translate`).
+        pattern: "*.fasta"
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
+    - cluster_tsv:
+        type: file
+        description: |
+          Two-column MMseqs2 cluster TSV (representative<TAB>member), output of
+          `mmseqs/easycluster` run on the catalogue AA FASTA.
+        pattern: "*.tsv"
+        ontologies:
+          - edam: http://edamontology.org/format_3475 # TSV
+output:
+  bed12:
+    - - meta:
+          type: map
+          description: Groovy Map matching the input meta.
+      - ${prefix}.bed12:
+          type: file
+          description: Deduplicated ORF catalogue as BED12 (genomic blocks).
+          pattern: "*.bed12"
+          ontologies:
+            - edam: http://edamontology.org/format_3586 # BED
+  catalogue_tsv:
+    - - meta:
+          type: map
+          description: Groovy Map matching the input meta.
+      - ${prefix}.tsv:
+          type: file
+          description: Deduplicated per-ORF catalogue table.
+          pattern: "*.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  orf_to_gene_tsv:
+    - - meta:
+          type: map
+          description: Groovy Map matching the input meta.
+      - ${prefix}.orf_to_gene.tsv:
+          type: file
+          description: ORF-to-gene mapping with collapsed members remapped to the survivor.
+          pattern: "*.orf_to_gene.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  multiqc:
+    - - meta:
+          type: map
+          description: Groovy Map matching the input meta.
+      - ${prefix}.mqc.tsv:
+          type: file
+          description: MultiQC custom-content TSV (per-class ORF counts, post-collapse).
+          pattern: "*.mqc.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  aa_fasta:
+    - - meta:
+          type: map
+          description: Groovy Map matching the input meta.
+      - ${prefix}.fasta:
+          type: file
+          description: Amino-acid FASTA of the surviving catalogue ORFs.
+          pattern: "*.fasta"
+          ontologies:
+            - edam: http://edamontology.org/format_1929 # FASTA
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+topics:
+  versions:
+    - versions.yml:
+        type: string
+        description: The name of the process
+authors:
+  - "@pinin4fjords"
+maintainers:
+  - "@pinin4fjords"

--- a/modules/nf-core/custom/orfcollapse/templates/orfcollapse.py
+++ b/modules/nf-core/custom/orfcollapse/templates/orfcollapse.py
@@ -192,6 +192,7 @@ def main():
                 "${task.process}": {
                     "python": platform.python_version(),
                     "pandas": pd.__version__,
+                    "pyyaml": yaml.__version__,
                 }
             },
             fh,

--- a/modules/nf-core/custom/orfcollapse/templates/orfcollapse.py
+++ b/modules/nf-core/custom/orfcollapse/templates/orfcollapse.py
@@ -6,12 +6,15 @@
 The coordinate-based merge in custom/orfmerge groups ORFs that overlap on the
 genome, but the same micropeptide is frequently encoded at several distinct,
 non-overlapping genomic loci (typically repetitive regions), and those copies
-survive as separate catalogue rows. Following the GENCODE Ribo-seq ORF catalogue
-convention (Mudge et al. 2022, Nat Biotechnol, doi:10.1038/s41587-022-01369-0;
-gencode-riboseqORFs collapse_cutoff 0.9), small ORFs (orf_class == "smORF", i.e.
-aa_length <= 100) are clustered by amino-acid sequence identity upstream
-(mmseqs/easycluster) and this module folds each multi-member cluster down to one
-representative.
+survive as separate catalogue rows. This adopts the peptide-level deduplication
+and 0.9 amino-acid-similarity threshold of the GENCODE Ribo-seq ORF
+consolidation (Mudge et al. 2022, Nat Biotechnol,
+doi:10.1038/s41587-022-01369-0; gencode-riboseqORFs collapse_cutoff 0.9),
+implemented here with MMseqs2 sequence-identity clustering (--min-seq-id 0.9)
+rather than that tool's longest-shared-string / P-site-overlap metric. Small
+ORFs (orf_class == "smORF", i.e. aa_length <= 100) are clustered by amino-acid
+identity upstream (mmseqs/easycluster) and this module folds each multi-member
+cluster down to one representative.
 
 Only smORF rows are collapsed; larger ORFs and transcript-anchored classes pass
 through untouched, preserving the deterministic coordinate/transcript merge from

--- a/modules/nf-core/custom/orfcollapse/templates/orfcollapse.py
+++ b/modules/nf-core/custom/orfcollapse/templates/orfcollapse.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Written by Jonathan Manning (@pinin4fjords). Released under the MIT license.
+
+"""Collapse small ORFs sharing an amino-acid cluster into a single catalogue entry.
+
+The coordinate-based merge in custom/orfmerge groups ORFs that overlap on the
+genome, but the same micropeptide is frequently encoded at several distinct,
+non-overlapping genomic loci (typically repetitive regions), and those copies
+survive as separate catalogue rows. Following the GENCODE Ribo-seq ORF catalogue
+convention (Mudge et al. 2022, Nat Biotechnol, doi:10.1038/s41587-022-01369-0;
+gencode-riboseqORFs collapse_cutoff 0.9), small ORFs (orf_class == "smORF", i.e.
+aa_length <= 100) are clustered by amino-acid sequence identity upstream
+(mmseqs/easycluster) and this module folds each multi-member cluster down to one
+representative.
+
+Only smORF rows are collapsed; larger ORFs and transcript-anchored classes pass
+through untouched, preserving the deterministic coordinate/transcript merge from
+upstream. Among the smORF members of a cluster the representative is chosen here
+(longest aa_length, ties broken by orf_id) so the result is independent of which
+sequence MMseqs2 labelled the cluster representative. Catalogue row order is
+preserved; dropped members fold their cross-caller / cross-sample evidence and
+gene mappings into the survivor.
+"""
+
+import argparse
+import platform
+import re
+import shlex
+import sys
+from collections import defaultdict
+
+import pandas as pd
+import yaml
+
+CALLERS = ("ribotish", "ribocode", "ribotricer", "rpbp", "price")
+# `bedtools getfasta -nameOnly -s` appends the strand as "(+)"/"(-)" to each
+# sequence name, so FASTA headers and MMseqs2 cluster ids arrive as
+# "<orf_id>(+)". Strip it to recover the bare orf_id used in the catalogue.
+STRAND_SUFFIX = re.compile(r"\\([+-]\\)\$")
+SCORE_DIRECTIONS = {
+    "ribotish": "min",
+    "ribocode": "min",
+    "ribotricer": "max",
+    "rpbp": "max",
+    "price": "min",
+}
+CLASS_ORDER = ("canonical_cds", "uORF", "dORF", "novel_u", "smORF", "other")
+SMORF_CLASS = "smORF"
+
+
+def read_fasta(path):
+    seqs = {}
+    name, chunks = None, []
+    with open(path) as fh:
+        for line in fh:
+            line = line.rstrip("\\n")
+            if line.startswith(">"):
+                if name is not None:
+                    seqs[name] = "".join(chunks)
+                header = line[1:].split()[0] if len(line) > 1 else ""
+                name = STRAND_SUFFIX.sub("", header)
+                chunks = []
+            else:
+                chunks.append(line)
+    if name is not None:
+        seqs[name] = "".join(chunks)
+    return seqs
+
+
+def read_clusters(path):
+    """Map member orf_id -> cluster key (representative id) from an mmseqs cluster TSV."""
+    cluster_of = {}
+    with open(path) as fh:
+        for line in fh:
+            fields = line.rstrip("\\n").split("\\t")
+            if len(fields) >= 2:
+                member = STRAND_SUFFIX.sub("", fields[1])
+                rep = STRAND_SUFFIX.sub("", fields[0])
+                cluster_of[member] = rep
+    return cluster_of
+
+
+def best_score(values, direction):
+    nums = []
+    for v in values:
+        try:
+            if v not in ("", None):
+                nums.append(float(v))
+        except ValueError:
+            continue
+    if not nums:
+        return ""
+    return f"{(max(nums) if direction == 'max' else min(nums)):.6g}"
+
+
+def merge_members(members):
+    """Fold smORF rows sharing an AA cluster into one representative row dict."""
+    rep = sorted(members, key=lambda r: (-int(r.get("aa_length") or 0), r["orf_id"]))[0]
+    out = dict(rep)
+    for c in CALLERS:
+        out[f"called_by_{c}"] = (
+            "1" if any(r.get(f"called_by_{c}") == "1" for r in members) else "0"
+        )
+        out[f"score_{c}"] = best_score(
+            [r.get(f"score_{c}", "") for r in members], SCORE_DIRECTIONS[c]
+        )
+    samples = sorted(
+        {s for r in members for s in (r.get("samples") or "").split(",") if s}
+    )
+    out["n_samples"] = str(len(samples))
+    out["samples"] = ",".join(samples)
+    return rep["orf_id"], out
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args(shlex.split("${args}"))
+
+    prefix = "${prefix}"
+
+    catalogue = pd.read_csv(
+        "${catalogue_tsv}", sep="\\t", comment="#", dtype=str, keep_default_na=False
+    )
+    header = list(catalogue.columns)
+    rows = catalogue.to_dict("records")
+
+    bed_index = {}
+    with open("${bed12}") as fh:
+        for line in fh:
+            parts = line.rstrip("\\n").split("\\t")
+            if len(parts) >= 12:
+                bed_index[parts[3]] = line.rstrip("\\n")
+
+    aa = read_fasta("${aa_fasta}")
+    cluster_of = read_clusters("${cluster_tsv}")
+
+    clusters = defaultdict(list)
+    for r in rows:
+        if r.get("orf_class") == SMORF_CLASS:
+            clusters[cluster_of.get(r["orf_id"], r["orf_id"])].append(r)
+
+    remap, merged_rows, dropped = {}, {}, set()
+    for members in clusters.values():
+        if len(members) < 2:
+            continue
+        rep_id, merged = merge_members(members)
+        merged_rows[rep_id] = merged
+        for m in members:
+            remap[m["orf_id"]] = rep_id
+            if m["orf_id"] != rep_id:
+                dropped.add(m["orf_id"])
+
+    kept = [merged_rows.get(r["orf_id"], r) for r in rows if r["orf_id"] not in dropped]
+    out = pd.DataFrame(kept, columns=header)
+    out.to_csv(f"{prefix}.tsv", sep="\\t", index=False)
+
+    with (
+        open(f"{prefix}.bed12", "w") as bh,
+        open(f"{prefix}.fasta", "w") as ah,
+    ):
+        for oid in out["orf_id"]:
+            if oid in bed_index:
+                bh.write(bed_index[oid] + "\\n")
+            if oid in aa:
+                ah.write(f">{oid}\\n{aa[oid]}\\n")
+
+    o2g = pd.read_csv("${orf_to_gene_tsv}", sep="\\t", dtype=str, keep_default_na=False)
+    o2g["orf_id"] = o2g["orf_id"].map(lambda o: remap.get(o, o))
+    o2g.drop_duplicates().to_csv(f"{prefix}.orf_to_gene.tsv", sep="\\t", index=False)
+
+    counts = out["orf_class"].value_counts()
+    with open(f"{prefix}.mqc.tsv", "w") as mh:
+        mh.write(
+            "# id: orf_catalogue\\n"
+            "# section_name: 'ORF catalogue'\\n"
+            "# description: 'Per-class ORF counts in the merged catalogue.'\\n"
+            "# plot_type: 'table'\\n"
+            "# pconfig:\\n"
+            "#   id: 'orf_catalogue_table'\\n"
+            "#   title: 'ORF catalogue'\\n"
+            "Class\\tCount\\n"
+        )
+        for cls in CLASS_ORDER:
+            mh.write(f"{cls}\\t{int(counts.get(cls, 0))}\\n")
+
+    with open("versions.yml", "w") as fh:
+        yaml.safe_dump(
+            {
+                "${task.process}": {
+                    "python": platform.python_version(),
+                    "pandas": pd.__version__,
+                }
+            },
+            fh,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+    return 0
+
+
+sys.exit(main())

--- a/modules/nf-core/custom/orfcollapse/tests/main.nf.test
+++ b/modules/nf-core/custom/orfcollapse/tests/main.nf.test
@@ -1,0 +1,61 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_ORFCOLLAPSE"
+    script "../main.nf"
+    process "CUSTOM_ORFCOLLAPSE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "custom/orfcollapse"
+
+    test("collapse identical small ORFs across loci") {
+
+        when {
+            process {
+                """
+                def dir = params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/orf_catalogue"
+                input[0] = [
+                    [ id: 'cohort' ],
+                    file("\${dir}/cohort.catalogue.bed12",   checkIfExists: true),
+                    file("\${dir}/cohort.catalogue.tsv",     checkIfExists: true),
+                    file("\${dir}/cohort.orf_to_gene.tsv",   checkIfExists: true),
+                    file("\${dir}/cohort.catalogue.aa.fasta",checkIfExists: true),
+                    file("\${dir}/cohort_cluster.tsv",       checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            def out  = path(process.out.catalogue_tsv[0][1]).text.readLines()
+            def cols = out[0].split('\t') as List
+            def rows = out.drop(1).collect { it.split('\t') }
+            def byId = rows.collectEntries { [(it[0]): it] }
+            def aa   = path(process.out.aa_fasta[0][1]).text
+            def o2g  = path(process.out.orf_to_gene_tsv[0][1]).text.readLines().drop(1)
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() },
+                // The two identical smORFs on different strands/loci collapse to one row.
+                { assert rows.size() == 3 },
+                { assert byId.containsKey('orf_00000001') },
+                { assert !byId.containsKey('orf_00000002') },
+                // The survivor unions both callers' evidence and both samples.
+                { assert byId['orf_00000001'][cols.indexOf('called_by_ribotish')] == '1' },
+                { assert byId['orf_00000001'][cols.indexOf('called_by_ribocode')] == '1' },
+                { assert byId['orf_00000001'][cols.indexOf('n_samples')] == '2' },
+                { assert byId['orf_00000001'][cols.indexOf('samples')] == 'sampleA,sampleB' },
+                // Non-smORF and unique smORF pass through.
+                { assert byId.containsKey('orf_00000003') },
+                { assert byId.containsKey('orf_00000004') },
+                // The dropped member's gene mapping is folded onto the survivor.
+                { assert o2g.any { it == 'orf_00000001\tg5\tt5' } },
+                // AA FASTA loses the dropped member and is keyed by bare orf_id.
+                { assert aa.contains('>orf_00000001') },
+                { assert !aa.contains('>orf_00000002') }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/custom/orfcollapse/tests/main.nf.test
+++ b/modules/nf-core/custom/orfcollapse/tests/main.nf.test
@@ -58,4 +58,32 @@ nextflow_process {
         }
     }
 
+    test("collapse identical small ORFs across loci - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                def dir = params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/orf_catalogue"
+                input[0] = [
+                    [ id: 'cohort' ],
+                    file("\${dir}/cohort.catalogue.bed12",   checkIfExists: true),
+                    file("\${dir}/cohort.catalogue.tsv",     checkIfExists: true),
+                    file("\${dir}/cohort.orf_to_gene.tsv",   checkIfExists: true),
+                    file("\${dir}/cohort.catalogue.aa.fasta",checkIfExists: true),
+                    file("\${dir}/cohort_cluster.tsv",       checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
 }

--- a/modules/nf-core/custom/orfcollapse/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/orfcollapse/tests/main.nf.test.snap
@@ -43,11 +43,65 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,3adb208375d6aeb89f31133eecf2b303"
+                    "versions.yml:md5,bee1c8b5fc00b775636b852c119623d1"
                 ]
             }
         ],
-        "timestamp": "2026-06-16T11:49:22.950955064",
+        "timestamp": "2026-06-17T10:10:52.259691163",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "collapse identical small ORFs across loci - stub": {
+        "content": [
+            {
+                "aa_fasta": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.bed12:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "catalogue_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "multiqc": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.mqc.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.orf_to_gene.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5b0bc84312ac10e7049f6feb6ac77990"
+                ]
+            }
+        ],
+        "timestamp": "2026-06-17T10:10:56.622346268",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/modules/nf-core/custom/orfcollapse/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/orfcollapse/tests/main.nf.test.snap
@@ -1,0 +1,56 @@
+{
+    "collapse identical small ORFs across loci": {
+        "content": [
+            {
+                "aa_fasta": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.fasta:md5,fd7aac4757475b5814e192bddc2ba51b"
+                    ]
+                ],
+                "bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.bed12:md5,299daed2c7d9d03faba1340684a57fa7"
+                    ]
+                ],
+                "catalogue_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.tsv:md5,2ae2eb7006ab613d0d23ea5eaa959615"
+                    ]
+                ],
+                "multiqc": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.mqc.tsv:md5,0541bc7510de3bc238145a4f913a9be9"
+                    ]
+                ],
+                "orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.orf_to_gene.tsv:md5,7920c0714282f9cdfe809f8f9a12a511"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,3adb208375d6aeb89f31133eecf2b303"
+                ]
+            }
+        ],
+        "timestamp": "2026-06-16T11:49:22.950955064",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    }
+}

--- a/modules/nf-core/custom/orfmerge/main.nf
+++ b/modules/nf-core/custom/orfmerge/main.nf
@@ -11,27 +11,27 @@ process CUSTOM_ORFMERGE {
     tuple val(meta), path(bed12s, arity: '1..*', stageAs: 'beds/*'), path(tsvs, arity: '1..*', stageAs: 'tsvs/*')
 
     output:
-    tuple val(meta), path("${prefix}.catalogue.bed12")    , emit: bed12
-    tuple val(meta), path("${prefix}.catalogue.tsv")      , emit: catalogue_tsv
-    tuple val(meta), path("${prefix}.orf_to_gene.tsv")    , emit: orf_to_gene_tsv
-    tuple val(meta), path("${prefix}.catalogue.mqc.tsv")  , emit: multiqc
-    path "versions.yml"                                   , emit: versions, topic: versions
+    tuple val(meta), path("${prefix}.bed12")           , emit: bed12
+    tuple val(meta), path("${prefix}.tsv")             , emit: catalogue_tsv
+    tuple val(meta), path("${prefix}.orf_to_gene.tsv") , emit: orf_to_gene_tsv
+    tuple val(meta), path("${prefix}.mqc.tsv")         , emit: multiqc
+    path "versions.yml"                                , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}.catalogue"
     args   = task.ext.args ?: ''
     template 'orfmerge.py'
 
     stub:
-    prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}.catalogue"
     """
-    touch ${prefix}.catalogue.bed12
-    touch ${prefix}.catalogue.tsv
+    touch ${prefix}.bed12
+    touch ${prefix}.tsv
     touch ${prefix}.orf_to_gene.tsv
-    touch ${prefix}.catalogue.mqc.tsv
+    touch ${prefix}.mqc.tsv
 
     python -c "import platform, yaml; yaml.safe_dump({'${task.process}': {'python': platform.python_version()}}, open('versions.yml', 'w'), default_flow_style=False, sort_keys=False)"
     """

--- a/modules/nf-core/custom/orfmerge/meta.yml
+++ b/modules/nf-core/custom/orfmerge/meta.yml
@@ -88,10 +88,10 @@ output:
           type: map
           description: |
             Groovy Map matching the input meta.
-      - ${prefix}.catalogue.bed12:
+      - ${prefix}.bed12:
           type: file
           description: Merged ORF catalogue as BED12 (genomic blocks).
-          pattern: "*.catalogue.bed12"
+          pattern: "*.bed12"
           ontologies:
             - edam: http://edamontology.org/format_3586 # BED
   catalogue_tsv:
@@ -99,14 +99,14 @@ output:
           type: map
           description: |
             Groovy Map matching the input meta.
-      - ${prefix}.catalogue.tsv:
+      - ${prefix}.tsv:
           type: file
           description: |
             Per-ORF table with `called_by_<caller>` and `score_<caller>`
             columns for each supported caller, `n_samples` / `samples`
             cross-sample recurrence columns, plus orf_class, aa_length,
             and host gene_id / transcript_id.
-          pattern: "*.catalogue.tsv"
+          pattern: "*.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
   orf_to_gene_tsv:
@@ -129,11 +129,11 @@ output:
           type: map
           description: |
             Groovy Map matching the input meta.
-      - ${prefix}.catalogue.mqc.tsv:
+      - ${prefix}.mqc.tsv:
           type: file
           description: |
             MultiQC custom-content TSV (per-class ORF counts).
-          pattern: "*.catalogue.mqc.tsv"
+          pattern: "*.mqc.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
   versions:

--- a/modules/nf-core/custom/orfmerge/templates/orfmerge.py
+++ b/modules/nf-core/custom/orfmerge/templates/orfmerge.py
@@ -26,11 +26,11 @@ Cross-sample recurrence is recorded in two further columns:
 
 Outputs:
 
-  ${prefix}.catalogue.bed12      merged catalogue (genomic blocks).
-  ${prefix}.catalogue.tsv        per-ORF table with caller-tracking cols.
+  ${prefix}.bed12                merged catalogue (genomic blocks).
+  ${prefix}.tsv                  per-ORF table with caller-tracking cols.
   ${prefix}.orf_to_gene.tsv      one row per (orf_id, gene_id, transcript_id);
                                  an ORF can map to multiple host transcripts.
-  ${prefix}.catalogue.mqc.tsv    MultiQC custom-content sidecar
+  ${prefix}.mqc.tsv              MultiQC custom-content sidecar
                                  (per-class counts).
 """
 
@@ -183,10 +183,10 @@ def load_normalised(tsv_paths, bed_paths):
 
 
 def write_catalogue(prefix, clusters, bed_index):
-    cat_bed = Path(f"{prefix}.catalogue.bed12")
-    cat_tsv = Path(f"{prefix}.catalogue.tsv")
+    cat_bed = Path(f"{prefix}.bed12")
+    cat_tsv = Path(f"{prefix}.tsv")
     o2g_tsv = Path(f"{prefix}.orf_to_gene.tsv")
-    mqc_tsv = Path(f"{prefix}.catalogue.mqc.tsv")
+    mqc_tsv = Path(f"{prefix}.mqc.tsv")
 
     catalogue_cols = (
         ["orf_id", "chrom", "start", "end", "strand", "gene_id", "transcript_id", "orf_class", "aa_length"]
@@ -196,6 +196,22 @@ def write_catalogue(prefix, clusters, bed_index):
     )
 
     per_class_counts = defaultdict(int)
+
+    # orf_ids are assigned in iteration order below, so sort first to make the
+    # numbering deterministic.
+    def _sort_key(cluster):
+        r = representative(cluster)
+        return (
+            r.get("chrom", ""),
+            int(r.get("start") or 0),
+            int(r.get("end") or 0),
+            r.get("strand", ""),
+            r.get("gene_id") or "",
+            r.get("transcript_id") or "",
+            r.get("orf_class", ""),
+        )
+
+    clusters = sorted(clusters, key=_sort_key)
 
     with open(cat_bed, "w") as bh, open(cat_tsv, "w") as th, open(o2g_tsv, "w") as oh:
         th.write("\\t".join(catalogue_cols) + "\\n")

--- a/modules/nf-core/custom/orfmerge/tests/main.nf.test
+++ b/modules/nf-core/custom/orfmerge/tests/main.nf.test
@@ -18,7 +18,7 @@ nextflow_process {
                 """
                 input[0] = channel.of([
                     [id: 'sample1', caller: 'ribotish'],
-                    file('https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orf-prediction-fixtures/data/genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribotish.pred.txt', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribotish.pred.txt', checkIfExists: true),
                     'ribotish'
                 ])
                 input[1] = channel.of([
@@ -35,7 +35,7 @@ nextflow_process {
                 """
                 input[0] = channel.of([
                     [id: 'sample1', caller: 'ribocode'],
-                    file('https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orf-prediction-fixtures/data/genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribocode.txt', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribocode.txt', checkIfExists: true),
                     'ribocode'
                 ])
                 input[1] = channel.of([
@@ -52,7 +52,7 @@ nextflow_process {
                 """
                 input[0] = channel.of([
                     [id: 'sample2', caller: 'ribotish'],
-                    file('https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orf-prediction-fixtures/data/genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribotish.pred.txt', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribotish.pred.txt', checkIfExists: true),
                     'ribotish'
                 ])
                 input[1] = channel.of([

--- a/modules/nf-core/custom/orfmerge/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/orfmerge/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.bed12:md5,d0de23019fbec9d96fd9302103a16278"
+                        "cohort.catalogue.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
                     ]
                 ],
                 "1": [
@@ -15,7 +15,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.tsv:md5,d2695c6f6eab75fd03a20d7441533d36"
+                        "cohort.catalogue.tsv:md5,d6af31aac0548c8ce0f447be02d06397"
                     ]
                 ],
                 "2": [
@@ -23,7 +23,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.orf_to_gene.tsv:md5,79699c0188eadd2aaf912a31a2c14464"
+                        "cohort.catalogue.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
                     ]
                 ],
                 "3": [
@@ -42,7 +42,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.bed12:md5,d0de23019fbec9d96fd9302103a16278"
+                        "cohort.catalogue.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
                     ]
                 ],
                 "catalogue_tsv": [
@@ -50,7 +50,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.tsv:md5,d2695c6f6eab75fd03a20d7441533d36"
+                        "cohort.catalogue.tsv:md5,d6af31aac0548c8ce0f447be02d06397"
                     ]
                 ],
                 "multiqc": [
@@ -66,7 +66,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.orf_to_gene.tsv:md5,79699c0188eadd2aaf912a31a2c14464"
+                        "cohort.catalogue.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
                     ]
                 ],
                 "versions": [
@@ -74,10 +74,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-12T13:28:01.081036",
+        "timestamp": "2026-06-16T11:49:30.349632545",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.1"
         }
     }
 }

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
@@ -2,13 +2,16 @@
 // Build a multi-caller Ribo-seq ORF catalogue from per-sample, per-caller
 // ORF prediction tables. Composes the normaliser (run once per caller-tagged
 // input), the merger (one cohort-level invocation), and bedtools/getfasta +
-// seqkit/translate to produce the catalogue AA FASTA.
+// seqkit/translate to produce the catalogue AA FASTA. An optional amino-acid
+// clustering pass (controlled by `val_collapse`) folds duplicate small ORFs.
 //
 
 include { CUSTOM_ORFNORMALISE } from '../../../modules/nf-core/custom/orfnormalise/main'
 include { CUSTOM_ORFMERGE     } from '../../../modules/nf-core/custom/orfmerge/main'
 include { BEDTOOLS_GETFASTA   } from '../../../modules/nf-core/bedtools/getfasta/main'
 include { SEQKIT_TRANSLATE    } from '../../../modules/nf-core/seqkit/translate/main'
+include { MMSEQS_EASYCLUSTER  } from '../../../modules/nf-core/mmseqs/easycluster/main'
+include { CUSTOM_ORFCOLLAPSE  } from '../../../modules/nf-core/custom/orfcollapse/main'
 
 workflow ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE {
 
@@ -20,6 +23,10 @@ workflow ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE {
     ch_fasta       // channel: [ val(meta), path(fasta) ]   - reference genome FASTA
     ch_gtf         // channel: [ val(meta), path(gtf)   ]   - reference GTF (used by
                    //          ribocode/ribotish normalisers; ignored by rpbp/price)
+    val_collapse   // boolean: cluster catalogue peptides by amino-acid identity
+                   //          and fold duplicate small ORFs to one representative
+                   //          each. When false the merged catalogue is emitted
+                   //          unchanged and the clustering modules do not run.
 
     main:
 
@@ -56,16 +63,45 @@ workflow ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE {
 
     CUSTOM_ORFMERGE ( ch_merge_in )
 
-    // 3. Lift the merged BED12 into nucleotide then amino-acid FASTA.
-    //    `bedtools getfasta -split` walks BED12 blocks in mRNA order;
-    //    `seqkit translate --trim` drops trailing stops.
+    // 3. Lift the merged BED12 into nucleotide then amino-acid FASTA, keyed by
+    //    orf_id. `bedtools getfasta -split -s -nameOnly` walks BED12 blocks in
+    //    mRNA order on the correct strand and names each sequence by the BED
+    //    name (orf_id); `seqkit translate --trim` drops trailing stops.
     BEDTOOLS_GETFASTA ( CUSTOM_ORFMERGE.out.bed12, ch_fasta.map { _meta, fa -> fa }.first() )
     SEQKIT_TRANSLATE  ( BEDTOOLS_GETFASTA.out.fasta )
 
+    // 4. Assemble the full merged catalogue (BED12 + tables + AA FASTA) on one
+    //    cohort record, then route by `val_collapse`. The coordinate merge only
+    //    collapses genomically overlapping ORFs, so the same micropeptide
+    //    encoded at distinct loci survives as separate rows; the collapse route
+    //    clusters peptides by amino-acid identity and folds the small-ORF
+    //    (aa_length <= 100) clusters to one representative each (GENCODE
+    //    Ribo-seq ORF catalogue convention, Mudge et al. 2022). The keep route
+    //    emits the merged catalogue untouched.
+    ch_routed = CUSTOM_ORFMERGE.out.bed12
+        .join(CUSTOM_ORFMERGE.out.catalogue_tsv)
+        .join(CUSTOM_ORFMERGE.out.orf_to_gene_tsv)
+        .join(CUSTOM_ORFMERGE.out.multiqc)
+        .join(SEQKIT_TRANSLATE.out.fastx)
+        .branch { _meta, _bed, _tsv, _o2g, _mqc, _aa ->
+            collapse: val_collapse
+            keep    : true
+        }
+
+    MMSEQS_EASYCLUSTER ( ch_routed.collapse.map { meta, _bed, _tsv, _o2g, _mqc, aa -> [ meta, aa ] } )
+
+    CUSTOM_ORFCOLLAPSE (
+        ch_routed.collapse
+            .map { meta, bed, tsv, o2g, _mqc, aa -> [ meta, bed, tsv, o2g, aa ] }
+            .join(MMSEQS_EASYCLUSTER.out.tsv)
+    )
+
+    // For a given run exactly one route carries records, so `mix` yields a
+    // single catalogue per output channel.
     emit:
-    catalogue_bed12    = CUSTOM_ORFMERGE.out.bed12
-    catalogue_tsv      = CUSTOM_ORFMERGE.out.catalogue_tsv
-    orf_to_gene_tsv    = CUSTOM_ORFMERGE.out.orf_to_gene_tsv
-    catalogue_aa_fasta = SEQKIT_TRANSLATE.out.fastx
-    multiqc            = CUSTOM_ORFMERGE.out.multiqc
+    catalogue_bed12    = CUSTOM_ORFCOLLAPSE.out.bed12.mix(ch_routed.keep.map { meta, bed, _tsv, _o2g, _mqc, _aa -> [ meta, bed ] })
+    catalogue_tsv      = CUSTOM_ORFCOLLAPSE.out.catalogue_tsv.mix(ch_routed.keep.map { meta, _bed, tsv, _o2g, _mqc, _aa -> [ meta, tsv ] })
+    orf_to_gene_tsv    = CUSTOM_ORFCOLLAPSE.out.orf_to_gene_tsv.mix(ch_routed.keep.map { meta, _bed, _tsv, o2g, _mqc, _aa -> [ meta, o2g ] })
+    catalogue_aa_fasta = CUSTOM_ORFCOLLAPSE.out.aa_fasta.mix(ch_routed.keep.map { meta, _bed, _tsv, _o2g, _mqc, aa -> [ meta, aa ] })
+    multiqc            = CUSTOM_ORFCOLLAPSE.out.multiqc.mix(ch_routed.keep.map { meta, _bed, _tsv, _o2g, mqc, _aa -> [ meta, mqc ] })
 }

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
@@ -15,6 +15,12 @@ description: |
        clusters catalogue peptides by amino-acid identity and folds duplicate
        small ORFs to one representative each.
 
+  The collapse identity threshold defaults to `--min-seq-id 0.9` (the GENCODE
+  Ribo-seq ORF catalogue convention; Mudge et al. 2022), set on
+  `MMSEQS_EASYCLUSTER` in this subworkflow's `nextflow.config`. Override it via
+  `ext.args` on `MMSEQS_EASYCLUSTER` in the consuming pipeline's config if a
+  different cutoff is wanted.
+
   Supports five callers via the per-record `caller` val: ribocode, ribotish,
   ribotricer, rpbp, price. Any subset can be supplied. When `ch_orf_tables` is empty
   the subworkflow short-circuits the merge + FASTA chain and the output

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
@@ -11,6 +11,9 @@ description: |
        clustering of normalised calls across callers and samples.
     3. `bedtools/getfasta` + `seqkit/translate` - lifts the merged BED12
        into a catalogue AA FASTA.
+    4. `mmseqs/easycluster` + `custom/orfcollapse` (optional, `val_collapse`) -
+       clusters catalogue peptides by amino-acid identity and folds duplicate
+       small ORFs to one representative each.
 
   Supports five callers via the per-record `caller` val: ribocode, ribotish,
   ribotricer, rpbp, price. Any subset can be supplied. When `ch_orf_tables` is empty
@@ -32,6 +35,8 @@ components:
   - custom/orfmerge
   - bedtools/getfasta
   - seqkit/translate
+  - mmseqs/easycluster
+  - custom/orfcollapse
 input:
   - ch_orf_tables:
       description: |
@@ -53,6 +58,13 @@ input:
         (ribotricer, rpbp, price). Pass `[ [:], [] ]` if no GTF is
         available (caller subset must then exclude ribocode and ribotish).
         Structure: [ val(meta), path(gtf) ]
+  - val_collapse:
+      description: |
+        Cluster catalogue peptides by amino-acid identity (mmseqs/easycluster)
+        and fold each multi-member small-ORF cluster to one representative
+        (custom/orfcollapse). When false the merged catalogue is emitted
+        unchanged and the clustering modules do not run.
+        Structure: val(collapse)
 output:
   - catalogue_bed12:
       description: |

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/nextflow.config
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/nextflow.config
@@ -4,7 +4,10 @@ process {
         ext.args   = '-split -s -nameOnly'
     }
     withName: 'ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:SEQKIT_TRANSLATE' {
-        ext.prefix = { "${meta.id}.catalogue.aa" }
+        ext.prefix = { "${meta.id}.catalogue" }
         ext.args   = '--trim'
+    }
+    withName: 'ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:MMSEQS_EASYCLUSTER' {
+        ext.args = '--min-seq-id 0.9 -c 0.8 --cov-mode 0'
     }
 }

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/tests/main.nf.test
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/tests/main.nf.test
@@ -12,6 +12,8 @@ nextflow_workflow {
     tag "custom/orfmerge"
     tag "bedtools/getfasta"
     tag "seqkit/translate"
+    tag "mmseqs/easycluster"
+    tag "custom/orfcollapse"
     tag "gunzip"
 
     setup {
@@ -36,12 +38,12 @@ nextflow_workflow {
                 input[0] = channel.of(
                     [
                         [id: 'sample1'],
-                        file('https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orf-prediction-fixtures/data/genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribotish.pred.txt', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribotish.pred.txt', checkIfExists: true),
                         'ribotish'
                     ],
                     [
                         [id: 'sample1'],
-                        file('https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-orf-prediction-fixtures/data/genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribocode.txt', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribocode.txt', checkIfExists: true),
                         'ribocode'
                     ]
                 )
@@ -50,6 +52,42 @@ nextflow_workflow {
                     [id: 'reference'],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf', checkIfExists: true)
                 ])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens [chr20] - ribotish + ribocode - collapse disabled") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [id: 'sample1'],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribotish.pred.txt', checkIfExists: true),
+                        'ribotish'
+                    ],
+                    [
+                        [id: 'sample1'],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribocode.txt', checkIfExists: true),
+                        'ribocode'
+                    ]
+                )
+                input[1] = GUNZIP.out.gunzip
+                input[2] = channel.of([
+                    [id: 'reference'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf', checkIfExists: true)
+                ])
+                input[3] = false
                 """
             }
         }

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.bed12:md5,d0de23019fbec9d96fd9302103a16278"
+                        "cohort.catalogue.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
                     ]
                 ],
                 "1": [
@@ -15,7 +15,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.tsv:md5,9b7e37df457221a36257c5a7772db5e7"
+                        "cohort.catalogue.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
                     ]
                 ],
                 "2": [
@@ -23,7 +23,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.orf_to_gene.tsv:md5,79699c0188eadd2aaf912a31a2c14464"
+                        "cohort.catalogue.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
                     ]
                 ],
                 "3": [
@@ -31,7 +31,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.aa.fasta:md5,f268ea70badac0c99fd682b389d019b9"
+                        "cohort.catalogue.fasta:md5,362312506423e6861f84108f226a6ad3"
                     ]
                 ],
                 "4": [
@@ -47,7 +47,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.aa.fasta:md5,f268ea70badac0c99fd682b389d019b9"
+                        "cohort.catalogue.fasta:md5,362312506423e6861f84108f226a6ad3"
                     ]
                 ],
                 "catalogue_bed12": [
@@ -55,7 +55,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.bed12:md5,d0de23019fbec9d96fd9302103a16278"
+                        "cohort.catalogue.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
                     ]
                 ],
                 "catalogue_tsv": [
@@ -63,7 +63,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.tsv:md5,9b7e37df457221a36257c5a7772db5e7"
+                        "cohort.catalogue.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
                     ]
                 ],
                 "multiqc": [
@@ -79,15 +79,106 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.orf_to_gene.tsv:md5,79699c0188eadd2aaf912a31a2c14464"
+                        "cohort.catalogue.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-12T13:28:39.988782",
+        "timestamp": "2026-06-16T12:00:23.161222511",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.1"
+        }
+    },
+    "homo_sapiens [chr20] - ribotish + ribocode - collapse disabled": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.fasta:md5,8cbe5d11cbc9cfe0ef67d875b2632fe0"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.mqc.tsv:md5,d8e6da169d5d0a95b9bb4332290d1dd6"
+                    ]
+                ],
+                "catalogue_aa_fasta": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.fasta:md5,8cbe5d11cbc9cfe0ef67d875b2632fe0"
+                    ]
+                ],
+                "catalogue_bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "catalogue_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
+                    ]
+                ],
+                "multiqc": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.mqc.tsv:md5,d8e6da169d5d0a95b9bb4332290d1dd6"
+                    ]
+                ],
+                "orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-16T12:00:30.555944584",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds peptide-level deduplication to the Ribo-seq ORF catalogue and makes the catalogue build deterministic and byte-stable. Three coupled changes plus the subworkflow wiring that ties them together.

### `custom/orfcollapse` (new module)

The coordinate merge in `custom/orfmerge` only collapses ORFs that overlap on the genome, so the same micropeptide encoded at several distinct, non-overlapping loci (typically repetitive regions) survives as separate catalogue rows. This module clusters catalogue peptides by amino-acid identity (`mmseqs/easycluster`, `--min-seq-id 0.9 -c 0.8`) and folds each multi-member small-ORF (`orf_class == smORF`, aa_length ≤ 100) cluster down to one representative, unioning the cross-caller (`called_by_*` / `score_*`), cross-sample (`n_samples` / `samples`) and gene-mapping evidence. Larger and transcript-anchored ORFs pass through untouched. The representative is chosen here (longest aa_length, ties by orf_id) so the result is independent of which sequence MMseqs2 labelled the cluster representative. This adopts the peptide-level deduplication and 0.9 amino-acid-similarity threshold of the GENCODE Ribo-seq ORF consolidation (Mudge et al. 2022, Nat Biotechnol, doi:10.1038/s41587-022-01369-0; gencode-riboseqORFs collapse_cutoff 0.9), implemented here with MMseqs2 sequence-identity clustering rather than that tool's longest-shared-string / P-site-overlap metric.

### `custom/orfmerge`

`orfmerge` assigned sequential `orf_id`s in cluster-build order, which followed the nondeterministic order in which per-caller inputs were collected (`.collect()`). Catalogue content was identical run-to-run but row order / `orf_id` numbering were not, making downstream snapshots flaky. Clusters are now sorted by genomic coordinate (`chrom, start, end, strand, gene_id, transcript_id, orf_class`) before `orf_id` assignment.

### `orftable_fasta_gtf_buildorfcatalogue` (subworkflow)

Lifts the merged BED12 to an amino-acid FASTA (`bedtools/getfasta -split -s -nameOnly` then `seqkit/translate --trim`, keyed by `orf_id`), clusters it with `mmseqs/easycluster`, and feeds `custom/orfcollapse`. The collapse pass is gated by a `val_collapse` boolean take input and routed with `branch`/`mix`: when false the merged catalogue is emitted unchanged and the clustering modules do not run.

### Output naming

`custom/orfmerge` and `custom/orfcollapse` move the `catalogue` descriptor out of the hard `path(...)` outputs and into the overridable default prefix (`${meta.id}.catalogue`), so output declarations are `${prefix}.<format>`. The emitted `catalogue_aa_fasta` is `<prefix>.fasta` regardless of the collapse toggle.

## Validation

- `custom/orfcollapse` module test: collapses identical-peptide smORFs on opposite strands, unions evidence, passes through non-smORF / unique ORFs.
- `custom/orfmerge` module test and the subworkflow test (both `val_collapse` routes) pass end-to-end on x86 Linux; snapshots regenerated in the modules-repo test context.
- Test fixtures live in `nf-core/test-datasets` (`modules` branch) and are referenced via `params.modules_testdata_base_path`.
