### PR TITLE
feat(subworkflows/fastq_qc_trim_filter_setstrandedness): emit reads_raw, reads_pre_bbsplit

### DIFF
--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -431,8 +431,8 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
 
     emit:
     reads             = ch_strand_inferred_fastq
-    reads_raw         = ch_reads_raw
-    reads_pre_bbsplit = ch_reads_pre_bbsplit
+    reads_cat         = ch_reads_cat
+    reads_trimmed     = ch_reads_trimmed
     trim_read_count   = ch_trim_read_count
     multiqc_files     = ch_multiqc_files.transpose()
 

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -189,6 +189,8 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         ch_filtered_reads = ch_filtered_reads.join(FQ_LINT.out.lint.map { meta, _lint -> meta })
     }
 
+    ch_reads_raw = ch_filtered_reads
+
     //
     // SUBWORKFLOW: Read QC, extract UMI and trim adapters with TrimGalore!
     //
@@ -290,6 +292,8 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         ch_lint_log_trimmed = FQ_LINT_AFTER_TRIMMING.out.lint
         ch_filtered_reads = ch_filtered_reads.join(FQ_LINT_AFTER_TRIMMING.out.lint.map { meta, _lint -> meta })
     }
+
+    ch_reads_pre_bbsplit = ch_filtered_reads
 
     //
     // MODULE: Remove genome contaminant reads
@@ -426,9 +430,11 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         .map { row -> [row[0], row.drop(1).findAll { f -> f != null }.collectMany { e -> (e instanceof List) ? e : [e] }] }
 
     emit:
-    reads            = ch_strand_inferred_fastq
-    trim_read_count  = ch_trim_read_count
-    multiqc_files    = ch_multiqc_files.transpose()
+    reads             = ch_strand_inferred_fastq
+    reads_raw         = ch_reads_raw
+    reads_pre_bbsplit = ch_reads_pre_bbsplit
+    trim_read_count   = ch_trim_read_count
+    multiqc_files     = ch_multiqc_files.transpose()
 
     // Individual outputs for workflow outputs
     lint_log_raw     = ch_lint_log_raw

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -293,7 +293,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         ch_filtered_reads = ch_filtered_reads.join(FQ_LINT_AFTER_TRIMMING.out.lint.map { meta, _lint -> meta })
     }
 
-    ch_reads_pre_bbsplit = ch_filtered_reads
+    ch_reads_trimmed = ch_filtered_reads
 
     //
     // MODULE: Remove genome contaminant reads

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -189,7 +189,7 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
         ch_filtered_reads = ch_filtered_reads.join(FQ_LINT.out.lint.map { meta, _lint -> meta })
     }
 
-    ch_reads_raw = ch_filtered_reads
+    ch_reads_cat = ch_filtered_reads
 
     //
     // SUBWORKFLOW: Read QC, extract UMI and trim adapters with TrimGalore!

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
@@ -174,7 +174,7 @@ output:
             type: file
             description: Preprocessed FastQ files
             pattern: "*.{fq,fastq},{,.gz}"
-  - reads_raw:
+  - reads_cat:
       description: Channel snapshot of reads before adapter trimming
       structure:
         - meta:

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
@@ -184,7 +184,7 @@ output:
             type: file
             description: Pre-trimming FastQ files
             pattern: "*.{fq,fastq},{,.gz}"
-  - reads_pre_bbsplit:
+  - reads_trimmed:
       description: Channel snapshot of reads after adapter trimming but before BBSplit/rRNA removal
       structure:
         - meta:

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/meta.yml
@@ -174,6 +174,26 @@ output:
             type: file
             description: Preprocessed FastQ files
             pattern: "*.{fq,fastq},{,.gz}"
+  - reads_raw:
+      description: Channel snapshot of reads before adapter trimming
+      structure:
+        - meta:
+            type: map
+            description: Groovy Map containing sample information
+        - reads:
+            type: file
+            description: Pre-trimming FastQ files
+            pattern: "*.{fq,fastq},{,.gz}"
+  - reads_pre_bbsplit:
+      description: Channel snapshot of reads after adapter trimming but before BBSplit/rRNA removal
+      structure:
+        - meta:
+            type: map
+            description: Groovy Map containing sample information
+        - reads:
+            type: file
+            description: Trimmed FastQ files prior to BBSplit/rRNA removal
+            pattern: "*.{fq,fastq},{,.gz}"
   - multiqc_files:
       description: MultiQC-compatible output files from tools used in preprocessing
       structure:

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
@@ -130,7 +130,11 @@ nextflow_workflow {
                     file(workflow.out.fastqc_filtered_html[0][1][1]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1][0]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1][1]).name,
-                ).match() }
+                ).match() },
+                { assert snapshot(
+                    workflow.out.reads_cat.collect    { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                    workflow.out.reads_trimmed.collect { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                ).match("intermediate_reads_pe_fastp_sortmerna") }
             )
         }
     }
@@ -223,7 +227,11 @@ nextflow_workflow {
                     file(workflow.out.fastqc_filtered_html[0][1][1]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1][0]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1][1]).name,
-                ).match() }
+                ).match() },
+                { assert snapshot(
+                    workflow.out.reads_cat.collect    { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                    workflow.out.reads_trimmed.collect { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                ).match("intermediate_reads_pe_fastp_ribodetector") }
             )
         }
     }
@@ -316,7 +324,11 @@ nextflow_workflow {
                     file(workflow.out.fastqc_filtered_html[0][1][1]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1][0]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1][1]).name,
-                ).match() }
+                ).match() },
+                { assert snapshot(
+                    workflow.out.reads_cat.collect    { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                    workflow.out.reads_trimmed.collect { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                ).match("intermediate_reads_pe_trimgalore_sortmerna") }
             )
         }
     }
