### PR TITLE
feat(catpack/{bins,contigs}): add support for gzipped inputs

### DIFF
--- a/modules/nf-core/catpack/bins/environment.yml
+++ b/modules/nf-core/catpack/bins/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::cat=6.0.1
+  - conda-forge::gzip=1.14

--- a/modules/nf-core/catpack/bins/main.nf
+++ b/modules/nf-core/catpack/bins/main.nf
@@ -4,8 +4,8 @@ process CATPACK_BINS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/cat:6.0.1--hdfd78af_1'
-        : 'quay.io/biocontainers/cat:6.0.1--hdfd78af_1'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
+        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
 
     input:
     tuple val(meta), path(bins, stageAs: 'bins/*')
@@ -13,7 +13,7 @@ process CATPACK_BINS {
     tuple val(meta3), path(taxonomy)
     tuple val(meta4), path(proteins)
     tuple val(meta5), path(diamond_table)
-    val(bin_suffix)
+    val bin_suffix
 
     output:
     tuple val(meta), path("*.ORF2LCA.txt"), emit: orf2lca
@@ -33,9 +33,22 @@ process CATPACK_BINS {
     def premade_proteins = proteins ? "-p ${proteins}" : ''
     def premade_table = diamond_table ? "-d ${diamond_table}" : ''
     """
+    # CAT_pack does not support gzipped input, so decompress any gzipped bins
+    # into a separate dir (bin_suffix must match the decompressed extension).
+    mkdir input_bins
+    for f in bins/*; do
+        [ -e "\$f" ] || continue
+        name=\$(basename "\$f")
+        if [[ "\$name" == *.gz ]]; then
+            gunzip -c "\$f" > "input_bins/\${name%.gz}"
+        else
+            ln -s "\$(readlink -f "\$f")" "input_bins/\${name}"
+        fi
+    done
+
     CAT_pack bins \\
         -n ${task.cpus} \\
-        -b bins/ \\
+        -b input_bins/ \\
         -d ${database} \\
         -t ${taxonomy} \\
         -s ${bin_suffix} \\

--- a/modules/nf-core/catpack/bins/main.nf
+++ b/modules/nf-core/catpack/bins/main.nf
@@ -32,26 +32,25 @@ process CATPACK_BINS {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def premade_proteins = proteins ? "-p ${proteins}" : ''
     def premade_table = diamond_table ? "-d ${diamond_table}" : ''
+    // CAT_pack does not support gzipped input. If bin_suffix ends in .gz,
+    // decompress the bins and strip .gz off the suffix passed to CAT_pack.
+    def is_compressed = bin_suffix.endsWith('.gz')
+    def cat_suffix = is_compressed ? bin_suffix - ~/\.gz$/ : bin_suffix
+    def bins_dir = is_compressed ? 'input_bins' : 'bins'
     """
-    # CAT_pack does not support gzipped input, so decompress any gzipped bins
-    # into a separate dir (bin_suffix must match the decompressed extension).
-    mkdir input_bins
-    for f in bins/*; do
-        [ -e "\$f" ] || continue
-        name=\$(basename "\$f")
-        if [[ "\$name" == *.gz ]]; then
-            gunzip -c "\$f" > "input_bins/\${name%.gz}"
-        else
-            ln -s "\$(readlink -f "\$f")" "input_bins/\${name}"
-        fi
-    done
+    if ${is_compressed}; then
+        mkdir input_bins
+        for f in bins/*${bin_suffix}; do
+            gunzip -c "\$f" > "input_bins/\$(basename "\$f" .gz)"
+        done
+    fi
 
     CAT_pack bins \\
         -n ${task.cpus} \\
-        -b input_bins/ \\
+        -b ${bins_dir}/ \\
         -d ${database} \\
         -t ${taxonomy} \\
-        -s ${bin_suffix} \\
+        -s ${cat_suffix} \\
         ${premade_proteins} \\
         ${premade_table} \\
         -o ${prefix} \\

--- a/modules/nf-core/catpack/bins/main.nf
+++ b/modules/nf-core/catpack/bins/main.nf
@@ -4,8 +4,8 @@ process CATPACK_BINS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
-        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/15/15bcec1eccda12562504e88d44abc8a29742c6b600ae178cc9579fedc3a69062/data'
+        : 'community.wave.seqera.io/library/cat_gzip:0ab95a62b35744c9'}"
 
     input:
     tuple val(meta), path(bins, stageAs: 'bins/*')

--- a/modules/nf-core/catpack/bins/meta.yml
+++ b/modules/nf-core/catpack/bins/meta.yml
@@ -29,9 +29,8 @@ input:
     - bins:
         type: file
         description: One or more nucleotide FASTA file containing binned long DNA
-          sequences. Files may be optionally gzipped (the module decompresses them
-          before running CAT_pack); in that case `bin_suffix` must refer to the
-          decompressed extension (e.g. `.fasta`).
+          sequences. Files may be optionally gzipped, in which case `bin_suffix`
+          must end in `.gz` (the module decompresses them before running CAT_pack).
         pattern: "*.{fasta,fna,fa,fas}{,.gz}"
         ontologies:
           - edam: "http://edamontology.org/format_1929"
@@ -92,7 +91,9 @@ input:
 
   - bin_suffix:
       type: string
-      description: Suffix to search for in the input files when `bins` is a directory.
+      description: Suffix to search for in the input files when `bins` is a directory
+        (e.g. `.fasta`). If it ends in `.gz` (e.g. `.fasta.gz`), the bins are
+        decompressed first and the `.gz` is stripped before running CAT_pack.
 
 output:
   orf2lca:

--- a/modules/nf-core/catpack/bins/meta.yml
+++ b/modules/nf-core/catpack/bins/meta.yml
@@ -28,8 +28,11 @@ input:
 
     - bins:
         type: file
-        description: One or more nucleotide FASTA file containing binned long DNA sequences.
-        pattern: "*.{fasta,fna,fa,fas}"
+        description: One or more nucleotide FASTA file containing binned long DNA
+          sequences. Files may be optionally gzipped (the module decompresses them
+          before running CAT_pack); in that case `bin_suffix` must refer to the
+          decompressed extension (e.g. `.fasta`).
+        pattern: "*.{fasta,fna,fa,fas}{,.gz}"
         ontologies:
           - edam: "http://edamontology.org/format_1929"
 

--- a/modules/nf-core/catpack/bins/tests/main.nf.test
+++ b/modules/nf-core/catpack/bins/tests/main.nf.test
@@ -116,7 +116,7 @@ nextflow_process {
                 input[2] = CATPACK_PREPARE.out.taxonomy
                 input[3] = [[:], []]
                 input[4] = [[:], []]
-                input[5] = '.fasta'
+                input[5] = '.fasta.gz'
                 """
             }
         }

--- a/modules/nf-core/catpack/bins/tests/main.nf.test
+++ b/modules/nf-core/catpack/bins/tests/main.nf.test
@@ -106,6 +106,39 @@ nextflow_process {
 
     }
 
+    test("sarscov2 - genome - fasta - gz") {
+
+        when {
+            process {
+                """
+                input[0] = [ [id:'test'], [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)  ] ]
+                input[1] = CATPACK_PREPARE.out.db
+                input[2] = CATPACK_PREPARE.out.taxonomy
+                input[3] = [[:], []]
+                input[4] = [[:], []]
+                input[5] = '.fasta'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot (
+                        process.out.orf2lca,
+                        process.out.bin2classification,
+                        process.out.diamond,
+                        process.out.faa,
+                        process.out.gff,
+                        process.out.versions_catpack,
+                        path(process.out.log.get(0).get(1)).readLines().last().contains("CAT is done!")
+                    ).match()
+                }
+            )
+        }
+
+    }
+
     test("sarscov2 - genome - fasta - stub") {
 
         options "-stub"
@@ -127,7 +160,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                        process.out
+                        sanitizeOutput(process.out)
                     ).match()
                 }
             )

--- a/modules/nf-core/catpack/bins/tests/main.nf.test.snap
+++ b/modules/nf-core/catpack/bins/tests/main.nf.test.snap
@@ -100,64 +100,66 @@
             "nextflow": "25.10.4"
         }
     },
+    "sarscov2 - genome - fasta - gz": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.ORF2LCA.txt:md5,27e3ca35dc7b977653b5bbf18076fc26"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.bin2classification.txt:md5,8cb8c364c1dea229f68e8c7a1747205d"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.concatenated.alignment.diamond:md5,9e2f9c188b183c18dd9572395a48a066"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.concatenated.predicted_proteins.faa:md5,1f8550f87d044d117422ca02827e4d18"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.concatenated.predicted_proteins.gff:md5,cb63331a0282175669107585cf4a66c1"
+                ]
+            ],
+            [
+                [
+                    "CATPACK_BINS",
+                    "catpack",
+                    "6.0"
+                ]
+            ],
+            false
+        ],
+        "timestamp": "2026-07-01T03:51:50.050645066",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
     "sarscov2 - genome - fasta - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.ORF2LCA.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.bin2classification.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.diamond:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.predicted_proteins.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.predicted_proteins.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        "CATPACK_BINS",
-                        "catpack",
-                        "6.0"
-                    ]
-                ],
                 "bin2classification": [
                     [
                         {
@@ -215,10 +217,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-08T13:21:54.940068383",
+        "timestamp": "2026-07-01T04:05:19.365698688",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/modules/nf-core/catpack/contigs/environment.yml
+++ b/modules/nf-core/catpack/contigs/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::cat=6.0.1
+  - conda-forge::gzip=1.14

--- a/modules/nf-core/catpack/contigs/main.nf
+++ b/modules/nf-core/catpack/contigs/main.nf
@@ -4,8 +4,8 @@ process CATPACK_CONTIGS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
-        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/15/15bcec1eccda12562504e88d44abc8a29742c6b600ae178cc9579fedc3a69062/data'
+        : 'community.wave.seqera.io/library/cat_gzip:0ab95a62b35744c9'}"
 
     input:
     tuple val(meta), path(contigs)

--- a/modules/nf-core/catpack/contigs/main.nf
+++ b/modules/nf-core/catpack/contigs/main.nf
@@ -4,8 +4,8 @@ process CATPACK_CONTIGS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/cat:6.0.1--hdfd78af_1'
-        : 'quay.io/biocontainers/cat:6.0.1--hdfd78af_1'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
+        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
 
     input:
     tuple val(meta), path(contigs)
@@ -32,9 +32,20 @@ process CATPACK_CONTIGS {
     def premade_proteins = proteins ? "--proteins_fasta ${proteins}" : ''
     def premade_table = diamond_table ? "--diamond_alignment ${diamond_table}" : ''
     """
+    # CAT_pack does not support gzipped input, so decompress any gzipped contigs.
+    contigs_fastas=""
+    for f in ${contigs}; do
+        if [[ "\$f" == *.gz ]]; then
+            gunzip -c "\$f" > "\$(basename "\$f" .gz)"
+            contigs_fastas="\${contigs_fastas} \$(basename "\$f" .gz)"
+        else
+            contigs_fastas="\${contigs_fastas} \$f"
+        fi
+    done
+
     CAT_pack contigs \\
         --nproc ${task.cpus} \\
-        --contigs_fasta ${contigs} \\
+        --contigs_fasta \${contigs_fastas## } \\
         --database_folder ${database} \\
         --taxonomy_folder ${taxonomy} \\
         --out_prefix ${prefix} \\

--- a/modules/nf-core/catpack/contigs/meta.yml
+++ b/modules/nf-core/catpack/contigs/meta.yml
@@ -28,8 +28,10 @@ input:
 
     - contigs:
         type: file
-        description: A nucleotide FASTA file containing long DNA sequences such as contigs.
-        pattern: "*.{fasta,fna,fa,fas}"
+        description: A nucleotide FASTA file containing long DNA sequences such as
+          contigs. May be optionally gzipped (the module decompresses it before
+          running CAT_pack).
+        pattern: "*.{fasta,fna,fa,fas}{,.gz}"
         ontologies:
           - edam: "http://edamontology.org/format_1929"
 

--- a/modules/nf-core/catpack/contigs/tests/main.nf.test
+++ b/modules/nf-core/catpack/contigs/tests/main.nf.test
@@ -57,6 +57,38 @@ nextflow_process {
 
     }
 
+    test("sarscov2 - genome - fasta - gz") {
+
+        when {
+            process {
+                """
+                input[0] = [ [id:'test'], [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)  ] ]
+                input[1] = CATPACK_PREPARE.out.db
+                input[2] = CATPACK_PREPARE.out.taxonomy
+                input[3] = [[:], []]
+                input[4] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot (
+                        process.out.orf2lca,
+                        process.out.contig2classification,
+                        process.out.diamond,
+                        process.out.faa,
+                        process.out.gff,
+                        process.out.versions_catpack,
+                        path(process.out.log.get(0).get(1)).readLines().last().contains("CAT is done!")
+                    ).match()
+                }
+            )
+        }
+
+    }
+
     test("sarscov2 - genome - fasta - stub") {
 
         options "-stub"
@@ -77,7 +109,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                        process.out
+                        sanitizeOutput(process.out)
                     ).match()
                 }
             )

--- a/modules/nf-core/catpack/contigs/tests/main.nf.test.snap
+++ b/modules/nf-core/catpack/contigs/tests/main.nf.test.snap
@@ -56,64 +56,66 @@
             "nextflow": "25.10.4"
         }
     },
+    "sarscov2 - genome - fasta - gz": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.ORF2LCA.txt:md5,a623b47f20751db12ce18c9ca7ac2536"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.contig2classification.txt:md5,3c3c79045bf6ae8b1292ae9afa2ec4af"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.alignment.diamond:md5,9e2f9c188b183c18dd9572395a48a066"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.predicted_proteins.faa:md5,1f8550f87d044d117422ca02827e4d18"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.predicted_proteins.gff:md5,4fc7a311726723ce5b17cede1dd1059c"
+                ]
+            ],
+            [
+                [
+                    "CATPACK_CONTIGS",
+                    "catpack",
+                    "6.0"
+                ]
+            ],
+            true
+        ],
+        "timestamp": "2026-07-01T03:52:17.052252749",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
     "sarscov2 - genome - fasta - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.ORF2LCA.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.contig2classification.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.diamond:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.predicted_proteins.faa:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.predicted_proteins.gff:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        "CATPACK_CONTIGS",
-                        "catpack",
-                        "6.0"
-                    ]
-                ],
                 "contig2classification": [
                     [
                         {
@@ -171,10 +173,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-08T13:22:06.153850855",
+        "timestamp": "2026-07-01T04:05:42.799018467",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/modules/nf-core/catpack/download/environment.yml
+++ b/modules/nf-core/catpack/download/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::cat=6.0.1
+  - conda-forge::gzip=1.14

--- a/modules/nf-core/catpack/download/main.nf
+++ b/modules/nf-core/catpack/download/main.nf
@@ -5,8 +5,8 @@ process CATPACK_DOWNLOAD {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/cat:6.0.1--hdfd78af_1'
-        : 'quay.io/biocontainers/cat:6.0.1--hdfd78af_1'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
+        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
 
     input:
     tuple val(meta), val(db)

--- a/modules/nf-core/catpack/download/main.nf
+++ b/modules/nf-core/catpack/download/main.nf
@@ -5,8 +5,8 @@ process CATPACK_DOWNLOAD {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
-        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/15/15bcec1eccda12562504e88d44abc8a29742c6b600ae178cc9579fedc3a69062/data'
+        : 'community.wave.seqera.io/library/cat_gzip:0ab95a62b35744c9'}"
 
     input:
     tuple val(meta), val(db)

--- a/modules/nf-core/catpack/prepare/environment.yml
+++ b/modules/nf-core/catpack/prepare/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::cat=6.0.1
+  - conda-forge::gzip=1.14

--- a/modules/nf-core/catpack/prepare/main.nf
+++ b/modules/nf-core/catpack/prepare/main.nf
@@ -6,8 +6,8 @@ process CATPACK_PREPARE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/cat:6.0.1--hdfd78af_1'
-        : 'quay.io/biocontainers/cat:6.0.1--hdfd78af_1'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
+        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
 
     input:
     tuple val(meta), path(db_fasta)

--- a/modules/nf-core/catpack/prepare/main.nf
+++ b/modules/nf-core/catpack/prepare/main.nf
@@ -6,8 +6,8 @@ process CATPACK_PREPARE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
-        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/15/15bcec1eccda12562504e88d44abc8a29742c6b600ae178cc9579fedc3a69062/data'
+        : 'community.wave.seqera.io/library/cat_gzip:0ab95a62b35744c9'}"
 
     input:
     tuple val(meta), path(db_fasta)

--- a/modules/nf-core/catpack/reads/environment.yml
+++ b/modules/nf-core/catpack/reads/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::cat=6.0.1
+  - conda-forge::gzip=1.14

--- a/modules/nf-core/catpack/reads/main.nf
+++ b/modules/nf-core/catpack/reads/main.nf
@@ -4,8 +4,8 @@ process CATPACK_READS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
-        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/15/15bcec1eccda12562504e88d44abc8a29742c6b600ae178cc9579fedc3a69062/data'
+        : 'community.wave.seqera.io/library/cat_gzip:0ab95a62b35744c9'}"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/catpack/reads/main.nf
+++ b/modules/nf-core/catpack/reads/main.nf
@@ -4,8 +4,8 @@ process CATPACK_READS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/cat:6.0.1--hdfd78af_1'
-        : 'quay.io/biocontainers/cat:6.0.1--hdfd78af_1'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
+        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/catpack/summarise/environment.yml
+++ b/modules/nf-core/catpack/summarise/environment.yml
@@ -5,3 +5,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::cat=6.0.1
+  - conda-forge::gzip=1.14

--- a/modules/nf-core/catpack/summarise/main.nf
+++ b/modules/nf-core/catpack/summarise/main.nf
@@ -4,8 +4,8 @@ process CATPACK_SUMMARISE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/cat:6.0.1--hdfd78af_1'
-        : 'quay.io/biocontainers/cat:6.0.1--hdfd78af_1'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
+        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
 
     input:
     tuple val(meta), path(classification)

--- a/modules/nf-core/catpack/summarise/main.nf
+++ b/modules/nf-core/catpack/summarise/main.nf
@@ -4,8 +4,8 @@ process CATPACK_SUMMARISE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1e58abd32df3c4d65314311ad1b3b8355fa3d9f229aa3e39a1db6c938eb406d1/data'
-        : 'community.wave.seqera.io/library/cat:6.0.1--6bec964806e8076a'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/15/15bcec1eccda12562504e88d44abc8a29742c6b600ae178cc9579fedc3a69062/data'
+        : 'community.wave.seqera.io/library/cat_gzip:0ab95a62b35744c9'}"
 
     input:
     tuple val(meta), path(classification)


### PR DESCRIPTION
Adds support for gzipped inputs to `catpack/bins` and `catpack/contigs` by explicit gunzip (tool doesn't have native support).
Also migrates all catpack modules to Seqera containers.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
