### PR TITLE
Update centrifuger to 1.1.2

### DIFF
--- a/modules/nf-core/centrifuger/build/environment.yml
+++ b/modules/nf-core/centrifuger/build/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::centrifuger=1.1.0"
+  - "bioconda::centrifuger=1.1.2"

--- a/modules/nf-core/centrifuger/build/main.nf
+++ b/modules/nf-core/centrifuger/build/main.nf
@@ -4,8 +4,8 @@ process CENTRIFUGER_BUILD {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/centrifuger:1.1.0--hf426362_0':
-        'quay.io/biocontainers/centrifuger:1.1.0--hf426362_0' }"
+        'https://depot.galaxyproject.org/singularity/centrifuger:1.1.2--h3be2455_0':
+        'quay.io/biocontainers/centrifuger:1.1.2--h3be2455_0' }"
 
     input:
     tuple val(meta), path(references, stageAs: 'genomes/*')

--- a/modules/nf-core/centrifuger/build/tests/main.nf.test.snap
+++ b/modules/nf-core/centrifuger/build/tests/main.nf.test.snap
@@ -12,15 +12,15 @@
                     [
                         "CENTRIFUGER_BUILD",
                         "centrifuger",
-                        "1.1.0-r299"
+                        "1.1.2-r329"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-22T09:25:20.178361",
+        "timestamp": "2026-06-25T12:17:34.407688",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "sarscov2 - fasta with reference file-stub": {
@@ -36,15 +36,15 @@
                     [
                         "CENTRIFUGER_BUILD",
                         "centrifuger",
-                        "1.1.0-r299"
+                        "1.1.2-r329"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-22T09:25:24.796791",
+        "timestamp": "2026-06-25T12:17:40.072898",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/modules/nf-core/centrifuger/centrifuger/environment.yml
+++ b/modules/nf-core/centrifuger/centrifuger/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::centrifuger=1.1.0"
+  - "bioconda::centrifuger=1.1.2"

--- a/modules/nf-core/centrifuger/centrifuger/main.nf
+++ b/modules/nf-core/centrifuger/centrifuger/main.nf
@@ -4,8 +4,8 @@ process CENTRIFUGER_CENTRIFUGER {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/centrifuger:1.1.0--hf426362_0':
-        'quay.io/biocontainers/centrifuger:1.1.0--hf426362_0' }"
+        'https://depot.galaxyproject.org/singularity/centrifuger:1.1.2--h3be2455_0':
+        'quay.io/biocontainers/centrifuger:1.1.2--h3be2455_0' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/centrifuger/centrifuger/tests/main.nf.test.snap
+++ b/modules/nf-core/centrifuger/centrifuger/tests/main.nf.test.snap
@@ -33,15 +33,15 @@
                     [
                         "CENTRIFUGER_CENTRIFUGER",
                         "centrifuger",
-                        "1.1.0-r299"
+                        "1.1.2-r329"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-24T13:19:03.877144",
+        "timestamp": "2026-06-25T12:19:08.934622",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "sarscov2 - fastq - single_end": {
@@ -62,15 +62,15 @@
                     [
                         "CENTRIFUGER_CENTRIFUGER",
                         "centrifuger",
-                        "1.1.0-r299"
+                        "1.1.2-r329"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-24T13:18:50.796221",
+        "timestamp": "2026-06-25T12:18:55.909052",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "sarscov2 - fastq - paired_end": {
@@ -97,15 +97,15 @@
                     [
                         "CENTRIFUGER_CENTRIFUGER",
                         "centrifuger",
-                        "1.1.0-r299"
+                        "1.1.2-r329"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-24T13:18:57.595009",
+        "timestamp": "2026-06-25T12:19:02.70994",
         "meta": {
             "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/modules/nf-core/centrifuger/quantification/environment.yml
+++ b/modules/nf-core/centrifuger/quantification/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::centrifuger=1.1.0"
+  - "bioconda::centrifuger=1.1.2"

--- a/modules/nf-core/centrifuger/quantification/main.nf
+++ b/modules/nf-core/centrifuger/quantification/main.nf
@@ -4,8 +4,8 @@ process CENTRIFUGER_QUANTIFICATION {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/centrifuger:1.1.0--hf426362_0':
-        'quay.io/biocontainers/centrifuger:1.1.0--hf426362_0' }"
+        'https://depot.galaxyproject.org/singularity/centrifuger:1.1.2--h3be2455_0':
+        'quay.io/biocontainers/centrifuger:1.1.2--h3be2455_0' }"
 
     input:
     tuple val(meta), path(classification_file)

--- a/modules/nf-core/centrifuger/quantification/tests/main.nf.test.snap
+++ b/modules/nf-core/centrifuger/quantification/tests/main.nf.test.snap
@@ -14,7 +14,7 @@
                     [
                         "CENTRIFUGER_QUANTIFICATION",
                         "centrifuger",
-                        "1.1.0-r299"
+                        "1.1.2-r329"
                     ]
                 ],
                 "report_file": [
@@ -29,12 +29,12 @@
                     [
                         "CENTRIFUGER_QUANTIFICATION",
                         "centrifuger",
-                        "1.1.0-r299"
+                        "1.1.2-r329"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-15T17:27:16.601991",
+        "timestamp": "2026-06-25T12:18:32.211137",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.0"
@@ -48,12 +48,12 @@
                     [
                         "CENTRIFUGER_QUANTIFICATION",
                         "centrifuger",
-                        "1.1.0-r299"
+                        "1.1.2-r329"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-15T17:27:08.763745",
+        "timestamp": "2026-06-25T12:18:25.524511",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.0"


### PR DESCRIPTION
Update centrifuger version from 1.1.0 to 1.1.2, which includes a new flag for output (kraken style report) in the quantification step. 
This needed in order to incorporate in the taxprofiler pipeline, where the kraken-style report is required for downstream tools like KrakenTools and Krona visualization. 

In 1.1.2 the 3rd option is **NEW**:
--output-format INT: output format. (0:centrifuge,default, 1:Metaphlan, 2:CAMI, 3:kraken-report) .       