### PR TITLE
feat(custom/orfmerge): cross-caller/sample consensus catalogue view (+ orftable subworkflow emit)

### DIFF
--- a/modules/nf-core/custom/orfcollapse/main.nf
+++ b/modules/nf-core/custom/orfcollapse/main.nf
@@ -11,12 +11,15 @@ process CUSTOM_ORFCOLLAPSE {
     tuple val(meta), path(bed12, stageAs: 'input/*'), path(catalogue_tsv, stageAs: 'input/*'), path(orf_to_gene_tsv, stageAs: 'input/*'), path(aa_fasta, stageAs: 'input/*'), path(cluster_tsv, stageAs: 'input/*')
 
     output:
-    tuple val(meta), path("${prefix}.bed12")           , emit: bed12
-    tuple val(meta), path("${prefix}.tsv")             , emit: catalogue_tsv
-    tuple val(meta), path("${prefix}.orf_to_gene.tsv") , emit: orf_to_gene_tsv
-    tuple val(meta), path("${prefix}.mqc.tsv")         , emit: multiqc
-    tuple val(meta), path("${prefix}.fasta")           , emit: aa_fasta
-    path "versions.yml"                                , emit: versions, topic: versions
+    tuple val(meta), path("${prefix}.bed12")                     , emit: bed12
+    tuple val(meta), path("${prefix}.tsv")                       , emit: catalogue_tsv
+    tuple val(meta), path("${prefix}.orf_to_gene.tsv")           , emit: orf_to_gene_tsv
+    tuple val(meta), path("${prefix}.mqc.tsv")                   , emit: multiqc
+    tuple val(meta), path("${prefix}.fasta")                     , emit: aa_fasta
+    tuple val(meta), path("${prefix}.consensus.bed12")           , emit: consensus_bed12
+    tuple val(meta), path("${prefix}.consensus.tsv")             , emit: consensus_tsv
+    tuple val(meta), path("${prefix}.consensus.orf_to_gene.tsv") , emit: consensus_orf_to_gene_tsv
+    path "versions.yml"                                          , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,6 +33,7 @@ process CUSTOM_ORFCOLLAPSE {
     prefix = task.ext.prefix ?: "${meta.id}.catalogue"
     """
     touch ${prefix}.bed12 ${prefix}.tsv ${prefix}.orf_to_gene.tsv ${prefix}.mqc.tsv ${prefix}.fasta
+    touch ${prefix}.consensus.bed12 ${prefix}.consensus.tsv ${prefix}.consensus.orf_to_gene.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/custom/orfcollapse/meta.yml
+++ b/modules/nf-core/custom/orfcollapse/meta.yml
@@ -130,6 +130,40 @@ output:
           pattern: "*.fasta"
           ontologies:
             - edam: http://edamontology.org/format_1929 # FASTA
+  consensus_bed12:
+    - - meta:
+          type: map
+          description: Groovy Map matching the input meta.
+      - ${prefix}.consensus.bed12:
+          type: file
+          description: |
+            Consensus view as BED12: the collapsed catalogue filtered to ORFs
+            supported by at least `--min-callers` distinct callers and recurring
+            in at least `--min-samples` samples (identical to the full collapsed
+            catalogue at the defaults of 1/1).
+          pattern: "*.consensus.bed12"
+          ontologies:
+            - edam: http://edamontology.org/format_3586 # BED
+  consensus_tsv:
+    - - meta:
+          type: map
+          description: Groovy Map matching the input meta.
+      - ${prefix}.consensus.tsv:
+          type: file
+          description: Consensus-filtered per-ORF table, same columns as the collapsed catalogue.
+          pattern: "*.consensus.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  consensus_orf_to_gene_tsv:
+    - - meta:
+          type: map
+          description: Groovy Map matching the input meta.
+      - ${prefix}.consensus.orf_to_gene.tsv:
+          type: file
+          description: ORF-to-gene mapping restricted to the consensus-filtered ORFs.
+          pattern: "*.consensus.orf_to_gene.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
   versions:
     - versions.yml:
         type: file

--- a/modules/nf-core/custom/orfcollapse/templates/orfcollapse.py
+++ b/modules/nf-core/custom/orfcollapse/templates/orfcollapse.py
@@ -6,15 +6,31 @@
 The coordinate-based merge in custom/orfmerge groups ORFs that overlap on the
 genome, but the same micropeptide is frequently encoded at several distinct,
 non-overlapping genomic loci (typically repetitive regions), and those copies
-survive as separate catalogue rows. This adopts the peptide-level deduplication
-and 0.9 amino-acid-similarity threshold of the GENCODE Ribo-seq ORF
-consolidation (Mudge et al. 2022, Nat Biotechnol,
-doi:10.1038/s41587-022-01369-0; gencode-riboseqORFs collapse_cutoff 0.9),
-implemented here with MMseqs2 sequence-identity clustering (--min-seq-id 0.9)
-rather than that tool's longest-shared-string / P-site-overlap metric. Small
-ORFs (orf_class == "smORF", i.e. aa_length <= 100) are clustered by amino-acid
-identity upstream (mmseqs/easycluster) and this module folds each multi-member
-cluster down to one representative.
+survive as separate catalogue rows. This peptide-level deduplication is inspired
+by the GENCODE Ribo-seq ORF consolidation (Mudge et al. 2022, Nat Biotechnol,
+doi:10.1038/s41587-022-01369-0; gencode-riboseqORFs collapse_cutoff 0.9), with
+two deliberate departures from that reference:
+
+  - GENCODE collapses overlapping ORFs of any size within a shared locus;
+    this restricts collapsing to small ORFs (orf_class == "smORF", i.e.
+    aa_length <= 100) and clusters them locus-agnostically across the whole
+    catalogue, since the target case is one micropeptide recurring at several
+    non-overlapping loci. The smORF-only restriction is this pipeline's choice,
+    not a GENCODE property.
+  - similarity is MMseqs2 global sequence identity (--min-seq-id 0.9,
+    mmseqs/easycluster upstream) rather than GENCODE's longest-shared-substring
+    / P-site-overlap metric, so the 0.9 here approximates rather than
+    reproduces collapse_cutoff 0.9.
+
+Small ORFs are clustered by amino-acid identity upstream (mmseqs/easycluster)
+and this module folds each multi-member cluster down to one representative.
+
+Alongside the collapsed catalogue it emits a consensus view (`*.consensus.*`)
+filtered to ORFs supported by at least `--min-callers` distinct callers and
+recurring in at least `--min-samples` samples (both default 1, i.e. no
+filtering). The filter is applied after the collapse, so the consensus is the
+high-confidence subset of the de-redundified catalogue and a folded
+micropeptide is judged on its combined cross-caller / cross-sample evidence.
 
 Only smORF rows are collapsed; larger ORFs and transcript-anchored classes pass
 through untouched, preserving the deterministic coordinate/transcript merge from
@@ -101,15 +117,9 @@ def merge_members(members):
     rep = sorted(members, key=lambda r: (-int(r.get("aa_length") or 0), r["orf_id"]))[0]
     out = dict(rep)
     for c in CALLERS:
-        out[f"called_by_{c}"] = (
-            "1" if any(r.get(f"called_by_{c}") == "1" for r in members) else "0"
-        )
-        out[f"score_{c}"] = best_score(
-            [r.get(f"score_{c}", "") for r in members], SCORE_DIRECTIONS[c]
-        )
-    samples = sorted(
-        {s for r in members for s in (r.get("samples") or "").split(",") if s}
-    )
+        out[f"called_by_{c}"] = "1" if any(r.get(f"called_by_{c}") == "1" for r in members) else "0"
+        out[f"score_{c}"] = best_score([r.get(f"score_{c}", "") for r in members], SCORE_DIRECTIONS[c])
+    samples = sorted({s for r in members for s in (r.get("samples") or "").split(",") if s})
     out["n_samples"] = str(len(samples))
     out["samples"] = ",".join(samples)
     return rep["orf_id"], out
@@ -117,13 +127,23 @@ def merge_members(members):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.parse_args(shlex.split("${args}"))
+    parser.add_argument(
+        "--min-callers",
+        type=int,
+        default=1,
+        help="Minimum distinct callers for an ORF to enter the consensus view (default: 1)",
+    )
+    parser.add_argument(
+        "--min-samples",
+        type=int,
+        default=1,
+        help="Minimum distinct samples for an ORF to enter the consensus view (default: 1)",
+    )
+    args = parser.parse_args(shlex.split("${args}"))
 
     prefix = "${prefix}"
 
-    catalogue = pd.read_csv(
-        "${catalogue_tsv}", sep="\\t", comment="#", dtype=str, keep_default_na=False
-    )
+    catalogue = pd.read_csv("${catalogue_tsv}", sep="\\t", comment="#", dtype=str, keep_default_na=False)
     header = list(catalogue.columns)
     rows = catalogue.to_dict("records")
 
@@ -155,21 +175,34 @@ def main():
 
     kept = [merged_rows.get(r["orf_id"], r) for r in rows if r["orf_id"] not in dropped]
     out = pd.DataFrame(kept, columns=header)
-    out.to_csv(f"{prefix}.tsv", sep="\\t", index=False)
-
-    with (
-        open(f"{prefix}.bed12", "w") as bh,
-        open(f"{prefix}.fasta", "w") as ah,
-    ):
-        for oid in out["orf_id"]:
-            if oid in bed_index:
-                bh.write(bed_index[oid] + "\\n")
-            if oid in aa:
-                ah.write(f">{oid}\\n{aa[oid]}\\n")
 
     o2g = pd.read_csv("${orf_to_gene_tsv}", sep="\\t", dtype=str, keep_default_na=False)
     o2g["orf_id"] = o2g["orf_id"].map(lambda o: remap.get(o, o))
-    o2g.drop_duplicates().to_csv(f"{prefix}.orf_to_gene.tsv", sep="\\t", index=False)
+    o2g = o2g.drop_duplicates()
+
+    def write_view(out_prefix, df):
+        """Write the catalogue TSV, BED12 and ORF-to-gene mapping for `df`."""
+        df.to_csv(f"{out_prefix}.tsv", sep="\\t", index=False)
+        with open(f"{out_prefix}.bed12", "w") as bh:
+            for oid in df["orf_id"]:
+                if oid in bed_index:
+                    bh.write(bed_index[oid] + "\\n")
+        o2g[o2g["orf_id"].isin(set(df["orf_id"]))].to_csv(f"{out_prefix}.orf_to_gene.tsv", sep="\\t", index=False)
+
+    # Full collapsed catalogue (+ amino-acid FASTA).
+    write_view(prefix, out)
+    with open(f"{prefix}.fasta", "w") as ah:
+        for oid in out["orf_id"]:
+            if oid in aa:
+                ah.write(f">{oid}\\n{aa[oid]}\\n")
+
+    # Consensus view: high-confidence subset of the collapsed catalogue, so a
+    # folded micropeptide is judged on its combined cross-caller / cross-sample
+    # evidence. At the default thresholds (1, 1) it equals the full catalogue.
+    n_callers = sum((out[f"called_by_{c}"] == "1").astype(int) for c in CALLERS)
+    n_samples = pd.to_numeric(out["n_samples"], errors="coerce").fillna(0).astype(int)
+    consensus = out[(n_callers >= args.min_callers) & (n_samples >= args.min_samples)]
+    write_view(f"{prefix}.consensus", consensus)
 
     counts = out["orf_class"].value_counts()
     with open(f"{prefix}.mqc.tsv", "w") as mh:

--- a/modules/nf-core/custom/orfcollapse/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/orfcollapse/tests/main.nf.test.snap
@@ -26,6 +26,30 @@
                         "cohort.catalogue.tsv:md5,2ae2eb7006ab613d0d23ea5eaa959615"
                     ]
                 ],
+                "consensus_bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,299daed2c7d9d03faba1340684a57fa7"
+                    ]
+                ],
+                "consensus_orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,7920c0714282f9cdfe809f8f9a12a511"
+                    ]
+                ],
+                "consensus_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,2ae2eb7006ab613d0d23ea5eaa959615"
+                    ]
+                ],
                 "multiqc": [
                     [
                         {
@@ -47,11 +71,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-17T10:10:52.259691163",
         "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.04.8"
+        },
+        "timestamp": "2026-06-25T20:22:39.073880596"
     },
     "collapse identical small ORFs across loci - stub": {
         "content": [
@@ -80,6 +104,30 @@
                         "cohort.catalogue.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "consensus_bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "consensus_orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "consensus_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
                 "multiqc": [
                     [
                         {
@@ -101,10 +149,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-17T10:10:56.622346268",
         "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.04.8"
+        },
+        "timestamp": "2026-06-25T20:22:43.127779465"
     }
 }

--- a/modules/nf-core/custom/orfmerge/main.nf
+++ b/modules/nf-core/custom/orfmerge/main.nf
@@ -11,11 +11,14 @@ process CUSTOM_ORFMERGE {
     tuple val(meta), path(bed12s, arity: '1..*', stageAs: 'beds/*'), path(tsvs, arity: '1..*', stageAs: 'tsvs/*')
 
     output:
-    tuple val(meta), path("${prefix}.bed12")           , emit: bed12
-    tuple val(meta), path("${prefix}.tsv")             , emit: catalogue_tsv
-    tuple val(meta), path("${prefix}.orf_to_gene.tsv") , emit: orf_to_gene_tsv
-    tuple val(meta), path("${prefix}.mqc.tsv")         , emit: multiqc
-    path "versions.yml"                                , emit: versions, topic: versions
+    tuple val(meta), path("${prefix}.bed12")                     , emit: bed12
+    tuple val(meta), path("${prefix}.tsv")                       , emit: catalogue_tsv
+    tuple val(meta), path("${prefix}.orf_to_gene.tsv")           , emit: orf_to_gene_tsv
+    tuple val(meta), path("${prefix}.mqc.tsv")                   , emit: multiqc
+    tuple val(meta), path("${prefix}.consensus.bed12")           , emit: consensus_bed12
+    tuple val(meta), path("${prefix}.consensus.tsv")             , emit: consensus_tsv
+    tuple val(meta), path("${prefix}.consensus.orf_to_gene.tsv") , emit: consensus_orf_to_gene_tsv
+    path "versions.yml"                                          , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,6 +35,9 @@ process CUSTOM_ORFMERGE {
     touch ${prefix}.tsv
     touch ${prefix}.orf_to_gene.tsv
     touch ${prefix}.mqc.tsv
+    touch ${prefix}.consensus.bed12
+    touch ${prefix}.consensus.tsv
+    touch ${prefix}.consensus.orf_to_gene.tsv
 
     python -c "import platform, yaml; yaml.safe_dump({'${task.process}': {'python': platform.python_version()}}, open('versions.yml', 'w'), default_flow_style=False, sort_keys=False)"
     """

--- a/modules/nf-core/custom/orfmerge/meta.yml
+++ b/modules/nf-core/custom/orfmerge/meta.yml
@@ -45,6 +45,13 @@ description: |
 
   Emits a small MultiQC custom-content TSV (per-class counts) for
   inclusion in downstream MultiQC reports.
+
+  Alongside the full catalogue, emits a consensus view (`*.consensus.*`)
+  filtered to ORFs supported by at least `--min-callers` distinct callers
+  and recurring in at least `--min-samples` samples (both default 1, i.e.
+  no filtering, so the consensus view equals the full catalogue). Raising
+  either threshold yields a higher-confidence catalogue without altering
+  the full one.
 keywords:
   - orf
   - ribo-seq
@@ -134,6 +141,44 @@ output:
           description: |
             MultiQC custom-content TSV (per-class ORF counts).
           pattern: "*.mqc.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  consensus_bed12:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map matching the input meta.
+      - ${prefix}.consensus.bed12:
+          type: file
+          description: |
+            Consensus-filtered catalogue as BED12 (ORFs meeting the
+            `--min-callers` / `--min-samples` thresholds).
+          pattern: "*.consensus.bed12"
+          ontologies:
+            - edam: http://edamontology.org/format_3586 # BED
+  consensus_tsv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map matching the input meta.
+      - ${prefix}.consensus.tsv:
+          type: file
+          description: |
+            Consensus-filtered per-ORF table, same columns as the full
+            catalogue TSV.
+          pattern: "*.consensus.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  consensus_orf_to_gene_tsv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map matching the input meta.
+      - ${prefix}.consensus.orf_to_gene.tsv:
+          type: file
+          description: |
+            ORF-to-gene mapping restricted to the consensus-filtered ORFs.
+          pattern: "*.consensus.orf_to_gene.tsv"
           ontologies:
             - edam: http://edamontology.org/format_3475 # TSV
   versions:

--- a/modules/nf-core/custom/orfmerge/templates/orfmerge.py
+++ b/modules/nf-core/custom/orfmerge/templates/orfmerge.py
@@ -41,6 +41,7 @@ import platform
 import shlex
 import sys
 from collections import defaultdict
+from contextlib import ExitStack
 from pathlib import Path
 
 import yaml
@@ -182,11 +183,17 @@ def load_normalised(tsv_paths, bed_paths):
     return rows, bed_index
 
 
-def write_catalogue(prefix, clusters, bed_index):
+def write_catalogue(prefix, clusters, bed_index, min_callers=1, min_samples=1):
     cat_bed = Path(f"{prefix}.bed12")
     cat_tsv = Path(f"{prefix}.tsv")
     o2g_tsv = Path(f"{prefix}.orf_to_gene.tsv")
     mqc_tsv = Path(f"{prefix}.mqc.tsv")
+    # Consensus view: the same catalogue filtered to ORFs supported by at least
+    # `min_callers` distinct callers and recurring in at least `min_samples`
+    # samples. At the defaults (1, 1) it is identical to the full catalogue.
+    con_bed = Path(f"{prefix}.consensus.bed12")
+    con_tsv = Path(f"{prefix}.consensus.tsv")
+    con_o2g = Path(f"{prefix}.consensus.orf_to_gene.tsv")
 
     catalogue_cols = (
         ["orf_id", "chrom", "start", "end", "strand", "gene_id", "transcript_id", "orf_class", "aa_length"]
@@ -213,17 +220,28 @@ def write_catalogue(prefix, clusters, bed_index):
 
     clusters = sorted(clusters, key=_sort_key)
 
-    with open(cat_bed, "w") as bh, open(cat_tsv, "w") as th, open(o2g_tsv, "w") as oh:
-        th.write("\\t".join(catalogue_cols) + "\\n")
+    with ExitStack() as stack:
+        bh = stack.enter_context(open(cat_bed, "w"))
+        th = stack.enter_context(open(cat_tsv, "w"))
+        oh = stack.enter_context(open(o2g_tsv, "w"))
+        cbh = stack.enter_context(open(con_bed, "w"))
+        cth = stack.enter_context(open(con_tsv, "w"))
+        coh = stack.enter_context(open(con_o2g, "w"))
+        header = "\\t".join(catalogue_cols) + "\\n"
+        th.write(header)
+        cth.write(header)
         oh.write("orf_id\\tgene_id\\ttranscript_id\\n")
+        coh.write("orf_id\\tgene_id\\ttranscript_id\\n")
         for idx, cluster in enumerate(clusters):
             rep = representative(cluster)
             stable_id = f"orf_{idx + 1:08d}"
+            bed_out = None
             bed_line = bed_index.get(rep["orf_id"])
             if bed_line:
                 parts = bed_line.split("\\t")
                 parts[3] = stable_id
-                bh.write("\\t".join(parts) + "\\n")
+                bed_out = "\\t".join(parts) + "\\n"
+                bh.write(bed_out)
 
             caller_cols = aggregate_caller_columns(cluster)
             row_out = [
@@ -242,9 +260,19 @@ def write_catalogue(prefix, clusters, bed_index):
 
             sample_ids = sorted({r.get("sample_id", "") for r in cluster if r.get("sample_id")})
             row_out += [str(len(sample_ids)), ",".join(sample_ids)]
-            th.write("\\t".join(row_out) + "\\n")
+            row_line = "\\t".join(row_out) + "\\n"
+            th.write(row_line)
 
             per_class_counts[rep.get("orf_class", "other")] += 1
+
+            # Consensus membership: distinct callers that flagged the cluster
+            # and distinct contributing samples must each meet the threshold.
+            n_callers = sum(1 for c in CALLERS if caller_cols[f"called_by_{c}"] == "1")
+            in_consensus = n_callers >= min_callers and len(sample_ids) >= min_samples
+            if in_consensus:
+                cth.write(row_line)
+                if bed_out:
+                    cbh.write(bed_out)
 
             seen_gt = set()
             for r in cluster:
@@ -253,6 +281,8 @@ def write_catalogue(prefix, clusters, bed_index):
                     continue
                 seen_gt.add(key)
                 oh.write(f"{stable_id}\\t{key[0]}\\t{key[1]}\\n")
+                if in_consensus:
+                    coh.write(f"{stable_id}\\t{key[0]}\\t{key[1]}\\n")
 
     with open(mqc_tsv, "w") as mh:
         mh.write("# id: orf_catalogue\\n")
@@ -285,6 +315,18 @@ def main():
         default=0.8,
         help="Reciprocal-overlap fraction for novel_u/smORF clustering (default: 0.8)",
     )
+    parser.add_argument(
+        "--min-callers",
+        type=int,
+        default=1,
+        help="Minimum distinct callers for an ORF to enter the consensus view (default: 1)",
+    )
+    parser.add_argument(
+        "--min-samples",
+        type=int,
+        default=1,
+        help="Minimum distinct samples for an ORF to enter the consensus view (default: 1)",
+    )
     args = parser.parse_args(shlex.split("${args}"))
 
     bed_paths = sorted(Path(p) for p in glob.glob("beds/*"))
@@ -294,7 +336,7 @@ def main():
     rows, bed_index = load_normalised(tsv_paths, bed_paths)
 
     if not rows:
-        write_catalogue(prefix, [], {})
+        write_catalogue(prefix, [], {}, min_callers=args.min_callers, min_samples=args.min_samples)
         write_versions()
         return 0
 
@@ -318,7 +360,7 @@ def main():
     for cls in ("novel_u", "smORF"):
         clusters.extend(cluster_by_reciprocal_overlap(by_class.get(cls, []), frac=args.reciprocal_overlap))
 
-    write_catalogue(prefix, clusters, bed_index)
+    write_catalogue(prefix, clusters, bed_index, min_callers=args.min_callers, min_samples=args.min_samples)
     write_versions()
     return 0
 

--- a/modules/nf-core/custom/orfmerge/templates/orfmerge.py
+++ b/modules/nf-core/custom/orfmerge/templates/orfmerge.py
@@ -41,7 +41,6 @@ import platform
 import shlex
 import sys
 from collections import defaultdict
-from contextlib import ExitStack
 from pathlib import Path
 
 import yaml
@@ -220,18 +219,15 @@ def write_catalogue(prefix, clusters, bed_index, min_callers=1, min_samples=1):
 
     clusters = sorted(clusters, key=_sort_key)
 
-    with ExitStack() as stack:
-        bh = stack.enter_context(open(cat_bed, "w"))
-        th = stack.enter_context(open(cat_tsv, "w"))
-        oh = stack.enter_context(open(o2g_tsv, "w"))
-        cbh = stack.enter_context(open(con_bed, "w"))
-        cth = stack.enter_context(open(con_tsv, "w"))
-        coh = stack.enter_context(open(con_o2g, "w"))
-        header = "\\t".join(catalogue_cols) + "\\n"
+    header = "\\t".join(catalogue_cols) + "\\n"
+    o2g_header = "orf_id\\tgene_id\\ttranscript_id\\n"
+
+    # First pass: write the full catalogue, recording which rows qualify for the
+    # consensus view (>= min_callers distinct callers and >= min_samples samples).
+    consensus_rows = []
+    with open(cat_bed, "w") as bh, open(cat_tsv, "w") as th, open(o2g_tsv, "w") as oh:
         th.write(header)
-        cth.write(header)
-        oh.write("orf_id\\tgene_id\\ttranscript_id\\n")
-        coh.write("orf_id\\tgene_id\\ttranscript_id\\n")
+        oh.write(o2g_header)
         for idx, cluster in enumerate(clusters):
             rep = representative(cluster)
             stable_id = f"orf_{idx + 1:08d}"
@@ -265,15 +261,7 @@ def write_catalogue(prefix, clusters, bed_index, min_callers=1, min_samples=1):
 
             per_class_counts[rep.get("orf_class", "other")] += 1
 
-            # Consensus membership: distinct callers that flagged the cluster
-            # and distinct contributing samples must each meet the threshold.
-            n_callers = sum(1 for c in CALLERS if caller_cols[f"called_by_{c}"] == "1")
-            in_consensus = n_callers >= min_callers and len(sample_ids) >= min_samples
-            if in_consensus:
-                cth.write(row_line)
-                if bed_out:
-                    cbh.write(bed_out)
-
+            o2g_pairs = []
             seen_gt = set()
             for r in cluster:
                 key = (r.get("gene_id", ""), r.get("transcript_id", ""))
@@ -281,8 +269,25 @@ def write_catalogue(prefix, clusters, bed_index, min_callers=1, min_samples=1):
                     continue
                 seen_gt.add(key)
                 oh.write(f"{stable_id}\\t{key[0]}\\t{key[1]}\\n")
-                if in_consensus:
-                    coh.write(f"{stable_id}\\t{key[0]}\\t{key[1]}\\n")
+                o2g_pairs.append(key)
+
+            # Consensus membership: distinct callers that flagged the cluster
+            # and distinct contributing samples must each meet the threshold.
+            n_callers = sum(1 for c in CALLERS if caller_cols[f"called_by_{c}"] == "1")
+            if n_callers >= min_callers and len(sample_ids) >= min_samples:
+                consensus_rows.append((bed_out, row_line, stable_id, o2g_pairs))
+
+    # Second pass: the consensus view is the full catalogue restricted to the
+    # qualifying rows.
+    with open(con_bed, "w") as cbh, open(con_tsv, "w") as cth, open(con_o2g, "w") as coh:
+        cth.write(header)
+        coh.write(o2g_header)
+        for bed_out, row_line, stable_id, o2g_pairs in consensus_rows:
+            if bed_out:
+                cbh.write(bed_out)
+            cth.write(row_line)
+            for gid, tid in o2g_pairs:
+                coh.write(f"{stable_id}\\t{gid}\\t{tid}\\n")
 
     with open(mqc_tsv, "w") as mh:
         mh.write("# id: orf_catalogue\\n")

--- a/modules/nf-core/custom/orfmerge/tests/consensus_threshold.config
+++ b/modules/nf-core/custom/orfmerge/tests/consensus_threshold.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'CUSTOM_ORFMERGE' {
+        ext.args = '--min-samples 2'
+    }
+}

--- a/modules/nf-core/custom/orfmerge/tests/main.nf.test
+++ b/modules/nf-core/custom/orfmerge/tests/main.nf.test
@@ -129,4 +129,49 @@ nextflow_process {
         }
     }
 
+    test("homo_sapiens [chr20] - consensus view, min-samples 2") {
+
+        config "./consensus_threshold.config"
+
+        when {
+            process {
+                """
+                ch_beds = CUSTOM_ORFNORMALISE_RIBOTISH.out.bed12
+                    .mix(CUSTOM_ORFNORMALISE_RIBOCODE.out.bed12)
+                    .mix(CUSTOM_ORFNORMALISE_RIBOTISH_SAMPLE2.out.bed12)
+                    .map { _meta, bed -> bed }
+                    .collect()
+                    .map { beds -> [ 'cohort', beds ] }
+                ch_tsvs = CUSTOM_ORFNORMALISE_RIBOTISH.out.tsv
+                    .mix(CUSTOM_ORFNORMALISE_RIBOCODE.out.tsv)
+                    .mix(CUSTOM_ORFNORMALISE_RIBOTISH_SAMPLE2.out.tsv)
+                    .map { _meta, tsv -> tsv }
+                    .collect()
+                    .map { tsvs -> [ 'cohort', tsvs ] }
+                input[0] = ch_beds
+                    .combine(ch_tsvs, by: 0)
+                    .map { _k, beds, tsvs -> [ [id: 'cohort'], beds, tsvs ] }
+                """
+            }
+        }
+
+        then {
+            def cols      = path(process.out.catalogue_tsv[0][1]).text.readLines()[0].split('\t') as List
+            def full_rows = path(process.out.catalogue_tsv[0][1]).text.readLines().drop(1)
+            def con_rows  = path(process.out.consensus_tsv[0][1]).text.readLines().drop(1)
+            def n_samples = cols.indexOf('n_samples')
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                // The full catalogue is unaffected by the threshold.
+                { assert full_rows.size() > 0 },
+                // The 2-sample ORF survives; single-sample ORFs are dropped, so
+                // the consensus view is a non-empty strict subset of the full one.
+                { assert con_rows.size() > 0 },
+                { assert con_rows.size() < full_rows.size() },
+                { assert con_rows.collect { it.split('\t') }.every { it[n_samples].toInteger() >= 2 } }
+            )
+        }
+    }
+
 }

