### PR TITLE
Add `process_long` to cellbender/removebackground

### DIFF
--- a/modules/nf-core/cellbender/removebackground/main.nf
+++ b/modules/nf-core/cellbender/removebackground/main.nf
@@ -1,6 +1,7 @@
 process CELLBENDER_REMOVEBACKGROUND {
     tag "$meta.id"
     label 'process_medium'
+    label 'process_long'
     label 'process_gpu'
 
     conda "${moduleDir}/environment.yml"

--- a/modules/nf-core/cellbender/removebackground/tests/main.nf.test
+++ b/modules/nf-core/cellbender/removebackground/tests/main.nf.test
@@ -21,8 +21,8 @@ nextflow_process {
             }
         }
         then {
+            assert process.success
             assertAll(
-                {assert process.success},
                 {assert snapshot(
                         process.out.findAll { key, val -> key.startsWith('versions') },
                         process.out.h5.collect{file(it[1]).name},
@@ -52,8 +52,8 @@ nextflow_process {
             }
         }
         then {
+            assert process.success
             assertAll(
-                {assert process.success},
                 {assert snapshot(process.out).match()}
             )
         }


### PR DESCRIPTION
In both nf-core/scrnaseq and nf-core/scdownstream we encountered issues with the runtime of cellbender. To prevent having pipeline-specific fixes, we assign the `process_long` label in the shared module.