### PR TITLE
Add ldak/kvikstep2 module

### DIFF
--- a/modules/nf-core/ldak/kvikstep1/environment.yml
+++ b/modules/nf-core/ldak/kvikstep1/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+  - genomedk
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - genomedk::ldak6=6.1

--- a/modules/nf-core/ldak/kvikstep1/main.nf
+++ b/modules/nf-core/ldak/kvikstep1/main.nf
@@ -1,0 +1,57 @@
+process LDAK_KVIKSTEP1 {
+    tag "${meta.id}:${meta2.id}"
+    label "process_medium"
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c9/c94e5424f08cbd7e0856ab3c3a9992b4080944a5d0c497ce0abcceb413db4a3e/data'
+        : 'community.wave.seqera.io/library/ldak6_r-base:452828f72b3c9129'}"
+
+    input:
+    tuple val(meta), path(bed), path(bim), path(fam)
+    tuple val(meta2), path(phenotype_file), val(mpheno), val(is_binary)
+    tuple val(meta3), path(quant_covariates_file)
+    tuple val(meta4), path(cat_covariates_file)
+
+    output:
+    tuple val(meta2), path("${prefix}.step1.root"), path("${prefix}.step1.loco.details"), path("${prefix}.step1.loco.prs"), emit: predictions
+    tuple val(meta2), path("${prefix}.step1.effects"), emit: effects, optional: true
+    tuple val(meta2), path("${prefix}.step1.log"), emit: log
+    tuple val("${task.process}"), val("ldak6"), eval("ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+'"), emit: versions_ldak6, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ""
+    def bfile_prefix = bed.baseName
+    prefix = task.ext.prefix ?: meta2.id
+    def covar_arg = quant_covariates_file ? "--covar ${quant_covariates_file}" : ""
+    def factors_arg = cat_covariates_file ? "--factors ${cat_covariates_file}" : ""
+    def binary_arg = is_binary ? "--binary YES" : ""
+    def mpheno_value = mpheno == null || (mpheno instanceof Collection && mpheno.isEmpty()) ? 1 : mpheno
+
+    """
+
+    ldak6 --kvik-step1 ${prefix} \\
+        --bfile ${bfile_prefix} \\
+        --pheno ${phenotype_file} \\
+        ${covar_arg} \\
+        ${factors_arg} \\
+        ${binary_arg} \\
+        --mpheno ${mpheno_value} \\
+        --max-threads ${task.cpus} \\
+        ${args} \\
+        2>&1 | tee ${prefix}.step1.log
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: meta2.id
+    """
+    touch ${prefix}.step1.root
+    touch ${prefix}.step1.loco.details
+    touch ${prefix}.step1.loco.prs
+    touch ${prefix}.step1.effects
+    touch ${prefix}.step1.log
+    """
+}

--- a/modules/nf-core/ldak/kvikstep1/meta.yml
+++ b/modules/nf-core/ldak/kvikstep1/meta.yml
@@ -1,0 +1,153 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ldak_kvikstep1"
+description: "Run LDAK-KVIK step 1 to fit the genome-wide model and emit the minimal prediction artifact tuple consumed by ldak/kvikstep2"
+keywords:
+  - "ldak"
+  - "kvik"
+  - "gwas"
+  - "association"
+tools:
+  - "ldak6":
+      description: "LDAK and LDAK-KVIK for mixed-model genome-wide association study (GWAS) and heritability analysis."
+      homepage: "https://dougspeed.com/ldak/"
+      documentation: "https://dougspeed.com/ldak-kvik/"
+      tool_dev_url: "https://github.com/dougspeed/LDAK"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing genotype information
+          Keep only the genotype analysis identifier in this map
+          The PLINK bundle must already be staged with basename `prefix`
+          e.g. `[ id:'merged_chr' ]`
+    - bed:
+        type: file
+        description: PLINK BED genotype file passed to `--bfile`
+        pattern: "*.bed"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - bim:
+        type: file
+        description: PLINK BIM variant file paired with the BED input
+        pattern: "*.bim"
+        ontologies: []
+    - fam:
+        type: file
+        description: PLINK FAM sample file paired with the BED input
+        pattern: "*.fam"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing phenotype information
+          Keep `id` as the phenotype-specific analysis identifier used for the step 1 output prefix
+          e.g. `[ id:'Y1' ]`
+    - phenotype_file:
+        type: file
+        description: Phenotype file passed to `--pheno`
+        pattern: "*.{txt,tsv,pheno,phe}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+    - mpheno:
+        type: integer
+        description: Optional phenotype column index passed to `--mpheno`; provide `[]` to use the module fallback of `1`
+    - is_binary:
+        type: boolean
+        description: Optional trait-type flag; pass `true` to add `--binary YES`
+          for case-control traits
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing quantitative covariate information
+          e.g. `[ id:'qcov' ]`
+    - quant_covariates_file:
+        type: file
+        optional: true
+        description: Optional quantitative covariates file passed to `--covar`;
+          provide `[]` when absent
+        pattern: "*.{txt,tsv,covar,cov}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing categorical covariate information
+          e.g. `[ id:'ccov' ]`
+    - cat_covariates_file:
+        type: file
+        optional: true
+        description: Optional categorical covariates file passed to `--factors`;
+          provide `[]` when absent
+        pattern: "*.{txt,tsv,covar,cov}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+output:
+  predictions:
+    - - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step1.root":
+          type: file
+          description: LDAK-KVIK step 1 root file
+          pattern: "*.step1.root"
+          ontologies: []
+      - "${prefix}.step1.loco.details":
+          type: file
+          description: LDAK-KVIK step 1 leave-one-chromosome-out (LOCO) details file
+          pattern: "*.step1.loco.details"
+          ontologies: []
+      - "${prefix}.step1.loco.prs":
+          type: file
+          description: LDAK-KVIK step 1 LOCO polygenic risk score (PRS) file. Together with the root and LOCO details files, this forms the direct `ldak/kvikstep2` handoff tuple; phenotype and covariate files remain explicit step 2 inputs.
+          pattern: "*.step1.loco.prs"
+          ontologies: []
+  effects:
+    - - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step1.effects":
+          type: file
+          description: Optional LDAK-KVIK step 1 effects file produced for quantitative traits
+          pattern: "*.step1.effects"
+          ontologies: []
+  log:
+    - - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step1.log":
+          type: file
+          description: LDAK-KVIK step 1 log file
+          pattern: "*.step1.log"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330"
+  versions_ldak6:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The command used to generate the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The command used to generate the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/ldak/kvikstep1/tests/main.nf.test
+++ b/modules/nf-core/ldak/kvikstep1/tests/main.nf.test
@@ -1,0 +1,214 @@
+nextflow_process {
+
+    name "Test Process LDAK_KVIKSTEP1"
+    script "../main.nf"
+    process "LDAK_KVIKSTEP1"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ldak"
+    tag "ldak/kvikstep1"
+
+    test("homo_sapiens popgen - quantitative with explicit mpheno 1") {
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                multiBed = file("plink_multichr.bed")
+                multiBed.bytes = sourceBed.bytes
+                multiFam = file("plink_multichr.fam")
+                multiFam.bytes = sourceFam.bytes
+                multiBim = file("plink_multichr.bim")
+                bimLines = sourceBim.readLines()
+                chrSplit = (int) Math.ceil(bimLines.size() / 2.0)
+                multiBim.text = bimLines.withIndex().collect { line, idx ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = idx < chrSplit ? "21" : "22"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    multiBed,
+                    multiBim,
+                    multiFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_quantitative_phenoname" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe", checkIfExists: true),
+                    1,
+                    false
+                ]
+
+                input[2] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.predictions.size() == 1 },
+                { assert process.out.effects.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                {
+                    def predictionTuple = process.out.predictions.get(0)
+                    def commandText = path(predictionTuple.get(1)).parent.resolve(".command.sh").text
+                    assert commandText.contains("--bfile plink_multichr")
+                    assert commandText.contains("--mpheno 1")
+                    assert !commandText.contains("--binary YES")
+                },
+                {
+                    def stablePredictions = process.out.predictions.collect { prediction ->
+                        [
+                            prediction[0],
+                            path(prediction[1]).fileName.toString(),
+                            path(prediction[2]).fileName.toString(),
+                            path(prediction[3]).fileName.toString()
+                        ]
+                    }
+                    def stableEffects = process.out.effects.collect { effect ->
+                        [effect[0], path(effect[1]).fileName.toString()]
+                    }
+                    def stableLogs = process.out.log.collect { log ->
+                        [log[0], path(log[1]).fileName.toString()]
+                    }
+                    assert snapshot(
+                        stablePredictions,
+                        stableEffects,
+                        stableLogs,
+                        process.out.findAll { key, val -> key.startsWith("versions") }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - binary with fallback mpheno 1") {
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                multiBed = file("plink_multichr.bed")
+                multiBed.bytes = sourceBed.bytes
+                multiFam = file("plink_multichr.fam")
+                multiFam.bytes = sourceFam.bytes
+                multiBim = file("plink_multichr.bim")
+                bimLines = sourceBim.readLines()
+                chrSplit = (int) Math.ceil(bimLines.size() / 2.0)
+                multiBim.text = bimLines.withIndex().collect { line, idx ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = idx < chrSplit ? "21" : "22"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    multiBed,
+                    multiBim,
+                    multiFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_binary_phenoname" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_binary_phenoname.phe", checkIfExists: true),
+                    [],
+                    true
+                ]
+
+                input[2] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.predictions.size() == 1 },
+                { assert process.out.effects.size() == 1 },
+                {
+                    def predictionTuple = process.out.predictions.get(0)
+                    def commandText = path(predictionTuple.get(1)).parent.resolve(".command.sh").text
+                    assert commandText.contains("--bfile plink_multichr")
+                    assert commandText.contains("--mpheno 1")
+                    assert commandText.contains("--binary YES")
+                }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                multiBed = file("plink_multichr.bed")
+                multiBed.bytes = sourceBed.bytes
+                multiFam = file("plink_multichr.fam")
+                multiFam.bytes = sourceFam.bytes
+                multiBim = file("plink_multichr.bim")
+                bimLines = sourceBim.readLines()
+                chrSplit = (int) Math.ceil(bimLines.size() / 2.0)
+                multiBim.text = bimLines.withIndex().collect { line, idx ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = idx < chrSplit ? "21" : "22"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    multiBed,
+                    multiBim,
+                    multiFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_quantitative_phenoname_stub" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe", checkIfExists: true),
+                    1,
+                    false
+                ]
+
+                input[2] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/ldak/kvikstep1/tests/main.nf.test.snap
+++ b/modules/nf-core/ldak/kvikstep1/tests/main.nf.test.snap
@@ -1,0 +1,123 @@
+{
+    "homo_sapiens popgen - quantitative with explicit mpheno 1": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "plink_simulated_quantitative_phenoname"
+                    },
+                    "plink_simulated_quantitative_phenoname.step1.root",
+                    "plink_simulated_quantitative_phenoname.step1.loco.details",
+                    "plink_simulated_quantitative_phenoname.step1.loco.prs"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "plink_simulated_quantitative_phenoname"
+                    },
+                    "plink_simulated_quantitative_phenoname.step1.effects"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "plink_simulated_quantitative_phenoname"
+                    },
+                    "plink_simulated_quantitative_phenoname.step1.log"
+                ]
+            ],
+            {
+                "versions_ldak6": [
+                    [
+                        "LDAK_KVIKSTEP1",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T12:21:03.058753703"
+    },
+    "homo_sapiens popgen - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.root:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "plink_simulated_quantitative_phenoname_stub.step1.loco.details:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "plink_simulated_quantitative_phenoname_stub.step1.loco.prs:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.effects:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        "LDAK_KVIKSTEP1",
+                        "ldak6",
+                        "6"
+                    ]
+                ],
+                "effects": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.effects:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "predictions": [
+                    [
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub"
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step1.root:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "plink_simulated_quantitative_phenoname_stub.step1.loco.details:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "plink_simulated_quantitative_phenoname_stub.step1.loco.prs:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_KVIKSTEP1",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T12:21:27.770425262"
+    }
+}

--- a/modules/nf-core/ldak/kvikstep2/environment.yml
+++ b/modules/nf-core/ldak/kvikstep2/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+  - genomedk
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - genomedk::ldak6=6.1

--- a/modules/nf-core/ldak/kvikstep2/main.nf
+++ b/modules/nf-core/ldak/kvikstep2/main.nf
@@ -1,0 +1,59 @@
+process LDAK_KVIKSTEP2 {
+    tag "${meta.id}:${meta2.id}"
+    label "process_medium"
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c9/c94e5424f08cbd7e0856ab3c3a9992b4080944a5d0c497ce0abcceb413db4a3e/data'
+        : 'community.wave.seqera.io/library/ldak6_r-base:452828f72b3c9129'}"
+
+    input:
+    tuple val(meta), path(bed), path(bim), path(fam)
+    tuple val(meta2), path(phenotype_file), val(mpheno)
+    tuple val(meta3), path(step1_root), path(step1_loco_details), path(step1_loco_prs)
+    tuple val(meta4), path(quant_covariates_file)
+    tuple val(meta5), path(cat_covariates_file)
+    tuple val(meta6), path(keep_file)
+
+    output:
+    tuple val(meta), val(meta2), path("${prefix}.step2.assoc"), emit: results
+    tuple val(meta), val(meta2), path("${prefix}.step2.summaries"), emit: summaries, optional: true
+    tuple val(meta), val(meta2), path("${prefix}.step2.pvalues"), emit: pvalues, optional: true
+    tuple val(meta), val(meta2), path("${prefix}.step2.log"), emit: log
+    tuple val("${task.process}"), val("ldak6"), eval("ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+'"), emit: versions_ldak6, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ""
+    def bfile_prefix = bed.baseName
+    prefix = task.ext.prefix ?: meta2.id
+    def covar_arg = quant_covariates_file ? "--covar ${quant_covariates_file}" : ""
+    def factors_arg = cat_covariates_file ? "--factors ${cat_covariates_file}" : ""
+    def keep_arg = keep_file ? "--keep ${keep_file}" : ""
+    def mpheno_value = mpheno == null || (mpheno instanceof Collection && mpheno.isEmpty()) ? 1 : mpheno
+
+    """
+
+    ldak6 --kvik-step2 ${prefix} \\
+        --bfile ${bfile_prefix} \\
+        --pheno ${phenotype_file} \\
+        ${covar_arg} \\
+        ${factors_arg} \\
+        --mpheno ${mpheno_value} \\
+        ${keep_arg} \\
+        --by-chr NO \\
+        --max-threads ${task.cpus} \\
+        ${args} \\
+        2>&1 | tee ${prefix}.step2.log
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: meta2.id
+    """
+    touch ${prefix}.step2.assoc
+    touch ${prefix}.step2.summaries
+    touch ${prefix}.step2.log
+    """
+}

