### PR TITLE
fix(qcatch): only pass --chemistry when set; bump to 0.2.12

### DIFF
--- a/modules/nf-core/qcatch/environment.yml
+++ b/modules/nf-core/qcatch/environment.yml
@@ -5,7 +5,7 @@ channels:
   - bioconda
 
 dependencies:
-  - conda-forge::pip=25.3
-  - conda-forge::python=3.14.3
+  - conda-forge::pip
+  - conda-forge::python=3.14.6
   - pip:
-      - qcatch==0.2.11
+      - qcatch==0.2.12

--- a/modules/nf-core/qcatch/environment.yml
+++ b/modules/nf-core/qcatch/environment.yml
@@ -5,7 +5,7 @@ channels:
   - bioconda
 
 dependencies:
-  - conda-forge::pip
+  - conda-forge::pip=25.3
   - conda-forge::python=3.14.6
   - pip:
       - qcatch==0.2.12

--- a/modules/nf-core/qcatch/main.nf
+++ b/modules/nf-core/qcatch/main.nf
@@ -13,7 +13,7 @@ process QCATCH {
     tuple val(meta), path("*.html")                , emit: report
     tuple val(meta), path("*_filtered_quants.h5ad") , emit: filtered_h5ad
     tuple val(meta), path("*_metrics_summary.csv")  , emit: metrics_summary
-    path  "versions.yml"                                    , emit: versions
+    tuple val("${task.process}"), val('qcatch'), eval("qcatch --version | sed -e 's/qcatch //g'"), emit: versions_qcatch, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -35,11 +35,6 @@ process QCATCH {
     mv ${prefix}/QCatch_report.html ${prefix}_qcatch_report.html
     mv ${prefix}/filtered_quants.h5ad ${prefix}_filtered_quants.h5ad
     mv ${prefix}/summary_table.csv ${prefix}_metrics_summary.csv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        qcatch: \$(qcatch --version | sed -e "s/qcatch //g")
-    END_VERSIONS
     """
 
     stub:
@@ -49,10 +44,5 @@ process QCATCH {
     touch ${prefix}_qcatch_report.html
     touch ${prefix}_filtered_quants.h5ad
     touch ${prefix}_metrics_summary.csv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        qcatch: \$(qcatch --version | sed -e "s/qcatch //g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/qcatch/main.nf
+++ b/modules/nf-core/qcatch/main.nf
@@ -4,8 +4,8 @@ process QCATCH {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/62/6233ebf32d1ce85d41398121c4b8c1449779fa13b1529e702e067bfca6f835b7/data':
-        'community.wave.seqera.io/library/pip_qcatch:05d150ed59c3ae84' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a7/a7d0112866550e3bcf97c40104596a3ca2ecbc26c13cf919fe76587554528281/data':
+        'community.wave.seqera.io/library/pip_qcatch:03b88593a5cca75b' }"
     input:
     tuple val(meta), val(chemistry), path(quant_dir)
 
@@ -21,12 +21,13 @@ process QCATCH {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def chemistry_arg = chemistry ? "--chemistry ${chemistry}" : ''
 
     """
     qcatch \\
         --input ${quant_dir} \\
         --output ${prefix} \\
-        --chemistry ${chemistry} \\
+        ${chemistry_arg} \\
         --save_filtered_h5ad \\
         --export_summary_table \\
         ${args}

--- a/modules/nf-core/qcatch/meta.yml
+++ b/modules/nf-core/qcatch/meta.yml
@@ -70,14 +70,27 @@ output:
             CSV file containing summary metrics from QC analysis
           pattern: "*_metrics_summary.csv"
           ontologies: []
+  versions_qcatch:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - qcatch:
+          type: string
+          description: The name of the tool
+      - qcatch --version | sed -e 's/qcatch //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: |
-          File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - qcatch:
+          type: string
+          description: The name of the tool
+      - qcatch --version | sed -e 's/qcatch //g':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@wzheng0520"
   - "@dongzehe"

--- a/modules/nf-core/qcatch/tests/main.nf.test
+++ b/modules/nf-core/qcatch/tests/main.nf.test
@@ -44,8 +44,7 @@ nextflow_process {
                     path(process.out.report[0][1]).size(),
                     process.out.filtered_h5ad,
                     process.out.metrics_summary,
-                    process.out.versions,
-                    path(process.out.versions[0]).yaml
+                    process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
         }
@@ -84,7 +83,7 @@ nextflow_process {
                 { assert path(process.out.report.get(0).get(1)).size() > 0 },
                 { assert path(process.out.filtered_h5ad.get(0).get(1)).size() > 0 },
                 { assert path(process.out.metrics_summary.get(0).get(1)).size() > 0 },
-                { assert snapshot(process.out.versions).match("remove_doublets_versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("remove_doublets_versions") }
             )
         }
     }

--- a/modules/nf-core/qcatch/tests/main.nf.test.snap
+++ b/modules/nf-core/qcatch/tests/main.nf.test.snap
@@ -18,16 +18,17 @@
                     "1k_pbmc_v3_metrics_summary.csv:md5,22deb2f3aea4e4abf476970576362428"
                 ]
             ],
