### PR TITLE
Deterministic collect() ordering in tximport and RSEM merge counts

### DIFF
--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
@@ -52,9 +52,19 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // Import and summarize quantifications with tximport
     // In per-sample mode, run once per sample instead of collecting all
     //
+    // Sorted for the same cache-stability reason as ch_tx2gene_quants above:
+    // an unsorted collect() over per-sample process outputs orders by task
+    // completion, which changes TXIMETA_TXIMPORT's staged input list (and
+    // therefore its cache key) between runs even when nothing changed. The
+    // R script discovers sample identity from the staged file/directory
+    // names itself (list.files()), not from list position, so sorting here
+    // has no effect on tximport's output.
+    //
     ch_tximport_input = skip_merge
         ? quant_results
-        : quant_results.collect{ meta_results -> meta_results[1] }.map { results -> [ ['id': 'all_samples'], results ] }
+        : quant_results
+            .toSortedList { a, b -> a[1].name <=> b[1].name }
+            .map { sorted -> [ ['id': 'all_samples'], sorted.collect { it[1] } ] }
 
     TXIMETA_TXIMPORT (
         ch_tximport_input,

--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
@@ -52,13 +52,8 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // Import and summarize quantifications with tximport
     // In per-sample mode, run once per sample instead of collecting all
     //
-    // Sorted for the same cache-stability reason as ch_tx2gene_quants above:
-    // an unsorted collect() over per-sample process outputs orders by task
-    // completion, which changes TXIMETA_TXIMPORT's staged input list (and
-    // therefore its cache key) between runs even when nothing changed. The
-    // R script discovers sample identity from the staged file/directory
-    // names itself (list.files()), not from list position, so sorting here
-    // has no effect on tximport's output.
+    // Sorted by name for a stable cache key; the R script derives sample
+    // identity from staged file names, not list position.
     //
     ch_tximport_input = skip_merge
         ? quant_results

--- a/subworkflows/nf-core/quantify_rsem/main.nf
+++ b/subworkflows/nf-core/quantify_rsem/main.nf
@@ -49,12 +49,20 @@ workflow QUANTIFY_RSEM {
     ch_merged_isoforms_long     = channel.empty()
 
     if (!skip_merge) {
+        //
+        // Sorted by staged file name so the input list order (and therefore
+        // CUSTOM_RSEMMERGECOUNTS's cache key) is stable across runs instead
+        // of following task-completion order. The module's script globs the
+        // staged directory itself (`./genes/*`, `./isoforms/*`), so sorting
+        // here doesn't change which columns land in the merged output.
+        //
         CUSTOM_RSEMMERGECOUNTS (
             ch_counts_gene
-                .collect{ _meta, genes_count -> genes_count }
-                .map { genes_count -> [ ['id': 'all_samples'], genes_count ] },
+                .toSortedList { a, b -> a[1].name <=> b[1].name }
+                .map { sorted -> [ ['id': 'all_samples'], sorted.collect { it[1] } ] },
             ch_counts_transcript
-                .collect{ _meta, transcripts_count -> transcripts_count }
+                .toSortedList { a, b -> a[1].name <=> b[1].name }
+                .map { sorted -> sorted.collect { it[1] } }
         )
         ch_merged_counts_gene       = CUSTOM_RSEMMERGECOUNTS.out.counts_gene
         ch_merged_tpm_gene          = CUSTOM_RSEMMERGECOUNTS.out.tpm_gene

--- a/subworkflows/nf-core/quantify_rsem/main.nf
+++ b/subworkflows/nf-core/quantify_rsem/main.nf
@@ -50,11 +50,8 @@ workflow QUANTIFY_RSEM {
 
     if (!skip_merge) {
         //
-        // Sorted by staged file name so the input list order (and therefore
-        // CUSTOM_RSEMMERGECOUNTS's cache key) is stable across runs instead
-        // of following task-completion order. The module's script globs the
-        // staged directory itself (`./genes/*`, `./isoforms/*`), so sorting
-        // here doesn't change which columns land in the merged output.
+        // Sorted by name for a stable cache key; the script globs the
+        // staged directory, so order doesn't affect output.
         //
         CUSTOM_RSEMMERGECOUNTS (
             ch_counts_gene


### PR DESCRIPTION
## Description

Follow-on to the fix already applied to `CUSTOM_TX2GENE`'s input in `quant_tximport_summarizedexperiment` (nf-core/modules#12166, #12168). The same pattern - an unsorted `collect()` over a queue channel fed by per-sample process outputs, staged as a multi-file `path` input - appears in two more places:

1. **`TXIMETA_TXIMPORT` input**, same subworkflow (`quant_tximport_summarizedexperiment/main.nf`): `ch_tximport_input` collected `quant_results` without sorting.
2. **`CUSTOM_RSEMMERGECOUNTS` inputs** (`quantify_rsem/main.nf`): both the gene-counts and transcript-counts collects were unsorted.

Queue-channel arrival order equals task-completion order, so the staged input list order - and therefore the task hash - changed run to run even when nothing else did, breaking `-resume` for these processes and everything downstream of them.

In both cases the underlying script already derives sample identity from the staged file/directory names itself rather than input list position:
- `TXIMETA_TXIMPORT`'s R template uses `list.files('quants', ...)` to discover inputs.
- `CUSTOM_RSEMMERGECOUNTS`'s script globs the staged directory (`./genes/*`, `./isoforms/*`), and bash expands globs lexicographically regardless of staging order.

So sorting the collected list by staged file name is a no-op on outputs - it only makes the input ordering (and cache key) reproducible. Verified with `nf-core subworkflows test` for both subworkflows: snapshots are byte-identical before and after.

## Changes

- `subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf`: sort `ch_tximport_input` by staged file name.
- `subworkflows/nf-core/quantify_rsem/main.nf`: sort both `CUSTOM_RSEMMERGECOUNTS` input collects by staged file name.

Related: nf-core/rnaseq#1879

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `nf-core subworkflows lint quant_tximport_summarizedexperiment` passes.
- [x] `nf-core subworkflows lint quantify_rsem` passes.
- [x] `nf-core subworkflows test quant_tximport_summarizedexperiment --profile docker` passes, snapshot unchanged.
- [x] `nf-core subworkflows test quantify_rsem --profile docker` passes, snapshot unchanged.