### PR TITLE
add hmmer/hmmemit with deterministic fasta output (-c flag in test)

### DIFF
--- a/modules/nf-core/hmmer/hmmemit/environment.yml
+++ b/modules/nf-core/hmmer/hmmemit/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::hmmer=3.4

--- a/modules/nf-core/hmmer/hmmemit/main.nf
+++ b/modules/nf-core/hmmer/hmmemit/main.nf
@@ -1,0 +1,35 @@
+process HMMER_HMMEMIT {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/hmmer:3.4--hb6cb901_4' :
+        'quay.io/biocontainers/hmmer:3.4--hb6cb901_4' }"
+
+    input:
+    tuple val(meta), path(hmm)
+
+    output:
+    tuple val(meta), path("${prefix}.fasta"), emit: fasta
+    tuple val("${task.process}"), val('hmmer'), eval("hmmemit -h | sed '2!d;s/^# HMMER *//;s/ .*//'"), topic: versions, emit: versions_hmmer
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix   = task.ext.prefix ?: "${meta.id}"
+    """
+    hmmemit \\
+        $args \\
+        -o ${prefix}.fasta \\
+        $hmm
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.fasta
+    """
+}

--- a/modules/nf-core/hmmer/hmmemit/meta.yml
+++ b/modules/nf-core/hmmer/hmmemit/meta.yml
@@ -1,0 +1,76 @@
+name: "hmmer_hmmemit"
+description: emit sequences from a profile HMM
+keywords:
+  - hidden markov model
+  - HMM
+  - hmmer
+  - sequence emission
+  - simulation
+  - profile
+tools:
+  - "hmmer":
+      description: "Biosequence analysis using profile hidden Markov models"
+      homepage: "http://hmmer.org"
+      documentation: "http://hmmer.org/documentation.html"
+      tool_dev_url: "https://github.com/EddyRivasLab/hmmer"
+      doi: "10.1371/journal.pcbi.1002195"
+      licence:
+        - "BSD"
+      identifier: "biotools:hmmer"
+      args_id: "$args"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - hmm:
+        type: file
+        description: |
+          Profile HMM file (e.g. as produced by hmmbuild),
+          containing one or more profile HMMs
+        pattern: "*.{hmm,hmm.gz}"
+        ontologies:
+          - edam: http://edamontology.org/data_1364 # HMM
+output:
+  fasta:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - ${prefix}.fasta:
+          type: file
+          description: |
+            Sequences emitted/sampled from the profile HMM in FASTA format.
+            Note: if `-a` is passed via `ext.args`, hmmemit emits a Stockholm
+            alignment instead; the `.fasta` extension is the default-format
+            convention used by this module. -c consensus in test = forced determinism
+          pattern: "*.fasta"
+          ontologies:
+            - edam: http://edamontology.org/format_1929 # FASTA
+  versions_hmmer:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - hmmer:
+          type: string
+          description: The name of the tool
+      - hmmemit -h | sed '2!d;s/^# HMMER *//;s/ .*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - hmmer:
+          type: string
+          description: The name of the tool
+      - hmmemit -h | sed '2!d;s/^# HMMER *//;s/ .*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@vagkaratzas"
+maintainers:
+  - "@vagkaratzas"

--- a/modules/nf-core/hmmer/hmmemit/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmemit/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_process {
+
+    name "Test Process HMMER_HMMEMIT"
+    script "../main.nf"
+    process "HMMER_HMMEMIT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "hmmer"
+    tag "hmmer/hmmemit"
+
+    test("sarscov2 - proteome - hmm - consensus") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.hmm.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - proteome - hmm - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.hmm.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/hmmer/hmmemit/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmer/hmmemit/tests/main.nf.test.snap
@@ -1,0 +1,54 @@
+{
+    "sarscov2 - proteome - hmm - consensus": {
+        "content": [
+            {
+                "fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,de724654ea485bd77d65e44f1fb76b20"
+                    ]
+                ],
+                "versions_hmmer": [
+                    [
+                        "HMMER_HMMEMIT",
+                        "hmmer",
+                        "3.4"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-19T21:50:20.21981309",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "sarscov2 - proteome - hmm - stub": {
+        "content": [
+            {
+                "fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_hmmer": [
+                    [
+                        "HMMER_HMMEMIT",
+                        "hmmer",
+                        "3.4"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-19T21:50:24.353117033",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    }
+}

--- a/modules/nf-core/hmmer/hmmemit/tests/nextflow.config
+++ b/modules/nf-core/hmmer/hmmemit/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: "HMMER_HMMEMIT" {
+        ext.args = '-c'
+    }
+}


### PR DESCRIPTION
Linked to this proteinfamilies [issue](https://github.com/nf-core/proteinfamilies/issues/167)

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
