### PR TITLE
new module: genometester4/glistmaker

### DIFF
--- a/modules/nf-core/genometester4/glistmaker/environment.yml
+++ b/modules/nf-core/genometester4/glistmaker/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::genometester4=4.0"

--- a/modules/nf-core/genometester4/glistmaker/main.nf
+++ b/modules/nf-core/genometester4/glistmaker/main.nf
@@ -1,0 +1,39 @@
+process GENOMETESTER4_GLISTMAKER {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/36/36ce7645eda890c172cecfa37b129d3600e0a23f64bbf05465df4423212ac958/data':
+        'community.wave.seqera.io/library/genometester4:4.0--061bc5822e0dd41d' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("*.list"), emit: list
+    tuple val("${task.process}"), val('genometester4'), eval("glistmaker --version | sed -e 's/glistmaker v//g' "), topic: versions, emit: versions_genometester4
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    glistmaker \\
+        $fasta \\
+        $args \\
+        --num_threads $task.cpus \\
+        -o ${prefix}
+    mv ${prefix}_22.list ${prefix}.list
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    touch ${prefix}.list
+    """
+}

--- a/modules/nf-core/genometester4/glistmaker/main.nf
+++ b/modules/nf-core/genometester4/glistmaker/main.nf
@@ -27,7 +27,7 @@ process GENOMETESTER4_GLISTMAKER {
         $args \\
         --num_threads $task.cpus \\
         -o ${prefix}
-    mv ${prefix}_22.list ${prefix}.list
+    mv ${prefix}_*.list ${prefix}.list
     """
 
     stub:

--- a/modules/nf-core/genometester4/glistmaker/meta.yml
+++ b/modules/nf-core/genometester4/glistmaker/meta.yml
@@ -1,0 +1,67 @@
+name: "genometester4_glistmaker"
+description: Create and count k-mer lists from nucelotide sequences.
+keywords:
+  - kmer
+  - sort
+  - alignment-free
+tools:
+  - "genometester4":
+      description: "A toolkit for performing set operations - union, intersection and
+        complement - on k-mer lists."
+      homepage: "https://github.com/bioinfo-ut/GenomeTester4"
+      documentation: "https://github.com/bioinfo-ut/GenomeTester4"
+      tool_dev_url: "https://github.com/bioinfo-ut/GenomeTester4"
+      doi: "10.1186/s13742-015-0097-y"
+      licence:
+        - "GPL v3"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - fasta:
+        type: file
+        description: fasta file
+        pattern: "*.{fasta,fa,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929"
+output:
+  list:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.list":
+          type: file
+          description: Compressed file containiing the list of observed k-mers and
+            their counts.
+          pattern: "*.list"
+          ontologies: []
+  versions_genometester4:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - genometester4:
+          type: string
+          description: The name of the tool
+      - "glistmaker --version | sed -e 's/glistmaker v//g' ":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - genometester4:
+          type: string
+          description: The name of the tool
+      - "glistmaker --version | sed -e 's/glistmaker v//g' ":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@snunzi"
+maintainers:
+  - "@snunzi"

--- a/modules/nf-core/genometester4/glistmaker/tests/main.nf.test
+++ b/modules/nf-core/genometester4/glistmaker/tests/main.nf.test
@@ -1,0 +1,63 @@
+nextflow_process {
+
+    name "Test Process GENOMETESTER4_GLISTMAKER"
+    script "../main.nf"
+    process "GENOMETESTER4_GLISTMAKER"
+    config "./nextflow.config"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "genometester4"
+    tag "genometester4/glistmaker"
+
+    test("sarscov2 - fasta") {
+
+        when {
+            process {
+                """
+
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.list,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fasta - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/genometester4/glistmaker/tests/main.nf.test.snap
+++ b/modules/nf-core/genometester4/glistmaker/tests/main.nf.test.snap
@@ -1,0 +1,69 @@
+{
+    "sarscov2 - fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.list:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "GENOMETESTER4_GLISTMAKER",
+                        "genometester4",
+                        "4.0"
+                    ]
+                ],
+                "list": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.list:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_genometester4": [
+                    [
+                        "GENOMETESTER4_GLISTMAKER",
+                        "genometester4",
+                        "4.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-10T09:06:01.245879765",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "sarscov2 - fasta": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.list:md5,bce56946d462f9cd30bcfa7ffdd6a471"
+                ]
+            ],
+            {
+                "versions_genometester4": [
+                    [
+                        "GENOMETESTER4_GLISTMAKER",
+                        "genometester4",
+                        "4.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-10T09:05:53.721439073",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/modules/nf-core/genometester4/glistmaker/tests/nextflow.config
+++ b/modules/nf-core/genometester4/glistmaker/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: GENOMETESTER4_GLISTMAKER {
+        ext.args = '-w 22'
+    }
+}


### PR DESCRIPTION
This PR adds a new module for genometester4/glistmaker. This tool converts raw sequence reads or assembled genomes into a binary list of all unique k-mers and their frequency counts.

## PR checklist

Closes #12332 

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`