--- a/modules/nf-core/custom/orfmerge/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/orfmerge/tests/main.nf.test.snap
@@ -35,6 +35,30 @@
                     ]
                 ],
                 "4": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,d6af31aac0548c8ce0f447be02d06397"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
+                "7": [
                     "versions.yml:md5,8e0b24bd9e91050a8715f1b1b61f0805"
                 ],
                 "bed12": [
@@ -51,6 +75,30 @@
                             "id": "cohort"
                         },
                         "cohort.catalogue.tsv:md5,d6af31aac0548c8ce0f447be02d06397"
+                    ]
+                ],
+                "consensus_bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "consensus_orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
+                "consensus_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,d6af31aac0548c8ce0f447be02d06397"
                     ]
                 ],
                 "multiqc": [
@@ -74,10 +122,139 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-16T11:49:30.349632545",
         "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.04.8"
+        },
+        "timestamp": "2026-06-25T15:00:35.322566328"
+    },
+    "homo_sapiens [chr20] - consensus view, min-samples 2": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.tsv:md5,d6af31aac0548c8ce0f447be02d06397"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.mqc.tsv:md5,d8e6da169d5d0a95b9bb4332290d1dd6"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,b3da4afa383cabedf6d8fbb646bb2ab0"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,70d7781708ccc279c1a2e122bf64700e"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,b066d24e30ebe24a89a664275e5af301"
+                    ]
+                ],
+                "7": [
+                    "versions.yml:md5,8e0b24bd9e91050a8715f1b1b61f0805"
+                ],
+                "bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "catalogue_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.tsv:md5,d6af31aac0548c8ce0f447be02d06397"
+                    ]
+                ],
+                "consensus_bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,b3da4afa383cabedf6d8fbb646bb2ab0"
+                    ]
+                ],
+                "consensus_orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,b066d24e30ebe24a89a664275e5af301"
+                    ]
+                ],
+                "consensus_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,70d7781708ccc279c1a2e122bf64700e"
+                    ]
+                ],
+                "multiqc": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.mqc.tsv:md5,d8e6da169d5d0a95b9bb4332290d1dd6"
+                    ]
+                ],
+                "orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,8e0b24bd9e91050a8715f1b1b61f0805"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.04.8"
+        },
+        "timestamp": "2026-06-25T15:00:42.506142784"
     }
 }

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
@@ -105,11 +105,12 @@ workflow ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE {
     catalogue_aa_fasta = CUSTOM_ORFCOLLAPSE.out.aa_fasta.mix(ch_routed.keep.map { meta, _bed, _tsv, _o2g, _mqc, aa -> [ meta, aa ] })
     multiqc            = CUSTOM_ORFCOLLAPSE.out.multiqc.mix(ch_routed.keep.map { meta, _bed, _tsv, _o2g, mqc, _aa -> [ meta, mqc ] })
 
-    // Consensus view of the merged catalogue (ORFs meeting the merger's
-    // --min-callers / --min-samples thresholds). It is a cross-caller /
-    // cross-sample evidence filter applied at merge time, so it precedes the
-    // optional amino-acid collapse and is emitted straight from the merger.
-    consensus_bed12           = CUSTOM_ORFMERGE.out.consensus_bed12
-    consensus_tsv             = CUSTOM_ORFMERGE.out.consensus_tsv
-    consensus_orf_to_gene_tsv = CUSTOM_ORFMERGE.out.consensus_orf_to_gene_tsv
+    // Consensus view: ORFs meeting the --min-callers / --min-samples thresholds.
+    // The filter is applied to the final catalogue, so when the amino-acid
+    // collapse runs the consensus is the high-confidence subset of the
+    // de-redundified catalogue (from CUSTOM_ORFCOLLAPSE); otherwise it comes
+    // straight from the merger.
+    consensus_bed12           = val_collapse ? CUSTOM_ORFCOLLAPSE.out.consensus_bed12 : CUSTOM_ORFMERGE.out.consensus_bed12
+    consensus_tsv             = val_collapse ? CUSTOM_ORFCOLLAPSE.out.consensus_tsv : CUSTOM_ORFMERGE.out.consensus_tsv
+    consensus_orf_to_gene_tsv = val_collapse ? CUSTOM_ORFCOLLAPSE.out.consensus_orf_to_gene_tsv : CUSTOM_ORFMERGE.out.consensus_orf_to_gene_tsv
 }

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
@@ -104,4 +104,12 @@ workflow ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE {
     orf_to_gene_tsv    = CUSTOM_ORFCOLLAPSE.out.orf_to_gene_tsv.mix(ch_routed.keep.map { meta, _bed, _tsv, o2g, _mqc, _aa -> [ meta, o2g ] })
     catalogue_aa_fasta = CUSTOM_ORFCOLLAPSE.out.aa_fasta.mix(ch_routed.keep.map { meta, _bed, _tsv, _o2g, _mqc, aa -> [ meta, aa ] })
     multiqc            = CUSTOM_ORFCOLLAPSE.out.multiqc.mix(ch_routed.keep.map { meta, _bed, _tsv, _o2g, mqc, _aa -> [ meta, mqc ] })
+
+    // Consensus view of the merged catalogue (ORFs meeting the merger's
+    // --min-callers / --min-samples thresholds). It is a cross-caller /
+    // cross-sample evidence filter applied at merge time, so it precedes the
+    // optional amino-acid collapse and is emitted straight from the merger.
+    consensus_bed12           = CUSTOM_ORFMERGE.out.consensus_bed12
+    consensus_tsv             = CUSTOM_ORFMERGE.out.consensus_tsv
+    consensus_orf_to_gene_tsv = CUSTOM_ORFMERGE.out.consensus_orf_to_gene_tsv
 }

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
@@ -97,9 +97,10 @@ output:
         Structure: [ val(meta), path(tsv) ]
   - consensus_bed12:
       description: |
