### PR TITLE
Guard against running on an empty per-sample input list in tximport/quantify_rsem

### DIFF
--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
@@ -53,10 +53,9 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // In per-sample mode, run once per sample instead of collecting all
     //
     // Sorted by name for a stable cache key; the R script derives sample
-    // identity from staged file names, not list position. The empty-list
-    // guard preserves the no-op-on-empty behaviour of the plain collect()
-    // this replaced, since toSortedList() always emits (even []) where
-    // collect() does not emit at all on an empty upstream.
+    // identity from staged file names, not list position. Filtered to
+    // skip TXIMETA_TXIMPORT when there are no samples, since
+    // toSortedList() emits [] rather than nothing on an empty channel.
     //
     ch_tximport_input = skip_merge
         ? quant_results

--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
@@ -53,12 +53,16 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // In per-sample mode, run once per sample instead of collecting all
     //
     // Sorted by name for a stable cache key; the R script derives sample
-    // identity from staged file names, not list position.
+    // identity from staged file names, not list position. The empty-list
+    // guard preserves the no-op-on-empty behaviour of the plain collect()
+    // this replaced, since toSortedList() always emits (even []) where
+    // collect() does not emit at all on an empty upstream.
     //
     ch_tximport_input = skip_merge
         ? quant_results
         : quant_results
             .toSortedList { a, b -> a[1].name <=> b[1].name }
+            .filter { sorted -> sorted.size() > 0 }
             .map { sorted -> [ ['id': 'all_samples'], sorted.collect { it[1] } ] }
 
     TXIMETA_TXIMPORT (

--- a/subworkflows/nf-core/quantify_rsem/main.nf
+++ b/subworkflows/nf-core/quantify_rsem/main.nf
@@ -51,11 +51,9 @@ workflow QUANTIFY_RSEM {
     if (!skip_merge) {
         //
         // Sorted by name for a stable cache key; the script globs the
-        // staged directory, so order doesn't affect output. The empty-list
-        // guards preserve the no-op-on-empty behaviour of the plain
-        // collect() this replaced, since toSortedList() always emits
-        // (even []) where collect() does not emit at all on an empty
-        // upstream.
+        // staged directory, so order doesn't affect output. Filtered to
+        // skip CUSTOM_RSEMMERGECOUNTS when there are no samples, since
+        // toSortedList() emits [] rather than nothing on an empty channel.
         //
         CUSTOM_RSEMMERGECOUNTS (
             ch_counts_gene

--- a/subworkflows/nf-core/quantify_rsem/main.nf
+++ b/subworkflows/nf-core/quantify_rsem/main.nf
@@ -51,14 +51,20 @@ workflow QUANTIFY_RSEM {
     if (!skip_merge) {
         //
         // Sorted by name for a stable cache key; the script globs the
-        // staged directory, so order doesn't affect output.
+        // staged directory, so order doesn't affect output. The empty-list
+        // guards preserve the no-op-on-empty behaviour of the plain
+        // collect() this replaced, since toSortedList() always emits
+        // (even []) where collect() does not emit at all on an empty
+        // upstream.
         //
         CUSTOM_RSEMMERGECOUNTS (
             ch_counts_gene
                 .toSortedList { a, b -> a[1].name <=> b[1].name }
+                .filter { sorted -> sorted.size() > 0 }
                 .map { sorted -> [ ['id': 'all_samples'], sorted.collect { it[1] } ] },
             ch_counts_transcript
                 .toSortedList { a, b -> a[1].name <=> b[1].name }
+                .filter { sorted -> sorted.size() > 0 }
                 .map { sorted -> sorted.collect { it[1] } }
         )
         ch_merged_counts_gene       = CUSTOM_RSEMMERGECOUNTS.out.counts_gene


### PR DESCRIPTION
## Description

Follow-up to #12377, caught by downstream CI on the nf-core/rnaseq consuming PR (nf-core/rnaseq#1885).

`#12377` swapped `collect()` for `toSortedList()` on the per-sample inputs feeding `TXIMETA_TXIMPORT` and `CUSTOM_RSEMMERGECOUNTS`, to make the staged input order (and therefore the task hash) deterministic. That swap has a side effect: `toSortedList()` always emits exactly one value, even `[]`, on an empty upstream, whereas the `collect()` it replaced emits nothing at all when the upstream is empty.

In a pipeline run where every sample is filtered out before reaching this point (e.g. all samples fail a trim-length threshold), the per-sample channel closes with zero elements. With the old `collect()`, that meant `TXIMETA_TXIMPORT`/`CUSTOM_RSEMMERGECOUNTS` were never invoked at all - a queue channel with no matching emission on one side means no invocation. With `toSortedList()`, the channel now emits a single `[]` value, so the process fires once with zero staged files, producing empty output files instead of being skipped.

## Changes

Add `.filter { sorted -> sorted.size() > 0 }` after each `toSortedList()` in both subworkflows, matching the guard already used for `CUSTOM_TX2GENE`'s input in the same subworkflow. Restores the original no-op-on-empty behaviour while keeping the ordering deterministic for the non-empty case.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `nf-core subworkflows test quant_tximport_summarizedexperiment --profile docker` passes, snapshot unchanged.
- [x] `nf-core subworkflows test quantify_rsem --profile docker` passes, snapshot unchanged.