### PR TITLE
docs: Add module-level docstring to barcodes.py

### DIFF
--- a/modules/nf-core/anndata/barcodes/templates/barcodes.py
+++ b/modules/nf-core/anndata/barcodes/templates/barcodes.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
+"""
+Filter an AnnData object based on a list of barcodes.
 
+This script reads a CSV file containing cell barcodes and an HDF5 file with an AnnData object,
+then subsets the AnnData object to include only cells whose barcodes are present in the provided list.
+The filtered AnnData object is written to a new HDF5 file.
+
+Inputs:
+    - ${barcodes}: CSV file with a single column of cell barcodes (one barcode per line, no header).
+    - ${h5ad}: HDF5 file containing an AnnData object.
+
+Outputs:
+    - ${prefix}.h5ad: HDF5 file containing the filtered AnnData object.
+    - versions.yml: YAML file with tool version information.
+"""
 import platform
 
 import anndata as ad


### PR DESCRIPTION
### 问题背景
这个PR解决了 `modules/nf-core/anndata/barcodes/templates/barcodes.py` 脚本缺少模块级docstring的问题。原始脚本没有文档说明，使得其目的、输入文件和输出不清晰，降低了代码的可读性和维护性，对社区贡献者理解和维护代码造成障碍。

### 修改内容
- **修改了什么**：在 `barcodes.py` 脚本的顶部添加了一个详细的模块级docstring。
- **为什么这样改**：为了提供脚本功能的清晰说明，包括其目的（基于barcode列表过滤AnnData对象）、输入文件（`${barcodes}` CSV文件和 `${h5ad}` HDF5文件）以及输出文件（`${prefix}.h5ad` 和 `versions.yml`）。这有助于新开发者和维护者快速理解代码，提高协作效率。
- **对代码质量/性能/安全性的提升**：增强了代码的文档化水平，提升了可读性和维护性，没有引入任何功能、性能或安全风险。所有原有代码逻辑保持不变。

### 验证方式
- 由于修改仅限于添加docstring，没有改变代码逻辑，因此现有的测试套件应继续通过。可以通过运行仓库的测试来验证。
- 手动审查docstring内容，确保其准确描述了脚本的输入和输出，与代码行为一致。
- 没有添加新的测试，因为这是纯文档改进。

### 其他信息
- **是否有 breaking changes**：没有breaking changes，docstring不影响代码执行。
- **是否需要更新文档**：不需要更新其他文档，这是一个内部代码改进。
- **是否有已知的限制**：无。