### PR TITLE
fix(dotseq/dotseq): make plotDOT() heatmap actually render

### DIFF
--- a/modules/nf-core/dotseq/dotseq/meta.yml
+++ b/modules/nf-core/dotseq/dotseq/meta.yml
@@ -65,12 +65,19 @@ input:
           Per-ORF annotation table (one row per ORF). Required columns:
           `orf_id` (matches the count matrix) and `gene_id` (parent gene;
           DOTSeq's DOU model groups child ORFs by gene). Optional columns:
-          `orf_type` (mORF / uORF / dORF; used by plotDOT()'s heatmap and
-          defaults to mORF when absent) and `chrom`, `start`, `end`,
-          `strand` (used only for downstream inspection - dummy ranges
-          are generated when absent because DOTSeq's fit does not depend
-          on genomic coordinates). Column names can be overridden via
-          task.ext.args (`--gene_id_col`, `--orf_type_col`, etc.).
+          `orf_type` (used by plotDOT()'s heatmap to pair a gene's main ORF
+          against its short ORFs; defaults to the main-ORF value when absent)
+          and `chrom`, `start`, `end`, `strand` (used only for downstream
+          inspection - dummy ranges are generated when absent because
+          DOTSeq's fit does not depend on genomic coordinates). Column names
+          can be overridden via task.ext.args (`--gene_id_col`,
+          `--orf_type_col`, etc.). plotDOT()'s heatmap hardcodes the literal
+          label `mORF` for a gene's main ORF and only accepts `uORF` or
+          `dORF` for the short-ORF bucket it is paired against; whichever
+          value in `orf_type` denotes the main ORF is remapped to `mORF`
+          internally (override the source value via `--orf_type_main_value`,
+          default `mORF`), but short-ORF rows must already be labelled
+          `uORF`/`dORF` or the heatmap is silently skipped.
         ontologies:
           - edam: "http://edamontology.org/format_3475"
 

--- a/modules/nf-core/dotseq/dotseq/templates/dotseq.R
+++ b/modules/nf-core/dotseq/dotseq/templates/dotseq.R
@@ -253,6 +253,9 @@ gene_ids <- as.character(ann[[opt\$gene_id_col]])
 orf_number <- ave(gene_ids, gene_ids, FUN = seq_along)
 orf_type <- if (opt\$orf_type_col %in% names(ann)) as.character(ann[[opt\$orf_type_col]]) else rep(opt\$orf_type_main_value, nrow(ann))
 orf_type[is.na(orf_type) | !nzchar(trimws(orf_type))] <- opt\$orf_type_main_value
+if (opt\$orf_type_main_value != "mORF") {
+    orf_type[orf_type == "mORF"] <- paste0(opt\$orf_type_main_value, "_not_main")
+}
 orf_type[orf_type == opt\$orf_type_main_value] <- "mORF"
 
 annotation_gr <- GRanges(

--- a/modules/nf-core/dotseq/dotseq/templates/dotseq.R
+++ b/modules/nf-core/dotseq/dotseq/templates/dotseq.R
@@ -34,7 +34,9 @@ option_list <- list(
     make_option("--gene_id_col",         type = "character", default = "gene_id",
                 help = "Annotation column holding the parent gene id [default: %default]"),
     make_option("--orf_type_col",        type = "character", default = "orf_type",
-                help = "Annotation column holding the ORF biotype (mORF/uORF/dORF/etc.); used by plotDOT()'s heatmap [default: %default]"),
+                help = "Annotation column holding the ORF biotype; used by plotDOT()'s heatmap [default: %default]"),
+    make_option("--orf_type_main_value", type = "character", default = "mORF",
+                help = "Value in --orf_type_col denoting a gene's main/canonical ORF. plotDOT()'s heatmap hardcodes the literal label 'mORF' for this bucket, so any other value found here is remapped to 'mORF' before plotting [default: %default]"),
     make_option("--chrom_col",           type = "character", default = "chrom",
                 help = "Optional annotation column with the ORF chromosome; dummy ranges built if absent."),
     make_option("--start_col",           type = "character", default = "start",
@@ -198,8 +200,11 @@ cnt <- cnt[, cond\$run, drop = FALSE]
 ## DOTSeq's DOU module fits a beta-binomial GLM per parent gene, grouping     ##
 ## the gene's child ORFs, so gene_id is load-bearing on the annotation. The   ##
 ## genomic ranges themselves are stored for downstream inspection only - the  ##
-## model fit does not depend on them. plotDOT()'s heatmap uses orf_type to    ##
-## bucket uORF/dORF, so we honour it when present.                            ##
+## model fit does not depend on them. plotDOT()'s heatmap buckets ORFs by     ##
+## orf_type into a hardcoded "mORF" main class plus a caller-chosen short-ORF ##
+## class, so the main-ORF value found in the annotation is remapped to the   ##
+## literal string "mORF" for DOTSeq's consumption regardless of what label    ##
+## the caller uses upstream.                                                  ##
 ################################################################################
 
 ann <- read_delim_auto(opt\$annotation_file)
@@ -246,8 +251,9 @@ strand[!strand %in% c("+", "-", "*")] <- "*"
 
 gene_ids <- as.character(ann[[opt\$gene_id_col]])
 orf_number <- ave(gene_ids, gene_ids, FUN = seq_along)
-orf_type <- if (opt\$orf_type_col %in% names(ann)) as.character(ann[[opt\$orf_type_col]]) else rep("mORF", nrow(ann))
-orf_type[is.na(orf_type) | !nzchar(trimws(orf_type))] <- "mORF"
+orf_type <- if (opt\$orf_type_col %in% names(ann)) as.character(ann[[opt\$orf_type_col]]) else rep(opt\$orf_type_main_value, nrow(ann))
+orf_type[is.na(orf_type) | !nzchar(trimws(orf_type))] <- opt\$orf_type_main_value
+orf_type[orf_type == opt\$orf_type_main_value] <- "mORF"
 
 annotation_gr <- GRanges(
     seqnames = chrom,
@@ -365,8 +371,14 @@ if (opt\$generate_plots) {
     }
 
     # plotDOT's default `force_new_device = TRUE` would reset our png() device;
-    # disable it. Return success so the heatmap fallback can distinguish a real
-    # plot from one that left a 0-byte file behind.
+    # disable it. `id_mapping = FALSE` is rejected by plotDOT()'s own internal
+    # heatmap helper (it only normalises FALSE -> NULL for some plot types),
+    # so NULL is used throughout to mean "no gene-symbol lookup" for every
+    # plot type. Some plotDOT() failures (e.g. too few paired ORFs to build a
+    # heatmap) are caught internally by the package itself and logged rather
+    # than raised, so no R error reaches this tryCatch and the png() device is
+    # closed having drawn nothing - check for a non-empty output file, not
+    # just the absence of a thrown error, to detect that case too.
     safe_plot_dot <- function(plot_type, fname, results_df = NULL, data = NULL,
                               annotation_params = list()) {
         if (is.null(results_df) || nrow(results_df) == 0) return(invisible(FALSE))
@@ -376,13 +388,15 @@ if (opt\$generate_plots) {
                 plot_type         = plot_type,
                 results           = results_df,
                 data              = data,
-                id_mapping        = FALSE,
+                id_mapping        = NULL,
                 plot_params       = list(top_hits = opt\$top_hits),
                 annotation_params = annotation_params,
                 force_new_device  = FALSE
             )
             dev.off()
-            invisible(TRUE)
+            drew_plot <- file.exists(fname) && file.info(fname)\$size > 0
+            if (!drew_plot && file.exists(fname)) unlink(fname)
+            invisible(drew_plot)
         }, error = \\(e) {
             while (length(dev.list()) > 0) dev.off()
             if (file.exists(fname)) unlink(fname)

--- a/modules/nf-core/dotseq/dotseq/tests/main.nf.test
+++ b/modules/nf-core/dotseq/dotseq/tests/main.nf.test
@@ -41,6 +41,7 @@ nextflow_process {
                 { assert process.out.volcano_plot.size() > 0 },
                 { assert process.out.composite_plot.size() > 0 },
                 { assert process.out.venn_plot.size() > 0 },
+                { assert process.out.heatmap_plot.size() > 0 },
                 { assert snapshot(
                     file(process.out.translation[0][1]).name,
                     file(process.out.dou[0][1]).name,
@@ -49,8 +50,45 @@ nextflow_process {
                     file(process.out.volcano_plot[0][1]).name,
                     file(process.out.composite_plot[0][1]).name,
                     file(process.out.venn_plot[0][1]).name,
+                    file(process.out.heatmap_plot[0][1]).name,
                     process.out.versions,
                     path(process.out.versions[0]).yaml
+                ).match() }
+            )
+        }
+    }
+
+    test("human - count matrix + annotation - non-mORF main label") {
+
+        config "./non_morf_main.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'cycling_vs_interphase' ],
+                    'condition',
+                    'Interphase',
+                    'Mitotic_Cycling'
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/dotseq/samplesheet.csv", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/dotseq/counts.tsv.gz", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/riboseq_expression/dotseq/annotation_non_morf.tsv.gz", checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.heatmap_plot.size() > 0 },
+                { assert snapshot(
+                    file(process.out.dou[0][1]).name,
+                    file(process.out.heatmap_plot[0][1]).name,
+                    process.out.versions
                 ).match() }
             )
         }

--- a/modules/nf-core/dotseq/dotseq/tests/main.nf.test.snap
+++ b/modules/nf-core/dotseq/dotseq/tests/main.nf.test.snap
@@ -5,38 +5,11 @@
                 "versions.yml:md5,5a3b9c79d3821d41e26d6147fe04421f"
             ]
         ],
-        "timestamp": "2026-05-22T12:30:00.000000000",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
-        }
-    },
-    "human - count matrix + annotation": {
-        "content": [
-            "cycling_vs_interphase.translation.dotseq.results.tsv",
-            "cycling_vs_interphase.dou.dotseq.results.tsv",
-            "cycling_vs_interphase.DOTSeqDataSets.rds",
-            "cycling_vs_interphase.interaction_p_distribution.png",
-            "cycling_vs_interphase.volcano.png",
-            "cycling_vs_interphase.composite.png",
-            "cycling_vs_interphase.venn.png",
-            [
-                "versions.yml:md5,5a3b9c79d3821d41e26d6147fe04421f"
-            ],
-            {
-                "DOTSEQ_DOTSEQ": {
-                    "bioconductor-dotseq": "1.0.0",
-                    "r-optparse": "1.8.2",
-                    "r-readr": "2.2.0",
-                    "r-dplyr": "1.2.1"
-                }
-            }
-        ],
-        "timestamp": "2026-05-22T12:30:00.000000000",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
-        }
+        },
+        "timestamp": "2026-05-22T12:30:00.000000000"
     },
     "human - count matrix + annotation - DOU module only": {
         "content": [
@@ -54,10 +27,52 @@
                 }
             }
         ],