-        Consensus view of the merged catalogue as BED12 (ORFs meeting the
-        merger's --min-callers / --min-samples thresholds; identical to the
-        full catalogue at the defaults of 1/1).
+        Consensus view of the catalogue as BED12 (ORFs meeting the
+        --min-callers / --min-samples thresholds; identical to the full
+        catalogue at the defaults of 1/1). Taken from the amino-acid collapse
+        when it runs, otherwise from the merger.
         Structure: [ val(meta), path(bed12) ]
   - consensus_tsv:
       description: |

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
@@ -95,6 +95,20 @@ output:
       description: |
         MultiQC custom-content sidecar (per-class ORF counts).
         Structure: [ val(meta), path(tsv) ]
+  - consensus_bed12:
+      description: |
+        Consensus view of the merged catalogue as BED12 (ORFs meeting the
+        merger's --min-callers / --min-samples thresholds; identical to the
+        full catalogue at the defaults of 1/1).
+        Structure: [ val(meta), path(bed12) ]
+  - consensus_tsv:
+      description: |
+        Consensus-filtered per-ORF table, same columns as the full catalogue.
+        Structure: [ val(meta), path(tsv) ]
+  - consensus_orf_to_gene_tsv:
+      description: |
+        ORF-to-gene mapping restricted to the consensus-filtered ORFs.
+        Structure: [ val(meta), path(tsv) ]
 authors:
   - "@pinin4fjords"
 maintainers:

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/nextflow.config
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/nextflow.config
@@ -4,7 +4,7 @@ process {
         ext.args   = '-split -s -nameOnly'
     }
     withName: 'ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:SEQKIT_TRANSLATE' {
-        ext.prefix = { "${meta.id}.catalogue" }
+        ext.prefix = { "${meta.id}.catalogue.aa" }
         ext.args   = '--trim'
     }
     withName: 'ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE:MMSEQS_EASYCLUSTER' {

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/tests/main.nf.test.snap
@@ -170,7 +170,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.fasta:md5,8cbe5d11cbc9cfe0ef67d875b2632fe0"
+                        "cohort.catalogue.aa.fasta:md5,8cbe5d11cbc9cfe0ef67d875b2632fe0"
                     ]
                 ],
                 "4": [
@@ -210,7 +210,7 @@
                         {
                             "id": "cohort"
                         },
-                        "cohort.catalogue.fasta:md5,8cbe5d11cbc9cfe0ef67d875b2632fe0"
+                        "cohort.catalogue.aa.fasta:md5,8cbe5d11cbc9cfe0ef67d875b2632fe0"
                     ]
                 ],
                 "catalogue_bed12": [
@@ -275,6 +275,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.04.8"
         },
