### PR TITLE
Add `round_digits` to `decoupler` and avoid sorting by `topTable` in `dream`

### DIFF
--- a/modules/nf-core/decoupler/decoupler/templates/decoupler.py
+++ b/modules/nf-core/decoupler/decoupler/templates/decoupler.py
@@ -45,6 +45,9 @@ def parse_ext_args(args_string: str):
     )
     parser.add_argument("--features_id_col", type=str, default="gene_id", help="Column name for feature IDs")
     parser.add_argument("--features_symbol_col", type=str, default="gene_name", help="Column name for feature symbols")
+    parser.add_argument(
+        "--round_digits", type=int, default=None, help="Number of digits to round numeric output columns"
+    )
     return parser.parse_args(args_list)
 
 
@@ -88,10 +91,15 @@ results = dc.decouple(mat=mat, net=net, methods=methods, **parsedargs)
 
 for result in results:
     # Save table
-    results[result].to_csv("${task.ext.prefix}" + "_" + result + "_decoupler.tsv", sep="\t")
-    contrast_name = results[result].index[0]
+    result_df = results[result].copy()
+    if parsed_args.round_digits is not None:
+        numeric_columns = result_df.select_dtypes(include="number").columns
+        result_df[numeric_columns] = result_df[numeric_columns].round(parsed_args.round_digits)
+
+    result_df.to_csv("${task.ext.prefix}" + "_" + result + "_decoupler.tsv", sep="\t")
+    contrast_name = result_df.index[0]
     plt.figure(figsize=(8, 6))
-    dc.plot_barplot(results[result], contrast_name, top=25, vertical=False)
+    dc.plot_barplot(result_df, contrast_name, top=25, vertical=False)
     plt.savefig("${task.ext.prefix}" + "_" + result + "_decoupler_plot.png", dpi=300, bbox_inches="tight")
     plt.close()
 

--- a/modules/nf-core/variancepartition/dream/templates/dream.R
+++ b/modules/nf-core/variancepartition/dream/templates/dream.R
@@ -340,8 +340,11 @@ fitmm <- eBayes(fitmm, proportion = opt\$proportion,
                 winsor.tail.p = winsor_tail_p_vals)
 
 results <- topTable(fitmm, coef = top_table_coef, number = Inf,
-                    adjust.method = opt\$adjust.method,
+                    sort.by = "none", adjust.method = opt\$adjust.method,
                     p.value = opt\$p.value, lfc = opt\$lfc, confint = opt\$confint)
+
+feature_order <- rownames(countMatrix)
+results <- results[feature_order[feature_order %in% rownames(results)], , drop = FALSE]
 
 results\$gene_id <- rownames(results)
 results <- results[, c("gene_id", setdiff(names(results), "gene_id"))]