@@ -413,7 +425,11 @@ nextflow_workflow {
                     file(workflow.out.fastqc_filtered_html[0][1][1]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1][0]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1][1]).name,
-                ).match() }
+                ).match() },
+                { assert snapshot(
+                    workflow.out.reads_cat.collect    { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                    workflow.out.reads_trimmed.collect { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                ).match("intermediate_reads_pe_fastp_bowtie2") }
             )
         }
     }
@@ -590,7 +606,11 @@ nextflow_workflow {
                     processed_ribo_removal_lint_report.md5(),
                     file(workflow.out.fastqc_filtered_html[0][1]).name,
                     file(workflow.out.fastqc_filtered_zip[0][1]).name,
-                ).match() }
+                ).match() },
+                { assert snapshot(
+                    workflow.out.reads_cat.collect    { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                    workflow.out.reads_trimmed.collect { meta, reads -> [meta, [reads].flatten().collect { f -> path(f).linesGzip.join('\n').md5() }] },
+                ).match("intermediate_reads_se_fastp_bowtie2") }
             )
         }
     }

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test.snap
@@ -1,4 +1,74 @@
 {
+    "intermediate_reads_pe_fastp_sortmerna": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "ffed109b6c4b5c3060502031cd0d3e34",
+                        "2d99ab920b1c5c8a662587c2c7f00b0c"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "6cec1ab71e8e7a3cb5a3651ccdfca4cc",
+                        "cdd8f57890d22e1feaf16847907814b4"
+                    ]
+                ]
+            ]
+        ],
+        "timestamp": "2026-06-19T16:02:55.544629327",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "intermediate_reads_pe_fastp_ribodetector": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "ffed109b6c4b5c3060502031cd0d3e34",
+                        "2d99ab920b1c5c8a662587c2c7f00b0c"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "6cec1ab71e8e7a3cb5a3651ccdfca4cc",
+                        "cdd8f57890d22e1feaf16847907814b4"
+                    ]
+                ]
+            ]
+        ],
+        "timestamp": "2026-06-19T16:03:10.159183083",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
     "homo_sapiens paired-end [fastq] fastp sortmerna": {
         "content": [
             "427d190cd40caeff5e2bd1967a21facb",
@@ -9,11 +79,11 @@
             "test_1_fastqc.zip",
             "test_2_fastqc.zip"
         ],
+        "timestamp": "2026-02-12T09:05:53.923664771",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-12T09:05:53.923664771"
+        }
     },
     "homo_sapiens paired-end [fastq] fastp ribodetector": {
         "content": [
@@ -25,11 +95,11 @@
             "test_1_fastqc.zip",
             "test_2_fastqc.zip"
         ],
+        "timestamp": "2026-02-12T09:06:16.903127796",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-12T09:06:16.903127796"
+        }
     },
     "homo_sapiens paired-end [fastq] trimgalore sortmerna": {
         "content": [
@@ -41,11 +111,44 @@
             "test_1_fastqc.zip",
             "test_2_fastqc.zip"
         ],
+        "timestamp": "2026-02-12T09:06:33.867211398",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-12T09:06:33.867211398"
+        }
+    },
+    "intermediate_reads_se_fastp_bowtie2": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test_se",
+                        "single_end": true,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "ffed109b6c4b5c3060502031cd0d3e34"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test_se",
+                        "single_end": true,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "12e1b4209d11758c5b2fb7137d25b177"
+                    ]
+                ]
+            ]
+        ],
+        "timestamp": "2026-06-19T16:03:50.943448586",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     },
     "homo_sapiens paired-end [fastq] fastp bowtie2": {
         "content": [
@@ -57,11 +160,11 @@
             "test_1_fastqc.zip",
             "test_2_fastqc.zip"
         ],
+        "timestamp": "2026-02-12T09:06:51.756578633",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-12T09:06:51.756578633"
+        }
     },
     "homo_sapiens single-end [fastq] fastp bowtie2": {
         "content": [
@@ -70,10 +173,80 @@
             "test_se_fastqc.html",
             "test_se_fastqc.zip"
         ],
+        "timestamp": "2026-02-12T09:07:08.160495752",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-12T09:07:08.160495752"
+        }
+    },
+    "intermediate_reads_pe_trimgalore_sortmerna": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "ffed109b6c4b5c3060502031cd0d3e34",
+                        "2d99ab920b1c5c8a662587c2c7f00b0c"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "6e0e10876e08a623089186c46e76237c",
+                        "9691a013fd8fe30c816aedf9f9e32884"
+                    ]
+                ]
+            ]
+        ],
+        "timestamp": "2026-06-19T16:03:22.222307759",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "intermediate_reads_pe_fastp_bowtie2": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "ffed109b6c4b5c3060502031cd0d3e34",
+                        "2d99ab920b1c5c8a662587c2c7f00b0c"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "strandedness": "auto"
+                    },
+                    [
+                        "6cec1ab71e8e7a3cb5a3651ccdfca4cc",
+                        "cdd8f57890d22e1feaf16847907814b4"
+                    ]
+                ]
+            ]
+        ],
+        "timestamp": "2026-06-19T16:03:34.579973861",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }


### PR DESCRIPTION

Add two new emit channels for pipelines that need reads at different preprocessing stages:
- reads_raw: snapshot of reads before adapter trimming (useful for contaminant screening comparison at the raw-read stage)
- reads_pre_bbsplit: snapshot after trimming but before BBSplit/rRNA removal

Both channels are zero-cost aliases (no copying or re-processing) and do not affect any existing outputs or behavior.

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