-        "timestamp": "2026-06-25T15:38:25.026291883"
+        "timestamp": "2026-06-25T20:02:00.203522045"
     }
 }

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/tests/main.nf.test.snap
@@ -42,6 +42,30 @@
                         "cohort.catalogue.mqc.tsv:md5,d8e6da169d5d0a95b9bb4332290d1dd6"
                     ]
                 ],
+                "5": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
+                    ]
+                ],
+                "7": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
                 "catalogue_aa_fasta": [
                     [
                         {
@@ -66,6 +90,30 @@
                         "cohort.catalogue.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
                     ]
                 ],
+                "consensus_bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "consensus_orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
+                "consensus_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
+                    ]
+                ],
                 "multiqc": [
                     [
                         {
@@ -84,11 +132,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-16T12:00:23.161222511",
         "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.04.8"
+        },
+        "timestamp": "2026-06-25T15:38:17.504637551"
     },
     "homo_sapiens [chr20] - ribotish + ribocode - collapse disabled": {
         "content": [
@@ -133,6 +181,30 @@
                         "cohort.catalogue.mqc.tsv:md5,d8e6da169d5d0a95b9bb4332290d1dd6"
                     ]
                 ],
+                "5": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
+                    ]
+                ],
+                "7": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
                 "catalogue_aa_fasta": [
                     [
                         {
@@ -157,6 +229,30 @@
                         "cohort.catalogue.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
                     ]
                 ],
+                "consensus_bed12": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.bed12:md5,59b9b0c4ceb890b58b8bcde4fecb2ac7"
+                    ]
+                ],
+                "consensus_orf_to_gene_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.orf_to_gene.tsv:md5,eebb86a1c52a7418ee9dc68c53bd9866"
+                    ]
+                ],
+                "consensus_tsv": [
+                    [
+                        {
+                            "id": "cohort"
+                        },
+                        "cohort.catalogue.consensus.tsv:md5,3f078bae5f266aed6d218eda26dc78fc"
+                    ]
+                ],
                 "multiqc": [
                     [
                         {
@@ -175,10 +271,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-16T12:00:30.555944584",
         "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
-        }
+            "nf-test": "0.9.3",
+            "nextflow": "25.04.8"
+        },
+        "timestamp": "2026-06-25T15:38:25.026291883"
     }
 }