--- a/modules/nf-core/ldak/kvikstep2/main.nf
+++ b/modules/nf-core/ldak/kvikstep2/main.nf
@@ -35,7 +35,6 @@ process LDAK_KVIKSTEP2 {
     def mpheno_value = mpheno == null || (mpheno instanceof Collection && mpheno.isEmpty()) ? 1 : mpheno
 
     """
-
     ldak6 --kvik-step2 ${prefix} \\
         --bfile ${bfile_prefix} \\
         --pheno ${phenotype_file} \\

--- a/modules/nf-core/ldak/kvikstep2/meta.yml
+++ b/modules/nf-core/ldak/kvikstep2/meta.yml
@@ -26,8 +26,7 @@ input:
         type: file
         description: PLINK BED genotype file passed to `--bfile`
         pattern: "*.bed"
-        ontologies:
-          - edam: "http://edamontology.org/format_3003"
+        ontologies: []
     - bim:
         type: file
         description: PLINK BIM variant file paired with the BED input
@@ -129,7 +128,8 @@ output:
           type: file
           description: LDAK-KVIK step 2 association results
           pattern: "*.step2.assoc"
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_3475"
   summaries:
     - - meta:
           type: map
@@ -145,7 +145,8 @@ output:
           type: file
           description: Optional LDAK-KVIK step 2 summary output
           pattern: "*.step2.summaries"
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_3475"
   pvalues:
     - - meta:
           type: map
@@ -161,7 +162,8 @@ output:
           type: file
           description: Optional LDAK-KVIK step 2 pvalue output
           pattern: "*.step2.pvalues"
-          ontologies: []
+          ontologies:
+            - edam: "http://edamontology.org/format_3475"
   log:
     - - meta:
           type: map

--- a/modules/nf-core/ldak/kvikstep2/meta.yml
+++ b/modules/nf-core/ldak/kvikstep2/meta.yml
@@ -1,0 +1,207 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "ldak_kvikstep2"
+description: "Run LDAK-KVIK step 2 association testing from the minimal step 1 prediction artifacts emitted by ldak/kvikstep1"
+keywords:
+  - "ldak"
+  - "kvik"
+  - "gwas"
+  - "association"
+tools:
+  - "ldak6":
+      description: "LDAK and LDAK-KVIK for mixed-model genome-wide association study (GWAS) and heritability analysis."
+      homepage: "https://dougspeed.com/ldak/"
+      documentation: "https://dougspeed.com/ldak-kvik/"
+      tool_dev_url: "https://github.com/dougspeed/LDAK"
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing genotype information
+          Keep only the genotype analysis identifier in this map
+          The PLINK bundle must already be staged with the basename consumed by `--bfile`
+          Optional chromosome selection such as `--chr 21` is command-line interface (CLI) behavior supplied via `task.ext.args`, not metadata identity
+          e.g. `[ id:'plink_multichr' ]`
+    - bed:
+        type: file
+        description: PLINK BED genotype file passed to `--bfile`
+        pattern: "*.bed"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - bim:
+        type: file
+        description: PLINK BIM variant file paired with the BED input
+        pattern: "*.bim"
+        ontologies: []
+    - fam:
+        type: file
+        description: PLINK FAM sample file paired with the BED input
+        pattern: "*.fam"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing phenotype information
+          Keep `id` as the phenotype-specific analysis identifier used for the step 2 output prefix
+          Keep `is_binary` for trait metadata propagation even though the documented step 2 command does not take `--binary`
+          e.g. `[ id:'Y1', is_binary:false ]`
+    - phenotype_file:
+        type: file
+        description: Phenotype file passed to `--pheno`
+        pattern: "*.{txt,tsv,pheno,phe}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+    - mpheno:
+        type: integer
+        optional: true
+        description: Optional phenotype column index passed to `--mpheno`; provide `[]` to use the module fallback of `1`
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing step 1 prediction artifact information
+          This tuple is the direct `predictions` output emitted by `ldak/kvikstep1`;
+          phenotype and covariate files remain explicit step 2 inputs rather than being bundled into an analysis-unit output.
+          e.g. `[ id:'Y1', is_binary:false ]`
+    - step1_root:
+        type: file
+        description: LDAK-KVIK step 1 root file
+        pattern: "*.step1.root"
+        ontologies: []
+    - step1_loco_details:
+        type: file
+        description: LDAK-KVIK step 1 leave-one-chromosome-out (LOCO) details file
+        pattern: "*.step1.loco.details"
+        ontologies: []
+    - step1_loco_prs:
+        type: file
+        description: LDAK-KVIK step 1 LOCO polygenic risk score (PRS) file
+        pattern: "*.step1.loco.prs"
+        ontologies: []
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing quantitative covariate information
+          e.g. `[ id:'qcov' ]`
+    - quant_covariates_file:
+        type: file
+        optional: true
+        description: Optional quantitative covariates file passed to `--covar`; provide `[]` when absent
+        pattern: "*.{txt,tsv,covar,cov}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+  - - meta5:
+        type: map
+        description: |
+          Groovy Map containing categorical covariate information
+          e.g. `[ id:'ccov' ]`
+    - cat_covariates_file:
+        type: file
+        optional: true
+        description: Optional categorical covariates file passed to `--factors`; provide `[]` when absent
+        pattern: "*.{txt,tsv,covar,cov}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+  - - meta6:
+        type: map
+        description: |
+          Groovy Map containing keep-file information
+          e.g. `[ id:'keep' ]`
+    - keep_file:
+        type: file
+        optional: true
+        description: Optional sample keep file passed to `--keep`; provide `[]` when absent
+        pattern: "*.{txt,tsv,keep}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475"
+output:
+  results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing genotype information
+            e.g. `[ id:'plink_multichr' ]`
+      - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step2.assoc":
+          type: file
+          description: LDAK-KVIK step 2 association results
+          pattern: "*.step2.assoc"
+          ontologies: []
+  summaries:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing genotype information
+            e.g. `[ id:'plink_multichr' ]`
+      - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step2.summaries":
+          type: file
+          description: Optional LDAK-KVIK step 2 summary output
+          pattern: "*.step2.summaries"
+          ontologies: []
+  pvalues:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing genotype information
+            e.g. `[ id:'plink_multichr' ]`
+      - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step2.pvalues":
+          type: file
+          description: Optional LDAK-KVIK step 2 pvalue output
+          pattern: "*.step2.pvalues"
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing genotype information
+            e.g. `[ id:'plink_multichr' ]`
+      - meta2:
+          type: map
+          description: |
+            Groovy Map containing phenotype information
+            e.g. `[ id:'Y1' ]`
+      - "${prefix}.step2.log":
+          type: file
+          description: LDAK-KVIK step 2 log file
+          pattern: "*.step2.log"
+          ontologies:
+            - edam: "http://edamontology.org/format_2330"
+  versions_ldak6:
+    - - "${task.process}":
+          type: string
+          description: The process the versions were collected from
+      - "ldak6":
+          type: string
+          description: The tool name
+      - "ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+'":
+          type: eval
+          description: The command used to generate the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - ldak6:
+          type: string
+          description: The tool name
+      - ldak6 --version 2>&1 | grep -oP '(?<=^Version )[0-9.]+':
+          type: eval
+          description: The command used to generate the version of the tool
+authors:
+  - "@lyh970817"
+maintainers:
+  - "@lyh970817"

--- a/modules/nf-core/ldak/kvikstep2/tests/main.nf.test
+++ b/modules/nf-core/ldak/kvikstep2/tests/main.nf.test
@@ -1,0 +1,286 @@
+nextflow_process {
+
+    name "Test Process LDAK_KVIKSTEP2"
+    script "../main.nf"
+    process "LDAK_KVIKSTEP2"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "ldak"
+    tag "ldak/kvikstep1"
+    tag "ldak/kvikstep2"
+
+    setup {
+        run("LDAK_KVIKSTEP1", alias: "LDAK_KVIKSTEP1_QUANTITATIVE") {
+            script "../../kvikstep1/main.nf"
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                multiBed = file("plink_multichr.bed")
+                multiBed.bytes = sourceBed.bytes
+                multiFam = file("plink_multichr.fam")
+                multiFam.bytes = sourceFam.bytes
+                multiBim = file("plink_multichr.bim")
+                bimLines = sourceBim.readLines()
+                chrSplit = (int) Math.ceil(bimLines.size() / 2.0)
+                multiBim.text = bimLines.withIndex().collect { line, idx ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = idx < chrSplit ? "21" : "22"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    multiBed,
+                    multiBim,
+                    multiFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_quantitative_phenoname" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe", checkIfExists: true),
+                    1,
+                    false
+                ]
+
+                input[2] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                """
+            }
+        }
+
+        run("LDAK_KVIKSTEP1", alias: "LDAK_KVIKSTEP1_BINARY") {
+            script "../../kvikstep1/main.nf"
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                multiBed = file("plink_multichr.bed")
+                multiBed.bytes = sourceBed.bytes
+                multiFam = file("plink_multichr.fam")
+                multiFam.bytes = sourceFam.bytes
+                multiBim = file("plink_multichr.bim")
+                bimLines = sourceBim.readLines()
+                chrSplit = (int) Math.ceil(bimLines.size() / 2.0)
+                multiBim.text = bimLines.withIndex().collect { line, idx ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = idx < chrSplit ? "21" : "22"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    multiBed,
+                    multiBim,
+                    multiFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_binary_phenoname" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_binary_phenoname.phe", checkIfExists: true),
+                    1,
+                    true
+                ]
+
+                input[2] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[3] = [[:], []]
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens popgen - quantitative with optional chr args and explicit mpheno 1") {
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                chrBed = file("plink_multichr.chr21.bed")
+                chrBed.bytes = sourceBed.bytes
+                chrFam = file("plink_multichr.chr21.fam")
+                chrFam.bytes = sourceFam.bytes
+                chrBim = file("plink_multichr.chr21.bim")
+                chrBim.text = sourceBim.readLines().collect { line ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = "21"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    chrBed,
+                    chrBim,
+                    chrFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_quantitative_phenoname", is_binary: false ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe", checkIfExists: true),
+                    1
+                ]
+
+                input[2] = LDAK_KVIKSTEP1_QUANTITATIVE.out.predictions
+
+                input[3] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[4] = [[:], []]
+                input[5] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.results.size() == 1 },
+                { assert process.out.log.size() == 1 },
+                {
+                    def resultFile = path(process.out.results.get(0).get(2))
+                    def commandText = resultFile.parent.resolve(".command.sh").text
+                    assert commandText.contains("--bfile plink_multichr.chr21")
+                    assert commandText.contains("--chr 21")
+                    assert commandText.contains("--mpheno 1")
+                    assert !commandText.contains("--binary YES")
+                },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - binary with fallback mpheno 1") {
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                chrBed = file("plink_multichr.chr21.bed")
+                chrBed.bytes = sourceBed.bytes
+                chrFam = file("plink_multichr.chr21.fam")
+                chrFam.bytes = sourceFam.bytes
+                chrBim = file("plink_multichr.chr21.bim")
+                chrBim.text = sourceBim.readLines().collect { line ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = "21"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    chrBed,
+                    chrBim,
+                    chrFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_binary_phenoname", is_binary: true ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_binary_phenoname.phe", checkIfExists: true),
+                    []
+                ]
+
+                input[2] = LDAK_KVIKSTEP1_BINARY.out.predictions
+
+                input[3] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[4] = [[:], []]
+                input[5] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.results.size() == 1 },
+                {
+                    def resultFile = path(process.out.results.get(0).get(2))
+                    def commandText = resultFile.parent.resolve(".command.sh").text
+                    assert commandText.contains("--mpheno 1")
+                    assert !commandText.contains("--binary YES")
+                },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens popgen - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
+                sourceBim = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bim", checkIfExists: true)
+                sourceFam = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.fam", checkIfExists: true)
+
+                chrBed = file("plink_multichr.chr21.bed")
+                chrBed.bytes = sourceBed.bytes
+                chrFam = file("plink_multichr.chr21.fam")
+                chrFam.bytes = sourceFam.bytes
+                chrBim = file("plink_multichr.chr21.bim")
+                chrBim.text = sourceBim.readLines().collect { line ->
+                    fields = line.split(/\\s+/)
+                    fields[0] = "21"
+                    fields.join("\\t")
+                }.join("\\n") + "\\n"
+
+                input[0] = [
+                    [ id: "plink_multichr" ],
+                    chrBed,
+                    chrBim,
+                    chrFam
+                ]
+
+                input[1] = [
+                    [ id: "plink_simulated_quantitative_phenoname_stub", is_binary: false ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_quantitative_phenoname.phe", checkIfExists: true),
+                    1
+                ]
+
+                input[2] = LDAK_KVIKSTEP1_QUANTITATIVE.out.predictions
+
+                input[3] = [
+                    [ id: "covariates" ],
+                    file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated_covariates.txt", checkIfExists: true)
+                ]
+
+                input[4] = [[:], []]
+                input[5] = [[:], []]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/ldak/kvikstep2/tests/main.nf.test
+++ b/modules/nf-core/ldak/kvikstep2/tests/main.nf.test
@@ -106,6 +106,9 @@ nextflow_process {
     test("homo_sapiens popgen - quantitative with optional chr args and explicit mpheno 1") {
 
         when {
+            params {
+                module_args = "--chr 21"
+            }
             process {
                 """
                 sourceBed = file(params.modules_testdata_base_path + "genomics/homo_sapiens/popgen/plink_simulated.bed", checkIfExists: true)
@@ -152,16 +155,6 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.results.size() == 1 },
-                { assert process.out.log.size() == 1 },
-                {
-                    def resultFile = path(process.out.results.get(0).get(2))
-                    def commandText = resultFile.parent.resolve(".command.sh").text
-                    assert commandText.contains("--bfile plink_multichr.chr21")
-                    assert commandText.contains("--chr 21")
-                    assert commandText.contains("--mpheno 1")
-                    assert !commandText.contains("--binary YES")
-                },
                 { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
             )
         }
@@ -216,13 +209,6 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.results.size() == 1 },
-                {
-                    def resultFile = path(process.out.results.get(0).get(2))
-                    def commandText = resultFile.parent.resolve(".command.sh").text
-                    assert commandText.contains("--mpheno 1")
-                    assert !commandText.contains("--binary YES")
-                },
                 { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
             )
         }

--- a/modules/nf-core/ldak/kvikstep2/tests/main.nf.test.snap
+++ b/modules/nf-core/ldak/kvikstep2/tests/main.nf.test.snap
@@ -1,0 +1,191 @@
+{
+    "homo_sapiens popgen - stub": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub",
+                            "is_binary": false
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step2.log"
+                    ]
+                ],
+                "pvalues": [
+                    
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub",
+                            "is_binary": false
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step2.assoc:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "summaries": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_quantitative_phenoname_stub",
+                            "is_binary": false
+                        },
+                        "plink_simulated_quantitative_phenoname_stub.step2.summaries:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_KVIKSTEP2",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:13:26.441080931"
+    },
+    "homo_sapiens popgen - binary with fallback mpheno 1": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_binary_phenoname",
+                            "is_binary": true
+                        },
+                        "plink_simulated_binary_phenoname.step2.log"
+                    ]
+                ],
+                "pvalues": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_binary_phenoname",
+                            "is_binary": true
+                        },
+                        "plink_simulated_binary_phenoname.step2.pvalues:md5,543365c1fba4deb7257b4c302ddf066a"
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_binary_phenoname",
+                            "is_binary": true
+                        },
+                        "plink_simulated_binary_phenoname.step2.assoc:md5,d6ebf8217166ebf3456b1ae43cd80509"
+                    ]
+                ],
+                "summaries": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_binary_phenoname",
+                            "is_binary": true
+                        },
+                        "plink_simulated_binary_phenoname.step2.summaries:md5,08286a71d7022d83fa72b05698f10bfb"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_KVIKSTEP2",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:12:59.403943741"
+    },
+    "homo_sapiens popgen - quantitative with optional chr args and explicit mpheno 1": {
+        "content": [
+            {
+                "log": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_quantitative_phenoname",
+                            "is_binary": false
+                        },
+                        "plink_simulated_quantitative_phenoname.step2.log"
+                    ]
+                ],
+                "pvalues": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_quantitative_phenoname",
+                            "is_binary": false
+                        },
+                        "plink_simulated_quantitative_phenoname.step2.pvalues:md5,9d108d5a8588e8487a96daf14e00a4d4"
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_quantitative_phenoname",
+                            "is_binary": false
+                        },
+                        "plink_simulated_quantitative_phenoname.step2.assoc:md5,aaa78c50b1e0d94231fde7b0349fed3a"
+                    ]
+                ],
+                "summaries": [
+                    [
+                        {
+                            "id": "plink_multichr"
+                        },
+                        {
+                            "id": "plink_simulated_quantitative_phenoname",
+                            "is_binary": false
+                        },
+                        "plink_simulated_quantitative_phenoname.step2.summaries:md5,bd7bb693468089d870782d888f57606a"
+                    ]
+                ],
+                "versions_ldak6": [
+                    [
+                        "LDAK_KVIKSTEP2",
+                        "ldak6",
+                        "6"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-08T13:12:32.782768174"
+    }
+}

--- a/modules/nf-core/ldak/kvikstep2/tests/nextflow.config
+++ b/modules/nf-core/ldak/kvikstep2/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: "LDAK_KVIKSTEP2" {
+        ext.args = "--chr 21"
+    }
+}

--- a/modules/nf-core/ldak/kvikstep2/tests/nextflow.config
+++ b/modules/nf-core/ldak/kvikstep2/tests/nextflow.config
@@ -1,5 +1,9 @@
+params {
+    module_args = ""
+}
+
 process {
     withName: "LDAK_KVIKSTEP2" {
-        ext.args = "--chr 21"
+        ext.args = { params.module_args ?: "" }
     }
 }


### PR DESCRIPTION
## PR checklist

This PR adds the `ldak/kvikstep2` module — Run LDAK-KVIK step 2 association testing from the minimal step 1 prediction artifacts emitted by ldak/kvikstep1. It upstreams `main.nf`, `meta.yml`, `environment.yml`, and nf-test tests (including a stub), with topic-based version reporting, and snapshots the full output contract via `sanitizeOutput`. Tests reuse the existing public `plink_simulated` fixtures from `nf-core/test-datasets`; no new test data required.

> **Draft — stacked submission.** This module's nf-test `setup{}` builds fixtures by running upstream LDAK modules, so this branch also includes its prerequisite module(s) — **ldak/kvikstep1** — in the diff against `master` (stacked-by-inclusion). Those will drop out as their own PRs merge. Kept as a draft until the prerequisites land; only Docker has been run so far (Singularity/Conda to follow).

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR (not necessary — reuses existing `plink_simulated` fixtures).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test ldak/kvikstep2 --profile docker`
    - [ ] `nf-core modules test ldak/kvikstep2 --profile singularity`
    - [ ] `nf-core modules test ldak/kvikstep2 --profile conda`
