### PR TITLE
Add plink/hwefilter module

### DIFF
--- a/modules/nf-core/plink/hwefilter/environment.yml
+++ b/modules/nf-core/plink/hwefilter/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::plink=1.90b6.21

--- a/modules/nf-core/plink/hwefilter/main.nf
+++ b/modules/nf-core/plink/hwefilter/main.nf
@@ -1,0 +1,45 @@
+process PLINK_HWEFILTER {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/plink:1.90b6.21--h779adbc_1'
+        : 'quay.io/biocontainers/plink:1.90b6.21--h779adbc_1'}"
+
+    input:
+    tuple val(meta), path(bed, stageAs: 'input/*'), path(bim, stageAs: 'input/*'), path(fam, stageAs: 'input/*')
+    val hwe
+
+    output:
+    tuple val(meta), path("*.bed"), emit: bed
+    tuple val(meta), path("*.bim"), emit: bim
+    tuple val(meta), path("*.fam"), emit: fam
+    tuple val("${task.process}"), val('plink'), eval("plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'"), emit: versions_plink, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    plink \\
+        --bed ${bed} \\
+        --bim ${bim} \\
+        --fam ${fam} \\
+        --hwe ${hwe} \\
+        --make-bed \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        --out ${prefix}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.bed
+    touch ${prefix}.bim
+    touch ${prefix}.fam
+    """
+}

--- a/modules/nf-core/plink/hwefilter/meta.yml
+++ b/modules/nf-core/plink/hwefilter/meta.yml
@@ -30,12 +30,14 @@ input:
         type: file
         description: PLINK extended MAP file
         pattern: "*.{bim}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3285 # PLINK MAP
     - fam:
         type: file
         description: PLINK sample information file
         pattern: "*.{fam}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3286 # PLINK PED
   - hwe:
       type: float
       description: Hardy-Weinberg equilibrium exact-test p-value threshold; variants below this value are removed
@@ -61,7 +63,8 @@ output:
           type: file
           description: PLINK extended MAP file after HWE filtering
           pattern: "*.{bim}"
-          ontologies: []
+          ontologies:
+            - edam: http://edamontology.org/format_3285 # PLINK MAP
   fam:
     - - meta:
           type: map
@@ -72,7 +75,8 @@ output:
           type: file
           description: PLINK sample information file after HWE filtering
           pattern: "*.{fam}"
-          ontologies: []
+          ontologies:
+            - edam: http://edamontology.org/format_3286 # PLINK PED
   versions_plink:
     - - "${task.process}":
           type: string

--- a/modules/nf-core/plink/hwefilter/meta.yml
+++ b/modules/nf-core/plink/hwefilter/meta.yml
@@ -1,0 +1,100 @@
+name: "plink_hwefilter"
+description: Remove variants that fail a Hardy-Weinberg equilibrium exact test and write a new PLINK binary fileset
+keywords:
+  - plink
+  - hardy-weinberg
+  - hwe
+  - filter
+  - quality control
+tools:
+  - "plink":
+      description: "Whole genome association analysis toolset, designed to perform a range of basic, large-scale analyses in a computationally efficient manner."
+      homepage: "https://www.cog-genomics.org/plink"
+      documentation: "https://www.cog-genomics.org/plink/1.9/filter#hwe"
+      tool_dev_url: "https://www.cog-genomics.org/plink/1.9/dev"
+      licence:
+        - "GPL"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bed:
+        type: file
+        description: PLINK binary biallelic genotype table file
+        pattern: "*.{bed}"
+        ontologies: []
+    - bim:
+        type: file
+        description: PLINK extended MAP file
+        pattern: "*.{bim}"
+        ontologies: []
+    - fam:
+        type: file
+        description: PLINK sample information file
+        pattern: "*.{fam}"
+        ontologies: []
+  - hwe:
+      type: float
+      description: Hardy-Weinberg equilibrium exact-test p-value threshold; variants below this value are removed
+output:
+  bed:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bed":
+          type: file
+          description: PLINK binary biallelic genotype table file after HWE filtering
+          pattern: "*.{bed}"
+          ontologies: []
+  bim:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bim":
+          type: file
+          description: PLINK extended MAP file after HWE filtering
+          pattern: "*.{bim}"
+          ontologies: []
+  fam:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fam":
+          type: file
+          description: PLINK sample information file after HWE filtering
+          pattern: "*.{fam}"
+          ontologies: []
+  versions_plink:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink:
+          type: string
+          description: The name of the tool
+      - "plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink:
+          type: string
+          description: The name of the tool
+      - "plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/plink/hwefilter/tests/main.nf.test
+++ b/modules/nf-core/plink/hwefilter/tests/main.nf.test
@@ -1,0 +1,58 @@
+nextflow_process {
+
+    name "Test Process PLINK_HWEFILTER"
+    script "../main.nf"
+    process "PLINK_HWEFILTER"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "plink"
+    tag "plink/hwefilter"
+
+    test("plink - hwefilter - binary") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                input[1] = 0.001
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("plink - hwefilter - binary - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                input[1] = 0.001
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/plink/hwefilter/tests/main.nf.test.snap
+++ b/modules/nf-core/plink/hwefilter/tests/main.nf.test.snap
@@ -1,0 +1,86 @@
+{
+    "plink - hwefilter - binary": {
+        "content": [
+            {
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,e1f17b70b8f213aa6d48dbde955451b4"
+                    ]
+                ],
+                "bim": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bim:md5,41351028a80a8cf5bec0ab2db04af6c9"
+                    ]
+                ],
+                "fam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fam:md5,d8081ba95728f56fda38d2868eab3a77"
+                    ]
+                ],
+                "versions_plink": [
+                    [
+                        "PLINK_HWEFILTER",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:03:59.555175567"
+    },
+    "plink - hwefilter - binary - stub": {
+        "content": [
+            {
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bim": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bim:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_plink": [
+                    [
+                        "PLINK_HWEFILTER",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:04:12.550931172"
+    }
+}


### PR DESCRIPTION
## PR checklist

The `plink/hwefilter` module runs PLINK's Hardy-Weinberg equilibrium exact test (`--hwe`) to remove variants that deviate significantly from HWE and writes out a new filtered PLINK binary fileset (`.bed`/`.bim`/`.fam`). This upstreams the module `main.nf`, `meta.yml`, `environment.yml`, and nf-test cases (including a stub). Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no new test data required.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test plink/hwefilter --profile docker`
    - [x] `nf-core modules test plink/hwefilter --profile singularity`
    - [x] `nf-core modules test plink/hwefilter --profile conda`