### PR DESCRIPTION
## Changes

Adds a configurable **consensus view** to the cross-sample ORF catalogue, alongside the existing full catalogue (which is always emitted, unchanged at the defaults).

- `custom/orfmerge` and `custom/orfcollapse` both gain `--min-callers N` / `--min-samples M` (default 1) and emit `*.consensus.{bed12,tsv,orf_to_gene.tsv}` filtered to ORFs supported by at least that many distinct callers and recurring in at least that many samples.
- The filter is applied to the **final** catalogue: when the amino-acid collapse runs, the consensus is the high-confidence subset of the de-redundified catalogue (so a folded micropeptide is judged on its combined cross-caller / cross-sample evidence); when collapse is disabled, it comes straight from the merger.
- At the defaults (`1`/`1`) nothing is filtered, so the consensus view equals the full catalogue and existing behaviour is unchanged. Raising either threshold (e.g. `--min-callers 2`) yields a higher-confidence catalogue that tames downstream ORF-level multiple testing, without discarding the full union.

The filter operates on the per-ORF evidence the catalogue already records (`called_by_<caller>` indicators and the distinct-sample set), so no new computation is introduced beyond writing the filtered files.

## Subworkflow

`orftable_fasta_gtf_buildorfcatalogue` exposes the consensus outputs (`consensus_bed12` / `consensus_tsv` / `consensus_orf_to_gene_tsv`) through its emit interface, sourced from `CUSTOM_ORFCOLLAPSE` when the collapse runs (`val_collapse`) and from `CUSTOM_ORFMERGE` otherwise.

## Other

- `SEQKIT_TRANSLATE` output prefix aligned to `.catalogue.aa` (matching its `.catalogue.nt` `BEDTOOLS_GETFASTA` sibling).
- `custom/orfcollapse` docstring corrected: the smORF-only restriction and locus-agnostic global-identity clustering are this module's design choices, not properties of the GENCODE consolidation it is inspired by; `--min-seq-id 0.9` approximates rather than reproduces `collapse_cutoff 0.9`.
- Replaced the modules' parenthesized/`ExitStack` multi-file writes with plain sequential `with` blocks, valid on the repo's `py38` target.

## Tests

- `custom/orfmerge`: added a `--min-samples 2` case asserting the consensus view is a non-empty strict subset of the full catalogue.
- Module and subworkflow snapshots regenerated.
