### PR TITLE
feat: add methylsieve module

### DIFF
--- a/modules/nf-core/methylsieve/environment.yml
+++ b/modules/nf-core/methylsieve/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/methylsieve
+  - "bioconda::methylsieve=0.1.0"

--- a/modules/nf-core/methylsieve/main.nf
+++ b/modules/nf-core/methylsieve/main.nf
@@ -1,0 +1,47 @@
+process METHYLSIEVE {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/92/92a979cffe85f24353179c5647b0e6151bf0c6d3bdbe8890101b6999107c4db5/data'
+        : 'community.wave.seqera.io/library/methylsieve:0.1.0--dd751f2cc2a188b1'}"
+
+    input:
+    tuple val(meta), path(bam)
+    tuple val(meta2), path(fasta), path(fai)
+
+    output:
+    tuple val(meta), path("${prefix}.bam"), emit: bam
+    tuple val(meta), path("*.stats.tsv"), emit: stats
+    tuple val("${task.process}"), val('methylsieve'), eval("methylsieve --version | sed 's/^methylsieve //'"), emit: versions_methylsieve, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    if ("${bam}" == "${prefix}.bam") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    methylsieve \\
+        --reference ${fasta} \\
+        --input ${bam} \\
+        --output ${prefix}.bam \\
+        --stats ${prefix}.stats.tsv \\
+        ${args}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    if ("${bam}" == "${prefix}.bam") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    touch ${prefix}.bam
+    touch ${prefix}.stats.tsv
+    """
+}

--- a/modules/nf-core/methylsieve/meta.yml
+++ b/modules/nf-core/methylsieve/meta.yml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "methylsieve"
+description: Filter/tag unconverted reads in methylation sequencing with methylsieve; for maximum throughput it can also run inline in the alignment pipe (aligner | methylsieve | sort) rather than as a standalone step
+keywords:
+  - methylation
+  - bisulfite
+  - em-seq
+  - unconverted
+  - bam
+  - qc
+tools:
+  - "methylsieve":
+      description: "Fast, robust filtering of unconverted reads in methylation sequencing."
+      homepage: "https://github.com/fulcrumgenomics/methylsieve"
+      documentation: "https://github.com/fulcrumgenomics/methylsieve"
+      tool_dev_url: "https://github.com/fulcrumgenomics/methylsieve"
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - bam:
+        type: file
+        description: |
+          Aligned SAM/BAM from a methylation aligner, in aligner (query-grouped) order.
+          Must NOT be coordinate-sorted.
+        pattern: "*.{bam,sam}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_2573" # SAM
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. `[ id:'genome' ]`
+    - fasta:
+        type: file
+        description: Reference genome FASTA file
+        pattern: "*.{fa,fasta,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/data_2044"
+          - edam: "http://edamontology.org/format_1929"
+    - fai:
+        type: file
+        description: Reference genome FASTA index (.fai)
+        pattern: "*.fai"
+        ontologies: []
+output:
+  bam:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "${prefix}.bam":
+          type: file
+          description: BAM with unconverted reads tagged (or filtered)
+          pattern: "*.bam"
+          ontologies:
+            - edam: "http://edamontology.org/format_2572" # BAM
+  stats:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.stats.tsv":
+          type: file
+          description: Per-context / per-spike-in conversion-rate statistics (TSV)
+          pattern: "*.stats.tsv"
+          ontologies: []
+  versions_methylsieve:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "methylsieve":
+          type: string
+          description: The name of the tool
+      - "methylsieve --version | sed 's/^methylsieve //'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - methylsieve:
+          type: string
+          description: The name of the tool
+      - methylsieve --version | sed 's/^methylsieve //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nh13"
+maintainers:
+  - "@nh13"

--- a/modules/nf-core/methylsieve/tests/main.nf.test
+++ b/modules/nf-core/methylsieve/tests/main.nf.test
@@ -1,0 +1,70 @@
+nextflow_process {
+
+    name "Test Process METHYLSIEVE"
+    script "../main.nf"
+    process "METHYLSIEVE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "methylsieve"
+
+    test("sarscov2 - paired_end bam") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.bam', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    bam(process.out.bam[0][1]).getReadsMD5(),
+                    sanitizeOutput(process.out, unstableKeys: ["bam"])
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - paired_end bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.bam', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'genome' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/methylsieve/tests/main.nf.test.snap
+++ b/modules/nf-core/methylsieve/tests/main.nf.test.snap
@@ -1,0 +1,71 @@
+{
+    "sarscov2 - paired_end bam": {
+        "content": [
+            "762e859a3d0ed1553655cde77665c940",
+            {
+                "bam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bam"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.stats.tsv:md5,86bfb92e82d7ce3984d6ebc5521a047b"
+                    ]
+                ],
+                "versions_methylsieve": [
+                    [
+                        "METHYLSIEVE",
+                        "methylsieve",
+                        "0.1.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T15:14:08.982831",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2 - paired_end bam - stub": {
+        "content": [
+            {
+                "bam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.stats.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_methylsieve": [
+                    [
+                        "METHYLSIEVE",
+                        "methylsieve",
+                        "0.1.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-26T14:52:22.33429",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a module for [methylsieve](https://github.com/fulcrumgenomics/methylsieve), a fast, robust filter for unconverted reads in methylation sequencing (bisulfite / EM-seq). For each template it tallies monitored cytosines against the reference and tags (or filters) incompletely-converted reads, emitting the BAM plus a per-context / per-spike-in conversion-rate statistics TSV. It runs inline in the alignment pipe (`aligner | methylsieve | samtools sort`).

Tested against the sarscov2 paired-end alignment fixture + reference (with `.fai`) and a stub run.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Followed the module conventions in the contribution docs.
- [x] Added a resource `label`.
- [x] Used BioConda and BioContainers (`bioconda::methylsieve=0.1.0`; Seqera Wave community container).
- [x] `nf-core modules test methylsieve --profile docker` passes.
- [x] Broadcast software version numbers to `topic: versions`.
