### PR TITLE
test: update freebayes test names and metadata

### DIFF
--- a/modules/nf-core/freebayes/main.nf
+++ b/modules/nf-core/freebayes/main.nf
@@ -47,6 +47,6 @@ process FREEBAYES {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo | gzip > ${prefix}.vcf.gz
+    echo "" | gzip > ${prefix}.vcf.gz
     """
 }

--- a/modules/nf-core/freebayes/meta.yml
+++ b/modules/nf-core/freebayes/meta.yml
@@ -28,28 +28,37 @@ input:
         type: file
         description: BAM/CRAM/SAM file
         pattern: "*.{bam,cram,sam}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_2572 # BAM
+          - edam: http://edamontology.org/format_3462 # CRAM
+          - edam: http://edamontology.org/format_2573 # SAM
     - input_1_index:
         type: file
         description: BAM/CRAM/SAM index file
         pattern: "*.{bai,crai}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3327 # BAI/CRAI index
     - input_2:
         type: file
         description: BAM/CRAM/SAM file
         pattern: "*.{bam,cram,sam}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_2572 # BAM
+          - edam: http://edamontology.org/format_3462 # CRAM
+          - edam: http://edamontology.org/format_2573 # SAM
     - input_2_index:
         type: file
         description: BAM/CRAM/SAM index file
         pattern: "*.{bai,crai}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3327 # BAI/CRAI index
     - target_bed:
         type: file
         description: Optional - Limit analysis to targets listed in this
           BED-format FILE.
         pattern: "*.bed"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3003 # BED
   - - meta2:
         type: map
         description: |
@@ -59,7 +68,8 @@ input:
         type: file
         description: reference fasta file
         pattern: ".{fa,fa.gz,fasta,fasta.gz}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
   - - meta3:
         type: map
         description: |
@@ -69,7 +79,8 @@ input:
         type: file
         description: reference fasta file index
         pattern: "*.{fa,fasta}.fai"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3327 # FASTA index
   - - meta4:
         type: map
         description: |
@@ -80,7 +91,8 @@ input:
         description: Optional - Limit analysis to samples listed (one per line) in
           the FILE.
         pattern: "*.txt"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_2330 # Textual format
   - - meta5:
         type: map
         description: |
@@ -91,7 +103,8 @@ input:
         description: Optional - Each line of FILE should list a sample and a
           population which it is part of.
         pattern: "*.txt"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_2330 # Textual format
   - - meta6:
         type: map
         description: |
@@ -105,7 +118,8 @@ input:
           or a region-specific format:
           seq_name start end sample_name copy_number
         pattern: "*.bed"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3003 # BED
 output:
   vcf:
     - - meta:

--- a/modules/nf-core/freebayes/tests/main.nf.test
+++ b/modules/nf-core/freebayes/tests/main.nf.test
@@ -80,7 +80,7 @@ nextflow_process {
 
     }
 
-    test("sarscov2 - [ cram, crai ] - fasta - fai") {
+    test("homo_sapiens - [ cram, crai ] - fasta - fai") {
 
         when {
             process {
@@ -116,7 +116,7 @@ nextflow_process {
 
     }
 
-    test("sarscov2 - [ bam, bai, bam, bai ] - fasta - fai") {
+    test("homo_sapiens - [ bam, bai, bam, bai ] - fasta - fai") {
 
         when {
             process {
@@ -152,7 +152,7 @@ nextflow_process {
 
     }
 
-    test("sarscov2 - [ cram, crai, cram, crai, bed ] - fasta - fai") {
+    test("homo_sapiens - [ cram, crai, cram, crai, bed ] - fasta - fai") {
 
         when {
             process {

--- a/modules/nf-core/freebayes/tests/main.nf.test.snap
+++ b/modules/nf-core/freebayes/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "sarscov2 - [ cram, crai, cram, crai, bed ] - fasta - fai": {
+    "homo_sapiens - [ cram, crai, cram, crai, bed ] - fasta - fai": {
         "content": [
             "test.vcf.gz",
             "5d2758e9ebd427d59c8d1eebdd1c0f44",
@@ -82,7 +82,7 @@
         },
         "timestamp": "2026-02-11T14:34:07.702759"
     },
-    "sarscov2 - [ cram, crai ] - fasta - fai": {
+    "homo_sapiens - [ cram, crai ] - fasta - fai": {
         "content": [
             "test.vcf.gz",
             "f578a2043bd4303e16487b64ea6ff524",
@@ -122,7 +122,7 @@
         },
         "timestamp": "2026-02-11T14:33:44.909226"
     },
-    "sarscov2 - [ bam, bai, bam, bai ] - fasta - fai": {
+    "homo_sapiens - [ bam, bai, bam, bai ] - fasta - fai": {
         "content": [
             "test.vcf.gz",
             "5d2758e9ebd427d59c8d1eebdd1c0f44",


### PR DESCRIPTION
## PR checklist

Closes #7766

## Description

Updates the affected `freebayes` nf-test names where human test data was labelled as `sarscov2`.

Also adds missing ontology entries to `modules/nf-core/freebayes/meta.yml`.

## Changes

- Renamed three `freebayes` nf-tests that use `homo_sapiens` test data.
- Updated the matching nf-test snapshot keys.
- Added missing EDAM ontology entries for `freebayes` inputs in `meta.yml`.
- Updated the `freebayes` stub gzip syntax required by module lint.

## Validation

- `nf-core modules lint freebayes`
- `./nf-test test modules/nf-core/freebayes/tests/main.nf.test`

Both passed locally.