-            [
-                "versions.yml:md5,9a1515424b4ac68efdad29b53da09a6a"
-            ],
             {
-                "QCATCH": {
-                    "qcatch": "version 0.2.12"
-                }
+                "versions_qcatch": [
+                    [
+                        "QCATCH",
+                        "qcatch",
+                        "version 0.2.12"
+                    ]
+                ]
             }
         ],
-        "timestamp": "2026-06-16T19:56:30.084878696",
+        "timestamp": "2026-06-16T20:39:20.393084026",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -61,7 +62,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,9a1515424b4ac68efdad29b53da09a6a"
+                    [
+                        "QCATCH",
+                        "qcatch",
+                        "version 0.2.12"
+                    ]
                 ],
                 "filtered_h5ad": [
                     [
@@ -87,12 +92,16 @@
                         "test_stub_qcatch_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,9a1515424b4ac68efdad29b53da09a6a"
+                "versions_qcatch": [
+                    [
+                        "QCATCH",
+                        "qcatch",
+                        "version 0.2.12"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2026-06-16T19:59:40.051468219",
+        "timestamp": "2026-06-16T20:32:42.256409881",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -100,11 +109,17 @@
     },
     "remove_doublets_versions": {
         "content": [
-            [
-                "versions.yml:md5,9a1515424b4ac68efdad29b53da09a6a"
-            ]
+            {
+                "versions_qcatch": [
+                    [
+                        "QCATCH",
+                        "qcatch",
+                        "version 0.2.12"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2026-06-16T19:59:31.246204576",
+        "timestamp": "2026-06-16T20:42:17.676057899",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/qcatch/tests/main.nf.test.snap
+++ b/modules/nf-core/qcatch/tests/main.nf.test.snap
@@ -1,13 +1,13 @@
 {
     "test_qcatch - 1k_pbmc_v3": {
         "content": [
-            4049155,
+            4050683,
             [
                 [
                     {
                         "id": "1k_pbmc_v3"
                     },
-                    "1k_pbmc_v3_filtered_quants.h5ad:md5,52f8feab612b585032d52ea8817caf99"
+                    "1k_pbmc_v3_filtered_quants.h5ad:md5,7e27940bb5286e04addc1c85b20a6986"
                 ]
             ],
             [
@@ -19,19 +19,19 @@
                 ]
             ],
             [
-                "versions.yml:md5,bd75bc6d669b1ce72b4094e55d93d045"
+                "versions.yml:md5,9a1515424b4ac68efdad29b53da09a6a"
             ],
             {
                 "QCATCH": {
-                    "qcatch": "version 0.2.11"
+                    "qcatch": "version 0.2.12"
                 }
             }
         ],
+        "timestamp": "2026-06-16T19:56:30.084878696",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-25T16:31:02.954262822"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "test_qcatch - stub": {
         "content": [
@@ -61,7 +61,7 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,bd75bc6d669b1ce72b4094e55d93d045"
+                    "versions.yml:md5,9a1515424b4ac68efdad29b53da09a6a"
                 ],
                 "filtered_h5ad": [
                     [
@@ -88,26 +88,26 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,bd75bc6d669b1ce72b4094e55d93d045"
+                    "versions.yml:md5,9a1515424b4ac68efdad29b53da09a6a"
                 ]
             }
         ],
+        "timestamp": "2026-06-16T19:59:40.051468219",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-25T16:34:17.397780003"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "remove_doublets_versions": {
         "content": [
             [
-                "versions.yml:md5,bd75bc6d669b1ce72b4094e55d93d045"
+                "versions.yml:md5,9a1515424b4ac68efdad29b53da09a6a"
             ]
         ],
+        "timestamp": "2026-06-16T19:59:31.246204576",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-25T16:34:00.029602757"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }


### PR DESCRIPTION
## Changes

Two small, related changes to the `qcatch` module:

### 1. Make `--chemistry` optional
The module previously always rendered `--chemistry ${chemistry}`. When no chemistry is supplied this produced `--chemistry null`. The command now only adds the flag when a value is provided:

```groovy
def chemistry_arg = chemistry ? "--chemistry ${chemistry}" : ''
```

This lets callers pass a null chemistry for protocols QCatch doesn't have a chemistry string for (e.g. 10x v1, drop-seq). QCatch's `--chemistry` is optional (it can auto-infer from metadata, or take `--n_partitions` for non-10X assays — which can be supplied via `ext.args`). The module input signature is unchanged.

### 2. Bump qcatch `0.2.11` → `0.2.12`
- `environment.yml`: `qcatch==0.2.12`, python `3.14.6`
- Regenerated Wave container references (Docker + Singularity)
- Refreshed snapshots

## Testing

All three nf-tests pass against the rebuilt `0.2.12` container (`-profile docker`):

```
test_qcatch - 1k_pbmc_v3     PASSED
test_qcatch - remove_doublets PASSED
test_qcatch - stub           PASSED
```

Snapshot changes are limited to the qcatch version string in `versions.yml`, the resulting md5s, and a ~0.03% report-size shift.