### PR TITLE
Add hmftools/amber module

### DIFF
--- a/modules/nf-core/hmftools/amber/environment.yml
+++ b/modules/nf-core/hmftools/amber/environment.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::hmftools-amber=4.2

--- a/modules/nf-core/hmftools/amber/main.nf
+++ b/modules/nf-core/hmftools/amber/main.nf
@@ -1,0 +1,60 @@
+process HMFTOOLS_AMBER {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/hmftools-amber:4.2--hdfd78af_0' :
+        'biocontainers/hmftools-amber:4.2--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(tumor_bam), path(tumor_bai), path(normal_bam), path(normal_bai)
+    path fasta
+    path fasta_fai
+    path loci
+
+    output:
+    tuple val(meta), path("${prefix}/"), emit: amber_dir
+    path "versions.yml",                emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def tumor_id  = meta.tumor_id  ?: "${meta.id}_tumor"
+    def normal_id = meta.normal_id ?: "${meta.id}_normal"
+    """
+    amber \\
+        -tumor ${tumor_id} \\
+        -tumor_bam ${tumor_bam} \\
+        -reference ${normal_id} \\
+        -reference_bam ${normal_bam} \\
+        -output_dir ${prefix} \\
+        -loci ${loci} \\
+        -ref_genome ${fasta} \\
+        -threads ${task.cpus} \\
+        ${args}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmftools-amber: \$(amber -version 2>&1 | grep -oP '(?<=AMBER version )[\\d.]+')
+    END_VERSIONS
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p ${prefix}
+    touch ${prefix}/${meta.id}.amber.baf.tsv.gz
+    touch ${prefix}/${meta.id}.amber.baf.vcf.gz
+    touch ${prefix}/${meta.id}.amber.contamination.tsv
+    touch ${prefix}/${meta.id}.amber.qc
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmftools-amber: \$(amber -version 2>&1 | grep -oP '(?<=AMBER version )[\\d.]+')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/hmftools/amber/meta.yml
+++ b/modules/nf-core/hmftools/amber/meta.yml
@@ -1,0 +1,68 @@
+name: hmftools_amber
+description: Generates a tumor BAF (B-allele frequency) file for use in PURPLE purity/ploidy estimation from tumor/normal BAM pairs.
+keywords:
+  - hmftools
+  - amber
+  - BAF
+  - tumor
+  - somatic
+  - cancer
+  - copy number
+tools:
+  - hmftools-amber:
+      description: AMBER generates a tumor BAF file for use in PURPLE.
+      homepage: https://github.com/hartwigmedical/hmftools/blob/master/amber/README.md
+      documentation: https://github.com/hartwigmedical/hmftools/blob/master/amber/README.md
+      tool_dev_url: https://github.com/hartwigmedical/hmftools
+      licence: ["GPL-3.0-only"]
+
+input:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information e.g. [ id:'sample1', tumor_id:'tumor', normal_id:'normal' ]
+  - tumor_bam:
+      type: file
+      description: Tumor sorted BAM file
+      pattern: "*.bam"
+  - tumor_bai:
+      type: file
+      description: Tumor BAM index file
+      pattern: "*.bai"
+  - normal_bam:
+      type: file
+      description: Normal sorted BAM file
+      pattern: "*.bam"
+  - normal_bai:
+      type: file
+      description: Normal BAM index file
+      pattern: "*.bai"
+  - fasta:
+      type: file
+      description: Reference genome FASTA file
+      pattern: "*.{fa,fasta}"
+  - fasta_fai:
+      type: file
+      description: Reference genome FASTA index
+      pattern: "*.fai"
+  - loci:
+      type: file
+      description: VCF file of germline heterozygous SNP loci
+      pattern: "*.vcf.gz"
+
+output:
+  - meta:
+      type: map
+      description: Groovy Map containing sample information
+  - amber_dir:
+      type: directory
+      description: Directory containing AMBER output files including BAF and QC files
+      pattern: "*/"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@JP-Bro"
+maintainers:
+  - "@JP-Bro"

--- a/modules/nf-core/hmftools/amber/tests/main.nf.test
+++ b/modules/nf-core/hmftools/amber/tests/main.nf.test
@@ -1,0 +1,40 @@
+nextflow_process {
+
+    name "Test Process HMFTOOLS_AMBER"
+    script "../main.nf"
+    process "HMFTOOLS_AMBER"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "hmftools"
+    tag "hmftools/amber"
+
+    test("homo_sapiens - bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', tumor_id:'test_tumor', normal_id:'test_normal' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                input[3] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz', checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #12121

Add module for AMBER (Allele Balance for Major chromosomal Events 
via Regression), part of the Hartwig Medical Foundation hmftools suite.

AMBER generates a tumor BAF file required for downstream tumor purity 
and ploidy estimation with PURPLE.

- main.nf
- meta.yml  
- environment.yml
- tests/main.nf.test (stub test)