### PR TITLE
refactor(pypolca): use assembly metadata as primary input

### DIFF
--- a/modules/nf-core/pypolca/run/main.nf
+++ b/modules/nf-core/pypolca/run/main.nf
@@ -8,8 +8,8 @@ process PYPOLCA_RUN {
         'quay.io/biocontainers/pypolca:0.4.0--pyhdfd78af_0' }"
 
     input:
-    tuple val(meta) , path(reads)
-    tuple val(meta2), path(contigs)
+    tuple val(meta) , path(contigs)
+    tuple val(meta2), path(reads)
 
     output:
     tuple val(meta), path("${prefix}/*_corrected.fasta"), emit: polished

--- a/modules/nf-core/pypolca/run/main.nf
+++ b/modules/nf-core/pypolca/run/main.nf
@@ -8,8 +8,7 @@ process PYPOLCA_RUN {
         'quay.io/biocontainers/pypolca:0.4.0--pyhdfd78af_0' }"
 
     input:
-    tuple val(meta) , path(contigs)
-    tuple val(meta2), path(reads)
+    tuple val(meta) , path(contigs), path(reads)
 
     output:
     tuple val(meta), path("${prefix}/*_corrected.fasta"), emit: polished

--- a/modules/nf-core/pypolca/run/meta.yml
+++ b/modules/nf-core/pypolca/run/meta.yml
@@ -27,11 +27,6 @@ input:
         ontologies:
           - edam: "http://edamontology.org/format_1929" # FASTA
 
-  - - meta2:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. `[ id:'sample1' ]`
     - reads:
         type: file
         description: List of short reads for assembly polishing. Length 1 for

--- a/modules/nf-core/pypolca/run/meta.yml
+++ b/modules/nf-core/pypolca/run/meta.yml
@@ -20,18 +20,6 @@ input:
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'sample1' ]`
-    - reads:
-        type: file
-        description: List of short reads for assembly polishing. Length 1 for
-          single-end and 2 for paired-end
-        pattern: "*.{fastq,fq}.gz"
-        ontologies:
-          - edam: "http://edamontology.org/format_1930" # FASTQ
-  - - meta2:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. `[ id:'sample1' ]`
     - contigs:
         type: file
         description: Genome assembly from long reads
@@ -39,6 +27,18 @@ input:
         ontologies:
           - edam: "http://edamontology.org/format_1929" # FASTA
 
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - reads:
+        type: file
+        description: List of short reads for assembly polishing. Length 1 for
+          single-end and 2 for paired-end
+        pattern: "*.{fastq,fq}.gz"
+        ontologies:
+          - edam: "http://edamontology.org/format_1930" # FASTQ
 output:
   polished:
     - - meta:

--- a/modules/nf-core/pypolca/run/tests/main.nf.test
+++ b/modules/nf-core/pypolca/run/tests/main.nf.test
@@ -16,15 +16,16 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                   [ id:'meta' ],
+                   file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+
+                input[1] = [
+                    [ id:'test', single_end:false ],
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ], // reads
-                ]
-                input[1] = [
-                    [ id:'meta2' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true), // assembly to polish
+                     ]
                 ]
                 """
             }

--- a/modules/nf-core/pypolca/run/tests/main.nf.test
+++ b/modules/nf-core/pypolca/run/tests/main.nf.test
@@ -16,16 +16,12 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                   [ id:'meta' ],
-                   file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
-                ]
-
-                input[1] = [
                     [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                     ]
+                    ]
                 ]
                 """
             }
@@ -52,15 +48,12 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
                     [
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
-                    ], // reads
-                ]
-                input[1] = [
-                    [ id:'meta2' ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true), // assembly to polish
+                    ]
                 ]
                 """
             }


### PR DESCRIPTION
Make assembly metadata the primary metadata object for pypolca/run
Swap input order to contigs then reads
Preserve assembly metadata in outputs without relying on secondary metadata fields
Update module tests and metadata specification accordingly