### PR TITLE
Fix issues related to samtools --write-index.

### DIFF
--- a/modules/nf-core/last/mafconvert/main.nf
+++ b/modules/nf-core/last/mafconvert/main.nf
@@ -27,6 +27,10 @@ process LAST_MAFCONVERT {
     def args3  = task.ext.args3  ?: ''   // bcftools mpileup
     def args4  = task.ext.args4  ?: ''   // bcftools call
     def prefix = task.ext.prefix ?: "${meta.id}"
+    if( format == 'bcf' ) {
+        // --write-index can not be used when samtools sort outputs to stdout like in the bcf case.
+        args2 = args2?.replaceAll(/\s*--write-index\b/, '')
+    }
     """
     set -o pipefail
 
@@ -68,7 +72,7 @@ process LAST_MAFCONVERT {
             ;;
         bcf)
             maf-convert $args \$DICT_ARGS sam $maf -r 'ID:${meta.id} SM:${meta.id}' |
-                samtools sort $args2 -u | bcftools mpileup $args3 --fasta-ref $fasta -Ou - | bcftools call $args4 -Ob > ${prefix}.bcf
+                samtools sort $args2 -u | bcftools mpileup $args3 --fasta-ref $fasta -Ou - | bcftools call $args4 -Ob -o ${prefix}.bcf
             bcftools stats ${prefix}.bcf > ${prefix}.stats
             ;;
         *)


### PR DESCRIPTION
When samtools or bcftools streams to standard output, it can not write an index as it does not know the output file name.

In MAF → BCF conversions:

 1. samtools streams to bcftools, so the `--write-index` argument has to be hidden from samtools.  Users may want to pass it because it is useful for BAM and CRAM conversion.  This patch edits `$args2` to do so when `$format` is `'bcf'`.
 2. bcftools was streaming to a file, therefore preventing the use of `--write-index`.  This patch replaces shell redirection with the `-o` option so that bcftools outputs directly to a file.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