-        "timestamp": "2026-05-22T12:30:00.000000000",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"
-        }
+        },
+        "timestamp": "2026-05-22T12:30:00.000000000"
+    },
+    "human - count matrix + annotation": {
+        "content": [
+            "cycling_vs_interphase.translation.dotseq.results.tsv",
+            "cycling_vs_interphase.dou.dotseq.results.tsv",
+            "cycling_vs_interphase.DOTSeqDataSets.rds",
+            "cycling_vs_interphase.interaction_p_distribution.png",
+            "cycling_vs_interphase.volcano.png",
+            "cycling_vs_interphase.composite.png",
+            "cycling_vs_interphase.venn.png",
+            "cycling_vs_interphase.heatmap.png",
+            [
+                "versions.yml:md5,5a3b9c79d3821d41e26d6147fe04421f"
+            ],
+            {
+                "DOTSEQ_DOTSEQ": {
+                    "bioconductor-dotseq": "1.0.0",
+                    "r-optparse": "1.8.2",
+                    "r-readr": "2.2.0",
+                    "r-dplyr": "1.2.1"
+                }
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-02T13:39:13.62096"
+    },
+    "human - count matrix + annotation - non-mORF main label": {
+        "content": [
+            "cycling_vs_interphase.dou.dotseq.results.tsv",
+            "cycling_vs_interphase.heatmap.png",
+            [
+                "versions.yml:md5,5a3b9c79d3821d41e26d6147fe04421f"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-02T14:03:07.451718"
     }
 }

--- a/modules/nf-core/dotseq/dotseq/tests/non_morf_main.config
+++ b/modules/nf-core/dotseq/dotseq/tests/non_morf_main.config
@@ -1,0 +1,7 @@
+includeConfig './nextflow.config'
+
+process {
+    withName: 'DOTSEQ_DOTSEQ' {
+        ext.args = '--orf_type_main_value canonical_cds'
+    }
+}


### PR DESCRIPTION
## Summary

`DOTSEQ_DOTSEQ`'s `*.heatmap.png` output has never actually been produced, for any annotation:

- The template calls `plotDOT()` with `id_mapping = FALSE`. DOTSeq's `plot_volcano()` normalises `isFALSE(id_mapping)` to `NULL`, but the heatmap's internal `cistronic_data()` helper has no such guard, so it evaluates `FALSE$ensembl_gene_id` and throws `$ operator is invalid for atomic vectors`. DOTSeq catches this internally and just logs a message, so no R error ever reaches the module's own `tryCatch`, and since nothing gets drawn between `png()` and `dev.off()`, no file is written at all - not even an empty one. The module's `safe_plot_dot()` only checked for a thrown exception, so it reported success regardless, silently swallowing the missing plot (the Nextflow output is `optional: true`).
- Fix: pass `id_mapping = NULL` (handled correctly by every `plotDOT()` plot type) and check for a non-empty output file rather than the absence of an exception. This also means the existing uORF/dORF heatmap fallback logic actually runs for the first time.

Separately, `cistronic_data()` hardcodes the literal string `"mORF"` for a gene's main ORF with no way to configure it, so an annotation using a different main-ORF label (e.g. `canonical_cds`, as nf-core/riboseq's `orf_class` column does) still produces no heatmap once the above is fixed, because there are no `"mORF"`-labelled rows to pair against. Added `--orf_type_main_value` (default `mORF`) so the template remaps whatever label the caller uses to `mORF` before building the annotation `GRanges`. `meta.yml` documents the `mORF`/`uORF`/`dORF` vocabulary constraint.

## Test plan

- [x] `nf-test test modules/nf-core/dotseq/dotseq/tests/main.nf.test --profile +docker --update-snapshot` - all 4 tests pass, snapshot updated
- [x] Added `heatmap_plot.size() > 0` to the existing test - now produces a real heatmap PNG that never existed before
- [x] Added a new test ("non-mORF main label") against a fixture on `pinin4fjords/test-datasets` (`add-dotseq-testdata` branch) with `orf_type` relabelled `mORF` → `canonical_cds`, using `--orf_type_main_value canonical_cds` - produces a heatmap
- [x] `nf-core modules lint dotseq/dotseq` - clean (2 pre-existing, unrelated container-registry-connectivity warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)