### PR TITLE
Add ldak/createthinweights module

### DIFF
--- a/modules/nf-core/ldak/createthinweights/environment.yml
+++ b/modules/nf-core/ldak/createthinweights/environment.yml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+dependencies:
+  - conda-forge::gawk=5.3.1

--- a/modules/nf-core/ldak/createthinweights/main.nf
+++ b/modules/nf-core/ldak/createthinweights/main.nf
@@ -19,7 +19,6 @@ process LDAK_CREATETHINWEIGHTS {
     script:
     prefix = task.ext.prefix ?: "${meta.id}"
     """
-
     gawk '{print \$1, 1}' < ${thin_predictors_file} > ${prefix}.weights.thin
     """
 

--- a/modules/nf-core/ldak/createthinweights/main.nf
+++ b/modules/nf-core/ldak/createthinweights/main.nf
@@ -1,0 +1,31 @@
+process LDAK_CREATETHINWEIGHTS {
+    tag "${meta.id}"
+    label 'process_single'
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a1/a125c778baf3865331101a104b60d249ee15fe1dca13bdafd888926cc5490a34/data'
+        : 'community.wave.seqera.io/library/gawk:5.3.1--e09efb5dfc4b8156'}"
+
+    input:
+    tuple val(meta), path(thin_predictors_file)
+
+    output:
+    tuple val(meta), path("${prefix}.weights.thin"), emit: thin_weights
+    tuple val("${task.process}"), val("gawk"), eval("gawk --version | sed -n '1{s/GNU Awk //;s/,.*//;p}'"), emit: versions_gawk, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+
+    gawk '{print \$1, 1}' < ${thin_predictors_file} > ${prefix}.weights.thin
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.weights.thin
+    """
+}

--- a/modules/nf-core/ldak/createthinweights/meta.yml
+++ b/modules/nf-core/ldak/createthinweights/meta.yml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ldak_createthinweights"
+description: "Create a simple unit-weight file from a linkage disequilibrium-adjusted kinship (LDAK) thinned predictor list"
+keywords:
+  - "ldak"
+  - "weights"
+  - "thin"
+  - "gwas"
+tools:
+  - "gawk":
+      description: "GNU Awk implementation used to convert a predictor list to unit weights."
+      homepage: "https://www.gnu.org/software/gawk/"
+      documentation: "https://www.gnu.org/software/gawk/manual/gawk.html"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing predictor-list metadata
+          e.g. `[ id:'example' ]`
+    - thin_predictors_file:
+        type: file
+        description: Thinned predictor list with one predictor identifier per line
+        pattern: "*.{in,txt,tsv}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2330"
+output:
+  thin_weights:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing predictor-list metadata
+            e.g. `[ id:'example' ]`
+      - "${prefix}.weights.thin":
+          type: file
+          description: Unit-weight file with predictor identifier and weight columns
+          pattern: "*.weights.thin"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330"
+  versions_gawk:
+    - - "${task.process}":
+          type: string
+          description: The process the versions were collected from
+      - "gawk":
+          type: string
+          description: The tool name
+      - "gawk --version | sed -n '1{s/GNU Awk //;s/,.*//;p}'":
+          type: eval
+          description: The command used to generate the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gawk:
+          type: string
+          description: The tool name
+      - gawk --version | sed -n '1{s/GNU Awk //;s/,.*//;p}':
+          type: eval
+          description: The command used to generate the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/ldak/createthinweights/tests/main.nf.test
+++ b/modules/nf-core/ldak/createthinweights/tests/main.nf.test
@@ -1,0 +1,72 @@
+nextflow_process {
+
+    name "Test Process LDAK_CREATETHINWEIGHTS"
+    script "../main.nf"
+    process "LDAK_CREATETHINWEIGHTS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ldak"
+    tag "ldak/thinpredictors"
+    tag "ldak/createthinweights"
+
+    setup {
+        run("LDAK_THINPREDICTORS") {
+            script "../../thinpredictors/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id: "plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens popgen - thin predictors to unit weights") {
+
+        when {
+            process {
+                """
+                input[0] = LDAK_THINPREDICTORS.out.thin_predictors
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.thin_weights.size() == 1 },
+                {
+                    def weightsFile = path(process.out.thin_weights.get(0).get(1))
+                    assert weightsFile.fileName.toString() == "plink_simulated.weights.thin"
+                    assert weightsFile.readLines().every { line -> line.endsWith(" 1") }
+                },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = LDAK_THINPREDICTORS.out.thin_predictors
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/ldak/createthinweights/tests/main.nf.test
+++ b/modules/nf-core/ldak/createthinweights/tests/main.nf.test
@@ -37,14 +37,8 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert process.out.thin_weights.size() == 1 },
-                {
-                    def weightsFile = path(process.out.thin_weights.get(0).get(1))
-                    assert weightsFile.fileName.toString() == "plink_simulated.weights.thin"
-                    assert weightsFile.readLines().every { line -> line.endsWith(" 1") }
-                },
                 { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
@@ -63,8 +57,8 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
                 { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }

--- a/modules/nf-core/ldak/createthinweights/tests/main.nf.test.snap
+++ b/modules/nf-core/ldak/createthinweights/tests/main.nf.test.snap
@@ -1,0 +1,54 @@
+{
+    "homo_sapiens popgen - stub": {
+        "content": [
+            {
+                "thin_weights": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.weights.thin:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "LDAK_CREATETHINWEIGHTS",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:08:06.997002755"
+    },
+    "homo_sapiens popgen - thin predictors to unit weights": {
+        "content": [
+            {
+                "thin_weights": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.weights.thin:md5,8ad0785bee9e9e15547904fc119fd70b"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "LDAK_CREATETHINWEIGHTS",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:07:30.610069516"
+    }
+}

--- a/modules/nf-core/ldak/thinpredictors/environment.yml
+++ b/modules/nf-core/ldak/thinpredictors/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+  - genomedk
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - genomedk::ldak6=6.1

--- a/modules/nf-core/ldak/thinpredictors/main.nf
+++ b/modules/nf-core/ldak/thinpredictors/main.nf
@@ -1,0 +1,37 @@
+process LDAK_THINPREDICTORS {
+    tag "${meta.id}"
+    label 'process_medium'
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c9/c94e5424f08cbd7e0856ab3c3a9992b4080944a5d0c497ce0abcceb413db4a3e/data'
+        : 'community.wave.seqera.io/library/ldak6_r-base:452828f72b3c9129'}"
+
+    input:
+    tuple val(meta), path(bed), path(bim), path(fam)
+
+    output:
+    tuple val(meta), path("${prefix}.in"), emit: thin_predictors
+    tuple val("${task.process}"), val("ldak6"), eval("ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+'"), emit: versions_ldak6, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: '--window-prune 0.98 --window-kb 100'
+    prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+
+    ldak6 \\
+        --thin ${prefix} \\
+        --bfile ${bed.baseName} \\
+        --max-threads ${task.cpus} \
+        ${args}
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.in
+    """
+}

--- a/modules/nf-core/ldak/thinpredictors/meta.yml
+++ b/modules/nf-core/ldak/thinpredictors/meta.yml
@@ -1,0 +1,61 @@
+name: ldak_thinpredictors
+description: Run linkage disequilibrium (LD) pruning with linkage disequilibrium-adjusted kinship (LDAK) to create a thinned predictor list for weighted kinship workflows
+keywords:
+  - ldak
+  - thinning
+  - predictors
+  - kinship
+tools:
+  - ldak6:
+      description: LDAK toolset for kinship, heritability, and association analyses
+      homepage: https://dougspeed.com/ldak/
+      documentation: https://dougspeed.com/ldak/
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing genotype-bundle metadata.
+          Expected keys:
+            - id (string): Sample identifier used as thin output prefix (for example, 'plink_merged').
+    - bed:
+        type: file
+        description: PLINK BED genotype file
+    - bim:
+        type: file
+        description: PLINK BIM variant file
+    - fam:
+        type: file
+        description: PLINK FAM sample file
+output:
+  thin_predictors:
+    - - meta:
+          type: map
+          description: Metadata map carried forward from input
+      - "${prefix}.in":
+          type: file
+          description: LDAK thinned predictor list emitted by `--thin`
+  versions_ldak6:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The expression used to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The expression used to obtain the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/ldak/thinpredictors/tests/main.nf.test
+++ b/modules/nf-core/ldak/thinpredictors/tests/main.nf.test
@@ -1,0 +1,73 @@
+nextflow_process {
+
+    name "Test Process LDAK_THINPREDICTORS"
+    script "../main.nf"
+    process "LDAK_THINPREDICTORS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ldak"
+    tag "ldak/thinpredictors"
+
+    test("homo_sapiens popgen - plink1") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: "plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.thin_predictors.size() == 1 },
+                {
+                    def thinFile = path(process.out.thin_predictors.get(0).get(1))
+                    assert thinFile.fileName.toString() == "plink_simulated.in"
+                    assert thinFile.readLines().size() > 0
+                },
+                {
+                    def stableThin = process.out.thin_predictors.collect { thinTuple ->
+                        [thinTuple[0], path(thinTuple[1]).fileName.toString()]
+                    }
+                    assert snapshot(
+                        stableThin,
+                        process.out.findAll { key, val -> key.startsWith("versions") }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: "plink_simulated" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true),
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/ldak/thinpredictors/tests/main.nf.test.snap
+++ b/modules/nf-core/ldak/thinpredictors/tests/main.nf.test.snap
@@ -1,0 +1,69 @@
+{
+    "homo_sapiens popgen - plink1": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated"
+                    },
+                    "plink_simulated.in"
+                ]
+            ],
+            {
+                "versions_ldak6": [
+                    [
+                        "LDAK_THINPREDICTORS",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T12:23:19.557725146"
+    },
+    "homo_sapiens popgen - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.in:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "LDAK_THINPREDICTORS",
+                        "ldak6",
+                        "6"
+                    ]
+                ],
+                "thin_predictors": [
+                    [
+                        {
+                            "id": "plink_simulated"
+                        },
+                        "plink_simulated.in:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_THINPREDICTORS",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T12:23:31.370986528"
+    }
+}


### PR DESCRIPTION
## PR checklist

This PR adds the `ldak/createthinweights` module — Create a simple unit-weight file from a linkage disequilibrium-adjusted kinship (LDAK) thinned predictor list. It upstreams `main.nf`, `meta.yml`, `environment.yml`, and nf-test tests (including a stub), with topic-based version reporting, and snapshots the full output contract via `sanitizeOutput`. Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no new test data required.

> **Draft — stacked submission.** This module's nf-test `setup{}` builds fixtures by running upstream LDAK modules, so this branch also includes its prerequisite module(s) — **ldak/thinpredictors** — in the diff against `master` (stacked-by-inclusion). Those will drop out as their own PRs merge. Kept as a draft until the prerequisites land; only Docker has been run so far (Singularity/Conda to follow).

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test ldak/createthinweights --profile docker`
    - [x] `nf-core modules test ldak/createthinweights --profile singularity`
    - [ ] `nf-core modules test ldak/createthinweights --profile conda`
