### PR TITLE
feat: add refsolver modules (identify, compare, score)

### DIFF
--- a/modules/nf-core/refsolver/compare/environment.yml
+++ b/modules/nf-core/refsolver/compare/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/ref-solver
+  - "bioconda::ref-solver=0.3.0"

--- a/modules/nf-core/refsolver/compare/main.nf
+++ b/modules/nf-core/refsolver/compare/main.nf
@@ -1,0 +1,40 @@
+process REFSOLVER_COMPARE {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3d/3d900b9428fe55a93e8beeb3d01e594d683dc8526e26fc1105f33738ac6ad698/data'
+        : 'community.wave.seqera.io/library/ref-solver:0.3.0--f7277dbf424ce3e5'}"
+
+    input:
+    tuple val(meta), path(input_a), path(input_b)
+
+    output:
+    tuple val(meta), path("${prefix}.${suffix}"), emit: report
+    tuple val("${task.process}"), val('refsolver'), eval("ref-solver --version | sed 's/^ref-solver //'"), emit: versions_refsolver, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("json") ? "json" : args.contains("tsv") ? "tsv" : "txt"
+    """
+    ref-solver \\
+        compare \\
+        ${args} \\
+        ${input_a} \\
+        ${input_b} \\
+        > ${prefix}.${suffix}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("json") ? "json" : args.contains("tsv") ? "tsv" : "txt"
+    """
+    touch ${prefix}.${suffix}
+    """
+}

--- a/modules/nf-core/refsolver/compare/meta.yml
+++ b/modules/nf-core/refsolver/compare/meta.yml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "refsolver_compare"
+description: Compare two sequence dictionaries (headers/references) using ref-solver
+keywords:
+  - reference
+  - genome
+  - compare
+  - bam
+  - qc
+tools:
+  - "refsolver":
+      description: "Identify which human reference genome was used to align a BAM/SAM/CRAM file."
+      homepage: "https://github.com/fulcrumgenomics/ref-solver"
+      documentation: "https://github.com/fulcrumgenomics/ref-solver"
+      tool_dev_url: "https://github.com/fulcrumgenomics/ref-solver"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - input_a:
+        type: file
+        description: First input (BAM, SAM, CRAM, .dict, TSV, ...)
+        pattern: "*.{bam,sam,cram,fa,fasta,fai,vcf,dict,tsv,csv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # SAM
+          - edam: "http://edamontology.org/format_3462" # CRAM
+          - edam: "http://edamontology.org/format_1929" # FASTA
+          - edam: "http://edamontology.org/format_3016" # VCF
+          - edam: "http://edamontology.org/format_3475" # TSV
+          - edam: "http://edamontology.org/format_3752" # CSV
+    - input_b:
+        type: file
+        description: |
+          Second input file to compare against (BAM, SAM, CRAM, .dict, TSV, ...).
+          To compare against a catalog reference ID instead, pass `--reference` via
+          task.ext.args and provide the ID as a file-less argument.
+        pattern: "*.{bam,sam,cram,fa,fasta,fai,vcf,dict,tsv,csv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # SAM
+          - edam: "http://edamontology.org/format_3462" # CRAM
+          - edam: "http://edamontology.org/format_1929" # FASTA
+          - edam: "http://edamontology.org/format_3016" # VCF
+          - edam: "http://edamontology.org/format_3475" # TSV
+          - edam: "http://edamontology.org/format_3752" # CSV
+output:
+  report:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "${prefix}.${suffix}":
+          type: file
+          description: Comparison report (text, JSON, or TSV depending on --format)
+          pattern: "*.{txt,json,tsv}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330" # Textual format
+            - edam: "http://edamontology.org/format_3464" # JSON
+            - edam: "http://edamontology.org/format_3475" # TSV
+  versions_refsolver:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "refsolver":
+          type: string
+          description: The name of the tool
+      - "ref-solver --version | sed 's/^ref-solver //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - refsolver:
+          type: string
+          description: The name of the tool
+      - ref-solver --version | sed 's/^ref-solver //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/refsolver/compare/tests/main.nf.test
+++ b/modules/nf-core/refsolver/compare/tests/main.nf.test
@@ -1,0 +1,60 @@
+nextflow_process {
+
+    name "Test Process REFSOLVER_COMPARE"
+    script "../main.nf"
+    process "REFSOLVER_COMPARE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "refsolver"
+    tag "refsolver/compare"
+
+    test("homo_sapiens - bam vs dict") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - bam vs dict - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/refsolver/compare/tests/main.nf.test.snap
+++ b/modules/nf-core/refsolver/compare/tests/main.nf.test.snap
@@ -1,0 +1,84 @@
+{
+    "homo_sapiens - bam vs dict": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,1d43ecc5fd4f7156882c2110b95df099"
+                    ]
+                ],
+                "1": [
+                    [
+                        "REFSOLVER_COMPARE",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,1d43ecc5fd4f7156882c2110b95df099"
+                    ]
+                ],
+                "versions_refsolver": [
+                    [
+                        "REFSOLVER_COMPARE",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T13:45:30.793635",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "homo_sapiens - bam vs dict - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "REFSOLVER_COMPARE",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_refsolver": [
+                    [
+                        "REFSOLVER_COMPARE",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T13:45:36.187897",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/refsolver/identify/environment.yml
+++ b/modules/nf-core/refsolver/identify/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/ref-solver
+  - "bioconda::ref-solver=0.3.0"

--- a/modules/nf-core/refsolver/identify/main.nf
+++ b/modules/nf-core/refsolver/identify/main.nf
@@ -1,0 +1,39 @@
+process REFSOLVER_IDENTIFY {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3d/3d900b9428fe55a93e8beeb3d01e594d683dc8526e26fc1105f33738ac6ad698/data'
+        : 'community.wave.seqera.io/library/ref-solver:0.3.0--f7277dbf424ce3e5'}"
+
+    input:
+    tuple val(meta), path(alignment)
+
+    output:
+    tuple val(meta), path("${prefix}.${suffix}"), emit: report
+    tuple val("${task.process}"), val('refsolver'), eval("ref-solver --version | sed 's/^ref-solver //'"), emit: versions_refsolver, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("json") ? "json" : args.contains("tsv") ? "tsv" : "txt"
+    """
+    ref-solver \\
+        identify \\
+        ${args} \\
+        ${alignment} \\
+        > ${prefix}.${suffix}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("json") ? "json" : args.contains("tsv") ? "tsv" : "txt"
+    """
+    touch ${prefix}.${suffix}
+    """
+}

