### PR TITLE
Add plink/ibc module

### DIFF
--- a/modules/nf-core/plink/ibc/environment.yml
+++ b/modules/nf-core/plink/ibc/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::plink=1.90b6.21

--- a/modules/nf-core/plink/ibc/main.nf
+++ b/modules/nf-core/plink/ibc/main.nf
@@ -1,0 +1,46 @@
+process PLINK_IBC {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/plink:1.90b6.21--h779adbc_1'
+        : 'quay.io/biocontainers/plink:1.90b6.21--h779adbc_1'}"
+
+    input:
+    tuple val(meta), path(bed, stageAs: 'input/*'), path(bim, stageAs: 'input/*'), path(fam, stageAs: 'input/*')
+
+    output:
+    tuple val(meta), path("*.bed"), emit: bed
+    tuple val(meta), path("*.bim"), emit: bim
+    tuple val(meta), path("*.fam"), emit: fam
+    tuple val(meta), path("*.ibc"), emit: ibc
+    tuple val("${task.process}"), val('plink'), eval("plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'"), emit: versions_plink, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    plink \\
+        --bed ${bed} \\
+        --bim ${bim} \\
+        --fam ${fam} \\
+        --ibc \\
+        --make-bed \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        --out ${prefix}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.bed
+    touch ${prefix}.bim
+    touch ${prefix}.fam
+    touch ${prefix}.ibc
+    """
+}

--- a/modules/nf-core/plink/ibc/meta.yml
+++ b/modules/nf-core/plink/ibc/meta.yml
@@ -1,0 +1,108 @@
+name: "plink_ibc"
+description: Compute individual-level inbreeding coefficients (Fhat1/Fhat2/Fhat3) and write a new PLINK binary fileset
+keywords:
+  - plink
+  - ibc
+  - inbreeding coefficient
+  - heterozygosity
+  - quality control
+tools:
+  - "plink":
+      description: "Whole genome association analysis toolset, designed to perform a range of basic, large-scale analyses in a computationally efficient manner."
+      homepage: "https://www.cog-genomics.org/plink"
+      documentation: "https://www.cog-genomics.org/plink/1.9/ibd#ibc"
+      tool_dev_url: "https://www.cog-genomics.org/plink/1.9/dev"
+      licence:
+        - "GPL"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bed:
+        type: file
+        description: PLINK binary biallelic genotype table file
+        pattern: "*.{bed}"
+        ontologies: []
+    - bim:
+        type: file
+        description: PLINK extended MAP file
+        pattern: "*.{bim}"
+        ontologies: []
+    - fam:
+        type: file
+        description: PLINK sample information file
+        pattern: "*.{fam}"
+        ontologies: []
+output:
+  bed:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bed":
+          type: file
+          description: PLINK binary biallelic genotype table file
+          pattern: "*.{bed}"
+          ontologies: []
+  bim:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.bim":
+          type: file
+          description: PLINK extended MAP file
+          pattern: "*.{bim}"
+          ontologies: []
+  fam:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fam":
+          type: file
+          description: PLINK sample information file
+          pattern: "*.{fam}"
+          ontologies: []
+  ibc:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.ibc":
+          type: file
+          description: Per-sample inbreeding coefficient report (Fhat1/Fhat2/Fhat3)
+          pattern: "*.{ibc}"
+          ontologies: []
+  versions_plink:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink:
+          type: string
+          description: The name of the tool
+      - "plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink:
+          type: string
+          description: The name of the tool
+      - "plink --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/plink/ibc/meta.yml
+++ b/modules/nf-core/plink/ibc/meta.yml
@@ -30,12 +30,14 @@ input:
         type: file
         description: PLINK extended MAP file
         pattern: "*.{bim}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3285 # PLINK MAP
     - fam:
         type: file
         description: PLINK sample information file
         pattern: "*.{fam}"
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3286 # PLINK PED
 output:
   bed:
     - - meta:
@@ -58,7 +60,8 @@ output:
           type: file
           description: PLINK extended MAP file
           pattern: "*.{bim}"
-          ontologies: []
+          ontologies:
+            - edam: http://edamontology.org/format_3285 # PLINK MAP
   fam:
     - - meta:
           type: map
@@ -69,7 +72,8 @@ output:
           type: file
           description: PLINK sample information file
           pattern: "*.{fam}"
-          ontologies: []
+          ontologies:
+            - edam: http://edamontology.org/format_3286 # PLINK PED
   ibc:
     - - meta:
           type: map

--- a/modules/nf-core/plink/ibc/tests/main.nf.test
+++ b/modules/nf-core/plink/ibc/tests/main.nf.test
@@ -1,0 +1,56 @@
+nextflow_process {
+
+    name "Test Process PLINK_IBC"
+    script "../main.nf"
+    process "PLINK_IBC"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "plink"
+    tag "plink/ibc"
+
+    test("plink - ibc - binary") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("plink - ibc - binary - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/plink/ibc/tests/main.nf.test.snap
+++ b/modules/nf-core/plink/ibc/tests/main.nf.test.snap
@@ -1,0 +1,102 @@
+{
+    "plink - ibc - binary": {
+        "content": [
+            {
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,e1f17b70b8f213aa6d48dbde955451b4"
+                    ]
+                ],
+                "bim": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bim:md5,41351028a80a8cf5bec0ab2db04af6c9"
+                    ]
+                ],
+                "fam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fam:md5,d8081ba95728f56fda38d2868eab3a77"
+                    ]
+                ],
+                "ibc": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.ibc:md5,8668b52f45ef0ddea0f6f6b0c940ed9b"
+                    ]
+                ],
+                "versions_plink": [
+                    [
+                        "PLINK_IBC",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:02:49.679410616"
+    },
+    "plink - ibc - binary - stub": {
+        "content": [
+            {
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bim": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bim:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fam": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "ibc": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.ibc:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_plink": [
+                    [
+                        "PLINK_IBC",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:03:01.451860004"
+    }
+}


### PR DESCRIPTION
## PR checklist

This adds the `plink/ibc` module, which runs PLINK's `--ibc` to compute per-sample inbreeding coefficients (Fhat1/Fhat2/Fhat3) from a binary fileset and emits both the `.ibc` report and an updated PLINK binary fileset. The module is upstreamed with its `main.nf`, `meta.yml`, `environment.yml`, and nf-test cases covering the real and stub runs. Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no new test data required.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test plink/ibc --profile docker`
    - [x] `nf-core modules test plink/ibc --profile singularity`
    - [x] `nf-core modules test plink/ibc --profile conda`
