### PR TITLE
Also support for the blasttab+ output format.

### DIFF
--- a/modules/nf-core/last/mafconvert/main.nf
+++ b/modules/nf-core/last/mafconvert/main.nf
@@ -12,7 +12,7 @@ process LAST_MAFCONVERT {
     tuple val(meta2), path(fasta), path(fai), path(gzi), path(sizes), path(dict) // see subworkflows/nf-core/fasta_bgzip_index_dict_samtools
 
     output:
-    tuple val(meta), path("*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"), emit: alignment
+    tuple val(meta), path("*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttab+.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"), emit: alignment
     tuple val(meta), path("*.{bai,crai,csi}"), emit: index, optional: true
     tuple val(meta), path("*.stats"),          emit: stats, optional: true
     // last-dotplot has no --version option so let's use lastal from the same suite

--- a/modules/nf-core/last/mafconvert/main.nf
+++ b/modules/nf-core/last/mafconvert/main.nf
@@ -12,7 +12,7 @@ process LAST_MAFCONVERT {
     tuple val(meta2), path(fasta), path(fai), path(gzi), path(sizes), path(dict) // see subworkflows/nf-core/fasta_bgzip_index_dict_samtools
 
     output:
-    tuple val(meta), path("*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttab+.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"), emit: alignment
+    tuple val(meta), path("*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttabplus.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"), emit: alignment
     tuple val(meta), path("*.{bai,crai,csi}"), emit: index, optional: true
     tuple val(meta), path("*.stats"),          emit: stats, optional: true
     // last-dotplot has no --version option so let's use lastal from the same suite
@@ -74,6 +74,10 @@ process LAST_MAFCONVERT {
             maf-convert $args \$DICT_ARGS sam $maf -r 'ID:${meta.id} SM:${meta.id}' |
                 samtools sort $args2 -u | bcftools mpileup $args3 --fasta-ref $fasta -Ou - | bcftools call $args4 -Ob -o ${prefix}.bcf
             bcftools stats ${prefix}.bcf > ${prefix}.stats
+            ;;
+        blasttab+)
+            maf-convert $args $format $maf |
+                gzip --no-name > ${prefix}.blasttabplus.gz
             ;;
         *)
             maf-convert $args $format $maf |

--- a/modules/nf-core/last/mafconvert/meta.yml
+++ b/modules/nf-core/last/mafconvert/meta.yml
@@ -69,14 +69,14 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttab+.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}":
+      - "*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttabplus.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}":
           type: file
           description: |
             Pairwise alignment exported to Axt, BAM, BCF, BED, BLAST, Chain,
             CRAM, GFF, HTML PSL, SAM or Tab format.  For BCF generation, pass
             options to `bcftools merge` with `task.ext.args3` and to `bcftools
             call` via `task.ext.args4`.
-          pattern: "*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttab+.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"
+          pattern: "*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttabplus.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"
           ontologies: []
   index:
     - - meta:

--- a/modules/nf-core/last/mafconvert/meta.yml
+++ b/modules/nf-core/last/mafconvert/meta.yml
@@ -28,7 +28,7 @@ input:
         ontologies: []
     - format:
         type: string
-        description: Output format (one of axt, bam, blast, blasttab, cram, chain,
+        description: Output format (one of axt, bam, blast, blasttab, blasttab+, cram, chain,
           gff, html, psl, sam, or tab)
   - - meta2:
         type: map
@@ -69,14 +69,14 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}":
+      - "*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttab+.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}":
           type: file
           description: |
             Pairwise alignment exported to Axt, BAM, BCF, BED, BLAST, Chain,
             CRAM, GFF, HTML PSL, SAM or Tab format.  For BCF generation, pass
             options to `bcftools merge` with `task.ext.args3` and to `bcftools
             call` via `task.ext.args4`.
-          pattern: "*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"
+          pattern: "*.{axt.gz,bam,bcf,bed.gz,blast.gz,blasttab.gz,blasttab+.gz,chain.gz,cram,gff.gz,html.gz,psl.gz,sam.gz,tab.gz}"
           ontologies: []
   index:
     - - meta:


### PR DESCRIPTION
`blasttab+` is same as `blasttab` plus two columns for sequence length and one for score.

https://gitlab.com/mcfrith/last/-/blob/main/doc/lastal.rst

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
