### PR TITLE
Add ldak/kvikstep1 module

### DIFF
--- a/modules/nf-core/ldak/kvikstep1/environment.yml
+++ b/modules/nf-core/ldak/kvikstep1/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+  - genomedk
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - genomedk::ldak6=6.1

--- a/modules/nf-core/ldak/kvikstep1/main.nf
+++ b/modules/nf-core/ldak/kvikstep1/main.nf
@@ -1,0 +1,57 @@
+process LDAK_KVIKSTEP1 {
+    tag "${meta.id}:${meta2.id}"
+    label "process_medium"
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c9/c94e5424f08cbd7e0856ab3c3a9992b4080944a5d0c497ce0abcceb413db4a3e/data'
+        : 'community.wave.seqera.io/library/ldak6_r-base:452828f72b3c9129'}"
+
+    input:
+    tuple val(meta), path(bed), path(bim), path(fam)
+    tuple val(meta2), path(phenotype_file), val(mpheno), val(is_binary)
+    tuple val(meta3), path(quant_covariates_file)
+    tuple val(meta4), path(cat_covariates_file)
+
+    output:
+    tuple val(meta2), path("${prefix}.step1.root"), path("${prefix}.step1.loco.details"), path("${prefix}.step1.loco.prs"), emit: predictions
+    tuple val(meta2), path("${prefix}.step1.effects"), emit: effects, optional: true
+    tuple val(meta2), path("${prefix}.step1.log"), emit: log
+    tuple val("${task.process}"), val("ldak6"), eval("ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+'"), emit: versions_ldak6, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ""
+    def bfile_prefix = bed.baseName
+    prefix = task.ext.prefix ?: meta2.id
+    def covar_arg = quant_covariates_file ? "--covar ${quant_covariates_file}" : ""
+    def factors_arg = cat_covariates_file ? "--factors ${cat_covariates_file}" : ""
+    def binary_arg = is_binary ? "--binary YES" : ""
+    def mpheno_value = mpheno == null || (mpheno instanceof Collection && mpheno.isEmpty()) ? 1 : mpheno
+
+    """
+
+    ldak6 --kvik-step1 ${prefix} \\
+        --bfile ${bfile_prefix} \\
+        --pheno ${phenotype_file} \\
+        ${covar_arg} \\
+        ${factors_arg} \\
+        ${binary_arg} \\
+        --mpheno ${mpheno_value} \\
+        --max-threads ${task.cpus} \\
+        ${args} \\
+        2>&1 | tee ${prefix}.step1.log
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: meta2.id
+    """
+    touch ${prefix}.step1.root
+    touch ${prefix}.step1.loco.details
+    touch ${prefix}.step1.loco.prs
+    touch ${prefix}.step1.effects
+    touch ${prefix}.step1.log
+    """
+}

--- a/modules/nf-core/ldak/kvikstep1/main.nf
+++ b/modules/nf-core/ldak/kvikstep1/main.nf
@@ -32,7 +32,6 @@ process LDAK_KVIKSTEP1 {
     def mpheno_value = mpheno == null || (mpheno instanceof Collection && mpheno.isEmpty()) ? 1 : mpheno
 
     """
-
     ldak6 --kvik-step1 ${prefix} \\
         --bfile ${bfile_prefix} \\
         --pheno ${phenotype_file} \\

