### PR TITLE
feat: add ferrohgvs modules (parse and normalize)

### DIFF
--- a/modules/nf-core/ferrohgvs/normalize/environment.yml
+++ b/modules/nf-core/ferrohgvs/normalize/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/ferro-hgvs
+  - "bioconda::ferro-hgvs=0.6.0"

--- a/modules/nf-core/ferrohgvs/normalize/main.nf
+++ b/modules/nf-core/ferrohgvs/normalize/main.nf
@@ -1,0 +1,45 @@
+process FERROHGVS_NORMALIZE {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7e/7e0f241c7350e07e9ed616a5402ce084099a3614dd26b8afee6a02aa041e5fd5/data'
+        : 'community.wave.seqera.io/library/ferro-hgvs:0.6.0--80a6f47dc50a3cf3'}"
+
+    input:
+    tuple val(meta), path(variants)
+    tuple val(meta2), path(reference)
+
+    output:
+    tuple val(meta), path("${prefix}.${suffix}"), emit: normalized
+    tuple val("${task.process}"), val('ferrohgvs'), eval("ferro --version | sed 's/^ferro //'"), emit: versions_ferrohgvs, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def reference_arg = reference ? "--reference ${reference}" : ""
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("--format json") || args.contains("-f json") ? "json" : "txt"
+    if ("${variants}" == "${prefix}.${suffix}") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    ferro \\
+        normalize \\
+        --input ${variants} \\
+        ${reference_arg} \\
+        --output ${prefix}.${suffix} \\
+        ${args}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("--format json") || args.contains("-f json") ? "json" : "txt"
+    """
+    touch ${prefix}.${suffix}
+    """
+}

