### PR TITLE
Add plink/missing module

### DIFF
--- a/modules/nf-core/plink/missing/environment.yml
+++ b/modules/nf-core/plink/missing/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::plink=1.90b6.21

--- a/modules/nf-core/plink/missing/main.nf
+++ b/modules/nf-core/plink/missing/main.nf
@@ -1,0 +1,48 @@
+process PLINK_MISSING {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/plink:1.90b6.21--h779adbc_1'
+        : 'quay.io/biocontainers/plink:1.90b6.21--h779adbc_1'}"
+
+    input:
+    tuple val(meta), path(bed, stageAs: 'input/*'), path(bim, stageAs: 'input/*'), path(fam, stageAs: 'input/*')
+
+    output:
+    tuple val(meta), path("*.bed"), emit: bed
+    tuple val(meta), path("*.bim"), emit: bim
+    tuple val(meta), path("*.fam"), emit: fam
+    tuple val(meta), path("*.imiss"), emit: imiss
+    tuple val(meta), path("*.lmiss"), emit: lmiss
+    tuple val("${task.process}"), val('plink'), eval("plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'"), emit: versions_plink, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    plink \\
+        --bed ${bed} \\
+        --bim ${bim} \\
+        --fam ${fam} \\
+        --missing \\
+        --make-bed \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        --out ${prefix}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.bed
+    touch ${prefix}.bim
+    touch ${prefix}.fam
+    touch ${prefix}.imiss
+    touch ${prefix}.lmiss
+    """
+}

--- a/modules/nf-core/plink/missing/meta.yml
+++ b/modules/nf-core/plink/missing/meta.yml
@@ -1,0 +1,118 @@
+name: "plink_missing"
+description: Compute sample-based and variant-based missing genotype rates and write a new PLINK binary fileset
+keywords:
+  - plink
+  - missingness
+  - missing genotype rate
+  - quality control
+tools:
+  - "plink":
+      description: "Whole genome association analysis toolset, designed to perform a
+        range of basic, large-scale analyses in a computationally efficient manner."
+      homepage: "https://www.cog-genomics.org/plink"
+      documentation: "https://www.cog-genomics.org/plink/1.9/basic_stats#missing"
+      tool_dev_url: "https://www.cog-genomics.org/plink/1.9/dev"
+      licence: ["GPL"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bed:
+        type: file
+        description: PLINK binary biallelic genotype table file
+        pattern: "*.{bed}"
+        ontologies: []
+    - bim:
+        type: file
+        description: PLINK extended MAP file
+        pattern: "*.{bim}"
+        ontologies: []
+    - fam:
+        type: file
+        description: PLINK sample information file
+        pattern: "*.{fam}"
+        ontologies: []
+output:
+  bed:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bed":
+          type: file
+          description: PLINK binary biallelic genotype table file
+          pattern: "*.{bed}"
+          ontologies: []
+  bim:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bim":
+          type: file
+          description: PLINK extended MAP file
+          pattern: "*.{bim}"
+          ontologies: []
+  fam:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fam":
+          type: file
+          description: PLINK sample information file
+          pattern: "*.{fam}"
+          ontologies: []
+  imiss:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.imiss":
+          type: file
+          description: Sample-based missing genotype report
+          pattern: "*.{imiss}"
+          ontologies: []
+  lmiss:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.lmiss":
+          type: file
+          description: Variant-based missing genotype report
+          pattern: "*.{lmiss}"
+          ontologies: []
+  versions_plink:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink:
+          type: string
+          description: The name of the tool
+      - "plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink:
+          type: string
+          description: The name of the tool
+      - "plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool

--- a/modules/nf-core/plink/missing/tests/main.nf.test
+++ b/modules/nf-core/plink/missing/tests/main.nf.test
@@ -1,0 +1,56 @@
+nextflow_process {
+
+    name "Test Process PLINK_MISSING"
+    script "../main.nf"
+    process "PLINK_MISSING"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "plink"
+    tag "plink/missing"
+
+    test("plink - missing - binary") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("plink - missing - binary - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/plink/missing/tests/main.nf.test.snap
+++ b/modules/nf-core/plink/missing/tests/main.nf.test.snap
@@ -1,0 +1,118 @@
+{
+    "plink - missing - binary": {
+        "content": [
+            {
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,e1f17b70b8f213aa6d48dbde955451b4"
+                    ]
+                ],
+                "bim": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bim:md5,41351028a80a8cf5bec0ab2db04af6c9"
+                    ]
+                ],
+                "fam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fam:md5,d8081ba95728f56fda38d2868eab3a77"
+                    ]
+                ],
+                "imiss": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.imiss:md5,34c5132dd89461260ed59f83df3911e8"
+                    ]
+                ],
+                "lmiss": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.lmiss:md5,87c37b8c05d5bb2a256081da43e7a0a0"
+                    ]
+                ],
+                "versions_plink": [
+                    [
+                        "PLINK_MISSING",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T06:56:12.402292915"
+    },
+    "plink - missing - binary - stub": {
+        "content": [
+            {
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bim": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bim:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "imiss": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.imiss:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "lmiss": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.lmiss:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_plink": [
+                    [
+                        "PLINK_MISSING",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T06:56:22.943811079"
+    }
+}


### PR DESCRIPTION
## PR checklist

Adds a `plink/missing` module wrapping PLINK 1.9 `--missing`. It computes per-sample (`.imiss`) and per-variant (`.lmiss`) missing-genotype rates and emits a regenerated PLINK binary fileset, a common step in genotype quality control.

Tests reuse the existing public `plink_simulated` fileset from `nf-core/test-datasets`, so no new test data is required.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
