### PR TITLE
feat: add minibwa modules (index and map)

### DIFF
--- a/modules/nf-core/minibwa/index/environment.yml
+++ b/modules/nf-core/minibwa/index/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/minibwa
+  - "bioconda::minibwa=0.2"

--- a/modules/nf-core/minibwa/index/main.nf
+++ b/modules/nf-core/minibwa/index/main.nf
@@ -1,0 +1,41 @@
+process MINIBWA_INDEX {
+    tag "$fasta"
+    // NOTE minibwa builds an FM-index with libsais; peak memory scales with the reference size.
+    memory { 280.MB * Math.ceil(fasta.size() / 10000000) * task.attempt }
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/65/65579835ae1cda4cac4bec86b6210473b95f88d2ce8e4d7b6257a81bee1e8a27/data'
+        : 'community.wave.seqera.io/library/minibwa:0.2--38d72f7ba96c74d9'}"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("minibwa"), emit: index
+    tuple val("${task.process}"), val('minibwa'), eval('minibwa version | grep -o -E "[0-9]+(\\.[0-9]+)+"'), emit: versions_minibwa, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${fasta}"
+    def args = task.ext.args ?: ''
+    """
+    mkdir minibwa
+    minibwa \\
+        index \\
+        $args \\
+        -t ${task.cpus} \\
+        $fasta \\
+        minibwa/${prefix}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${fasta}"
+    """
+    mkdir minibwa
+    touch minibwa/${prefix}.l2b
+    touch minibwa/${prefix}.mbw
+    """
+}

--- a/modules/nf-core/minibwa/index/meta.yml
+++ b/modules/nf-core/minibwa/index/meta.yml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "minibwa_index"
+description: Create a minibwa index for a reference genome
+keywords:
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - "minibwa":
+      description: "Aligning short and accurate long reads to a reference genome, a
+        reimplementation of bwa-mem."
+      homepage: "https://github.com/lh3/minibwa"
+      documentation: "https://github.com/lh3/minibwa"
+      tool_dev_url: "https://github.com/lh3/minibwa"
+      licence: ["GPL-2.0-or-later"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        type: file
+        description: Input genome fasta file
+        ontologies:
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
+output:
+  index:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - minibwa:
+          type: directory
+          description: minibwa genome index files
+          pattern: "*.{l2b,mbw}"
+          ontologies:
+            - edam: "http://edamontology.org/data_3210"
+  versions_minibwa:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - minibwa:
+          type: string
+          description: The name of the tool
+      - minibwa version | grep -o -E "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - minibwa:
+          type: string
+          description: The name of the tool
+      - minibwa version | grep -o -E "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/minibwa/index/tests/main.nf.test
+++ b/modules/nf-core/minibwa/index/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_process {
+
+    name "Test Process MINIBWA_INDEX"
+    script "../main.nf"
+    process "MINIBWA_INDEX"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "minibwa"
+    tag "minibwa/index"
+
+    test("sarscov2 - fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fasta - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/minibwa/index/tests/main.nf.test.snap
+++ b/modules/nf-core/minibwa/index/tests/main.nf.test.snap
@@ -1,0 +1,60 @@
+{
+    "sarscov2 - fasta - stub": {
+        "content": [
+            {
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "genome.fasta.l2b:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genome.fasta.mbw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions_minibwa": [
+                    [
+                        "MINIBWA_INDEX",
+                        "minibwa",
+                        "0.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-01T16:48:44.253299",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - fasta": {
+        "content": [
+            {
+                "index": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "genome.fasta.l2b:md5,ce853b9123f9af32450d99760f63f434",
+                            "genome.fasta.mbw:md5,b7c37be4b0070d844f99ed1120bdab50"
+                        ]
+                    ]
+                ],
+                "versions_minibwa": [
+                    [
+                        "MINIBWA_INDEX",
+                        "minibwa",
+                        "0.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-01T16:48:40.594179",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/minibwa/map/environment.yml
+++ b/modules/nf-core/minibwa/map/environment.yml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/htslib
+  - "bioconda::htslib=1.23.1"
+  # renovate: datasource=conda depName=bioconda/minibwa
+  - "bioconda::minibwa=0.2"
+  # renovate: datasource=conda depName=bioconda/samtools
+  - "bioconda::samtools=1.23.1"

--- a/modules/nf-core/minibwa/map/main.nf
+++ b/modules/nf-core/minibwa/map/main.nf
@@ -1,0 +1,71 @@
+process MINIBWA_MAP {
+    tag "${meta.id}"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ec/ecd6faa7d0bc3c9a6f49bb0ace74108375850ae8ba4ae6c5fbcc1679f756b374/data'
+        : 'community.wave.seqera.io/library/minibwa_samtools_htslib:6f37dc94f6ac9e37'}"
+
+    input:
+    tuple val(meta), path(reads)
+    tuple val(meta2), path(index)
+    tuple val(meta3), path(fasta)
+    val sort_bam
+
+    output:
+    tuple val(meta), path("*.{sam,bam,cram}"), emit: aligned
+    tuple val(meta), path("*.{bai,csi,crai}"), emit: index, optional: true
+    tuple val("${task.process}"), val('minibwa'), eval('minibwa version | grep -o -E "[0-9]+(\\.[0-9]+)+"'), emit: versions_minibwa, topic: versions
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), emit: versions_samtools, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def samtools_command = sort_bam ? 'sort' : 'view'
+
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher = (args2 =~ extension_pattern)
+    def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    def reference = fasta && extension == "cram" ? "--reference ${fasta}" : ""
+    if (!fasta && extension == "cram") {
+        error("Fasta reference is required for CRAM output")
+    }
+    """
+    INDEX=`find -L ./ -name "*.l2b" | sed 's/\\.l2b\$//'`
+
+    minibwa \\
+        map \\
+        ${args} \\
+        -t ${task.cpus} \\
+        \$INDEX \\
+        ${reads} \\
+        | samtools ${samtools_command} ${args2} -@ ${task.cpus} ${reference} -o ${prefix}.${extension} -
+    """
+
+    stub:
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension_pattern = /(--output-fmt|-O)+\s+(\S+)/
+    def extension_matcher = (args2 =~ extension_pattern)
+    def extension = extension_matcher.getCount() > 0 ? extension_matcher[0][2].toLowerCase() : "bam"
+    if (!fasta && extension == "cram") {
+        error("Fasta reference is required for CRAM output")
+    }
+
+    def create_index = ""
+    if (extension == "cram") {
+        create_index = "touch ${prefix}.crai"
+    }
+    else if (extension == "bam") {
+        create_index = "touch ${prefix}.csi"
+    }
+    """
+    touch ${prefix}.${extension}
+    ${create_index}
+    """
+}

--- a/modules/nf-core/minibwa/map/meta.yml
+++ b/modules/nf-core/minibwa/map/meta.yml
@@ -1,0 +1,137 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "minibwa_map"
+description: Align fastq reads to a fasta reference using minibwa
+keywords:
+  - map
+  - mem
+  - alignment
+  - fastq
+  - bam
+  - sam
+tools:
+  - "minibwa":
+      description: "Aligning short and accurate long reads to a reference genome, a
+        reimplementation of bwa-mem."
+      homepage: "https://github.com/lh3/minibwa"
+      documentation: "https://github.com/lh3/minibwa"
+      tool_dev_url: "https://github.com/lh3/minibwa"
+      licence: ["GPL-2.0-or-later"]
+      identifier: ""
+  - "samtools":
+      description: "Tools for dealing with SAM, BAM and CRAM files"
+      homepage: "http://www.htslib.org"
+      documentation: "http://www.htslib.org/doc/samtools.html"
+      doi: "10.1093/bioinformatics/btp352"
+      licence: ["MIT"]
+      identifier: "biotools:samtools"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+        ontologies:
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1930"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference/index information
+          e.g. [ id:'test' ]
+    - index:
+        type: file
+        description: minibwa genome index files
+        pattern: "Directory containing minibwa index *.{l2b,mbw}"
+        ontologies:
+          - edam: "http://edamontology.org/data_3210"
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome' ]
+    - fasta:
+        type: file
+        description: Reference genome in FASTA format
+        pattern: "*.{fa,fasta,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
+  - sort_bam:
+      type: boolean
+      description: use samtools sort (true) or samtools view (false)
+      pattern: "true or false"
+output:
+  aligned:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{sam,bam,cram}":
+          type: file
+          description: Output SAM/BAM/CRAM file containing read alignments
+          pattern: "*.{sam,bam,cram}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2573"
+            - edam: "http://edamontology.org/format_2572"
+            - edam: "http://edamontology.org/format_3462"
+  index:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{bai,csi,crai}":
+          type: file
+          description: Index file for the aligned BAM/CRAM file
+          pattern: "*.{bai,csi,crai}"
+          ontologies: []
+  versions_minibwa:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - minibwa:
+          type: string
+          description: The name of the tool
+      - minibwa version | grep -o -E "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - minibwa:
+          type: string
+          description: The name of the tool
+      - minibwa version | grep -o -E "[0-9]+(\.[0-9]+)+":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools version | sed '1!d;s/.* //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/minibwa/map/tests/main.nf.test
+++ b/modules/nf-core/minibwa/map/tests/main.nf.test
@@ -1,0 +1,143 @@
+nextflow_process {
+
+    name "Test Process MINIBWA_MAP"
+    script "../main.nf"
+    process "MINIBWA_MAP"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "minibwa"
+    tag "minibwa/map"
+    tag "minibwa/index"
+
+    setup {
+        run("MINIBWA_INDEX") {
+            script "../../index/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    [:], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ])
+                """
+            }
+        }
+    }
+
+    test("sarscov2 - fastq, index, fasta, false") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
+                ])
+                input[1] = MINIBWA_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.aligned[0][1]).getHeaderMD5(),
+                    bam(process.out.aligned[0][1]).getReadsMD5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - fastq, index, fasta, true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:true ], // meta map
+                    [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)]
+                ])
+                input[1] = MINIBWA_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.aligned[0][1]).getHeaderMD5(),
+                    bam(process.out.aligned[0][1]).getReadsMD5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, true") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = MINIBWA_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.aligned[0][1]).getHeaderMD5(),
+                    bam(process.out.aligned[0][1]).getReadsMD5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [fastq1, fastq2], index, fasta, true - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = MINIBWA_INDEX.out.index
+                input[2] = Channel.of([[:], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)])
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/minibwa/map/tests/main.nf.test.snap
+++ b/modules/nf-core/minibwa/map/tests/main.nf.test.snap
@@ -1,0 +1,126 @@
+{
+    "sarscov2 - [fastq1, fastq2], index, fasta, true - stub": {
+        "content": [
+            {
+                "aligned": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_minibwa": [
+                    [
+                        "MINIBWA_MAP",
+                        "minibwa",
+                        "0.2"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "MINIBWA_MAP",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-01T16:49:16.00544",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - [fastq1, fastq2], index, fasta, true": {
+        "content": [
+            "16004c47bd99242197a941ba808f222d",
+            "f3a1593b170cf1e9b9008b3afb77cc53",
+            {
+                "versions_minibwa": [
+                    [
+                        "MINIBWA_MAP",
+                        "minibwa",
+                        "0.2"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "MINIBWA_MAP",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T10:34:10.030597",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - fastq, index, fasta, false": {
+        "content": [
+            "6ca35eff022cd0901eb22edb02033b48",
+            "798439cbd7fd81cbcc5078022dc5479d",
+            {
+                "versions_minibwa": [
+                    [
+                        "MINIBWA_MAP",
+                        "minibwa",
+                        "0.2"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "MINIBWA_MAP",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T10:33:58.165445",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - fastq, index, fasta, true": {
+        "content": [
+            "abee21926b58cc6ca485138e445c5d52",
+            "94fcf617f5b994584c4e8d4044e16b4f",
+            {
+                "versions_minibwa": [
+                    [
+                        "MINIBWA_MAP",
+                        "minibwa",
+                        "0.2"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "MINIBWA_MAP",
+                        "samtools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T10:34:03.931595",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds two new modules for [minibwa](https://github.com/lh3/minibwa), a reimplementation of bwa-mem for aligning short and accurate long reads:

- **`minibwa/index`** — builds the `.l2b`/`.mbw` FM-index for a reference genome.
- **`minibwa/map`** — aligns FastQ reads to a minibwa index, piping through `samtools sort`/`view` (via the `sort_bam` input) to emit SAM/BAM/CRAM plus optional indices.

Both are tested against the sarscov2 genome/fastq fixtures with stub runs.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Followed the module conventions in the contribution docs.
- [x] Added a resource `label`.
- [x] Used BioConda and BioContainers (`bioconda::minibwa=0.2`; Seqera Wave community containers).
- [x] `nf-core modules test minibwa/index --profile docker` and `minibwa/map` pass.
- [x] Broadcast software version numbers to `topic: versions`.
