### PR TITLE
Fix bff meta.yml output meta type from file to map

### DIFF
--- a/modules/nf-core/bff/meta.yml
+++ b/modules/nf-core/bff/meta.yml
@@ -43,7 +43,7 @@ input:
 output:
   assignment:
     - - meta:
-          type: file
+          type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
@@ -56,7 +56,7 @@ output:
             - edam: http://edamontology.org/format_3752
   metrics:
     - - meta:
-          type: file
+          type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`
@@ -69,7 +69,7 @@ output:
             - edam: http://edamontology.org/format_3752
   params:
     - - meta:
-          type: file
+          type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1' ]`


### PR DESCRIPTION
## Summary
- Corrects the `meta` output channel type in `modules/nf-core/bff/meta.yml` from `file` to `map` for assignment, metrics, and params outputs
- Aligns output meta typing with the input meta definition and standard nf-core module conventions

## Test plan
- [x] Verified meta input already uses `type: map`
- [x] Confirmed output meta descriptions reference Groovy sample maps, not files
- [x] No functional pipeline changes; meta.yml schema fix only