### PR TITLE
Fix `last/mafconvert` output channel `stats`.

### DIFF
--- a/modules/nf-core/last/mafconvert/main.nf
+++ b/modules/nf-core/last/mafconvert/main.nf
@@ -14,7 +14,7 @@ process LAST_MAFCONVERT {
     output:
     tuple val(meta), path("*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"), emit: alignment
     tuple val(meta), path("*.{bai,crai,csi}"), emit: index, optional: true
-    tuple val(meta), path("*.{stats}"),        emit: stats, optional: true
+    tuple val(meta), path("*.stats"),          emit: stats, optional: true
     // last-dotplot has no --version option so let's use lastal from the same suite
     tuple val("${task.process}"), val('last'), eval("lastal --version | sed 's/lastal //'"), emit: versions_last, topic: versions
 

--- a/modules/nf-core/last/mafconvert/meta.yml
+++ b/modules/nf-core/last/mafconvert/meta.yml
@@ -87,7 +87,7 @@ output:
       - "*.{bai,crai,csi}":
           type: file
           description: |
-            Optional index for the BAM, BCF or CRAM files. Pass `--with-index`
+            Optional index for the BAM, BCF or CRAM files. Pass `--write-index`
             to `samtools` via `task.ext.args2`, or BAM and CRAM, and to
             `bcftools call` via `task.ext.arg4` for BCF.
           pattern: "*.{bai,crai,csi}"

--- a/modules/nf-core/last/mafconvert/meta.yml
+++ b/modules/nf-core/last/mafconvert/meta.yml
@@ -98,10 +98,10 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*.{stats}":
+      - "*.stats":
           type: file
           description: Statistics on the BCF files.
-          pattern: "*.{stats}"
+          pattern: "*.stats"
           ontologies: []
   versions_last:
     - - "${task.process}":


### PR DESCRIPTION
`path("*.{stats}")` → `path("*.stats")`

The first does not match `*.stats`…

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
