### PR TITLE
Add plink2/pcawts module

### DIFF
--- a/modules/nf-core/plink2/pcawts/environment.yml
+++ b/modules/nf-core/plink2/pcawts/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::plink2=2.00a5.10

--- a/modules/nf-core/plink2/pcawts/main.nf
+++ b/modules/nf-core/plink2/pcawts/main.nf
@@ -1,0 +1,46 @@
+process PLINK2_PCAWTS {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/plink2:2.00a5.10--h4ac6f70_0'
+        : 'quay.io/biocontainers/plink2:2.00a5.10--h4ac6f70_0'}"
+
+    input:
+    tuple val(meta), val(npcs), path(pgen), path(pvar), path(psam)
+
+    output:
+    tuple val(meta), path("*.eigenvec.allele"), emit: allele_weights
+    tuple val(meta), path("*.eigenvec"), emit: eigenvec
+    tuple val(meta), path("*.eigenval"), emit: eigenval
+    tuple val(meta), path("*.log"), emit: log
+    tuple val("${task.process}"), val('plink2'), eval("plink2 --version 2>&1 | sed 's/^PLINK v//;s/ .*//'"), emit: versions_plink2, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def n_pcs = npcs ?: 10
+    """
+    plink2 \\
+        --pgen ${pgen} \\
+        --pvar ${pvar} \\
+        --psam ${psam} \\
+        --pca ${n_pcs} allele-wts \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        --out ${prefix}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.eigenvec.allele
+    touch ${prefix}.eigenvec
+    touch ${prefix}.eigenval
+    touch ${prefix}.log
+    """
+}

--- a/modules/nf-core/plink2/pcawts/meta.yml
+++ b/modules/nf-core/plink2/pcawts/meta.yml
@@ -50,7 +50,8 @@ output:
           type: file
           description: Per-allele PCA weights for projecting new samples onto the reference PCs
           pattern: "*.{eigenvec.allele}"
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_3475"
   eigenvec:
     - - meta:
           type: map
@@ -61,7 +62,8 @@ output:
           type: file
           description: Principal component scores for the input samples
           pattern: "*.{eigenvec}"
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_3475"
   eigenval:
     - - meta:
           type: map

--- a/modules/nf-core/plink2/pcawts/meta.yml
+++ b/modules/nf-core/plink2/pcawts/meta.yml
@@ -1,0 +1,111 @@
+name: "plink2_pcawts"
+description: Run a principal component analysis with plink2 and emit per-allele PCA weights for projection
+keywords:
+  - plink2
+  - pca
+  - allele weights
+  - projection
+  - ancestry
+tools:
+  - "plink2":
+      description: "Whole genome association analysis toolset, designed to perform a range of basic, large-scale analyses in a computationally efficient manner."
+      homepage: "https://www.cog-genomics.org/plink/2.0/"
+      documentation: "https://www.cog-genomics.org/plink/2.0/strat#pca"
+      tool_dev_url: "https://www.cog-genomics.org/plink/2.0/"
+      licence:
+        - "GPL"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test' ]
+    - npcs:
+        type: integer
+        description: Number of principal components to compute
+    - pgen:
+        type: file
+        description: PLINK2 binary genotype table
+        pattern: "*.{pgen}"
+        ontologies: []
+    - pvar:
+        type: file
+        description: PLINK2 variant information file
+        pattern: "*.{pvar}"
+        ontologies: []
+    - psam:
+        type: file
+        description: PLINK2 sample information file
+        pattern: "*.{psam}"
+        ontologies: []
+output:
+  allele_weights:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.eigenvec.allele":
+          type: file
+          description: Per-allele PCA weights for projecting new samples onto the reference PCs
+          pattern: "*.{eigenvec.allele}"
+          ontologies: []
+  eigenvec:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.eigenvec":
+          type: file
+          description: Principal component scores for the input samples
+          pattern: "*.{eigenvec}"
+          ontologies: []
+  eigenval:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.eigenval":
+          type: file
+          description: Eigenvalues of the principal components
+          pattern: "*.{eigenval}"
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "*.log":
+          type: file
+          description: PLINK2 log file
+          pattern: "*.{log}"
+          ontologies: []
+  versions_plink2:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink2:
+          type: string
+          description: The name of the tool
+      - "plink2 --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - plink2:
+          type: string
+          description: The name of the tool
+      - "plink2 --version 2>&1 | sed 's/^PLINK v//;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/plink2/pcawts/tests/main.nf.test
+++ b/modules/nf-core/plink2/pcawts/tests/main.nf.test
@@ -27,7 +27,6 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert path(process.out.allele_weights[0][1]).readLines().size() > 1 },
                 { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
             )
         }