--- a/modules/nf-core/ldak/kvikstep1/meta.yml
+++ b/modules/nf-core/ldak/kvikstep1/meta.yml
@@ -1,0 +1,153 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ldak_kvikstep1"
+description: "Run LDAK-KVIK step 1 to fit the genome-wide model and emit the minimal prediction artifact tuple consumed by ldak/kvikstep2"
+keywords:
+  - "ldak"
+  - "kvik"
+  - "gwas"
+  - "association"
+tools:
+  - "ldak6":
+      description: "LDAK and LDAK-KVIK for mixed-model genome-wide association study (GWAS) and heritability analysis."
+      homepage: "https://dougspeed.com/ldak/"
+      documentation: "https://dougspeed.com/ldak-kvik/"
+      tool_dev_url: "https://github.com/dougspeed/LDAK"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing genotype information
+          Keep only the genotype analysis identifier in this map
+          The PLINK bundle must already be staged with basename `prefix`
+          e.g. `[ id:'merged_chr' ]`
+    - bed:
+        type: file
+        description: PLINK BED genotype file passed to `--bfile`
+        pattern: "*.bed"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - bim:
+        type: file
+        description: PLINK BIM variant file paired with the BED input
+        pattern: "*.bim"
+        ontologies: []
+    - fam:
+        type: file
+        description: PLINK FAM sample file paired with the BED input
+        pattern: "*.fam"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing phenotype information
+          Keep `id` as the phenotype-specific analysis identifier used for the step 1 output prefix
+          e.g. `[ id:'Y1' ]`
+    - phenotype_file:
+        type: file
+        description: Phenotype file passed to `--pheno`
+        pattern: "*.{txt,tsv,pheno,phe}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+    - mpheno:
+        type: integer
+        description: Optional phenotype column index passed to `--mpheno`; provide `[]` to use the module fallback of `1`
+    - is_binary:
+        type: boolean
+        description: Optional trait-type flag; pass `true` to add `--binary YES`
+          for case-control traits
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing quantitative covariate information
+          e.g. `[ id:'qcov' ]`
+    - quant_covariates_file:
+        type: file
+        optional: true
+        description: Optional quantitative covariates file passed to `--covar`;
+          provide `[]` when absent
+        pattern: "*.{txt,tsv,covar,cov}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing categorical covariate information
+          e.g. `[ id:'ccov' ]`
+    - cat_covariates_file:
+        type: file
+        optional: true
+        description: Optional categorical covariates file passed to `--factors`;
+          provide `[]` when absent
+        pattern: "*.{txt,tsv,covar,cov}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+output:
+  predictions:
+    - - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step1.root":
+          type: file
+          description: LDAK-KVIK step 1 root file
+          pattern: "*.step1.root"
+          ontologies: []
+      - "${prefix}.step1.loco.details":
+          type: file
+          description: LDAK-KVIK step 1 leave-one-chromosome-out (LOCO) details file
+          pattern: "*.step1.loco.details"
+          ontologies: []
+      - "${prefix}.step1.loco.prs":
+          type: file
+          description: LDAK-KVIK step 1 LOCO polygenic risk score (PRS) file. Together with the root and LOCO details files, this forms the direct `ldak/kvikstep2` handoff tuple; phenotype and covariate files remain explicit step 2 inputs.
+          pattern: "*.step1.loco.prs"
+          ontologies: []
+  effects:
+    - - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step1.effects":
+          type: file
+          description: Optional LDAK-KVIK step 1 effects file produced for quantitative traits
+          pattern: "*.step1.effects"
+          ontologies: []
+  log:
+    - - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step1.log":
+          type: file
+          description: LDAK-KVIK step 1 log file
+          pattern: "*.step1.log"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330"
+  versions_ldak6:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The command used to generate the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The command used to generate the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/ldak/kvikstep1/meta.yml
+++ b/modules/nf-core/ldak/kvikstep1/meta.yml
@@ -24,8 +24,7 @@ input:
         type: file
         description: PLINK BED genotype file passed to `--bfile`
         pattern: "*.bed"
-        ontologies:
-          - edam: "http://edamontology.org/format_3003"
+        ontologies: []
     - bim:
         type: file
         description: PLINK BIM variant file paired with the BED input
@@ -92,7 +91,8 @@ output:
           type: file
           description: LDAK-KVIK step 1 root file
           pattern: "*.step1.root"
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_2330"
       - "${prefix}.step1.loco.details":
           type: file
           description: LDAK-KVIK step 1 leave-one-chromosome-out (LOCO) details file
@@ -124,8 +124,7 @@ output:
           type: file
           description: LDAK-KVIK step 1 log file
           pattern: "*.step1.log"
-          ontologies:
-            - edam: "http://edamontology.org/format_2330"
+          ontologies: []
   versions_ldak6:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/ldak/kvikstep1/tests/main.nf.test
+++ b/modules/nf-core/ldak/kvikstep1/tests/main.nf.test
@@ -56,18 +56,8 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert process.out.predictions.size() == 1 },
-                { assert process.out.effects.size() == 1 },
-                { assert process.out.log.size() == 1 },
-                {
-                    def predictionTuple = process.out.predictions.get(0)
-                    def commandText = path(predictionTuple.get(1)).parent.resolve(".command.sh").text
-                    assert commandText.contains("--bfile plink_multichr")
-                    assert commandText.contains("--mpheno 1")
-                    assert !commandText.contains("--binary YES")
-                },
                 {
                     // predictions bundles a stable root/loco.prs pair with the non-deterministic
                     // loco.details estimate, so the whole channel is filename-only under
@@ -130,10 +120,8 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert process.out.predictions.size() == 1 },
-                { assert process.out.effects.size() == 1 },
                 {
                     def predictionTuple = process.out.predictions.get(0)
                     def commandText = path(predictionTuple.get(1)).parent.resolve(".command.sh").text
@@ -194,8 +182,8 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
                 { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["predictions", "effects", "log"])).match() }
             )
         }

