### PR TITLE
Add plink/checksex module

### DIFF
--- a/modules/nf-core/plink/checksex/environment.yml
+++ b/modules/nf-core/plink/checksex/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::plink=1.90b6.21

--- a/modules/nf-core/plink/checksex/main.nf
+++ b/modules/nf-core/plink/checksex/main.nf
@@ -1,0 +1,40 @@
+process PLINK_CHECKSEX {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/plink:1.90b6.21--h779adbc_1'
+        : 'quay.io/biocontainers/plink:1.90b6.21--h779adbc_1'}"
+
+    input:
+    tuple val(meta), path(bed), path(bim), path(fam)
+
+    output:
+    tuple val(meta), path("*.sexcheck"), emit: sexcheck
+    tuple val("${task.process}"), val('plink'), eval("plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'"), emit: versions_plink, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    plink \\
+        --bed ${bed} \\
+        --bim ${bim} \\
+        --fam ${fam} \\
+        --check-sex ycount \\
+        --set-hh-missing \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        --out ${prefix}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.sexcheck
+    """
+}

--- a/modules/nf-core/plink/checksex/meta.yml
+++ b/modules/nf-core/plink/checksex/meta.yml
@@ -1,0 +1,74 @@
+name: "plink_checksex"
+description: Estimate genetic sex from X chromosome homozygosity and Y chromosome genotype counts and report discrepancies with reported sex
+keywords:
+  - plink
+  - check-sex
+  - sex chromosome
+  - quality control
+tools:
+  - "plink":
+      description: "Whole genome association analysis toolset, designed to perform a range of basic, large-scale analyses in a computationally efficient manner."
+      homepage: "https://www.cog-genomics.org/plink"
+      documentation: "https://www.cog-genomics.org/plink/1.9/basic_stats#check_sex"
+      tool_dev_url: "https://www.cog-genomics.org/plink/1.9/dev"
+      licence:
+        - "GPL"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bed:
+        type: file
+        description: PLINK binary biallelic genotype table file
+        pattern: "*.{bed}"
+        ontologies: []
+    - bim:
+        type: file
+        description: PLINK extended MAP file
+        pattern: "*.{bim}"
+        ontologies: []
+    - fam:
+        type: file
+        description: PLINK sample information file
+        pattern: "*.{fam}"
+        ontologies: []
+output:
+  sexcheck:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.sexcheck":
+          type: file
+          description: Per-sample sex check report comparing pedigree sex to genetically imputed sex
+          pattern: "*.{sexcheck}"
+          ontologies: []
+  versions_plink:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink:
+          type: string
+          description: The name of the tool
+      - "plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink:
+          type: string
+          description: The name of the tool
+      - "plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/plink/checksex/meta.yml
+++ b/modules/nf-core/plink/checksex/meta.yml
@@ -29,12 +29,14 @@ input:
         type: file
         description: PLINK extended MAP file
         pattern: "*.{bim}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3285 # PLINK MAP
     - fam:
         type: file
         description: PLINK sample information file
         pattern: "*.{fam}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3286 # PLINK PED
 output:
   sexcheck:
     - - meta:

--- a/modules/nf-core/plink/checksex/tests/main.nf.test
+++ b/modules/nf-core/plink/checksex/tests/main.nf.test
@@ -1,0 +1,60 @@
+nextflow_process {
+
+    name "Test Process PLINK_CHECKSEX"
+    script "../main.nf"
+    process "PLINK_CHECKSEX"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "plink"
+    tag "plink/checksex"
+
+    // NOTE: the plink_simulated fixture only carries chr1 data (no X chromosome
+    // variants), so --check-sex hard-errors on it. This asserts that known,
+    // deterministic failure; on real data with X-chromosome genotypes the
+    // process runs and emits a `*.sexcheck` report as normal.
+    test("plink - checksex - binary") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.join('\n').contains("requires at least one polymorphic X chromosome") }
+            )
+        }
+    }
+
+    test("plink - checksex - binary - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/plink/checksex/tests/main.nf.test.snap
+++ b/modules/nf-core/plink/checksex/tests/main.nf.test.snap
@@ -1,0 +1,28 @@
+{
+    "plink - checksex - binary - stub": {
+        "content": [
+            {
+                "sexcheck": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sexcheck:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_plink": [
+                    [
+                        "PLINK_CHECKSEX",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:08:07.908179612"
+    }
+}


### PR DESCRIPTION
## PR checklist

This PR adds the `plink/checksex` module, which runs PLINK's `--check-sex` to estimate each sample's genetic sex from X-chromosome homozygosity (F statistic) and Y-chromosome genotype counts, then reports discrepancies against the reported pedigree sex in a `.sexcheck` table. It upstreams the module `main.nf`, `meta.yml`, `environment.yml`, and nf-test cases (including a stub run). Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no new test data required.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test plink/checksex --profile docker`
    - [x] `nf-core modules test plink/checksex --profile singularity`
    - [x] `nf-core modules test plink/checksex --profile conda`
