### PR TITLE
style: update author format to Harvard style for krona

### DIFF
--- a/modules/nf-core/krona/kronadb/meta.yml
+++ b/modules/nf-core/krona/kronadb/meta.yml
@@ -18,6 +18,7 @@ tools:
         title: "Interactive metagenomic visualization in a Web browser"
         source: "BMC Bioinformatics"
       identifier: biotools:krona
+#  There is no input. This module downloads a pre-built taxonomy database for use with Krona Tools.
 output:
   db:
     - taxonomy/taxonomy.tab:

--- a/modules/nf-core/krona/kronadb/meta.yml
+++ b/modules/nf-core/krona/kronadb/meta.yml
@@ -17,6 +17,7 @@ tools:
         year: 2011
         title: "Interactive metagenomic visualization in a Web browser"
         source: "BMC Bioinformatics"
+      licence: ["https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt"]
       identifier: biotools:krona
 #  There is no input. This module downloads a pre-built taxonomy database for use with Krona Tools.
 output:

--- a/modules/nf-core/krona/kronadb/meta.yml
+++ b/modules/nf-core/krona/kronadb/meta.yml
@@ -11,9 +11,12 @@ tools:
         Bioinformatics tools as well as from text and XML files.
       homepage: https://github.com/marbl/Krona/wiki/KronaTools
       documentation: https://github.com/marbl/Krona/wiki/Installing
-      doi:
-        10.1186/1471-2105-12-385
-        #  There is no input. This module downloads a pre-built taxonomy database for use with Krona Tools.
+      doi: 10.1186/1471-2105-12-385
+      publication:
+        author: "Ondov B.D., Bergman N.H. & Phillippy A.M."
+        year: 2011
+        title: "Interactive metagenomic visualization in a Web browser"
+        source: "BMC Bioinformatics"
       identifier: biotools:krona
 output:
   db:

--- a/modules/nf-core/krona/ktimportkrona/meta.yml
+++ b/modules/nf-core/krona/ktimportkrona/meta.yml
@@ -14,6 +14,11 @@ tools:
       homepage: https://github.com/marbl/Krona/wiki/KronaTools
       documentation: http://manpages.ubuntu.com/manpages/impish/man1/ktImportTaxonomy.1.html
       doi: 10.1186/1471-2105-12-385
+      publication:
+        author: "Ondov B.D., Bergman N.H. & Phillippy A.M."
+        year: 2011
+        title: "Interactive metagenomic visualization in a Web browser"
+        source: "BMC Bioinformatics"
       identifier: biotools:krona
 input:
   - html:

--- a/modules/nf-core/krona/ktimportkrona/meta.yml
+++ b/modules/nf-core/krona/ktimportkrona/meta.yml
@@ -19,6 +19,7 @@ tools:
         year: 2011
         title: "Interactive metagenomic visualization in a Web browser"
         source: "BMC Bioinformatics"
+      licence: ["https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt"]
       identifier: biotools:krona
 input:
   - html:

--- a/modules/nf-core/krona/ktimporttaxonomy/meta.yml
+++ b/modules/nf-core/krona/ktimporttaxonomy/meta.yml
@@ -20,6 +20,7 @@ tools:
         year: 2011
         title: "Interactive metagenomic visualization in a Web browser"
         source: "BMC Bioinformatics"
+      licence: ["https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt"]
       identifier: biotools:krona
 input:
   - - meta:

--- a/modules/nf-core/krona/ktimporttaxonomy/meta.yml
+++ b/modules/nf-core/krona/ktimporttaxonomy/meta.yml
@@ -15,6 +15,11 @@ tools:
       homepage: https://github.com/marbl/Krona/wiki/KronaTools
       documentation: http://manpages.ubuntu.com/manpages/impish/man1/ktImportTaxonomy.1.html
       doi: 10.1186/1471-2105-12-385
+      publication:
+        author: "Ondov B.D., Bergman N.H. & Phillippy A.M."
+        year: 2011
+        title: "Interactive metagenomic visualization in a Web browser"
+        source: "BMC Bioinformatics"
       identifier: biotools:krona
 input:
   - - meta:

--- a/modules/nf-core/krona/ktimporttext/meta.yml
+++ b/modules/nf-core/krona/ktimporttext/meta.yml
@@ -16,6 +16,11 @@ tools:
       documentation: http://manpages.ubuntu.com/manpages/impish/man1/ktImportTaxonomy.1.html
       tool_dev_url: https://github.com/marbl/Krona
       doi: 10.1186/1471-2105-12-385
+      publication:
+        author: "Ondov B.D., Bergman N.H. & Phillippy A.M."
+        year: 2011
+        title: "Interactive metagenomic visualization in a Web browser"
+        source: "BMC Bioinformatics"
       licence: ["https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt"]
       identifier: biotools:krona
 input:

--- a/modules/nf-core/krona/ktupdatetaxonomy/meta.yml
+++ b/modules/nf-core/krona/ktupdatetaxonomy/meta.yml
@@ -18,6 +18,7 @@ tools:
         title: "Interactive metagenomic visualization in a Web browser"
         source: "BMC Bioinformatics"
       identifier: biotools:krona
+#  There is no input. This module downloads a pre-built taxonomy database for use with Krona Tools.
 output:
   db:
     - taxonomy/taxonomy.tab:

--- a/modules/nf-core/krona/ktupdatetaxonomy/meta.yml
+++ b/modules/nf-core/krona/ktupdatetaxonomy/meta.yml
@@ -17,6 +17,7 @@ tools:
         year: 2011
         title: "Interactive metagenomic visualization in a Web browser"
         source: "BMC Bioinformatics"
+      licence: ["https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt"]
       identifier: biotools:krona
 #  There is no input. This module downloads a pre-built taxonomy database for use with Krona Tools.
 output:

--- a/modules/nf-core/krona/ktupdatetaxonomy/meta.yml
+++ b/modules/nf-core/krona/ktupdatetaxonomy/meta.yml
@@ -11,9 +11,12 @@ tools:
         Bioinformatics tools as well as from text and XML files.
       homepage: https://github.com/marbl/Krona/wiki/KronaTools
       documentation: https://github.com/marbl/Krona/wiki/Installing
-      doi:
-        10.1186/1471-2105-12-385
-        # There is no input. This module downloads a pre-built taxonomy database for use with Krona Tools.
+      doi: 10.1186/1471-2105-12-385
+      publication:
+        author: "Ondov B.D., Bergman N.H. & Phillippy A.M."
+        year: 2011
+        title: "Interactive metagenomic visualization in a Web browser"
+        source: "BMC Bioinformatics"
       identifier: biotools:krona
 output:
   db:


### PR DESCRIPTION
Update author format in krona meta.yml files to follow Harvard style recommendation.

Changes:
- Added `publication` object with `author`, `year`, `title`, and `source` fields
- Author format: `Ondov B.D., Bergman N.H. & Phillippy A.M.` (Harvard style)
- Fixed DOI format in ktupdatetaxonomy (was incorrectly formatted with comment)

Files updated:
- `modules/nf-core/krona/ktimporttaxonomy/meta.yml`
- `modules/nf-core/krona/ktupdatetaxonomy/meta.yml`

Reference: [Harvard citation style](https://en.wikipedia.org/wiki/Harvard_referencing_style)