### PR TITLE
Add plink2/king module

### DIFF
--- a/modules/nf-core/plink2/king/environment.yml
+++ b/modules/nf-core/plink2/king/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::plink2=2.00a5.10"

--- a/modules/nf-core/plink2/king/main.nf
+++ b/modules/nf-core/plink2/king/main.nf
@@ -1,0 +1,50 @@
+process PLINK2_KING {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/plink2:2.00a5.10--h4ac6f70_0'
+        : 'quay.io/biocontainers/plink2:2.00a5.10--h4ac6f70_0'}"
+
+    input:
+    tuple val(meta), path(plink_genotype_file), path(plink_variant_file), path(plink_sample_file)
+
+    output:
+    tuple val(meta), path("*.kin0"), emit: kin0
+    tuple val(meta), path("*.king*"), emit: king
+    tuple val("${task.process}"), val('plink2'), eval("plink2 --version 2>&1 | sed 's/^PLINK v//;s/ .*//'"), emit: versions_plink2, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def mode = plink_genotype_file.extension == 'pgen' ? '--pfile' : '--bfile'
+    def input = "${plink_genotype_file.getBaseName()}"
+    """
+    plink2 \\
+        ${mode} ${input} \\
+        --make-king-table \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        --out ${prefix}
+
+    plink2 \\
+        ${mode} ${input} \\
+        --make-king triangle bin \\
+        --threads ${task.cpus} \\
+        ${args2} \\
+        --out ${prefix}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.kin0
+    touch ${prefix}.king.bin
+    touch ${prefix}.king.id
+    """
+}

--- a/modules/nf-core/plink2/king/meta.yml
+++ b/modules/nf-core/plink2/king/meta.yml
@@ -1,0 +1,90 @@
+name: "plink2_king"
+description: Estimate pairwise kinship using the KING-robust estimator, producing both a kinship table and a triangular KING relatedness matrix
+keywords:
+  - plink2
+  - king
+  - kinship
+  - relatedness
+  - ibd
+  - quality control
+tools:
+  - "plink2":
+      description: |
+        Whole genome association analysis toolset, designed to perform a range
+        of basic, large-scale analyses in a computationally efficient manner
+      homepage: "http://www.cog-genomics.org/plink/2.0/"
+      documentation: "http://www.cog-genomics.org/plink/2.0/distance#king_cutoff"
+      doi: "10.1186/s13742-015-0047-8"
+      licence:
+        - "GPL v3"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - plink_genotype_file:
+        type: file
+        description: PLINK binary genotype table file or PLINK 2 binary genotype table
+          file
+        pattern: "*.{bed,pgen}"
+        ontologies: []
+    - plink_variant_file:
+        type: file
+        description: PLINK extended MAP file or PLINK 2 variant information file
+        pattern: "*.{bim,pvar}"
+        ontologies: []
+    - plink_sample_file:
+        type: file
+        description: PLINK sample information file or PLINK 2 sample information file
+        pattern: "*.{fam,psam}"
+        ontologies: []
+output:
+  kin0:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.kin0":
+          type: file
+          description: Pairwise KING-robust kinship coefficient table
+          pattern: "*.{kin0}"
+          ontologies: []
+  king:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.king*":
+          type: file
+          description: Triangular KING-robust relatedness matrix (binary) and its sample id file
+          pattern: "*.king*"
+          ontologies: []
+  versions_plink2:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink2:
+          type: string
+          description: The name of the tool
+      - "plink2 --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink2:
+          type: string
+          description: The name of the tool
+      - "plink2 --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/plink2/king/meta.yml
+++ b/modules/nf-core/plink2/king/meta.yml
@@ -51,7 +51,8 @@ output:
           type: file
           description: Pairwise KING-robust kinship coefficient table
           pattern: "*.{kin0}"
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_3475"
   king:
     - - meta:
           type: map

--- a/modules/nf-core/plink2/king/tests/main.nf.test
+++ b/modules/nf-core/plink2/king/tests/main.nf.test
@@ -1,0 +1,102 @@
+nextflow_process {
+
+    name "Test Process PLINK2_KING"
+    script "../main.nf"
+    process "PLINK2_KING"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "plink2"
+    tag "plink2/king"
+
+    test("plink2 - king - binary") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("plink2 - king - binary - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.bim', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.fam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("plink2 - king - pgen") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("plink2 - king - pgen - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/plink2/king/tests/main.nf.test.snap
+++ b/modules/nf-core/plink2/king/tests/main.nf.test.snap
@@ -1,0 +1,150 @@
+{
+    "plink2 - king - binary - stub": {
+        "content": [
+            {
+                "kin0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.kin0:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "king": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.king.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.king.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions_plink2": [
+                    [
+                        "PLINK2_KING",
+                        "plink2",
+                        "2.00a5.10LM"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:08:16.364470903"
+    },
+    "plink2 - king - pgen": {
+        "content": [
+            {
+                "kin0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.kin0:md5,2a9943405a5647864931e1e4439bb0ed"
+                    ]
+                ],
+                "king": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.king.bin:md5,2504ff10065093d69ad063f92be42dc7",
+                            "test.king.id:md5,9273630aef63cbab6cdcde65f1dafc47"
+                        ]
+                    ]
+                ],
+                "versions_plink2": [
+                    [
+                        "PLINK2_KING",
+                        "plink2",
+                        "2.00a5.10LM"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:08:28.651662287"
+    },
+    "plink2 - king - binary": {
+        "content": [
+            {
+                "kin0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.kin0:md5,2a9943405a5647864931e1e4439bb0ed"
+                    ]
+                ],
+                "king": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.king.bin:md5,2504ff10065093d69ad063f92be42dc7",
+                            "test.king.id:md5,9273630aef63cbab6cdcde65f1dafc47"
+                        ]
+                    ]
+                ],
+                "versions_plink2": [
+                    [
+                        "PLINK2_KING",
+                        "plink2",
+                        "2.00a5.10LM"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:08:04.563633465"
+    },
+    "plink2 - king - pgen - stub": {
+        "content": [
+            {
+                "kin0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.kin0:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "king": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test.king.bin:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.king.id:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions_plink2": [
+                    [
+                        "PLINK2_KING",
+                        "plink2",
+                        "2.00a5.10LM"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T07:08:41.204016772"
+    }
+}


### PR DESCRIPTION
## PR checklist

This module runs `plink2 --make-king` to estimate pairwise kinship with the KING-robust estimator, producing both a `.kin0` kinship coefficient table and a triangular KING relatedness matrix. It upstreams the `plink2/king` module, which accepts both PLINK1 (bed/bim/fam) and PLINK2 (pgen/pvar/psam) genotype inputs. Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no new test data required.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test plink2/king --profile docker`
    - [x] `nf-core modules test plink2/king --profile singularity`
    - [x] `nf-core modules test plink2/king --profile conda`
