### PR TITLE
feat: add bwamem3 modules (index and mem)

### DIFF
--- a/modules/nf-core/bwamem3/index/environment.yml
+++ b/modules/nf-core/bwamem3/index/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/bwa-mem3
+  - "bioconda::bwa-mem3=0.3.0"

--- a/modules/nf-core/bwamem3/index/main.nf
+++ b/modules/nf-core/bwamem3/index/main.nf
@@ -1,0 +1,44 @@
+process BWAMEM3_INDEX {
+    tag "${meta.id}"
+    // NOTE bwa-mem3 builds an FM-index with libsais; peak memory scales with the reference size.
+    memory { 280.MB * Math.ceil(fasta.size() / 10000000) * task.attempt }
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/45/45a11b91903b7e31b9418ca5fe6852c82a2b1ee1b0772ad6623618cb0ba9da55/data'
+        : 'community.wave.seqera.io/library/bwa-mem3:0.3.0--89c56b3ab74a5e5c'}"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("bwamem3"), emit: index
+    tuple val("${task.process}"), val('bwamem3'), eval("bwa-mem3 version | sed -nE '1 s/^([0-9]+(\\.[0-9]+)+).*/\\1/p'"), emit: versions_bwamem3, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${fasta}"
+    def args = task.ext.args ?: ''
+    """
+    mkdir bwamem3
+    bwa-mem3 \\
+        index \\
+        $args \\
+        -t ${task.cpus} \\
+        -p bwamem3/${prefix} \\
+        $fasta
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${fasta}"
+    """
+    mkdir bwamem3
+    touch bwamem3/${prefix}.0123
+    touch bwamem3/${prefix}.amb
+    touch bwamem3/${prefix}.ann
+    touch bwamem3/${prefix}.bwt.2bit.64
+    touch bwamem3/${prefix}.pac
+    """
+}

--- a/modules/nf-core/bwamem3/index/meta.yml
+++ b/modules/nf-core/bwamem3/index/meta.yml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "bwamem3_index"
+description: Create bwa-mem3 index for reference genome
+keywords:
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - "bwamem3":
+      description: "Short-read aligner derived from bwa-mem2 with correctness fixes,
+        performance improvements, and methylation-aware alignment."
+      homepage: "https://github.com/fg-labs/bwa-mem3"
+      documentation: "https://github.com/fg-labs/bwa-mem3"
+      tool_dev_url: "https://github.com/fg-labs/bwa-mem3"
+      licence: ["MIT AND Apache-2.0"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        type: file
+        description: Input genome fasta file
+        ontologies:
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
+output:
+  index:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - bwamem3:
+          type: directory
+          description: bwa-mem3 genome index files
+          pattern: "*.{0123,amb,ann,bwt.2bit.64,pac}"
+          ontologies:
+            - edam: "http://edamontology.org/data_3210"
+  versions_bwamem3:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwamem3:
+          type: string
+          description: The name of the tool
+      - bwa-mem3 version | sed -nE '1 s/^([0-9]+(\.[0-9]+)+).*/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwamem3:
+          type: string
+          description: The name of the tool
+      - bwa-mem3 version | sed -nE '1 s/^([0-9]+(\.[0-9]+)+).*/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/bwamem3/index/tests/main.nf.test
+++ b/modules/nf-core/bwamem3/index/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_process {
+
+    name "Test Process BWAMEM3_INDEX"
+    script "../main.nf"
+    process "BWAMEM3_INDEX"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bwamem3"
+    tag "bwamem3/index"
+
+    test("sarscov2 - fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fasta - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bwamem3/index/tests/main.nf.test.snap
+++ b/modules/nf-core/bwamem3/index/tests/main.nf.test.snap
@@ -1,0 +1,66 @@
+{
+    "sarscov2 - fasta - stub": {
+        "content": [
+            {
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "genome.fasta.0123:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genome.fasta.amb:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genome.fasta.ann:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genome.fasta.bwt.2bit.64:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genome.fasta.pac:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions_bwamem3": [
+                    [
+                        "BWAMEM3_INDEX",
+                        "bwamem3",
+                        "0.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-05T12:45:59.541588",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - fasta": {
+        "content": [
+            {
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "genome.fasta.0123:md5,b02870de80106104abcb03cd9463e7d8",
+                            "genome.fasta.amb:md5,3a68b8b2287e07dd3f5f95f4344ba76e",
+                            "genome.fasta.ann:md5,c32e11f6c859f166c7525a9c1d583567",
+                            "genome.fasta.bwt.2bit.64:md5,d097a1b82dee375d41a1ea69895a9216",
+                            "genome.fasta.pac:md5,983e3d2cd6f36e2546e6d25a0da78d66"
+                        ]
+                    ]
+                ],
+                "versions_bwamem3": [
+                    [
+                        "BWAMEM3_INDEX",
+                        "bwamem3",
+                        "0.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-05T12:45:54.003393",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/bwamem3/mem/environment.yml
+++ b/modules/nf-core/bwamem3/mem/environment.yml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/bwa-mem3
+  - "bioconda::bwa-mem3=0.3.0"
+  # renovate: datasource=conda depName=bioconda/htslib
+  - "bioconda::htslib=1.23.1"
+  # renovate: datasource=conda depName=bioconda/samtools
+  - "bioconda::samtools=1.23.1"

--- a/modules/nf-core/bwamem3/mem/main.nf
+++ b/modules/nf-core/bwamem3/mem/main.nf
@@ -1,0 +1,71 @@
+process BWAMEM3_MEM {
+    tag "${meta.id}"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/80/80064f4b7f3a9d932fd4019f39a56ed949d403765b6a11a849c7ce19e74490ed/data'
+        : 'community.wave.seqera.io/library/bwa-mem3_samtools_htslib:c28a809633c294ed'}"
+
+    input:
+    tuple val(meta), path(reads)
+    tuple val(meta2), path(index)
+    tuple val(meta3), path(fasta)
+    val sort_bam
+
+    output:
+    tuple val(meta), path("*.{sam,bam,cram}"), emit: aligned
+    tuple val(meta), path("*.{bai,csi,crai}"), emit: index, optional: true
+    tuple val("${task.process}"), val('bwamem3'), eval("bwa-mem3 version | sed -nE '1 s/^([0-9]+(\\.[0-9]+)+).*/\\1/p'"), emit: versions_bwamem3, topic: versions
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), emit: versions_samtools, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def samtools_command = sort_bam ? 'sort' : 'view'
+
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher = (args2 =~ extension_pattern)
+    def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    def reference = fasta && extension == "cram" ? "--reference ${fasta}" : ""
+    if (!fasta && extension == "cram") {
+        error("Fasta reference is required for CRAM output")
+    }
+    """
+    INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
+
+    bwa-mem3 \\
+        mem \\
+        ${args} \\
+        -t ${task.cpus} \\
+        \$INDEX \\
+        ${reads} \\
+        | samtools ${samtools_command} ${args2} -@ ${task.cpus} ${reference} -o ${prefix}.${extension} -
+    """
+
+    stub:
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher = (args2 =~ extension_pattern)
+    def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    if (!fasta && extension == "cram") {
+        error("Fasta reference is required for CRAM output")
+    }
+
+    def create_index = ""
+    if (extension == "cram") {
+        create_index = "touch ${prefix}.crai"
+    }
+    else if (extension == "bam") {
+        create_index = "touch ${prefix}.csi"
+    }
+    """
+    touch ${prefix}.${extension}
+    ${create_index}
+    """
+}

--- a/modules/nf-core/bwamem3/mem/meta.yml
+++ b/modules/nf-core/bwamem3/mem/meta.yml
@@ -1,0 +1,137 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "bwamem3_mem"
+description: Align fastq reads to a fasta reference using bwa-mem3
+keywords:
+  - mem
+  - bwa
+  - alignment
+  - map
+  - fastq
+  - bam
+  - sam
+tools:
+  - "bwamem3":
+      description: "Short-read aligner derived from bwa-mem2 with correctness fixes,
+        performance improvements, and methylation-aware alignment."
+      homepage: "https://github.com/fg-labs/bwa-mem3"
+      documentation: "https://github.com/fg-labs/bwa-mem3"
+      tool_dev_url: "https://github.com/fg-labs/bwa-mem3"
+      licence: ["MIT AND Apache-2.0"]
+      identifier: ""
+  - "samtools":
+      description: "Tools for dealing with SAM, BAM and CRAM files"
+      homepage: "http://www.htslib.org"
+      documentation: "http://www.htslib.org/doc/samtools.html"
+      doi: "10.1093/bioinformatics/btp352"
+      licence: ["MIT"]
+      identifier: "biotools:samtools"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+        ontologies:
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1930"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference/index information
+          e.g. [ id:'test' ]
+    - index:
+        type: file
+        description: bwa-mem3 genome index files
+        pattern: "Directory containing bwa-mem3 index *.{0123,amb,ann,bwt.2bit.64,pac}"
+        ontologies:
+          - edam: "http://edamontology.org/data_3210"
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome' ]
+    - fasta:
+        type: file
+        description: Reference genome in FASTA format
+        pattern: "*.{fa,fasta,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
+  - sort_bam:
+      type: boolean
+      description: use samtools sort (true) or samtools view (false)
+output:
+  aligned:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{sam,bam,cram}":
+          type: file
+          description: Output SAM/BAM/CRAM file containing read alignments
+          pattern: "*.{sam,bam,cram}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2573"
+            - edam: "http://edamontology.org/format_2572"
+            - edam: "http://edamontology.org/format_3462"
+  index:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{bai,csi,crai}":
+          type: file
+          description: Index file for the aligned BAM/CRAM file
+          pattern: "*.{bai,csi,crai}"
+          ontologies: []
+  versions_bwamem3:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwamem3:
+          type: string
+          description: The name of the tool
+      - bwa-mem3 version | sed -nE '1 s/^([0-9]+(\.[0-9]+)+).*/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - bwamem3:
+          type: string
+          description: The name of the tool
+      - bwa-mem3 version | sed -nE '1 s/^([0-9]+(\.[0-9]+)+).*/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/bwamem3/mem/tests/main.nf.test
+++ b/modules/nf-core/bwamem3/mem/tests/main.nf.test
@@ -1,0 +1,174 @@
+nextflow_process {
+
+    name "Test Process BWAMEM3_MEM"
+    script "../main.nf"
+    process "BWAMEM3_MEM"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bwamem3"
+    tag "bwamem3/mem"
+    tag "bwamem3/index"
+
+    setup {
+        run("BWAMEM3_INDEX") {
+            script "../../index/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    [:], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                """
+            }
+        }
+    }
+
+    test("sarscov2 - fastq, index, fasta, false") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
+                ])
+                input[1] = BWAMEM3_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.aligned[0][1]).getHeaderMD5(),
+                    bam(process.out.aligned[0][1]).getReadsMD5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - fastq, index, fasta, true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
+                ])
+                input[1] = BWAMEM3_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.aligned[0][1]).getHeaderMD5(),
+                    bam(process.out.aligned[0][1]).getReadsMD5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, false") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = BWAMEM3_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.aligned[0][1]).getHeaderMD5(),
+                    bam(process.out.aligned[0][1]).getReadsMD5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = BWAMEM3_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.aligned[0][1]).getHeaderMD5(),
+                    bam(process.out.aligned[0][1]).getReadsMD5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, true - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = BWAMEM3_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/bwamem3/mem/tests/main.nf.test.snap
+++ b/modules/nf-core/bwamem3/mem/tests/main.nf.test.snap
@@ -1,0 +1,153 @@
+{
+    "sarscov2 - [fastq1, fastq2], index, fasta, false": {
+        "content": [
+            "b56fc692668c91ca145664f20b26203d",
+            "57aeef88ed701a8ebc8e2f0a381b2a6",
+            {
+                "versions_bwamem3": [
+                    [
+                        "BWAMEM3_MEM",
+                        "bwamem3",
+                        "0.3.0"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "BWAMEM3_MEM",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T10:09:40.964957",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, true - stub": {
+        "content": [
+            {
+                "aligned": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_bwamem3": [
+                    [
+                        "BWAMEM3_MEM",
+                        "bwamem3",
+                        "0.3.0"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "BWAMEM3_MEM",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-05T12:47:06.412821",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, true": {
+        "content": [
+            "fe740265bf7094b01d230c3e47c410eb",
+            "af8628d9df18b2d3d4f6fd47ef2bb872",
+            {
+                "versions_bwamem3": [
+                    [
+                        "BWAMEM3_MEM",
+                        "bwamem3",
+                        "0.3.0"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "BWAMEM3_MEM",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T10:09:53.876474",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - fastq, index, fasta, false": {
+        "content": [
+            "9ef11b7211dbe8923d9e86a1f89d91d7",
+            "798439cbd7fd81cbcc5078022dc5479d",
+            {
+                "versions_bwamem3": [
+                    [
+                        "BWAMEM3_MEM",
+                        "bwamem3",
+                        "0.3.0"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "BWAMEM3_MEM",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T10:09:15.08671",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - fastq, index, fasta, true": {
+        "content": [
+            "5655952e689a11a50037538ebc0214bc",
+            "94fcf617f5b994584c4e8d4044e16b4f",
+            {
+                "versions_bwamem3": [
+                    [
+                        "BWAMEM3_MEM",
+                        "bwamem3",
+                        "0.3.0"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "BWAMEM3_MEM",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T10:09:28.089372",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds two new modules for [bwa-mem3](https://github.com/fg-labs/bwa-mem3), a short-read aligner derived from bwa-mem2 with correctness fixes, performance improvements, and methylation-aware alignment:

- **`bwamem3/index`** — builds an FM-index for a reference genome (`.0123`, `.amb`, `.ann`, `.bwt.2bit.64`, `.pac`), mirroring `bwamem2/index`.
- **`bwamem3/mem`** — aligns FastQ reads to a bwa-mem3 index, piping through `samtools sort`/`view` (selected via the `sort_bam` input) to emit SAM/BAM/CRAM plus optional indices, mirroring `bwamem2/mem`.

Suggested reading order: `index` first, then `mem`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] Add a resource `label`.
- [x] Use BioConda and BioContainers if possible to fulfil software requirements (`bioconda::bwa-mem3=0.3.0`; Seqera Wave community containers, including a `bwa-mem3 + samtools + htslib` image for `mem`).
- [x] `nf-core modules test bwamem3/index --profile docker` (2/2 passing) and `bwamem3/mem` (5/5 passing).
- [x] Broadcast software version numbers to `topic: versions`.
