### PR TITLE
fix(custom/orfmerge): deterministic orf_id ordering

### DIFF
--- a/modules/nf-core/custom/orfmerge/templates/orfmerge.py
+++ b/modules/nf-core/custom/orfmerge/templates/orfmerge.py
@@ -197,6 +197,22 @@ def write_catalogue(prefix, clusters, bed_index):
 
     per_class_counts = defaultdict(int)
 
+    # Stable genomic ordering so orf_id assignment is deterministic regardless of
+    # the order in which per-caller inputs were collected upstream.
+    def _sort_key(cluster):
+        r = representative(cluster)
+        return (
+            r.get("chrom", ""),
+            int(r.get("start") or 0),
+            int(r.get("end") or 0),
+            r.get("strand", ""),
+            r.get("gene_id") or "",
+            r.get("transcript_id") or "",
+            r.get("orf_class", ""),
+        )
+
+    clusters = sorted(clusters, key=_sort_key)
+
     with open(cat_bed, "w") as bh, open(cat_tsv, "w") as th, open(o2g_tsv, "w") as oh:
         th.write("\\t".join(catalogue_cols) + "\\n")
         oh.write("orf_id\\tgene_id\\ttranscript_id\\n")


### PR DESCRIPTION
## Summary

`custom/orfmerge` assigned sequential `orf_id`s in the order clusters were built, which follows the order in which per-caller normalised inputs were collected by the calling workflow. Nextflow `.collect()` does not guarantee a stable order, so although the catalogue **content** was identical run-to-run, the row order and `orf_id` numbering were not - making downstream snapshots flaky.

This sorts clusters by genomic coordinate (`chrom, start, end, strand, gene_id, transcript_id, orf_class`) before assigning `orf_id`s, so the merged catalogue is byte-deterministic.

## Validation
Verified against two independent pipeline runs: pre-fix the catalogue differed only by row order / `orf_id` (content identical when sorted); the sort makes it byte-identical.

## Draft - pending
- [ ] Regenerate the `custom/orfmerge` test snapshot (orf_id ordering changes).
- [ ] (test data migration tracked with the catalogue subworkflow PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