--- a/modules/nf-core/plink2/pcawts/tests/main.nf.test
+++ b/modules/nf-core/plink2/pcawts/tests/main.nf.test
@@ -1,0 +1,60 @@
+nextflow_process {
+
+    name "Test Process PLINK2_PCAWTS"
+    script "../main.nf"
+    process "PLINK2_PCAWTS"
+    config "./nextflow.config"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "plink2"
+    tag "plink2/pcawts"
+
+    test("plink2 - pcawts - pgen") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    2,
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.allele_weights[0][1]).readLines().size() > 1 },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
+            )
+        }
+    }
+
+    test("plink2 - pcawts - pgen - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    2,
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pgen', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.pvar', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.psam', checkIfExists: true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/plink2/pcawts/tests/main.nf.test.snap
+++ b/modules/nf-core/plink2/pcawts/tests/main.nf.test.snap
@@ -1,0 +1,102 @@
+{
+    "plink2 - pcawts - pgen": {
+        "content": [
+            {
+                "allele_weights": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pcawts.eigenvec.allele:md5,e2fe1145fd1e13faa73ac48d4d81c3b4"
+                    ]
+                ],
+                "eigenval": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pcawts.eigenval:md5,afd4610b17155c5795be4125734dd9fc"
+                    ]
+                ],
+                "eigenvec": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pcawts.eigenvec:md5,66bc56667abab9799cb2c69f0caee6da"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pcawts.log"
+                    ]
+                ],
+                "versions_plink2": [
+                    [
+                        "PLINK2_PCAWTS",
+                        "plink2",
+                        "2.00a5.10LM"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T12:18:50.146298751"
+    },
+    "plink2 - pcawts - pgen - stub": {
+        "content": [
+            {
+                "allele_weights": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pcawts.eigenvec.allele:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "eigenval": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pcawts.eigenval:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "eigenvec": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pcawts.eigenvec:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_pcawts.log"
+                    ]
+                ],
+                "versions_plink2": [
+                    [
+                        "PLINK2_PCAWTS",
+                        "plink2",
+                        "2.00a5.10LM"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T12:19:01.410864816"
+    }
+}

--- a/modules/nf-core/plink2/pcawts/tests/nextflow.config
+++ b/modules/nf-core/plink2/pcawts/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: PLINK2_PCAWTS {
+        ext.prefix = { "${meta.id}_pcawts" }
+    }
+}


### PR DESCRIPTION
## PR checklist

This PR adds the `plink2/pcawts` module. It runs a principal component analysis with `plink2 --pca <n> allele-wts` on a PLINK2 binary fileset (pgen/pvar/psam) and emits the per-allele PCA weights (`.eigenvec.allele`), the principal component scores (`.eigenvec`), the eigenvalues (`.eigenval`), and the plink2 log, with topic-based version reporting. The per-allele weights are the key output: they allow new samples to be projected onto the reference principal components (e.g. for ancestry inference) without recomputing the PCA. Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no new test data required.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test plink2/pcawts --profile docker`
    - [x] `nf-core modules test plink2/pcawts --profile singularity`
    - [x] `nf-core modules test plink2/pcawts --profile conda`