--- a/modules/nf-core/variancepartition/dream/tests/main.nf.test.snap
+++ b/modules/nf-core/variancepartition/dream/tests/main.nf.test.snap
@@ -15,11 +15,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
+        "timestamp": "2025-12-23T18:57:51.598745459",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-23T18:57:51.598745459"
+        }
     },
     "RNAseq - Feature Counts - formula + comparison contrast string - interaction": {
         "content": [
@@ -37,11 +37,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
+        "timestamp": "2025-12-26T15:10:51.980662299",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-26T15:10:51.980662299"
+        }
     },
     "Mus musculus - contrasts - matrix - no formula": {
         "content": [
@@ -61,149 +61,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
+        "timestamp": "2025-12-16T15:52:08.047223666",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-16T15:52:08.047223666"
-    },
-    "Mus musculus - expression table - contrasts + blocking factors": {
-        "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "treatment_mCherry_hND6",
-                            "variable": "treatment",
-                            "reference": "mCherry",
-                            "target": "hND6",
-                            "blocking_factors": "sample_number",
-                            "formula": "~ treatment + (1 | sample_number)"
-                        },
-                        "treatment_mCherry_hND6.dream.results.tsv:md5,df0717ddf702543c375c1a5f4eae3fd7"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "treatment_mCherry_hND6",
-                            "variable": "treatment",
-                            "reference": "mCherry",
-                            "target": "hND6",
-                            "blocking_factors": "sample_number",
-                            "formula": "~ treatment + (1 | sample_number)"
-                        },
-                        "treatment_mCherry_hND6.dream.model.txt:md5,7103206474aa480ffd9cec149263489f"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
-                ],
-                "model": [
-                    [
-                        {
-                            "id": "treatment_mCherry_hND6",
-                            "variable": "treatment",
-                            "reference": "mCherry",
-                            "target": "hND6",
-                            "blocking_factors": "sample_number",
-                            "formula": "~ treatment + (1 | sample_number)"
-                        },
-                        "treatment_mCherry_hND6.dream.model.txt:md5,7103206474aa480ffd9cec149263489f"
-                    ]
-                ],
-                "results": [
-                    [
-                        {
-                            "id": "treatment_mCherry_hND6",
-                            "variable": "treatment",
-                            "reference": "mCherry",
-                            "target": "hND6",
-                            "blocking_factors": "sample_number",
-                            "formula": "~ treatment + (1 | sample_number)"
-                        },
-                        "treatment_mCherry_hND6.dream.results.tsv:md5,df0717ddf702543c375c1a5f4eae3fd7"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-16T19:59:57.947286403"
-    },
-    "Mus musculus - expression table - contrasts + blocking factors stub": {
-        "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "treatment_mCherry_hND6",
-                            "variable": "treatment",
-                            "reference": "mCherry",
-                            "target": "hND6",
-                            "blocking_factors": "sample_number",
-                            "formula": "~ treatment + (1 | sample_number)"
-                        },
-                        "treatment_mCherry_hND6.dream.results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "treatment_mCherry_hND6",
-                            "variable": "treatment",
-                            "reference": "mCherry",
-                            "target": "hND6",
-                            "blocking_factors": "sample_number",
-                            "formula": "~ treatment + (1 | sample_number)"
-                        },
-                        "treatment_mCherry_hND6.dream.model.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,03b686ec8c67a91501ebb2b2a5234e77"
-                ],
-                "model": [
-                    [
-                        {
-                            "id": "treatment_mCherry_hND6",
-                            "variable": "treatment",
-                            "reference": "mCherry",
-                            "target": "hND6",
-                            "blocking_factors": "sample_number",
-                            "formula": "~ treatment + (1 | sample_number)"
-                        },
-                        "treatment_mCherry_hND6.dream.model.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "results": [
-                    [
-                        {
-                            "id": "treatment_mCherry_hND6",
-                            "variable": "treatment",
-                            "reference": "mCherry",
-                            "target": "hND6",
-                            "blocking_factors": "sample_number",
-                            "formula": "~ treatment + (1 | sample_number)"
-                        },
-                        "treatment_mCherry_hND6.dream.results.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "versions": [
-                    "versions.yml:md5,03b686ec8c67a91501ebb2b2a5234e77"
-                ]
-            }
-        ],
-        "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-11-10T16:18:37.294899756"
+        }
     },
     "Mus musculus - expression table - contrasts + formula + weighted comparison contrast string": {
         "content": [
@@ -221,11 +83,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
+        "timestamp": "2025-12-23T18:57:42.761838155",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-23T18:57:42.761838155"
+        }
     },
     "Mus musculus - expression table - contrasts + formula + comparison contrast string - no intercept stub": {
         "content": [
@@ -284,11 +146,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-13T15:35:07.121696674",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        },
-        "timestamp": "2026-01-13T15:35:07.121696674"
+        }
     },
     "RNAseq - Voom - Feature Counts - formula + comparison contrast string - interaction": {
         "content": [
@@ -316,11 +178,11 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
+        "timestamp": "2026-01-13T15:53:31.743589111",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        },
-        "timestamp": "2026-01-13T15:53:31.743589111"
+        }
     },
     "RNAseq - Feature Counts - formula + comparison contrast string - interaction with seed": {
         "content": [
@@ -332,7 +194,7 @@
                             "formula": "~ genotype * treatment",
                             "comparison": "genotypeWT - treatmentTreated"
                         },
-                        "genotype_WT_KO_treatment_Control_Treated.dream.results.tsv:md5,90a06e6b4945c706025582a4c9fddf2c"
+                        "genotype_WT_KO_treatment_Control_Treated.dream.results.tsv:md5,1d4c862325e4f5228c6277344c2f6b7d"
                     ]
                 ],
                 "1": [
@@ -371,7 +233,7 @@
                             "formula": "~ genotype * treatment",
                             "comparison": "genotypeWT - treatmentTreated"
                         },
-                        "genotype_WT_KO_treatment_Control_Treated.dream.results.tsv:md5,90a06e6b4945c706025582a4c9fddf2c"
+                        "genotype_WT_KO_treatment_Control_Treated.dream.results.tsv:md5,1d4c862325e4f5228c6277344c2f6b7d"
                     ]
                 ],
                 "versions": [
@@ -379,11 +241,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-06-19T15:01:27.265474319",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-05-07T19:32:24.587570625"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "Mus musculus - expression table - contrasts + formula + comparison contrast string": {
         "content": [
@@ -401,10 +263,10 @@
                 "versions.yml:md5,fc1f26eb2194018e99fc2916332676b7"
             ]
         ],
+        "timestamp": "2025-12-26T15:11:01.472042429",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.04.2"
-        },
-        "timestamp": "2025-12-26T15:11:01.472042429"
+        }
     }
 }

--- a/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/abundance_differential_filter/tests/main.nf.test.snap
@@ -1108,7 +1108,7 @@
                         "fc_threshold": 1.5,
                         "stat_threshold": 0.05
                     },
-                    "treatment_mCherry_hND6_test_filtered.tsv:md5,68017f084a058f7502415f8aecda42ee"
+                    "treatment_mCherry_hND6_test_filtered.tsv:md5,91242680e2b4b312802dc7a65f397773"
                 ]
             ],
             [
@@ -1135,10 +1135,10 @@
                 "versions.yml:md5,736da31f06f854355d45aeb9d9c874e0"
             ]
         ],
-        "timestamp": "2026-05-20T14:15:35.598682502",
+        "timestamp": "2026-06-19T15:05:15.4675545",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.4"
         }
     },
     "deseq2 - mouse - basic": {


### PR DESCRIPTION
`decoupler` was not using the `round_digits` feature that we have in nf-core/differentialabundance. The changes here fix that. Additionally, in `dream`, we do not rely on topTable to automatically sort rows, which was causing also some instability. 
In the dream test there is also a removal of an obsolete test. 

For: https://github.com/nf-core/differentialabundance/pull/745