### PR TITLE
Add ldak/thinpredictors module

### DIFF
--- a/modules/nf-core/ldak/thinpredictors/environment.yml
+++ b/modules/nf-core/ldak/thinpredictors/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+  - genomedk
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - genomedk::ldak6=6.1

--- a/modules/nf-core/ldak/thinpredictors/main.nf
+++ b/modules/nf-core/ldak/thinpredictors/main.nf
@@ -8,6 +8,8 @@ process LDAK_THINPREDICTORS {
 
     input:
     tuple val(meta), path(bed), path(bim), path(fam)
+    val window_prune
+    val window_kb
 
     output:
     tuple val(meta), path("${prefix}.in"), emit: thin_predictors
@@ -17,15 +19,15 @@ process LDAK_THINPREDICTORS {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: '--window-prune 0.98 --window-kb 100'
+    def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
-
     """
-
     ldak6 \\
         --thin ${prefix} \\
         --bfile ${bed.baseName} \\
-        --max-threads ${task.cpus} \
+        --window-prune ${window_prune} \\
+        --window-kb ${window_kb} \\
+        --max-threads ${task.cpus} \\
         ${args}
     """
 

--- a/modules/nf-core/ldak/thinpredictors/main.nf
+++ b/modules/nf-core/ldak/thinpredictors/main.nf
@@ -1,0 +1,37 @@
+process LDAK_THINPREDICTORS {
+    tag "${meta.id}"
+    label 'process_medium'
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c9/c94e5424f08cbd7e0856ab3c3a9992b4080944a5d0c497ce0abcceb413db4a3e/data'
+        : 'community.wave.seqera.io/library/ldak6_r-base:452828f72b3c9129'}"
+
+    input:
+    tuple val(meta), path(bed), path(bim), path(fam)
+
+    output:
+    tuple val(meta), path("${prefix}.in"), emit: thin_predictors
+    tuple val("${task.process}"), val("ldak6"), eval("ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+'"), emit: versions_ldak6, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: '--window-prune 0.98 --window-kb 100'
+    prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+
+    ldak6 \\
+        --thin ${prefix} \\
+        --bfile ${bed.baseName} \\
+        --max-threads ${task.cpus} \
+        ${args}
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.in
+    """
+}

--- a/modules/nf-core/ldak/thinpredictors/meta.yml
+++ b/modules/nf-core/ldak/thinpredictors/meta.yml
@@ -24,11 +24,13 @@ input:
     - bim:
         type: file
         description: PLINK BIM variant file
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3285 # PLINK MAP
     - fam:
         type: file
         description: PLINK FAM sample file
-        ontologies: []
+        ontologies:
+          - edam: http://edamontology.org/format_3286 # PLINK PED
   - window_prune:
       type: float
       description: Correlation squared (r²) threshold passed to LDAK `--window-prune` (for example, 0.98)

--- a/modules/nf-core/ldak/thinpredictors/meta.yml
+++ b/modules/nf-core/ldak/thinpredictors/meta.yml
@@ -20,12 +20,21 @@ input:
     - bed:
         type: file
         description: PLINK BED genotype file
+        ontologies: []
     - bim:
         type: file
         description: PLINK BIM variant file
+        ontologies: []
     - fam:
         type: file
         description: PLINK FAM sample file
+        ontologies: []
+  - window_prune:
+      type: float
+      description: Correlation squared (r²) threshold passed to LDAK `--window-prune` (for example, 0.98)
+  - window_kb:
+      type: integer
+      description: Window size in kilobases passed to LDAK `--window-kb` (for example, 100)
 output:
   thin_predictors:
     - - meta:
@@ -34,6 +43,7 @@ output:
       - "${prefix}.in":
           type: file
           description: LDAK thinned predictor list emitted by `--thin`
+          ontologies: []
   versions_ldak6:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/ldak/thinpredictors/meta.yml
+++ b/modules/nf-core/ldak/thinpredictors/meta.yml
@@ -1,0 +1,61 @@
+name: ldak_thinpredictors
+description: Run linkage disequilibrium (LD) pruning with linkage disequilibrium-adjusted kinship (LDAK) to create a thinned predictor list for weighted kinship workflows
+keywords:
+  - ldak
+  - thinning
+  - predictors
+  - kinship
+tools:
+  - ldak6:
+      description: LDAK toolset for kinship, heritability, and association analyses
+      homepage: https://dougspeed.com/ldak/
+      documentation: https://dougspeed.com/ldak/
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing genotype-bundle metadata.
+          Expected keys:
+            - id (string): Sample identifier used as thin output prefix (for example, 'plink_merged').
+    - bed:
+        type: file
+        description: PLINK BED genotype file
+    - bim:
+        type: file
+        description: PLINK BIM variant file
+    - fam:
+        type: file
+        description: PLINK FAM sample file
+output:
+  thin_predictors:
+    - - meta:
+          type: map
+          description: Metadata map carried forward from input
+      - "${prefix}.in":
+          type: file
+          description: LDAK thinned predictor list emitted by `--thin`
+  versions_ldak6:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The expression used to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The expression used to obtain the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/ldak/thinpredictors/tests/main.nf.test
+++ b/modules/nf-core/ldak/thinpredictors/tests/main.nf.test
@@ -1,0 +1,65 @@
+nextflow_process {
+
+    name "Test Process LDAK_THINPREDICTORS"
+    script "../main.nf"
+    process "LDAK_THINPREDICTORS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ldak"
+    tag "ldak/thinpredictors"
+
+    test("homo_sapiens popgen - plink1") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: "plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.thin_predictors.size() == 1 },
+                {
+                    def thinFile = path(process.out.thin_predictors.get(0).get(1))
+                    assert thinFile.fileName.toString() == "plink_simulated.in"
+                    assert thinFile.readLines().size() > 0
+                },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: "plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/ldak/thinpredictors/tests/main.nf.test
+++ b/modules/nf-core/ldak/thinpredictors/tests/main.nf.test
@@ -20,6 +20,8 @@ nextflow_process {
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
                 ]
+                input[1] = 0.98
+                input[2] = 100
                 """
             }
         }
