### PR TITLE
`jellyfish/count`: add support for gzipped input and test

### DIFF
--- a/modules/nf-core/jellyfish/count/main.nf
+++ b/modules/nf-core/jellyfish/count/main.nf
@@ -20,17 +20,13 @@ process JELLYFISH_COUNT {
     task.ext.when == null || task.ext.when
 
     script:
+    def is_compressed = fasta.getName().endsWith(".gz") ? true : false
+    def fasta_name    = fasta.getName().replace(".gz", "")
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     """
-    if [[ ${fasta} == *.gz ]]; then
-        zcat ${fasta} > ${fasta.baseName}.fasta
-    fi
-    if [[ ${fasta} == *.fa ]]; then
-        cp ${fasta} ${fasta.baseName}.fasta
-    fi
-    if [[ ${fasta} == *.fastq ]]; then
-        cp ${fasta} ${fasta.baseName}.fasta
+    if [ "${is_compressed}" == "true" ]; then
+    gzip -c -d ${fasta} > ${fasta_name}
     fi
     jellyfish \\
         count \\
@@ -39,7 +35,7 @@ process JELLYFISH_COUNT {
         -s ${size} \\
         -t $task.cpus \\
         -o ${prefix}.jf \\
-        ${fasta.baseName}.fasta
+        ${fasta_name}
     """
 
     stub:

--- a/modules/nf-core/jellyfish/count/main.nf
+++ b/modules/nf-core/jellyfish/count/main.nf
@@ -23,14 +23,23 @@ process JELLYFISH_COUNT {
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     """
+    if [[ ${fasta} == *.gz ]]; then
+        zcat ${fasta} > ${fasta.baseName}.fasta
+    fi
+    if [[ ${fasta} == *.fa ]]; then
+        cp ${fasta} ${fasta.baseName}.fasta
+    fi
+    if [[ ${fasta} == *.fastq ]]; then
+        cp ${fasta} ${fasta.baseName}.fasta
+    fi
     jellyfish \\
         count \\
-        ${args} \\
+        $args \\
         -m ${kmer_length} \\
         -s ${size} \\
-        -t ${task.cpus} \\
+        -t $task.cpus \\
         -o ${prefix}.jf \\
-        ${fasta}
+        ${fasta.baseName}.fasta
     """
 
     stub:

--- a/modules/nf-core/jellyfish/count/meta.yml
+++ b/modules/nf-core/jellyfish/count/meta.yml
@@ -25,8 +25,8 @@ input:
           e.g. `[ id:'sample1' ]`
     - fasta:
         type: file
-        description: Nucleotide sequences in FASTA format
-        pattern: "*.{fasta,fa,fna,faa}"
+        description: Nucleotide sequences in FASTA format, can be gzipped.
+        pattern: "*.{fasta,fa,fna,faa,gz}"
         ontologies:
           - edam: http://edamontology.org/format_1929 # FASTA
   - kmer_length:

--- a/modules/nf-core/jellyfish/count/tests/main.nf.test
+++ b/modules/nf-core/jellyfish/count/tests/main.nf.test
@@ -33,6 +33,30 @@ nextflow_process {
 
     }
 
+    test("sarscov2 - fasta - gzipped") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                input[1] = 7
+                input[2] = '100M'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["jf"])).match() }
+            )
+        }
+
+    }
+
     test("sarscov2 - fasta - stub") {
 
         options "-stub"

--- a/modules/nf-core/jellyfish/count/tests/main.nf.test.snap
+++ b/modules/nf-core/jellyfish/count/tests/main.nf.test.snap
@@ -50,5 +50,31 @@
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
         }
+    },
+    "sarscov2 - fasta - gzipped": {
+        "content": [
+            {
+                "jf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.jf"
+                    ]
+                ],
+                "versions_jellyfish": [
+                    [
+                        "JELLYFISH_COUNT",
+                        "jellyfish",
+                        "2.3.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-19T11:12:28.08906372",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.0"
+        }
     }
 }


### PR DESCRIPTION
Allow gzipped input, and test if it works.