### PR TITLE
feat: add gapseq/medium module

### DIFF
--- a/modules/nf-core/gapseq/medium/environment.yml
+++ b/modules/nf-core/gapseq/medium/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::gapseq=2.1.0

--- a/modules/nf-core/gapseq/medium/main.nf
+++ b/modules/nf-core/gapseq/medium/main.nf
@@ -1,0 +1,38 @@
+process GAPSEQ_MEDIUM {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'community.wave.seqera.io/library/gapseq:2.1.0--31c8824b3592beaf' :
+        'quay.io/biocontainers/gapseq:2.1.0--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(draft), path(pathways)
+
+    output:
+    tuple val(meta), path("*.csv") , emit: medium
+    tuple val(meta), path("*.log") , emit: log      , optional: true
+    tuple val("${task.process}"), val('gapseq'), eval('gapseq -v 2>&1 | grep -oP "\\d+\\.\\d+\\.\\d+"'), topic: versions, emit: versions_gapseq
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    gapseq \
+        medium \
+        -m $draft \
+        -p $pathways \
+        $args \
+        -o ${prefix}-medium.csv
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}-medium.csv
+    """
+}

--- a/modules/nf-core/gapseq/medium/main.nf
+++ b/modules/nf-core/gapseq/medium/main.nf
@@ -3,9 +3,9 @@ process GAPSEQ_MEDIUM {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'community.wave.seqera.io/library/gapseq:2.1.0--31c8824b3592beaf' :
-        'quay.io/biocontainers/gapseq:2.1.0--hdfd78af_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/gapseq:2.1.0--hdfd78af_0'
+        : 'quay.io/biocontainers/gapseq:2.1.0--hdfd78af_0'}"
 
     input:
     tuple val(meta), path(draft), path(pathways)

--- a/modules/nf-core/gapseq/medium/meta.yml
+++ b/modules/nf-core/gapseq/medium/meta.yml
@@ -1,0 +1,85 @@
+name: gapseq_medium
+description: Predict growth medium from a draft model and pathway predictions
+keywords:
+  - metabolic model
+  - growth medium
+  - gap filling
+  - gapseq
+  - bacteria
+  - genome-scale model
+tools:
+  - gapseq:
+      description: |
+        gapseq predicts a growth medium from a draft model and pathway predictions.
+      homepage: https://github.com/jotech/gapseq
+      documentation: https://gapseq.readthedocs.io/
+      tool_dev_url: https://github.com/jotech/gapseq
+      doi: "10.1186/s13059-021-02295-1"
+      licence:
+        - "AGPL-3.0-only"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - draft:
+        type: file
+        description: Draft model from gapseq draft
+        pattern: "*.RDS"
+        ontologies: []
+    - pathways:
+        type: file
+        description: Pathway prediction table from gapseq find
+        pattern: "*-all-Pathways.tbl"
+        ontologies: []
+output:
+  medium:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.csv":
+          type: file
+          description: Predicted growth medium CSV file
+          pattern: "*.csv"
+          ontologies:
+            - edam: http://edamontology.org/format_3752
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.log":
+          type: file
+          description: Log files from gapseq medium prediction
+          pattern: "*.log"
+          ontologies: []
+  versions_gapseq:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gapseq:
+          type: string
+          description: The name of the tool
+      - gapseq -v 2>&1 | grep -oP "\d+\.\d+\.\d+":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gapseq:
+          type: string
+          description: The name of the tool
+      - gapseq -v 2>&1 | grep -oP "\d+\.\d+\.\d+":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@brovolia"
+maintainers:
+  - "@brovolia"

--- a/modules/nf-core/gapseq/medium/tests/main.nf.test
+++ b/modules/nf-core/gapseq/medium/tests/main.nf.test
@@ -28,11 +28,11 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert path(process.out.medium[0][1]).exists() },
-                { assert snapshot(
-                    process.out.medium.collect { meta, medium -> [meta, file(medium).getName()] },
-                    process.out.log.collect { meta, log -> [meta, (log instanceof List ? log : [log]).collect { file(it).getName() }.sort()] },
-                    process.out.findAll { key, val -> key.startsWith('versions') }
-                ).match() }
+                { with(path(process.out.medium[0][1]).csv) {
+                    assert columnCount == 3
+                    assert rowCount > 0
+                }},
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/gapseq/medium/tests/main.nf.test
+++ b/modules/nf-core/gapseq/medium/tests/main.nf.test
@@ -1,0 +1,39 @@
+nextflow_process {
+
+    name "Test Process GAPSEQ_MEDIUM"
+    script "../main.nf"
+    process "GAPSEQ_MEDIUM"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gapseq"
+    tag "gapseq/medium"
+
+    test("gapseq medium prediction from draft and pathways") {
+
+        when {
+            config "./nextflow.config"
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/gapseq/test-draft.RDS', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/candidatus_portiera_aleyrodidarum/gapseq/proteome-all-Pathways.tbl', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.medium[0][1]).exists() },
+                { assert snapshot(
+                    process.out.medium.collect { meta, medium -> [meta, file(medium).getName()] },
+                    process.out.log.collect { meta, log -> [meta, (log instanceof List ? log : [log]).collect { file(it).getName() }.sort()] },
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/gapseq/medium/tests/main.nf.test.snap
+++ b/modules/nf-core/gapseq/medium/tests/main.nf.test.snap
@@ -1,18 +1,18 @@
 {
     "gapseq medium prediction from draft and pathways": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test-medium.csv"
-                ]
-            ],
-            [
-                
-            ],
             {
+                "log": [
+                    
+                ],
+                "medium": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test-medium.csv:md5,c12ef037faf0546ab38d7d195a2f5669"
+                    ]
+                ],
                 "versions_gapseq": [
                     [
                         "GAPSEQ_MEDIUM",
@@ -26,6 +26,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-07-02T15:53:20.922046956"
+        "timestamp": "2026-07-03T11:33:57.352738751"
     }
 }

--- a/modules/nf-core/gapseq/medium/tests/main.nf.test.snap
+++ b/modules/nf-core/gapseq/medium/tests/main.nf.test.snap
@@ -1,0 +1,31 @@
+{
+    "gapseq medium prediction from draft and pathways": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test-medium.csv"
+                ]
+            ],
+            [
+                
+            ],
+            {
+                "versions_gapseq": [
+                    [
+                        "GAPSEQ_MEDIUM",
+                        "gapseq",
+                        "2.1.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-07-02T15:53:20.922046956"
+    }
+}

--- a/modules/nf-core/gapseq/medium/tests/nextflow.config
+++ b/modules/nf-core/gapseq/medium/tests/nextflow.config
@@ -1,0 +1,3 @@
+singularity {
+    pullTimeout = '20m'
+}


### PR DESCRIPTION

- Add gapseq medium submodule for predicting growth media
- Takes draft model (RDS) and pathways (TBL) as inputs  
- Outputs predicted medium compounds in CSV format
- Test uses test-draft.RDS fixture from test-datasets
- Module tested with gapseq v2.1.0 and generates snapshot
- Fixed linting issues: environment.yml format and removed invalid ext keys