@@ -27,12 +29,6 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.thin_predictors.size() == 1 },
-                {
-                    def thinFile = path(process.out.thin_predictors.get(0).get(1))
-                    assert thinFile.fileName.toString() == "plink_simulated.in"
-                    assert thinFile.readLines().size() > 0
-                },
                 { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
@@ -51,6 +47,8 @@ nextflow_process {
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
                     file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
                 ]
+                input[1] = 0.98
+                input[2] = 100
                 """
             }
         }

--- a/modules/nf-core/ldak/thinpredictors/tests/main.nf.test.snap
+++ b/modules/nf-core/ldak/thinpredictors/tests/main.nf.test.snap
@@ -1,0 +1,54 @@
+{
+    "homo_sapiens popgen - plink1": {
+        "content": [
+            {
+                "thin_predictors": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.in:md5,127248de349af5a0ad0497e7c8eeac1d"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_THINPREDICTORS",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:10:05.206276295"
+    },
+    "homo_sapiens popgen - stub": {
+        "content": [
+            {
+                "thin_predictors": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.in:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_THINPREDICTORS",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:10:28.985094482"
+    }
+}


### PR DESCRIPTION
## PR checklist

This PR adds the `ldak/thinpredictors` module. It runs LDAK (`ldak6 --thin`) to perform linkage-disequilibrium pruning on a PLINK binary fileset (bed/bim/fam) and emit a thinned predictor list, which downstream LDAK steps use to build weighted kinship matrices. It upstreams `main.nf`, `meta.yml`, `environment.yml`, and nf-test tests (including a stub), with topic-based version reporting. Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no new test data required.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test ldak/thinpredictors --profile docker`
    - [x] `nf-core modules test ldak/thinpredictors --profile singularity`
    - [x] `nf-core modules test ldak/thinpredictors --profile conda`