--- a/modules/nf-core/refsolver/identify/meta.yml
+++ b/modules/nf-core/refsolver/identify/meta.yml
@@ -1,0 +1,77 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "refsolver_identify"
+description: Identify which reference genome a BAM/SAM/CRAM was aligned to using ref-solver
+keywords:
+  - reference
+  - genome
+  - identify
+  - bam
+  - qc
+tools:
+  - "refsolver":
+      description: "Identify which human reference genome was used to align a BAM/SAM/CRAM file."
+      homepage: "https://github.com/fulcrumgenomics/ref-solver"
+      documentation: "https://github.com/fulcrumgenomics/ref-solver"
+      tool_dev_url: "https://github.com/fulcrumgenomics/ref-solver"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - alignment:
+        type: file
+        description: |
+          Input file whose sequence dictionary is matched against the catalog.
+          Accepts BAM, SAM, CRAM, FASTA, FAI, VCF, .dict, TSV, or CSV.
+        pattern: "*.{bam,sam,cram,fa,fasta,fai,vcf,dict,tsv,csv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # SAM
+          - edam: "http://edamontology.org/format_3462" # CRAM
+          - edam: "http://edamontology.org/format_1929" # FASTA
+          - edam: "http://edamontology.org/format_3016" # VCF
+          - edam: "http://edamontology.org/format_3475" # TSV
+          - edam: "http://edamontology.org/format_3752" # CSV
+output:
+  report:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "${prefix}.${suffix}":
+          type: file
+          description: Identification report (text, JSON, or TSV depending on --format)
+          pattern: "*.{txt,json,tsv}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330" # Textual format
+            - edam: "http://edamontology.org/format_3464" # JSON
+            - edam: "http://edamontology.org/format_3475" # TSV
+  versions_refsolver:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "refsolver":
+          type: string
+          description: The name of the tool
+      - "ref-solver --version | sed 's/^ref-solver //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - refsolver:
+          type: string
+          description: The name of the tool
+      - ref-solver --version | sed 's/^ref-solver //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/refsolver/identify/tests/main.nf.test
+++ b/modules/nf-core/refsolver/identify/tests/main.nf.test
@@ -1,0 +1,83 @@
+nextflow_process {
+
+    name "Test Process REFSOLVER_IDENTIFY"
+    script "../main.nf"
+    process "REFSOLVER_IDENTIFY"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "refsolver"
+    tag "refsolver/identify"
+
+    test("grch37 dictionary - tsv") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(
+                    "name\\tlength\\tmd5",
+                    "1\\t249250621\\t1b22b98cdeb4a9304cb5d48026a85128",
+                    "2\\t243199373\\ta0d9851da00400dec1098a9255ac712e",
+                    "3\\t198022430\\tfdfd811849cc2fadebc929bb925902e5",
+                    "4\\t191154276\\t23dccd106897542ad87d2765d28a19a1",
+                    "5\\t180915260\\t0740173db9ffd264d728f32784845cd7",
+                    "6\\t171115067\\t1d3a93a248d92a729ee764823acbbc6b",
+                    "7\\t159138663\\t618366e953d6aaad97dbe4777c29375e",
+                    "8\\t146364022\\t96f514a9929e410c6651697bded59aec",
+                    "9\\t141213431\\t3e273117f15e0a400f01055d9f393768",
+                    "10\\t135534747\\t988c28e000e84c26d552359af1ea2e1d",
+                    "11\\t135006516\\t98c59049a2df285c76ffb1c6db8f8b96",
+                    "12\\t133851895\\t51851ac0e1a115847ad36449b0015864",
+                    "13\\t115169878\\t283f8d7892baa81b510a015719ca7b0b",
+                    "14\\t107349540\\t98f3cae32b2a2e9524bc19813927542e",
+                    "15\\t102531392\\te5645a794a8238215b2cd77acb95a078",
+                    "16\\t90354753\\tfc9b1a7b42b97a864f56b348b06095e6",
+                    "17\\t81195210\\t351f64d4f4f9ddd45b35336ad97aa6de",
+                    "18\\t78077248\\tb15d4b2d29dde9d3e4f93d1d0f2cbc9c",
+                    "19\\t59128983\\t1aacd71f30db8e561810913e0b72636d",
+                    "20\\t63025520\\t0dec9660ec1efaaf33281c0d5ea2560f",
+                    "21\\t48129895\\t2979a6085bfe28e3ad6f552f361ed74d",
+                    "22\\t51304566\\ta718acaa6135fdca8357d5bfe94211dd",
+                    "X\\t155270560\\t7e0e2e580297b7764e31dbc80c2540dd",
+                    "Y\\t59373566\\t1fa3474750af0948bdf97d5a0ee52e51",
+                    "MT\\t16569\\tc68f52674c9fb33aef52dcf399755519"
+                )
+                    .collectFile(name: 'reference.tsv', newLine: true, sort: false)
+                    .map { tsv -> [ [ id:'test' ], tsv ] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("grch37 dictionary - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of("name\\tlength\\tmd5", "MT\\t16569\\tc68f52674c9fb33aef52dcf399755519")
+                    .collectFile(name: 'reference.tsv', newLine: true, sort: false)
+                    .map { tsv -> [ [ id:'test' ], tsv ] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/refsolver/identify/tests/main.nf.test.snap
+++ b/modules/nf-core/refsolver/identify/tests/main.nf.test.snap
@@ -1,0 +1,84 @@
+{
+    "grch37 dictionary - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "REFSOLVER_IDENTIFY",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_refsolver": [
+                    [
+                        "REFSOLVER_IDENTIFY",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T13:45:43.572551",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "grch37 dictionary - tsv": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d8afd2da34cbcc99e7e70746686548fd"
+                    ]
+                ],
+                "1": [
+                    [
+                        "REFSOLVER_IDENTIFY",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d8afd2da34cbcc99e7e70746686548fd"
+                    ]
+                ],
+                "versions_refsolver": [
+                    [
+                        "REFSOLVER_IDENTIFY",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T13:45:39.884508",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/refsolver/score/environment.yml
+++ b/modules/nf-core/refsolver/score/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/ref-solver
+  - "bioconda::ref-solver=0.3.0"

--- a/modules/nf-core/refsolver/score/main.nf
+++ b/modules/nf-core/refsolver/score/main.nf
@@ -1,0 +1,40 @@
+process REFSOLVER_SCORE {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3d/3d900b9428fe55a93e8beeb3d01e594d683dc8526e26fc1105f33738ac6ad698/data'
+        : 'community.wave.seqera.io/library/ref-solver:0.3.0--f7277dbf424ce3e5'}"
+
+    input:
+    tuple val(meta), path(query), path(reference)
+
+    output:
+    tuple val(meta), path("${prefix}.${suffix}"), emit: report
+    tuple val("${task.process}"), val('refsolver'), eval("ref-solver --version | sed 's/^ref-solver //'"), emit: versions_refsolver, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("json") ? "json" : args.contains("tsv") ? "tsv" : "txt"
+    """
+    ref-solver \\
+        score \\
+        ${args} \\
+        ${query} \\
+        ${reference} \\
+        > ${prefix}.${suffix}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = args.contains("json") ? "json" : args.contains("tsv") ? "tsv" : "txt"
+    """
+    touch ${prefix}.${suffix}
+    """
+}

--- a/modules/nf-core/refsolver/score/meta.yml
+++ b/modules/nf-core/refsolver/score/meta.yml
@@ -1,0 +1,87 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "refsolver_score"
+description: Score a query sequence dictionary against a reference using ref-solver
+keywords:
+  - reference
+  - genome
+  - score
+  - bam
+  - qc
+tools:
+  - "refsolver":
+      description: "Identify which human reference genome was used to align a BAM/SAM/CRAM file."
+      homepage: "https://github.com/fulcrumgenomics/ref-solver"
+      documentation: "https://github.com/fulcrumgenomics/ref-solver"
+      tool_dev_url: "https://github.com/fulcrumgenomics/ref-solver"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - query:
+        type: file
+        description: Query file to score (BAM, SAM, CRAM, FASTA, FAI, VCF, .dict, TSV, CSV)
+        pattern: "*.{bam,sam,cram,fa,fasta,fai,vcf,dict,tsv,csv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # SAM
+          - edam: "http://edamontology.org/format_3462" # CRAM
+          - edam: "http://edamontology.org/format_1929" # FASTA
+          - edam: "http://edamontology.org/format_3016" # VCF
+          - edam: "http://edamontology.org/format_3475" # TSV
+          - edam: "http://edamontology.org/format_3752" # CSV
+    - reference:
+        type: file
+        description: Reference file to compare against (BAM, SAM, CRAM, FASTA, FAI, VCF, .dict, TSV, CSV)
+        pattern: "*.{bam,sam,cram,fa,fasta,fai,vcf,dict,tsv,csv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # SAM
+          - edam: "http://edamontology.org/format_3462" # CRAM
+          - edam: "http://edamontology.org/format_1929" # FASTA
+          - edam: "http://edamontology.org/format_3016" # VCF
+          - edam: "http://edamontology.org/format_3475" # TSV
+          - edam: "http://edamontology.org/format_3752" # CSV
+output:
+  report:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "${prefix}.${suffix}":
+          type: file
+          description: Scoring report (text, JSON, or TSV depending on --format)
+          pattern: "*.{txt,json,tsv}"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330" # Textual format
+            - edam: "http://edamontology.org/format_3464" # JSON
+            - edam: "http://edamontology.org/format_3475" # TSV
+  versions_refsolver:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "refsolver":
+          type: string
+          description: The name of the tool
+      - "ref-solver --version | sed 's/^ref-solver //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - refsolver:
+          type: string
+          description: The name of the tool
+      - ref-solver --version | sed 's/^ref-solver //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/refsolver/score/tests/main.nf.test
+++ b/modules/nf-core/refsolver/score/tests/main.nf.test
@@ -1,0 +1,60 @@
+nextflow_process {
+
+    name "Test Process REFSOLVER_SCORE"
+    script "../main.nf"
+    process "REFSOLVER_SCORE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "refsolver"
+    tag "refsolver/score"
+
+    test("homo_sapiens - bam vs dict") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - bam vs dict - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.dict', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/refsolver/score/tests/main.nf.test.snap
+++ b/modules/nf-core/refsolver/score/tests/main.nf.test.snap
@@ -1,0 +1,84 @@
+{
+    "homo_sapiens - bam vs dict": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,4cdfc7880af26b2205f0c8bbff56b74c"
+                    ]
+                ],
+                "1": [
+                    [
+                        "REFSOLVER_SCORE",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,4cdfc7880af26b2205f0c8bbff56b74c"
+                    ]
+                ],
+                "versions_refsolver": [
+                    [
+                        "REFSOLVER_SCORE",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T13:45:48.074381",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "homo_sapiens - bam vs dict - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "REFSOLVER_SCORE",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_refsolver": [
+                    [
+                        "REFSOLVER_SCORE",
+                        "refsolver",
+                        "0.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T13:45:53.48822",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds three modules for [ref-solver](https://github.com/fulcrumgenomics/ref-solver), a tool that identifies which human reference genome was used to align a BAM/SAM/CRAM file by matching its sequence dictionary against a catalog of known references:

- **`refsolver/identify`** — identify the reference genome of an alignment (or `.dict`/TSV/FASTA/FAI/VCF) against the built-in catalog.
- **`refsolver/compare`** — compare two sequence dictionaries (or an input against a catalog reference ID via `--reference`).
- **`refsolver/score`** — score a query dictionary against a reference (no catalog), with tunable match/coverage/order weights.

All three emit a text/JSON/TSV report (selectable via `task.ext.args`). The `identify` test generates a GRCh37 dictionary inline (so no test-data files are committed); `compare`/`score` run against the nf-core homo_sapiens BAM + `.dict` fixtures. Stub runs included.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Followed the module conventions in the contribution docs.
- [x] Added a resource `label`.
- [x] Used BioConda and BioContainers (`bioconda::ref-solver=0.3.0`; Seqera Wave community container).
- [x] `nf-core modules test refsolver/<sub> --profile docker` passes for all three.
- [x] Broadcast software version numbers to `topic: versions`.