--- a/modules/nf-core/ldak/kvikstep1/tests/main.nf.test
+++ b/modules/nf-core/ldak/kvikstep1/tests/main.nf.test
@@ -1,0 +1,203 @@
+nextflow_process {
+
+    name "Test Process LDAK_KVIKSTEP1"
+    script "../main.nf"
+    process "LDAK_KVIKSTEP1"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ldak"
+    tag "ldak/kvikstep1"
+
+    test("homo_sapiens popgen - quantitative with explicit mpheno 1") {
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                multiBed = file("plink_multichr.bed")
+                multiBed.bytes = sourceBed.bytes
+                multiFam = file("plink_multichr.fam")
+                multiFam.bytes = sourceFam.bytes
+                multiBim = file("plink_multichr.bim")
+                bimLines = sourceBim.readLines()
+                chrSplit = (int) Math.ceil(bimLines.size() / 2.0)
+                multiBim.text = bimLines.withIndex().collect { line, idx ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = idx < chrSplit ? "21" : "22"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    multiBed,
+                    multiBim,
+                    multiFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_quantitative_phenoname" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe", checkIfExists: true),
+                    1,
+                    false
+                ]
+
+                input[2] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.predictions.size() == 1 },
+                { assert process.out.effects.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                {
+                    def predictionTuple = process.out.predictions.get(0)
+                    def commandText = path(predictionTuple.get(1)).parent.resolve(".command.sh").text
+                    assert commandText.contains("--bfile plink_multichr")
+                    assert commandText.contains("--mpheno 1")
+                    assert !commandText.contains("--binary YES")
+                },
+                {
+                    // predictions bundles a stable root/loco.prs pair with the non-deterministic
+                    // loco.details estimate, so the whole channel is filename-only under
+                    // sanitizeOutput; keep the stable members' content covered separately.
+                    def predictionTuple = process.out.predictions.get(0)
+                    assert snapshot(
+                        sanitizeOutput(process.out, unstableKeys: ["predictions", "effects", "log"]),
+                        path(predictionTuple.get(1)).readLines(),
+                        path(predictionTuple.get(3)).readLines()
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - binary with fallback mpheno 1") {
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                multiBed = file("plink_multichr.bed")
+                multiBed.bytes = sourceBed.bytes
+                multiFam = file("plink_multichr.fam")
+                multiFam.bytes = sourceFam.bytes
+                multiBim = file("plink_multichr.bim")
+                bimLines = sourceBim.readLines()
+                chrSplit = (int) Math.ceil(bimLines.size() / 2.0)
+                multiBim.text = bimLines.withIndex().collect { line, idx ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = idx < chrSplit ? "21" : "22"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    multiBed,
+                    multiBim,
+                    multiFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_binary_phenoname" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_binary_phenoname.phe", checkIfExists: true),
+                    [],
+                    true
+                ]
+
+                input[2] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.predictions.size() == 1 },
+                { assert process.out.effects.size() == 1 },
+                {
+                    def predictionTuple = process.out.predictions.get(0)
+                    def commandText = path(predictionTuple.get(1)).parent.resolve(".command.sh").text
+                    assert commandText.contains("--bfile plink_multichr")
+                    assert commandText.contains("--mpheno 1")
+                    assert commandText.contains("--binary YES")
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                multiBed = file("plink_multichr.bed")
+                multiBed.bytes = sourceBed.bytes
+                multiFam = file("plink_multichr.fam")
+                multiFam.bytes = sourceFam.bytes
+                multiBim = file("plink_multichr.bim")
+                bimLines = sourceBim.readLines()
+                chrSplit = (int) Math.ceil(bimLines.size() / 2.0)
+                multiBim.text = bimLines.withIndex().collect { line, idx ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = idx < chrSplit ? "21" : "22"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    multiBed,
+                    multiBim,
+                    multiFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_quantitative_phenoname_stub" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe", checkIfExists: true),
+                    1,
+                    false
+                ]
+
+                input[2] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["predictions", "effects", "log"])).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/ldak/kvikstep1/tests/main.nf.test.snap
+++ b/modules/nf-core/ldak/kvikstep1/tests/main.nf.test.snap
@@ -1,0 +1,306 @@
+{
+    "homo_sapiens popgen - quantitative with explicit mpheno 1": {
+        "content": [
+            {
+                "effects": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname"
+                        },
+                        "plink_simulated_quantitative_phenoname.step1.effects"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname"
+                        },
+                        "plink_simulated_quantitative_phenoname.step1.log"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname"
+                        },
+                        "plink_simulated_quantitative_phenoname.step1.root",
+                        "plink_simulated_quantitative_phenoname.step1.loco.details",
+                        "plink_simulated_quantitative_phenoname.step1.loco.prs"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_KVIKSTEP1",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            },
+            [
+                "Analysis KVIK",
+                "Regression Linear",
+                "Datafile plink_multichr.bed",
+                "Phenotypes plink_simulated_quantitative_phenoname.phe",
+                "Covariates plink_simulated_covariates.txt",
+                "Top_Predictors none",
+                "Factors none",
+                "Phenotype_Number 1",
+                "Num_Samples_Used 200",
+                "Num_Predictors_Used 220",
+                "Num_Chromosomes 2"
+            ],
+            [
+                "FID IID Chr21 Chr22",
+                "per0 per0 0 0",
+                "per1 per1 0 0",
+                "per2 per2 0 0",
+                "per3 per3 0 0",
+                "per4 per4 0 0",
+                "per5 per5 0 0",
+                "per6 per6 0 0",
+                "per7 per7 0 0",
+                "per8 per8 0 0",
+                "per9 per9 0 0",
+                "per10 per10 0 0",
+                "per11 per11 0 0",
+                "per12 per12 0 0",
+                "per13 per13 0 0",
+                "per14 per14 0 0",
+                "per15 per15 0 0",
+                "per16 per16 0 0",
+                "per17 per17 0 0",
+                "per18 per18 0 0",
+                "per19 per19 0 0",
+                "per20 per20 0 0",
+                "per21 per21 0 0",
+                "per22 per22 0 0",
+                "per23 per23 0 0",
+                "per24 per24 0 0",
+                "per25 per25 0 0",
+                "per26 per26 0 0",
+                "per27 per27 0 0",
+                "per28 per28 0 0",
+                "per29 per29 0 0",
+                "per30 per30 0 0",
+                "per31 per31 0 0",
+                "per32 per32 0 0",
+                "per33 per33 0 0",
+                "per34 per34 0 0",
+                "per35 per35 0 0",
+                "per36 per36 0 0",
+                "per37 per37 0 0",
+                "per38 per38 0 0",
+                "per39 per39 0 0",
+                "per40 per40 0 0",
+                "per41 per41 0 0",
+                "per42 per42 0 0",
+                "per43 per43 0 0",
+                "per44 per44 0 0",
+                "per45 per45 0 0",
+                "per46 per46 0 0",
+                "per47 per47 0 0",
+                "per48 per48 0 0",
+                "per49 per49 0 0",
+                "per50 per50 0 0",
+                "per51 per51 0 0",
+                "per52 per52 0 0",
+                "per53 per53 0 0",
+                "per54 per54 0 0",
+                "per55 per55 0 0",
+                "per56 per56 0 0",
+                "per57 per57 0 0",
+                "per58 per58 0 0",
+                "per59 per59 0 0",
+                "per60 per60 0 0",
+                "per61 per61 0 0",
+                "per62 per62 0 0",
+                "per63 per63 0 0",
+                "per64 per64 0 0",
+                "per65 per65 0 0",
+                "per66 per66 0 0",
+                "per67 per67 0 0",
+                "per68 per68 0 0",
+                "per69 per69 0 0",
+                "per70 per70 0 0",
+                "per71 per71 0 0",
+                "per72 per72 0 0",
+                "per73 per73 0 0",
+                "per74 per74 0 0",
+                "per75 per75 0 0",
+                "per76 per76 0 0",
+                "per77 per77 0 0",
+                "per78 per78 0 0",
+                "per79 per79 0 0",
+                "per80 per80 0 0",
+                "per81 per81 0 0",
+                "per82 per82 0 0",
+                "per83 per83 0 0",
+                "per84 per84 0 0",
+                "per85 per85 0 0",
+                "per86 per86 0 0",
+                "per87 per87 0 0",
+                "per88 per88 0 0",
+                "per89 per89 0 0",
+                "per90 per90 0 0",
+                "per91 per91 0 0",
+                "per92 per92 0 0",
+                "per93 per93 0 0",
+                "per94 per94 0 0",
+                "per95 per95 0 0",
+                "per96 per96 0 0",
+                "per97 per97 0 0",
+                "per98 per98 0 0",
+                "per99 per99 0 0",
+                "per100 per100 0 0",
+                "per101 per101 0 0",
+                "per102 per102 0 0",
+                "per103 per103 0 0",
+                "per104 per104 0 0",
+                "per105 per105 0 0",
+                "per106 per106 0 0",
+                "per107 per107 0 0",
+                "per108 per108 0 0",
+                "per109 per109 0 0",
+                "per110 per110 0 0",
+                "per111 per111 0 0",
+                "per112 per112 0 0",
+                "per113 per113 0 0",
+                "per114 per114 0 0",
+                "per115 per115 0 0",
+                "per116 per116 0 0",
+                "per117 per117 0 0",
+                "per118 per118 0 0",
+                "per119 per119 0 0",
+                "per120 per120 0 0",
+                "per121 per121 0 0",
+                "per122 per122 0 0",
+                "per123 per123 0 0",
+                "per124 per124 0 0",
+                "per125 per125 0 0",
+                "per126 per126 0 0",
+                "per127 per127 0 0",
+                "per128 per128 0 0",
+                "per129 per129 0 0",
+                "per130 per130 0 0",
+                "per131 per131 0 0",
+                "per132 per132 0 0",
+                "per133 per133 0 0",
+                "per134 per134 0 0",
+                "per135 per135 0 0",
+                "per136 per136 0 0",
+                "per137 per137 0 0",
+                "per138 per138 0 0",
+                "per139 per139 0 0",
+                "per140 per140 0 0",
+                "per141 per141 0 0",
+                "per142 per142 0 0",
+                "per143 per143 0 0",
+                "per144 per144 0 0",
+                "per145 per145 0 0",
+                "per146 per146 0 0",
+                "per147 per147 0 0",
+                "per148 per148 0 0",
+                "per149 per149 0 0",
+                "per150 per150 0 0",
+                "per151 per151 0 0",
+                "per152 per152 0 0",
+                "per153 per153 0 0",
+                "per154 per154 0 0",
+                "per155 per155 0 0",
+                "per156 per156 0 0",
+                "per157 per157 0 0",
+                "per158 per158 0 0",
+                "per159 per159 0 0",
+                "per160 per160 0 0",
+                "per161 per161 0 0",
+                "per162 per162 0 0",
+                "per163 per163 0 0",
+                "per164 per164 0 0",
+                "per165 per165 0 0",
+                "per166 per166 0 0",
+                "per167 per167 0 0",
+                "per168 per168 0 0",
+                "per169 per169 0 0",
+                "per170 per170 0 0",
+                "per171 per171 0 0",
+                "per172 per172 0 0",
+                "per173 per173 0 0",
+                "per174 per174 0 0",
+                "per175 per175 0 0",
+                "per176 per176 0 0",
+                "per177 per177 0 0",
+                "per178 per178 0 0",
+                "per179 per179 0 0",
+                "per180 per180 0 0",
+                "per181 per181 0 0",
+                "per182 per182 0 0",
+                "per183 per183 0 0",
+                "per184 per184 0 0",
+                "per185 per185 0 0",
+                "per186 per186 0 0",
+                "per187 per187 0 0",
+                "per188 per188 0 0",
+                "per189 per189 0 0",
+                "per190 per190 0 0",
+                "per191 per191 0 0",
+                "per192 per192 0 0",
+                "per193 per193 0 0",
+                "per194 per194 0 0",
+                "per195 per195 0 0",
+                "per196 per196 0 0",
+                "per197 per197 0 0",
+                "per198 per198 0 0",
+                "per199 per199 0 0"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:13:00.238698342"
+    },
+    "homo_sapiens popgen - stub": {
+        "content": [
+            {
+                "effects": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.effects"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.log"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.root",
+                        "plink_simulated_quantitative_phenoname_stub.step1.loco.details",
+                        "plink_simulated_quantitative_phenoname_stub.step1.loco.prs"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_KVIKSTEP1",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:13:29.53535367"
+    }
+}


### PR DESCRIPTION
## PR checklist

No associated issue.

This PR adds the `ldak/kvikstep1` module, which runs LDAK-KVIK step 1 to fit the genome-wide model and emits the prediction-artifact tuple consumed by `ldak/kvikstep2`. It includes `main.nf`, `meta.yml`, `environment.yml`, and nf-test coverage (including a stub).

This branch was rebased onto the current `master` after `ldak/thinpredictors` merged. Its diff is self-contained: it contains no other unmerged LDAK modules or test dependencies. Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no companion fixture PR is required.

> **Draft.** The module lint has no failures, but still reports the current `has_meta_containers` warning for its existing Wave provenance metadata. The PR remains a draft until that warning is resolved.

- [x] This comment contains a description of changes (with reason).
- [x] If you have fixed a bug or added code that should be tested, add tests!
- [x] If you have added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test ldak/kvikstep1 --profile docker`
    - [x] `nf-core modules test ldak/kvikstep1 --profile singularity`
    - [x] `nf-core modules test ldak/kvikstep1 --profile conda`