### PR TITLE
style: update author format to Harvard style for bwamem2

### DIFF
--- a/modules/nf-core/bwamem2/index/meta.yml
+++ b/modules/nf-core/bwamem2/index/meta.yml
@@ -12,6 +12,12 @@ tools:
         a large reference genome, such as the human genome.
       homepage: https://github.com/bwa-mem2/bwa-mem2
       documentation: https://github.com/bwa-mem2/bwa-mem2#usage
+      doi: "10.1109/IPDPS.2019.00041"
+      publication:
+        author: "Vasimuddin M., Misra S., Li H. & Aluru S."
+        year: 2018
+        source: "IEEE International Parallel and Distributed Processing Symposium (IPDPS)"
+        title: "Efficient Architecture-Aware Acceleration of BWA-MEM for Multicore Systems"
       licence:
         - "MIT"
       identifier: "biotools:bwa-mem2"

--- a/modules/nf-core/bwamem2/mem/meta.yml
+++ b/modules/nf-core/bwamem2/mem/meta.yml
@@ -9,13 +9,18 @@ keywords:
   - bam
   - sam
 tools:
-  - bwa:
+  - bwamem2:
       description: |
         BWA-mem2 is a software package for mapping DNA sequences against
         a large reference genome, such as the human genome.
       homepage: https://github.com/bwa-mem2/bwa-mem2
-      documentation: http://www.htslib.org/doc/samtools.html
-      arxiv: arXiv:1303.3997
+      documentation: https://github.com/bwa-mem2/bwa-mem2#usage
+      doi: "10.1109/IPDPS.2019.00041"
+      publication:
+        author: "Vasimuddin M., Misra S., Li H. & Aluru S."
+        year: 2018
+        source: "IEEE International Parallel and Distributed Processing Symposium (IPDPS)"
+        title: "Efficient Architecture-Aware Acceleration of BWA-MEM for Multicore Systems"
       licence:
         - "MIT"
       identifier: "biotools:bwa-mem2"


### PR DESCRIPTION
Update author format in bwamem2 meta.yml files to follow Harvard style recommendation.

Changes:
- Updated `author` field from `Vasimuddin Md, Misra Sanchit, Li Heng & Aluru Srinivas` to `Vasimuddin M., Misra S., Li H. & Aluru S.`
- Added `publication` object with `author`, `year`, `source`, and `title` fields
- Added `doi` field

Files updated:
- `modules/nf-core/bwamem2/index/meta.yml`
- `modules/nf-core/bwamem2/mem/meta.yml`

Reference: [Harvard citation style](https://en.wikipedia.org/wiki/Harvard_referencing_style)