### PR TITLE
Bump trimgalore to 2.3.0

### DIFF
--- a/modules/nf-core/trimgalore/environment.yml
+++ b/modules/nf-core/trimgalore/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::trim-galore=2.1.0
+  - bioconda::trim-galore=2.3.0

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -5,8 +5,8 @@ process TRIMGALORE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7e/7e44249e3fafe3d136ea726225551b51bca642387e16d9687b3e602207dedb20/data' :
-        'community.wave.seqera.io/library/trim-galore:2.1.0--27e6376b8f6c1872'}"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e0/e00369598bd6b7b34a7c83d5496c381104bf8b885c31a4b65b92e6ea2059fbb3/data' :
+        'community.wave.seqera.io/library/trim-galore:2.3.0--6a38a479b4972363'}"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/trimgalore/tests/main.nf.test.snap
+++ b/modules/nf-core/trimgalore/tests/main.nf.test.snap
@@ -30,7 +30,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }
@@ -74,7 +74,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }
@@ -110,7 +110,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }
@@ -142,7 +142,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }
@@ -170,7 +170,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }


### PR DESCRIPTION
## Summary
- Bumps Trim Galore from 2.1.0 to 2.3.0 (latest release, confirmed available on bioconda)
- Updates `environment.yml` conda pin, and Docker/Singularity container URLs in `main.nf` (rebuilt via Wave)
- Regenerates the version string in `tests/main.nf.test.snap`

## Test plan
- [x] `nf-test test modules/nf-core/trimgalore/tests/main.nf.test --profile docker` - all 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)