### PR TITLE
fix(pypolca): normalize version string

### DIFF
--- a/modules/nf-core/pypolca/run/main.nf
+++ b/modules/nf-core/pypolca/run/main.nf
@@ -15,7 +15,7 @@ process PYPOLCA_RUN {
     tuple val(meta), path("${prefix}/*_corrected.fasta"), emit: polished
     tuple val(meta), path("${prefix}/*.vcf")            , emit: vcf
     tuple val(meta), path("${prefix}/*.report")         , emit: report
-    tuple val("${task.process}"), val('pypolca'), eval('pypolca --version'), emit: versions_pypolca, topic: versions
+    tuple val("${task.process}"), val('pypolca'), eval("pypolca --version | sed 's/^pypolca, version //'"), emit: versions_pypolca, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/pypolca/run/meta.yml
+++ b/modules/nf-core/pypolca/run/meta.yml
@@ -10,7 +10,8 @@ tools:
       homepage: "https://github.com/gbouras13/pypolca"
       documentation: "https://github.com/gbouras13/pypolca?tab=readme-ov-file#usage"
       doi: "10.1099/mgen.0.001254"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 
 input:
@@ -83,7 +84,7 @@ output:
       - pypolca:
           type: string
           description: The name of the tool
-      - pypolca --version:
+      - pypolca --version | sed 's/^pypolca, version //':
           type: eval
           description: The expression to obtain the version of the tool
 
@@ -95,7 +96,7 @@ topics:
       - pypolca:
           type: string
           description: The name of the tool
-      - pypolca --version:
+      - pypolca --version | sed 's/^pypolca, version //':
           type: eval
           description: The expression to obtain the version of the tool
 

--- a/modules/nf-core/pypolca/run/tests/main.nf.test.snap
+++ b/modules/nf-core/pypolca/run/tests/main.nf.test.snap
@@ -33,7 +33,7 @@
                     [
                         "PYPOLCA_RUN",
                         "pypolca",
-                        "pypolca, version 0.4.0"
+                        "0.4.0"
                     ]
                 ],
                 "polished": [
@@ -67,15 +67,15 @@
                     [
                         "PYPOLCA_RUN",
                         "pypolca",
-                        "pypolca, version 0.4.0"
+                        "0.4.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-06-17T17:54:58.267857871",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-22T09:53:24.585375024"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }


### PR DESCRIPTION
PyPOLCA reports its version as:

pypolca, version 0.4.0

Normalize the reported version to emit only the version number:

0.4.0

This follows the version reporting style used by other nf-core modules and avoids including extra text in the versions channel output.

Updates the module test snapshot accordingly.