--- a/modules/nf-core/ferrohgvs/normalize/meta.yml
+++ b/modules/nf-core/ferrohgvs/normalize/meta.yml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ferrohgvs_normalize"
+description: Normalize HGVS variant descriptions to canonical form with ferro
+keywords:
+  - hgvs
+  - variant
+  - normalize
+  - nomenclature
+  - canonical
+tools:
+  - "ferrohgvs":
+      description: "A Rust library and CLI for parsing, validating, and normalizing HGVS variant descriptions."
+      homepage: "https://github.com/fulcrumgenomics/ferro-hgvs"
+      documentation: "https://github.com/fulcrumgenomics/ferro-hgvs"
+      tool_dev_url: "https://github.com/fulcrumgenomics/ferro-hgvs"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - variants:
+        type: file
+        description: Text file of HGVS variant descriptions, one per line
+        pattern: "*.{txt,tsv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+          - edam: "http://edamontology.org/format_2330" # Textual format
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'reference' ]
+    - reference:
+        type: directory
+        description: |
+          Optional reference data directory produced by `ferro prepare`. If omitted,
+          normalization uses the built-in provider for basic single-exon variants.
+output:
+  normalized:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "${prefix}.${suffix}":
+          type: file
+          description: Normalized variants (text or JSON), one record per input variant
+          pattern: "*.{txt,json}"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+            - edam: "http://edamontology.org/format_3464" # JSON
+  versions_ferrohgvs:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ferrohgvs:
+          type: string
+          description: The name of the tool
+      - ferro --version | sed 's/^ferro //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ferrohgvs:
+          type: string
+          description: The name of the tool
+      - ferro --version | sed 's/^ferro //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/ferrohgvs/normalize/tests/main.nf.test
+++ b/modules/nf-core/ferrohgvs/normalize/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_process {
+
+    name "Test Process FERROHGVS_NORMALIZE"
+    script "../main.nf"
+    process "FERROHGVS_NORMALIZE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ferrohgvs"
+    tag "ferrohgvs/normalize"
+
+    test("hgvs variants - no reference") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of("NM_000088.3:c.589G>T", "NM_000088.3:c.79_80insG")
+                    .collectFile(name: 'variants.txt', newLine: true)
+                    .map { variants -> [ [ id:'test' ], variants ] }
+                input[1] = [ [:], [] ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("hgvs variants - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of("NM_000088.3:c.589G>T")
+                    .collectFile(name: 'variants.txt', newLine: true)
+                    .map { variants -> [ [ id:'test' ], variants ] }
+                input[1] = [ [:], [] ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/ferrohgvs/normalize/tests/main.nf.test.snap
+++ b/modules/nf-core/ferrohgvs/normalize/tests/main.nf.test.snap
@@ -1,0 +1,54 @@
+{
+    "hgvs variants - no reference": {
+        "content": [
+            {
+                "normalized": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,57a862a7641e7ca2b66139c4d3c0c676"
+                    ]
+                ],
+                "versions_ferrohgvs": [
+                    [
+                        "FERROHGVS_NORMALIZE",
+                        "ferrohgvs",
+                        "0.6.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T15:05:00.102703",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "hgvs variants - stub": {
+        "content": [
+            {
+                "normalized": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ferrohgvs": [
+                    [
+                        "FERROHGVS_NORMALIZE",
+                        "ferrohgvs",
+                        "0.6.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T15:05:04.14196",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/ferrohgvs/parse/environment.yml
+++ b/modules/nf-core/ferrohgvs/parse/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/ferro-hgvs
+  - "bioconda::ferro-hgvs=0.6.0"

--- a/modules/nf-core/ferrohgvs/parse/main.nf
+++ b/modules/nf-core/ferrohgvs/parse/main.nf
@@ -1,0 +1,42 @@
+process FERROHGVS_PARSE {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7e/7e0f241c7350e07e9ed616a5402ce084099a3614dd26b8afee6a02aa041e5fd5/data'
+        : 'community.wave.seqera.io/library/ferro-hgvs:0.6.0--80a6f47dc50a3cf3'}"
+
+    input:
+    tuple val(meta), path(variants)
+
+    output:
+    tuple val(meta), path("${prefix}.${suffix}"), emit: parsed
+    tuple val("${task.process}"), val('ferrohgvs'), eval("ferro --version | sed 's/^ferro //'"), emit: versions_ferrohgvs, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("--format json") || args.contains("-f json") ? "json" : "txt"
+    if ("${variants}" == "${prefix}.${suffix}") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    ferro \\
+        parse \\
+        --input ${variants} \\
+        --output ${prefix}.${suffix} \\
+        ${args}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("--format json") || args.contains("-f json") ? "json" : "txt"
+    """
+    touch ${prefix}.${suffix}
+    """
+}

--- a/modules/nf-core/ferrohgvs/parse/meta.yml
+++ b/modules/nf-core/ferrohgvs/parse/meta.yml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ferrohgvs_parse"
+description: Parse and validate HGVS variant descriptions with ferro
+keywords:
+  - hgvs
+  - variant
+  - parse
+  - validation
+  - nomenclature
+tools:
+  - "ferrohgvs":
+      description: "A Rust library and CLI for parsing, validating, and normalizing HGVS variant descriptions."
+      homepage: "https://github.com/fulcrumgenomics/ferro-hgvs"
+      documentation: "https://github.com/fulcrumgenomics/ferro-hgvs"
+      tool_dev_url: "https://github.com/fulcrumgenomics/ferro-hgvs"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - variants:
+        type: file
+        description: Text file of HGVS variant descriptions, one per line
+        pattern: "*.{txt,tsv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+          - edam: "http://edamontology.org/format_2330" # Textual format
+output:
+  parsed:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "${prefix}.${suffix}":
+          type: file
+          description: Parse results (text or JSON), one record per input variant
+          pattern: "*.{txt,json}"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+            - edam: "http://edamontology.org/format_3464" # JSON
+  versions_ferrohgvs:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ferrohgvs:
+          type: string
+          description: The name of the tool
+      - ferro --version | sed 's/^ferro //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ferrohgvs:
+          type: string
+          description: The name of the tool
+      - ferro --version | sed 's/^ferro //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/ferrohgvs/parse/tests/main.nf.test
+++ b/modules/nf-core/ferrohgvs/parse/tests/main.nf.test
@@ -1,0 +1,79 @@
+nextflow_process {
+
+    name "Test Process FERROHGVS_PARSE"
+    script "../main.nf"
+    process "FERROHGVS_PARSE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ferrohgvs"
+    tag "ferrohgvs/parse"
+
+    test("hgvs variants - text") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of("NM_000088.3:c.589G>T", "NM_000088.3:c.79_80insG")
+                    .collectFile(name: 'variants.txt', newLine: true)
+                    .map { variants -> [ [ id:'test' ], variants ] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("hgvs variants - json") {
+
+        config "./nextflow_json.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of("NM_000088.3:c.589G>T", "NM_000088.3:c.79_80insG")
+                    .collectFile(name: 'variants.txt', newLine: true)
+                    .map { variants -> [ [ id:'test' ], variants ] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("hgvs variants - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of("NM_000088.3:c.589G>T")
+                    .collectFile(name: 'variants.txt', newLine: true)
+                    .map { variants -> [ [ id:'test' ], variants ] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/ferrohgvs/parse/tests/main.nf.test.snap
+++ b/modules/nf-core/ferrohgvs/parse/tests/main.nf.test.snap
@@ -1,0 +1,80 @@
+{
+    "hgvs variants - json": {
+        "content": [
+            {
+                "parsed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,eb780fa5e799e8a8cdb54b9eafa7ca30"
+                    ]
+                ],
+                "versions_ferrohgvs": [
+                    [
+                        "FERROHGVS_PARSE",
+                        "ferrohgvs",
+                        "0.6.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T15:05:10.77896",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "hgvs variants - stub": {
+        "content": [
+            {
+                "parsed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ferrohgvs": [
+                    [
+                        "FERROHGVS_PARSE",
+                        "ferrohgvs",
+                        "0.6.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T15:05:14.784066",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "hgvs variants - text": {
+        "content": [
+            {
+                "parsed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,fa02b24267a453c660532747fc69b83d"
+                    ]
+                ],
+                "versions_ferrohgvs": [
+                    [
+                        "FERROHGVS_PARSE",
+                        "ferrohgvs",
+                        "0.6.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T15:05:07.434024",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/ferrohgvs/parse/tests/nextflow_json.config
+++ b/modules/nf-core/ferrohgvs/parse/tests/nextflow_json.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'FERROHGVS_PARSE' {
+        ext.args = '--format json'
+    }
+}


### PR DESCRIPTION
## Description

Adds two new modules for [ferro-hgvs](https://github.com/fulcrumgenomics/ferro-hgvs) (binary `ferro`), a Rust library and CLI for HGVS variant descriptions:

- **`ferrohgvs/parse`** — parse and validate HGVS variant descriptions (text or JSON output).
- **`ferrohgvs/normalize`** — normalize HGVS variants to canonical form (optional reference data directory).

Test inputs (HGVS strings) are generated inline via `collectFile`, so no test-data files are committed.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Followed the module conventions in the contribution docs.
- [x] Added a resource `label`.
- [x] Used BioConda and BioContainers (`bioconda::ferro-hgvs=0.6.0`; Seqera Wave community containers).
- [x] `nf-core modules test ferrohgvs/parse --profile docker` and `ferrohgvs/normalize` pass.
- [x] Broadcast software version numbers to `topic: versions`.
