### PR TITLE
feat: add dupblaster module

### DIFF
--- a/modules/nf-core/dupblaster/environment.yml
+++ b/modules/nf-core/dupblaster/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/dupblaster
+  - "bioconda::dupblaster=0.1.1"

--- a/modules/nf-core/dupblaster/main.nf
+++ b/modules/nf-core/dupblaster/main.nf
@@ -1,0 +1,45 @@
+process DUPBLASTER {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ac/ac756f5169c3a6e6e0ab5884bbdc49171a6d0f669066b7494df75185ad4b0716/data'
+        : 'community.wave.seqera.io/library/dupblaster:0.1.1--e033684cd2346e47'}"
+
+    input:
+    tuple val(meta), path(bam)
+
+    output:
+    tuple val(meta), path("${prefix}.bam"), emit: bam
+    tuple val(meta), path("*.tsv"), emit: stats
+    tuple val("${task.process}"), val('dupblaster'), eval("dupblaster --version | sed 's/^dupblaster //'"), emit: versions_dupblaster, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    if ("${bam}" == "${prefix}.bam") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    dupblaster \\
+        --input ${bam} \\
+        --output ${prefix}.bam \\
+        --stats ${prefix}.dupblaster.tsv \\
+        ${args}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    if ("${bam}" == "${prefix}.bam") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    touch ${prefix}.bam
+    touch ${prefix}.dupblaster.tsv
+    """
+}

--- a/modules/nf-core/dupblaster/meta.yml
+++ b/modules/nf-core/dupblaster/meta.yml
@@ -1,0 +1,80 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "dupblaster"
+description: Streaming duplicate marking for NGS alignments with dupblaster; for maximum throughput it can also run inline in the alignment pipe (aligner | dupblaster | sort) rather than as a standalone step
+keywords:
+  - duplicates
+  - markduplicates
+  - bam
+  - alignment
+tools:
+  - "dupblaster":
+      description: "Blazingly fast, streaming duplicate detection for NGS data."
+      homepage: "https://github.com/fulcrumgenomics/dupblaster"
+      documentation: "https://github.com/fulcrumgenomics/dupblaster"
+      tool_dev_url: "https://github.com/fulcrumgenomics/dupblaster"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - bam:
+        type: file
+        description: |
+          Query-grouped SAM/BAM (all alignments for the same read name adjacent,
+          e.g. straight from the aligner). Must NOT be coordinate-sorted.
+        pattern: "*.{bam,sam}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # SAM
+output:
+  bam:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "${prefix}.bam":
+          type: file
+          description: BAM with duplicates marked
+          pattern: "*.bam"
+          ontologies:
+            - edam: "http://edamontology.org/format_2572" # BAM
+  stats:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.tsv":
+          type: file
+          description: Duplicate-marking statistics (TSV)
+          pattern: "*.tsv"
+          ontologies: []
+  versions_dupblaster:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "dupblaster":
+          type: string
+          description: The name of the tool
+      - "dupblaster --version | sed 's/^dupblaster //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - dupblaster:
+          type: string
+          description: The name of the tool
+      - dupblaster --version | sed 's/^dupblaster //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/dupblaster/tests/main.nf.test
+++ b/modules/nf-core/dupblaster/tests/main.nf.test
@@ -1,0 +1,60 @@
+nextflow_process {
+
+    name "Test Process DUPBLASTER"
+    script "../main.nf"
+    process "DUPBLASTER"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "dupblaster"
+
+    test("sarscov2 - paired_end bam") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.bam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    sanitizeOutput(process.out, unstableKeys: ["bam"])
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - paired_end bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.bam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/dupblaster/tests/main.nf.test.snap
+++ b/modules/nf-core/dupblaster/tests/main.nf.test.snap
@@ -1,0 +1,71 @@
+{
+    "sarscov2 - paired_end bam": {
+        "content": [
+            "762e859a3d0ed1553655cde77665c940",
+            {
+                "bam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bam"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.dupblaster.tsv:md5,c0a7f17287f7b941c9082920ab5cef30"
+                    ]
+                ],
+                "versions_dupblaster": [
+                    [
+                        "DUPBLASTER",
+                        "dupblaster",
+                        "0.1.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T15:08:44.068739",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - paired_end bam - stub": {
+        "content": [
+            {
+                "bam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.dupblaster.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_dupblaster": [
+                    [
+                        "DUPBLASTER",
+                        "dupblaster",
+                        "0.1.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T14:49:30.962066",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a module for [dupblaster](https://github.com/fulcrumgenomics/dupblaster), a blazingly fast, streaming duplicate marker for NGS data (an exact, order-independent alternative to `samblaster`). It reads a query-grouped SAM/BAM (typically straight from the aligner) and emits a BAM with duplicates marked, plus a statistics TSV. It drops into the standard `align → mark-dups → sort` pipeline (e.g. `bwa-mem3 | dupblaster | mako/samtools sort`).

Tested against the sarscov2 paired-end alignment fixture with a stub run.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Followed the module conventions in the contribution docs.
- [x] Added a resource `label`.
- [x] Used BioConda and BioContainers (`bioconda::dupblaster=0.1.1`; Seqera Wave community container).
- [x] `nf-core modules test dupblaster --profile docker` passes.
- [x] Broadcast software version numbers to `topic: versions`.
