### PR TITLE
Add phenotype input to plink/vcf

### DIFF
--- a/modules/nf-core/plink/vcf/main.nf
+++ b/modules/nf-core/plink/vcf/main.nf
@@ -1,14 +1,15 @@
 process PLINK_VCF {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/plink:1.90b6.21--h779adbc_1' :
-        'quay.io/biocontainers/plink:1.90b6.21--h779adbc_1' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/plink:1.90b6.21--h779adbc_1'
+        : 'quay.io/biocontainers/plink:1.90b6.21--h779adbc_1'}"
 
     input:
     tuple val(meta), path(vcf)
+    tuple val(meta2), path(pheno)
 
     output:
     tuple val(meta), path("*.bed"), emit: bed, optional: true
@@ -23,12 +24,14 @@ process PLINK_VCF {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def pheno_args = pheno ? "--pheno ${pheno}" : ''
 
     """
     plink \\
         --vcf ${vcf} \\
-        $args \\
-        --threads $task.cpus \\
+        ${pheno_args} \\
+        ${args} \\
+        --threads ${task.cpus} \\
         --out ${prefix}
     """
 

--- a/modules/nf-core/plink/vcf/meta.yml
+++ b/modules/nf-core/plink/vcf/meta.yml
@@ -23,7 +23,17 @@ input:
     - vcf:
         type: file
         description: Variant calling file (vcf)
-        pattern: "*.{vcf}"
+        pattern: "*.{vcf,vcf.gz}"
+        ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing phenotype sample information
+          e.g. [ id:'test', single_end:false ]
+    - pheno:
+        type: file
+        description: Optional PLINK phenotype file passed with `--pheno`
+        pattern: "*.{phe,pheno,txt}"
         ontologies: []
 output:
   bed:

--- a/modules/nf-core/plink/vcf/tests/main.nf.test
+++ b/modules/nf-core/plink/vcf/tests/main.nf.test
@@ -18,7 +18,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
-				    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true) ]
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true) ]
+                input[1] = [ [ id:'test', single_end:false ], [] ]
 
                 """
             }
@@ -27,6 +28,41 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
+                {
+                    def bedFile = path(process.out.bed.get(0).get(1))
+                    def commandText = bedFile.parent.resolve(".command.sh").text
+                    assert !commandText.contains("--pheno ")
+                },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test-plink-vcf-with-pheno") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.vcf.gz', checkIfExists: true) ]
+                input[1] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/plink_simulated.phe', checkIfExists: true) ]
+
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                {
+                    def bedFile = path(process.out.bed.get(0).get(1))
+                    def commandText = bedFile.parent.resolve(".command.sh").text
+                    assert commandText.contains("--pheno ")
+                    assert commandText.contains("plink_simulated.phe")
+                },
                 { assert snapshot(process.out).match() }
             )
         }
@@ -40,7 +76,8 @@ nextflow_process {
                 """
                 input[0] = [
                     [ id:'test', single_end:false ], // meta map
-				    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true) ]
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf', checkIfExists: true) ]
+                input[1] = [ [ id:'test', single_end:false ], [] ]
 
                 """
             }

--- a/modules/nf-core/plink/vcf/tests/main.nf.test.snap
+++ b/modules/nf-core/plink/vcf/tests/main.nf.test.snap
@@ -1,4 +1,83 @@
 {
+    "test-plink-vcf-with-pheno": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bed:md5,e1f17b70b8f213aa6d48dbde955451b4"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bim:md5,41351028a80a8cf5bec0ab2db04af6c9"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fam:md5,1913d482a886b6759c6bbd8a60229bcd"
+                    ]
+                ],
+                "3": [
+                    [
+                        "PLINK_VCF",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ],
+                "bed": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bed:md5,e1f17b70b8f213aa6d48dbde955451b4"
+                    ]
+                ],
+                "bim": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bim:md5,41351028a80a8cf5bec0ab2db04af6c9"
+                    ]
+                ],
+                "fam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fam:md5,1913d482a886b6759c6bbd8a60229bcd"
+                    ]
+                ],
+                "versions_plink": [
+                    [
+                        "PLINK_VCF",
+                        "plink",
+                        "1.90b6.21"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-07-10T02:56:42.555610735"
+    },
     "test-plink-vcf-stub": {
         "content": [
             {
@@ -72,11 +151,11 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-11T15:59:36.415559294",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-11T15:59:36.415559294"
     },
     "test-plink-vcf": {
         "content": [
@@ -151,10 +230,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-11T15:59:21.043652828",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-03-11T15:59:21.043652828"
     }
 }


### PR DESCRIPTION
## PR checklist

This PR adds an optional phenotype file input to `plink/vcf`. When a phenotype file is provided, the module passes it to PLINK with `--pheno`; output mode and conversion flags such as `--make-bed` remain controlled by `ext.args`.

The tests cover the existing no-phenotype path, a phenotype-backed VCF conversion using existing `nf-core/test-datasets` fixtures, and the stub path.

Local checks run:

- `nf-core modules lint --dir modules plink/vcf`
- `nf-core modules test plink/vcf --profile docker`
- `nf-core modules test plink/vcf --profile singularity`
- `nf-core modules test plink/vcf --profile conda`

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test plink/vcf --profile docker`
    - [x] `nf-core modules test plink/vcf --profile singularity`
    - [x] `nf-core modules test plink/vcf --profile conda`
