### PR TITLE
Update shinyngs modules to r-shinyngs 3.1.1

### DIFF
--- a/modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+++ b/modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
@@ -1,0 +1,3302 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-64:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-biobase-2.70.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-delayedarray-0.36.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-genomicranges-1.62.1-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-iranges-2.44.0-r45h01b2380_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-limma-3.66.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4arrays-1.10.1-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4vectors-0.48.0-r45h01b2380_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-sparsearray-1.10.8-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-xvector-0.50.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.2.0-h281d09f_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-askpass-1.2.1-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.5.3-h502d0c9_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base64enc-0.1_6-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-beeswarm-0.4.0-r45h54b55ab_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cachem-1.1.0-r45h54b55ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.6-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.2-r45heaba542_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-commonmark-2.0.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-curl-7.1.0-r45h10955f1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.18.4-r45h1c8cec4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.39-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.2.1-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.7-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r45h3697838_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fastmap-1.2.0-r45h3697838_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fs-2.1.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.1-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-hexbin-1.28.5-r45heaba542_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-htmltools-0.5.9-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-httpuv-1.6.17-r45h6d565e7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.3.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-jsonlite-2.0.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-later-1.4.8-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_9-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lazyeval-0.2.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.5-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_66-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.7_5-r45h0e4624f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_4-r45h0e4624f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mime-0.13-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_170-r45heaba542_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-openssl-2.4.2-r45h68c19f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ps-1.9.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.2.2-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-qap-0.1_2-r45heaba542_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rappdirs-0.3.4-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.1.2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpptoml-0.2.3-r45h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-renv-1.2.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.5-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.3.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-s7-0.2.2-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sass-0.4.10-r45h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-seriation-1.5.8-r45heaba542_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.7-r45h3d52c89_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sys-3.4.3-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.1-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tsp-1.2.7-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.7.3-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vegan-2.7_5-r45h11cdb10_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xfun-0.60-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-yaml-2.3.12-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+md5: a9f577daf3de00bca7c3c76c0ecbd1de
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28948
+timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+depends:
+- ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+- sysroot_linux-64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 3713752
+timestamp: 1784214522814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+sha256: 08d7238663fc408ba2ab60b02fa3d06a7ca9d872962e03e90c7e0fdecb7ed1d0
+md5: 32fd07abe84eb14f17c7f5cc6fa8df82
+depends:
+- binutils_impl_linux-64 2.46.1 default_hfdba357_102
+license: GPL-3.0-only
+license_family: GPL
+size: 36337
+timestamp: 1784214551894
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-biobase-2.70.0-r45h01b2380_0.conda
+sha256: d23fb8b3abab1d8241a9172fc1a4ca586c31d18cb2c4fb5152c53a6cd659777a
+md5: 782edae8ecb3df45c26652d215977957
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2355711
+timestamp: 1770509543214
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+sha256: 97221eda3007381c0a6498608baaebdcec6047f7f26b121c19149fd56aabf032
+md5: 27556377d159490ea87696727ae41808
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-generics
+license: Artistic-2.0
+size: 653523
+timestamp: 1770415244399
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-delayedarray-0.36.0-r45h01b2380_0.conda
+sha256: 1f1fd7027ffffebeaca5c416f05d91bcd3a05cf1d043ee347fffbcdde6978c01
+md5: 8a5b2ea0550afcb925ff5f267ff741ea
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-sparsearray >=1.10.0,<1.11.0
+- bioconductor-sparsearray >=1.10.8,<1.11.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 2204619
+timestamp: 1772123650559
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-genomicranges-1.62.1-r45h01b2380_0.conda
+sha256: 0d5ea1e661e10cfeecf763a7466efebc616ca55a2c9f6ce33cbe41c7eb1a0a4b
+md5: 5dd6ca03e419938e6e4e3bc6b7796b45
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2306994
+timestamp: 1772108656670
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-iranges-2.44.0-r45h01b2380_1.conda
+sha256: 964697eeaeb946ecfe076f3b43eec9bafa018ef21d2dc3555d6c28ca817e4d79
+md5: d6811165f0b3db78b08fdc2c4938bc4e
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2344215
+timestamp: 1770546527540
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-limma-3.66.0-r45h01b2380_0.conda
+sha256: c8dcbf3abfc0c1cf4ff6e68c828e0c59052c2b65dd3dd15aa1d39dbca679991e
+md5: 54dbec67b82ef291760cb0c2927c5002
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-statmod
+license: GPL-2.0-or-later
+size: 3099884
+timestamp: 1770417840293
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+sha256: 169809ca754b2c07f7356f1fc4f365b7d5154fd66229543584f69008fa347c5a
+md5: cdf0406fc3caa814ff7b7876a42973a5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-matrixstats >=1.4.1
+license: Artistic-2.0
+size: 449898
+timestamp: 1770417102301
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4arrays-1.10.1-r45h01b2380_0.conda
+sha256: 0b8729dc75999ab80ff333242f1052de1642f2f5653d344c06a652143b1326bd
+md5: 0b2ad083cc4002a36926c7c31be1c5c8
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-abind
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1027424
+timestamp: 1770628251018
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4vectors-0.48.0-r45h01b2380_1.conda
+sha256: d6ffd7388683d03ab6133a3f8efdb69d917718a54c3d08b744c1b4910b876e82
+md5: db7c8f69c137a9a97a11518ce59ca149
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2061150
+timestamp: 1770508921246
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+sha256: 875f5be76bc3b83766ec0cfacf888570d529907412519a537c5f7a318e489976
+md5: cfe7c256532f9a4fc87ec3be955bb9e6
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 598298
+timestamp: 1770628899171
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-sparsearray-1.10.8-r45h01b2380_0.conda
+sha256: 7f1f2c6012e51daa1d5ea291b7928e396763dd073ebef228f2352118d4287096
+md5: 2b73e1653c675b4ba118bb085862771c
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-xvector >=0.50.0,<0.51.0
+- bioconductor-xvector >=0.50.0,<0.51.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-matrixstats
+license: Artistic-2.0
+size: 1636745
+timestamp: 1772107896548
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+sha256: b8ade9f2ab8cc2835357653f5a9bc840323c05f7656659dfb40d20e5623f8ebd
+md5: 74eb95090e807c18f5bc81cb9fb39b3c
+depends:
+- bioconductor-biobase >=2.70.0,<2.71.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-delayedarray >=0.36.0,<0.37.0
+- bioconductor-genomicranges >=1.62.0,<1.63.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1416452
+timestamp: 1772218138703
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-xvector-0.50.0-r45h01b2380_0.conda
+sha256: c0921f72138df07e69bdae7c16cc1b35deebfaf0fa93e16dfa731838a6c358b7
+md5: ec982ddb97e04a6b40454395fd2dd229
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 641687
+timestamp: 1770628594641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+sha256: c88dd33c89b33409ebcd558d78fdc66a63c18f8b06e04d170668ffb6c8ecfabd
+md5: 983b92277d78c0d0ec498e460caa0e6d
+depends:
+- tk
+license: TCL
+size: 129594
+timestamp: 1750261567920
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+md5: d2ffd7602c02f2b316fd921d39876885
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 260182
+timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+sha256: dee93a82d045f9aa8277829aa465224afa3c7a6ac18388de66099b2be7f705e7
+md5: 6130ad6705adc993b5d8482b7f66e01f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 210929
+timestamp: 1784091008551
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+md5: a9965dd99f683c5f444428f896635716
+depends:
+- __unix
+license: ISC
+size: 128866
+timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
+md5: bb6c4808bfa69d6f7f6b07e5846ced37
+depends:
+- __glibc >=2.17,<3.0.a0
+- fontconfig >=2.15.0,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.1,<79.0a0
+- libexpat >=2.7.3,<3.0a0
+- libfreetype >=2.14.1
+- libfreetype6 >=2.14.1
+- libgcc >=14
+- libglib >=2.86.3,<3.0a0
+- libpng >=1.6.53,<1.7.0a0
+- libstdcxx >=14
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 989514
+timestamp: 1766415934926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
+sha256: ae0b83efb7545ea40845253b76bbfeb12349bd32001728b8f58d726cd532d467
+md5: d09779693563f4a1a0bdb0f715ba2bf0
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 hae6b9f4_2
+- libgcc >=14
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 194776
+timestamp: 1782911792708
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
+md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 281880
+timestamp: 1780450077431
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
+md5: 8462b5322567212beeb025f3519fb3e2
+depends:
+- libfreetype 2.14.3 ha770c72_0
+- libfreetype6 2.14.3 h73754d4_0
+license: GPL-2.0-only OR FTL
+size: 173839
+timestamp: 1774298173462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
+md5: f9f81ea472684d75b9dd8d0b328cf655
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 61244
+timestamp: 1757438574066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+sha256: a48400ec4b73369c1c59babe4ad35821b63a88bba0ec40a80cea5f8c53a26b83
+md5: e3be72048d3c4a78b8e27ec48ba06252
+depends:
+- binutils_impl_linux-64 >=2.45
+- libgcc >=15.2.0
+- libgcc-devel_linux-64 15.2.0 hcc6f6b0_119
+- libgomp >=15.2.0
+- libsanitizer 15.2.0 h90f66d4_19
+- libstdcxx >=15.2.0
+- libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 81180457
+timestamp: 1778269124617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+sha256: b24b13d467898a9b9a17a868a2686412a98f8935dc7cc51547dd90645d4e8436
+md5: 28bc49875f9c38e2401696b3e48d0798
+depends:
+- gcc_impl_linux-64 15.2.0.*
+- binutils_linux-64
+- sysroot_linux-64
+license: BSD-3-Clause
+license_family: BSD
+size: 29330
+timestamp: 1781279944230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.2.0-h281d09f_19.conda
+sha256: 2f6a962bfcb74b8262dc0af5cf0716acbd96f769a0443dd231d1041c222b0ca6
+md5: 5d4fdb7935b8aa1cdb2e22ef8958101e
+depends:
+- gcc_impl_linux-64 >=15.2.0
+- libgcc >=15.2.0
+- libgfortran5 >=15.2.0
+- libstdcxx >=15.2.0
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 20041854
+timestamp: 1778269291096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
+md5: cf09e9fc938518e91d0706572cadf17a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 100054
+timestamp: 1780454302233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+sha256: 132a918b676dd1f533d7c6f95e567abf7081a6ea3251c3280de35ef600e0da87
+md5: fec079ba39c9cca093bf4c00001825de
+depends:
+- libblas >=3.8.0,<4.0a0
+- libcblas >=3.8.0,<4.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3376423
+timestamp: 1626369596591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+sha256: 3f5288346b9fe233352443b3c2e31f1fde845e39d3e96475fc05ec2e782af158
+md5: 9d41f3899b512199af0a4bb939b83e21
+depends:
+- gcc_impl_linux-64 15.2.0 he0086c7_19
+- libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+- sysroot_linux-64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16356816
+timestamp: 1778269332159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
+sha256: f78da7a8b49943a6ce48372a5bc85ab741ac86666f1040e8876545065ec1096e
+md5: 5e194579a5f72c70102f342aa362f5f9
+depends:
+- gxx_impl_linux-64 15.2.0.*
+- gcc_linux-64 ==15.2.0 h7be306e_27
+- binutils_linux-64
+- sysroot_linux-64
+license: BSD-3-Clause
+license_family: BSD
+size: 27848
+timestamp: 1781279944230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
+md5: 72e956a71241633d8c80aa198fd08784
+depends:
+- libharfbuzz-devel 14.2.1 h17a8019_1
+license: MIT
+license_family: MIT
+size: 11039
+timestamp: 1782800611635
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+md5: c80d8a3b84358cb967fa81e7075fbc8a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 12723451
+timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+md5: 86d9cba083cd041bfbf242a01a7a1999
+constrains:
+- sysroot_linux-64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1278712
+timestamp: 1765578681495
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+md5: b38117a3c920364aff79f870c984b4a3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 134088
+timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+depends:
+- __glibc >=2.17,<3.0.a0
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1388990
+timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+md5: 449500f2c089da11c40f5c21312e3e07
+depends:
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 745303
+timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
+md5: a752488c68f2e7c456bcbd8f16eec275
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 261513
+timestamp: 1773113328888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+build_number: 8
+sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+md5: 00fc660ab1b2f5ca07e92b4900d10c79
+depends:
+- libopenblas >=0.3.33,<0.3.34.0a0
+- libopenblas >=0.3.33,<1.0a0
+constrains:
+- blas 2.308   openblas
+- mkl <2027
+- libcblas   3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18804
+timestamp: 1779859100675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+build_number: 8
+sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+md5: 33a413f1095f8325e5c30fde3b0d2445
+depends:
+- libblas 3.11.0 8_h4a7cf45_openblas
+constrains:
+- blas 2.308   openblas
+- liblapacke 3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18778
+timestamp: 1779859107964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
+md5: f9c59d277a16ec8f272b2d5dd2ec3335
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 480327
+timestamp: 1782911787190
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+md5: 6c77a605a7a689d17d4819c0f8ac9a00
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 73490
+timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+depends:
+- ncurses
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 134676
+timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+md5: 172bf1cd1ff8629f2b1179945ed45055
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 112766
+timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+md5: b24d3c612f71e7aa74158d92106318b2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77856
+timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+md5: a360c33a5abe61c07959e449fa1453eb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 58592
+timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
+md5: e289f3d17880e44b633ba911d57a321b
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8049
+timestamp: 1774298163029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
+md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 384575
+timestamp: 1774298162622
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+constrains:
+- libgcc-ng ==15.2.0=*_19
+- libgomp 15.2.0 he0feb66_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1041084
+timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+sha256: 38a557eba305468ac1f90ac85e50d8defd76141cb0b8a43b2fc1aca71dd5d5f2
+md5: 683fcb168e1df9a21fa80d5aa2d9330b
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 3095909
+timestamp: 1778268932148
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+md5: 331ee9b72b9dff570d56b1302c5ab37d
+depends:
+- libgcc 15.2.0 he0feb66_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27694
+timestamp: 1778269016987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
+md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
+depends:
+- libgfortran5 15.2.0 h68bc16d_19
+constrains:
+- libgfortran-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27655
+timestamp: 1778269042954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
+md5: 85072b0ad177c966294f129b7c04a2d5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15.2.0
+constrains:
+- libgfortran 15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2483673
+timestamp: 1778269025089
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
+md5: 889febc66cd9e4190f80ef9718fa239b
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libiconv >=1.18,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- libffi >=3.5.2,<3.6.0a0
+- pcre2 >=10.47,<10.48.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4754220
+timestamp: 1782463895250
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+md5: faac990cb7aedc7f3a2224f2c9b0c26c
+depends:
+- __glibc >=2.17,<3.0.a0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 603817
+timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+md5: fb4669c3990b94ea32fbb81f433e9aa6
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1297668
+timestamp: 1782800580119
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+md5: 99cf21100441e51272f1cd6fe0632a20
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libharfbuzz 14.2.1 h17a8019_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1970690
+timestamp: 1782800603897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+md5: 915f5995e94f60e9a4826e0b0920ee88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-only
+size: 790176
+timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+sha256: 716332fd31b3808da7a4235a05212a9e9da05e854864c3def2dea0b5d2bf7610
+md5: 466badda5536d85ddc63ee9404f29735
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 652868
+timestamp: 1783731886811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+build_number: 8
+sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+md5: 809be8ba8712c77bc7d44c2d99390dc4
+depends:
+- libblas 3.11.0 8_h4a7cf45_openblas
+constrains:
+- blas 2.308   openblas
+- libcblas   3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18790
+timestamp: 1779859115086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+md5: b88d90cad08e6bc8ad540cb310a761fb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 113478
+timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+md5: 2a45e7f8af083626f009645a6481f12d
+depends:
+- __glibc >=2.17,<3.0.a0
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 663344
+timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
+md5: 2d3278b721e40468295ca755c3b84070
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.33,<0.3.34.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5931919
+timestamp: 1776993658641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+md5: eba48a68a1a2b9d3c0d9511548db85db
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 317729
+timestamp: 1776315175087
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+sha256: 71118885feab91c61bea4e9532ec46e0653b24f02e563681f822915aee8435bb
+md5: af5ddfb52ad25d833c70c7511478d4eb
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 70092
+timestamp: 1783936855082
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+sha256: 7a58892a52739ce4c0f7109de9e91b4353104748eb04fc6441d88e8af444ba99
+md5: 67eef12ce33f7ff99900c212d7076fc2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15.2.0
+- libstdcxx >=15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7930689
+timestamp: 1778269054623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+md5: eecce068c7e4eddeb169591baac20ac4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 304790
+timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+md5: 5794b3bdc38177caf969dabd3af08549
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc 15.2.0 he0feb66_19
+constrains:
+- libstdcxx-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 5852044
+timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+sha256: a2385f3611d5cd25378f9cf2367183320731709c067ddd08d43330d3170f15b8
+md5: bcfe7eae40158c3e355d2f9d3ed41230
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 20765069
+timestamp: 1778268963689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
+md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
+depends:
+- __glibc >=2.17,<3.0.a0
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 452337
+timestamp: 1783084902636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+md5: 01bb81d12c957de066ea7362007df642
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-3-Clause
+license_family: BSD
+size: 40017
+timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+sha256: e28e4519223f78b3163599ca89c3f2d80bfb53e907e7fc74e806e60d1efa578b
+md5: 4e33d49bf4fc853855a3b00643aa5484
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 419935
+timestamp: 1779396012261
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+md5: aea31d2e5b1091feca96fcfe945c3cf9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 429011
+timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+md5: 92ed62436b625154323d40d5f2f11dd7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- pthread-stubs
+- xorg-libxau >=1.0.11,<2.0a0
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 395888
+timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+md5: d87ff7921124eccd67248aa483c23fec
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- zlib 1.3.2 *_2
+license: Zlib
+license_family: Other
+size: 63629
+timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+sha256: d652c7bd4d3b6f82b0f6d063b0d8df6f54cc47531092d7ff008e780f3261bdda
+md5: 33405d2a66b1411db9f7242c8b97c9e7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 513088
+timestamp: 1727801714848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+md5: fc21868a1a5aacc937e7a18747acb8a5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 918956
+timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+md5: 79dd2074b5cd5c5c6b2930514a11e22d
+depends:
+- __glibc >=2.17,<3.0.a0
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3159683
+timestamp: 1781069855778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+sha256: 2f17a165a04833bd249215336b00df912bad7f03ae445a36765b47593df34057
+md5: a4b80dd6e9e0784ba48e6803bef1e17a
+license: GPL-2.0-or-later
+license_family: GPL
+size: 22516793
+timestamp: 1780595446569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
+md5: d53ffc0edc8eabf4253508008493c5bc
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.17.1,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- harfbuzz >=13.2.1
+- libexpat >=2.7.4,<3.0a0
+- libfreetype >=2.14.2
+- libfreetype6 >=2.14.2
+- libgcc >=14
+- libglib >=2.86.4,<3.0a0
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 458036
+timestamp: 1774281947855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+md5: 7a3bff861a6583f1889021facefc08b1
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1222481
+timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+sha256: 9e5b5be056820ade8b09ef73cf9f4bea037eb9887145d0297ac99e0add88878d
+md5: 7cd77fef4da3e1ca9484394616cb71f1
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 376220
+timestamp: 1784286827180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+sha256: 4ce2e1ee31a6217998f78c31ce7dc0a3e0557d9238b51d49dd20c52d467a126d
+md5: f2c23a77b25efcad57d377b34bd84941
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 593603
+timestamp: 1769710381284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+md5: b3c17d95b5a10c6e64a21fa17573e70e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 8252
+timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+sha256: 5055913d786b82f33a14f493f32945b3b2b5d528ea2f52856ca02b296f6511eb
+md5: dde4691fe168112a90efba6aaa08f13d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: LGPL (>= 2)
+license_family: LGPL
+size: 82526
+timestamp: 1757460261392
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-askpass-1.2.1-r45h54b55ab_1.conda
+sha256: 5c4d2bcc1beba7703acbfe1610a846ce2a4010456714705dfa63989cee722a00
+md5: 1ae3c72e90c6a3871c594448d3e152e4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-sys >=2.1
+license: MIT
+license_family: MIT
+size: 31983
+timestamp: 1758383536121
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+sha256: 90e7ae8aa427274d7d2e510060b68925e60e897ecaa5ea135bb33afa7eb12134
+md5: b5291c60f52b43108a2973ba6f5885d1
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 72543
+timestamp: 1757447376176
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.5.3-h502d0c9_3.conda
+sha256: e6fa14f597334a5178e5ea0ce2290e1bcb5d165d36f6dbcf41a516cba3176dff
+md5: 8e584ef995c58d546ca1b2642fa4deae
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.18.4,<2.0a0
+- curl
+- gcc_linux-64 >=14
+- gfortran_impl_linux-64
+- gsl >=2.7,<2.8.0a0
+- gxx_linux-64 >=14
+- icu >=78.3,<79.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libglib >=2.88.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- make
+- pango >=1.56.4,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- readline >=8.3,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- tzdata >=2024a
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxt >=1.3.1,<2.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 27369225
+timestamp: 1781522577217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base64enc-0.1_6-r45h54b55ab_0.conda
+sha256: 7a3751a340766ee25380a51df70c8356a64cfeb6ac3d982a86e92eb99fec2943
+md5: e573dc135976197e7f819eec202c93f1
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 48616
+timestamp: 1770027796335
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-beeswarm-0.4.0-r45h54b55ab_5.conda
+sha256: 0b1e86ec24e2acc3eae1020cc5b19f9f7e172df8871b4f042fbca11d0fc2e0a6
+md5: 787c18b3e1532606bf796a360cf2ea39
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 89369
+timestamp: 1757583631217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+sha256: 177f262fda25552b8ce3e7685220deefba1625314575a892cd4abca06ddf06a4
+md5: f1b6b9a4e77b21df8a6949102db4f468
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 644936
+timestamp: 1763112090227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+sha256: fafc7a0acb8fc595b8fd89e75ec0b1d7d5af71b2b493570fa05e1f5612d299c2
+md5: dae60c429ab933e549832bc223e95639
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-cachem
+- r-htmltools >=0.5.7
+- r-jquerylib >=0.1.3
+- r-jsonlite
+- r-lifecycle
+- r-memoise >=2.0.1
+- r-mime
+- r-rlang
+- r-sass >=0.4.0
+license: MIT
+license_family: MIT
+size: 5538377
+timestamp: 1778923739710
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+sha256: 20dd6e4aa94d2d5ea97419add6bcac50f81400d297e9933659ff35da41fe2f6d
+md5: c922b0a6584376d3587d8cb3670f5cac
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 256017
+timestamp: 1757560386979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cachem-1.1.0-r45h54b55ab_2.conda
+sha256: 75a21c955abf03fa1804d47c94f5091cd772b614e074b63b02347a23f5649a53
+md5: 42617e710293f0b76ccc08855e0edbc4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fastmap
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76879
+timestamp: 1757441544326
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+sha256: f9f49b2b845f279af84a33c8af19a915b2731c0bd892c608205cbad8a34f423d
+md5: a5cc8a8d0dc08dc769c65a13b3573739
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-processx >=3.4.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 454090
+timestamp: 1757475635573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.6-r45h3697838_0.conda
+sha256: a894e558a680a31444090de217b73f8fc06a3f4c07746d2cde4b6f86acdae0b1
+md5: ed8dcbbe9d66e9093ba58891e3b6065a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1323795
+timestamp: 1775733704549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.2-r45heaba542_0.conda
+sha256: 521cb81e41e3a63717ec7cf317598b8a793969e60c57328b7d382bfea4178b5d
+md5: 421758eee50879a9a7ff122543e38e14
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 592267
+timestamp: 1770285739523
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+sha256: aec327dd836824278a2adf006f426a58d834828de74de7f8348f2f5f068de702
+md5: 8e9e5b14f74a6040c77e0b9c8bfa84ca
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 109200
+timestamp: 1757452164030
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_3-r45h54b55ab_0.conda
+sha256: 16bbbc7347aaee2c73d132584711f42cf612de501197e154385247818018b7a0
+md5: 472eadbb95c9103963bae1631ec23b0f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2542148
+timestamp: 1784283276786
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-commonmark-2.0.0-r45h54b55ab_1.conda
+sha256: 211423381b2e832619cdb964e7fe3833b09871d0140066ca90fd3e91eb86231b
+md5: 769e161acb18575460780ab99acc454e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 139818
+timestamp: 1757422097696
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+sha256: 5993a1b5c08c78a35cdbcf20376773eb7c4def2d28615e49f96008b43a4c05c0
+md5: 71c68a3993a696b6b75f7a6550b3750f
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 246247
+timestamp: 1778089270609
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+sha256: 9126a0408696133893e674549ca7aef317768dba503765a7ed032616aabe5b49
+md5: 4f111ce078b9690abaad6248b831a370
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 168201
+timestamp: 1757452410374
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+sha256: 217e5e210501b7fa611d6c6c46ae1551f443e2359e27164240da5a1219b2551a
+md5: 523a15023a79bd6f0dcb95ba6756ceed
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.3.6
+- r-jsonlite
+- r-lazyeval
+- r-r6
+license: MIT
+license_family: MIT
+size: 382037
+timestamp: 1757479275516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-curl-7.1.0-r45h10955f1_0.conda
+sha256: f2185d7bb29d869cc0d8e65a1913ab715e4f976666f94c18931cfa6b51b12821
+md5: dbfb442102b495d7bfc9f50321410a42
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 473709
+timestamp: 1777147706848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.18.4-r45h1c8cec4_0.conda
+sha256: fc5c6970d5ebbb92ccb61313efab7160869ae2851e48105e5dfff10f939a4bf6
+md5: 141a897d44a6a63b43dc6c1776ba7136
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MPL-2.0
+license_family: OTHER
+size: 2566399
+timestamp: 1783428409426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+sha256: 1edafb4e01397265da1816f3164a451d36f02546f2589c5f45051886ab9f91a8
+md5: f69bda3cb40132707f6efff4c749ce09
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-magrittr >=1.0.1
+- r-viridis
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4839264
+timestamp: 1757633933010
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.39-r45h3697838_0.conda
+sha256: 33ce40552bc1810252c4445082392638ff2fb883147cf36c3e4017e9b0dc5474
+md5: a0e856537aa7d62a6835e3a528d29517
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 218412
+timestamp: 1763566744987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.2.1-r45h3697838_0.conda
+sha256: 42067805b0742b933de7e1ca4311645797ac687cee6aacd630d9d4c585dfa830
+md5: 7c8e643f764769a184f0d0d06ac0e789
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1445950
+timestamp: 1775207093582
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+sha256: 38eee3a12260e5fff1e2af04250f6b67091b01c694f101ae6448da12c3fcca09
+md5: b78224895a1ad7fb52311ab071c2ec00
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-crosstalk
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httpuv
+- r-jquerylib
+- r-jsonlite >=0.9.16
+- r-magrittr
+- r-promises
+license: GPL-3.0-only
+license_family: GPL3
+size: 1439901
+timestamp: 1757566758266
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+sha256: ec00c0162d803af3c8059e9504d1d0c8b60cabe805c347a4a20300f2cce9e700
+md5: 6ac48e7c4c46b6c0538a779d0a43008a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-gridextra >=2.3
+- r-gtable
+license: GPL-3
+license_family: GPL3
+size: 950098
+timestamp: 1757760318911
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.3-r45h54b55ab_0.conda
+sha256: 19d03273f9d5e1aa41302e1cf080dcb95ced5b955bc978df39eee71a9686a86c
+md5: e43b3e7101a90ac57f58a21da67c99a4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 33411
+timestamp: 1775287239478
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+sha256: d3accfeab1416151515c37e5edc94b18868998db4936183459f8040117d5c83c
+md5: 4e0c71ab78d7292372a89d4daecb49af
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 111914
+timestamp: 1757447684244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.7-r45h54b55ab_0.conda
+sha256: 68dcc5aa6fc4408f9cac5aeaa03a7e6a5d127a949fc72b3fed31fd1af3bbeee5
+md5: 309740f1b6a2d4cb16d395be786c85c5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 329435
+timestamp: 1763566090233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r45h3697838_2.conda
+sha256: 06c5e73ed5c9c15e7ca944e3a5fabfbcabd9f4aec71804404ecf51c56f78fd8f
+md5: 7896efcfd50f8c1f207acce5d4ab1cc0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1429269
+timestamp: 1757441256046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fastmap-1.2.0-r45h3697838_2.conda
+sha256: bfec10cec03b434d9010690c61d43a0be79418f67a0713ce31da207a40e1570c
+md5: 245526991ad3b8a1dc97f2dcb5031065
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 73870
+timestamp: 1757421441326
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+sha256: 865df12d8cdd8cf577abc8f785a0aa4ee50b4f8751256dffe4676a350943d591
+md5: e9fccb3617ec9776569c6496fa254e64
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.1.1
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 1335664
+timestamp: 1757461248044
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+sha256: c95d1e61946bf81128be213dea7a07b5196c6e13caf9c6452c38145da8d2dfb1
+md5: 5abe392c8f8c5b954ebdc5fe46fcc709
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-codetools
+- r-iterators
+license: Apache-2.0
+license_family: APACHE
+size: 140909
+timestamp: 1757490449004
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fs-2.1.0-r45h3697838_0.conda
+sha256: 748304679610fe9f5d078f5b9be7c8693858ff5f66db55e43fb98d0e4e07d375
+md5: 67c48aad5ce921ad990b951a1f194f42
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 243286
+timestamp: 1777152733514
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+sha256: 196d29aa2d809d9115dce27236470219e1057d394654b5d73182f0e9d117f2fa
+md5: 4a667a55fc37e12dcbe510262ca61d19
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 424919
+timestamp: 1757627324320
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+sha256: 88a5cf4bac0a553943996bc930b1ea28f2635c262c1b2c5a42b026b69f227f02
+md5: f19c9493b80f63a41fa017ec3b27bc2e
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 88225
+timestamp: 1757455977192
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+sha256: 20c4ea52e72cb2e50907f9e5a446f16b0fce467fec4edab236eeb3b46890f3dd
+md5: b3a121ed6a71f3b674859ccbb15ad56b
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 67477
+timestamp: 1777325952298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+sha256: f8c0982d1579b810fc24cb702f8922794fce7bdfb9d3bf96867a4b038205b045
+md5: 9be31d2adf526d3c38b78a05333ddf30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-beeswarm
+- r-ggplot2 >=3.3.0
+- r-lifecycle
+- r-vipor
+license: GPL-3.0-or-later
+license_family: GPL3
+size: 1761662
+timestamp: 1764399956063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+sha256: 4e0401174fac5b54f124a8e7e418995a74918e8cd52a456a82db3fc5a373f0e0
+md5: bcdfec44c6bf587e65f56de61334a413
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=0.9.2
+- r-mass
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 221547
+timestamp: 1757758420492
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+sha256: 3a91d5334b7d99bc247386eaf0d331e119852e381e769e266f70df20eab22689
+md5: 866fbbf3f356140922d618f26f2b889c
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-gtable >=0.3.6
+- r-isoband
+- r-lifecycle >=1.0.1
+- r-rlang >=1.1.0
+- r-s7
+- r-scales >=1.4.0
+- r-vctrs >=0.6.0
+- r-withr >=2.5.0
+license: MIT
+license_family: MIT
+size: 7812326
+timestamp: 1776860393567
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.1-r45h54b55ab_0.conda
+sha256: c2760270ffabd95e9d0a0caa9cc705c5a0370ad119ace5495acc043b1a35d198
+md5: 65911c2e9cac35ea0235d3d6d4aa9625
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 171639
+timestamp: 1776413601349
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+sha256: e82d7e308a7e6d3eb90d9ea33d1f56d24bd69804995db2dacd5b20b7a20c34e4
+md5: aad2c473bf6f930833d0dc881811cf62
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-gtable
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 529159
+timestamp: 1782547830828
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+sha256: fcd2601af8213f39af6f720e22c8f858b3451f8e3d93cbc9e6aedb2d6f88483e
+md5: f686123cfba49e6299fae7e029a40266
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-lifecycle
+- r-rlang
+license: MIT
+license_family: MIT
+size: 228864
+timestamp: 1757463478042
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+sha256: 2d26e9b5c0e688cc76d33d81f8f62c59de9dc2f0695fd7b110991fa222db5524
+md5: d0bd1b5a09e5d631b8de31949ea19ece
+depends:
+- r-assertthat
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+- r-dendextend >=1.12.0
+- r-egg
+- r-ggplot2 >=2.2.0
+- r-htmlwidgets
+- r-magrittr >=1.0.1
+- r-plotly >=4.7.1
+- r-rcolorbrewer
+- r-reshape2
+- r-scales
+- r-seriation
+- r-viridis
+- r-webshot
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1693764
+timestamp: 1758426737719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-hexbin-1.28.5-r45heaba542_1.conda
+sha256: d3fa5cfc23220d3e279526a36ebcdc375ed2fc6cd45086248bd64a34c6be43d5
+md5: d622c8377663b5d7bdf5da48069f76cb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-only
+license_family: GPL2
+size: 1594722
+timestamp: 1757483295739
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+sha256: e676112aac0dbfe123fcb3108cce376782211a096c898a3af46fdf32a37e12e9
+md5: 0b5902d6af02a23bda1794d46090db42
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.18
+license: GPL-2.0-or-later
+license_family: GPL
+size: 57308
+timestamp: 1772794436225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-htmltools-0.5.9-r45h3697838_0.conda
+sha256: 1fa1fcdf980d0da17a583e41810da190eb9caf586c3fdf36312d045d9bb812e7
+md5: 2a2297687ae137e7fa90d3c996895e61
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-digest
+- r-ellipsis
+- r-fastmap >=1.1.0
+- r-rlang >=0.4.10
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 367095
+timestamp: 1764860550376
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+sha256: 4c3998ce4b4882429e52eed5c6c53d59056814d8fbc34a41ba79b990fdec1441
+md5: 6f767715f90e7caf17af72959bfcb11e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.7
+- r-jsonlite >=0.9.16
+- r-knitr >=1.8
+- r-rmarkdown
+- r-yaml
+license: MIT
+license_family: MIT
+size: 426023
+timestamp: 1757552859817
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-httpuv-1.6.17-r45h6d565e7_0.conda
+sha256: f0755cf37e28f0e1a142eef051918c90c9e8fece46edb5e40191a7898d8cb217
+md5: 1be1d81542b9c87b4d5197a41dbd0da9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-later >=0.8.0
+- r-promises
+- r-r6
+- r-rcpp >=1.0.7
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 553922
+timestamp: 1773825458255
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+sha256: 4adb565d2b3365108d7efb926c2acdc68c11ef2ad32ed03d1108a3005cf8cdd8
+md5: 259658089c383f2915b167da3e7890aa
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-curl >=0.9.1
+- r-jsonlite
+- r-mime
+- r-openssl >=0.8
+- r-r6
+license: MIT
+license_family: MIT
+size: 474019
+timestamp: 1771005817336
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+sha256: dcc78f60308390c6549e25308fb2437421e8fcaeeb45378b6fbe3a49e3d3cd0b
+md5: b240e3c0e61de35f1f43729f4ea2888e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.0.0
+- r-curl >=5.1.0
+- r-glue
+- r-lifecycle
+- r-magrittr
+- r-openssl
+- r-r6
+- r-rappdirs
+- r-rlang >=1.1.0
+- r-vctrs >=0.6.3
+- r-withr
+license: MIT
+license_family: MIT
+size: 935264
+timestamp: 1784022303810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.3.0-r45h3697838_0.conda
+sha256: a09a6f2f37890560217117463f0722283f8939af945b3e616b9791f2429325b0
+md5: fb538d0b46d6a44aa1ff666b15422ba6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-cpp11
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1657523
+timestamp: 1766530500097
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+sha256: c90d0faa668d2753db9da9458ca085891a3030c6537f5675fe0c1a1b5af2103c
+md5: 7746a41a4cb97cec59db2d5a2cac0701
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 350171
+timestamp: 1757459846270
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+sha256: abb2cd923ed271df8774e696f2e455f8c641532cc984fd770b87852a0017d7ab
+md5: 7113381f500ebcc8a33b61101817d120
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-jsonlite
+- r-openssl >=1.2.1
+license: MIT
+license_family: MIT
+size: 248113
+timestamp: 1776846446837
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+sha256: 3b98f72bb32d4758854805b664b4404602a583da32c9b96026536f5676f41812
+md5: 49a9ed6ed01f4ae6067ead552795bfce
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools
+license: MIT
+license_family: MIT
+size: 307113
+timestamp: 1757459485295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-jsonlite-2.0.0-r45h54b55ab_1.conda
+sha256: bd24c57226192b0decdcddd6fd5fa74db1f29685904e4aff87f2c16eb6493416
+md5: 026c72026f431daf8a5719e09e704faa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 638574
+timestamp: 1757419590757
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+sha256: e2184f1cb58aedacd94d1dbe6e8b5dfa3508151f454e80f6bd49486bdb90625c
+md5: 35b31b96aa7bc052ad6347322a1481f1
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-evaluate >=0.15
+- r-highr >=0.11
+- r-xfun >=0.52
+- r-yaml >=2.1.19
+license: GPL-2.0-or-later
+license_family: GPL
+size: 988526
+timestamp: 1766309267127
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+sha256: 42a06b7c346d6e4550dca1024bbf89e3c22962d568cfe4e8b8be824dea326110
+md5: a41490fdf607381035aa0304c21407c9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 70182
+timestamp: 1757456007088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-later-1.4.8-r45h3697838_0.conda
+sha256: 895f18dfc5a0521c22ad9e38619ea6cf170e38d54aaa4596fb1d0dad7845703b
+md5: a6b2c9882bb1d700f9108bc93c2c12a8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.12.9
+- r-rlang
+license: MIT
+license_family: MIT
+size: 153472
+timestamp: 1772707291964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_9-r45h54b55ab_0.conda
+sha256: ee233422c029d7b341dd05604d133db6f698ec1cdd4ad8690a312d0f7d958793
+md5: 234365e95fa3cf27bd7946f208d1ed0b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1416943
+timestamp: 1770694116947
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lazyeval-0.2.3-r45h54b55ab_0.conda
+sha256: 581fec2d1215b6d7b6d35ce9588271ba4bd89c75b0f131c04a718b79cbe2180f
+md5: 5634c3ee3e3c77f7462047a70ed35321
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang
+license: GPL-3.0-only
+license_family: GPL3
+size: 192307
+timestamp: 1775429492578
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+sha256: b7a4d8d98a96d17d18c80fb7e1c8e6cb09b9bd2542e74d91a7f483afccb30ee6
+md5: 5f8369dfbdff08878e58bf15529fca3a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 132636
+timestamp: 1767865665455
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+sha256: 1f594c5be675a53caef3368ea85c048b8bcbc4385e2bd582e977981a1edd5e3e
+md5: b936b3596737a3a1d513e1258d5d0355
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-commonmark >=2.0.0
+- r-xfun >=0.55
+license: MIT
+license_family: MIT
+size: 392980
+timestamp: 1784144498175
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.5-r45h54b55ab_0.conda
+sha256: 5b09fdee8ef5426082844d17d360756922ba74f9e3c428f501373295a5e9228d
+md5: 2e26e018edc1f198aa72a8f2127fab00
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 211086
+timestamp: 1775298609420
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+sha256: 5f27ccd93b39c2435ed6e9b8302ae50d51eb5b6058d7d11edba403e9723f48c6
+md5: 755b46b2896c8526a18074b3b651dfbc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-litedown >=0.6
+- r-xfun
+license: MIT
+license_family: MIT
+size: 72190
+timestamp: 1757496654397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_66-r45h54b55ab_0.conda
+sha256: 89218d4083593e5eae881fe5136befa358333d90a7de1a0ede13e8cd7bb5244e
+md5: 700d7bffd1c317597b574b218b567017
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1141176
+timestamp: 1784201795136
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.7_5-r45h0e4624f_0.conda
+sha256: de3447368ff93fb293c022d4a1eb8bcffe9044f52baf65c19218d6966815b88d
+md5: ca378a648cfa47523266acd1a0251729
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4301827
+timestamp: 1774809406103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r45h54b55ab_1.conda
+sha256: 06177df6c2f39df0a90b456557d226c2ffa9eaf55505b35d0ca9a81fe793dc49
+md5: 3deafa947ef32bf21d87b57e74d3711b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 484755
+timestamp: 1757442394466
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+sha256: 91b0eedec5cf5de195b442b97eda508f22fdedbdbc487f74e3868d3e95380fdd
+md5: 2b04206ff6ea5a92e8e36bdaa5feb3cc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cachem
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 57750
+timestamp: 1757456335587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_4-r45h0e4624f_0.conda
+sha256: 83a5233b6162c55f5021dea34464bd64d87f18b7815e738c42d06a046780e594
+md5: e33882c93c191f5d9a9b346431f02b43
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-nlme >=3.1_64
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 3644492
+timestamp: 1762539595584
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mime-0.13-r45h54b55ab_1.conda
+sha256: 03116d6a8db71492d036c6c052d6cfbf5a98c06da071e42aedb5c740920d6b61
+md5: 26aa2fa52d4caed58336f2b4887916d6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 64912
+timestamp: 1757441376534
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+sha256: 97d463c2146c483992a25fe497755e9cf714f95ca611a93d8adbb41c068e9e74
+md5: c78bd534986cde8fc0cb08cc9a1a2cc6
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+license: MIT
+license_family: MIT
+size: 247241
+timestamp: 1757455926748
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_170-r45heaba542_0.conda
+sha256: 83964b5b1ea49ed78be1fd7606650cf1ea68b92febe3d0bbdb9fda1be30f2d5b
+md5: 17487ca56832572cb95f9cc1314ddabb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 2356999
+timestamp: 1784288204943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-openssl-2.4.2-r45h68c19f5_0.conda
+sha256: 2796cf7768c939a58344157fcddec88dbdadf9cabd3ab0b24d9bbaf7916b9ebd
+md5: 6568a5797c9d74e89ef94b82724665aa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.6,<4.0a0
+- r-askpass
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 680716
+timestamp: 1781024845749
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+sha256: 09df5e8326b04412a26b6c4d896e04adbceba45194457c6d30f370d5ccb4b397
+md5: 0c015ba0c5444777a683c05e4a000f21
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-getopt >=1.20.2
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 119289
+timestamp: 1776419503742
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+sha256: f5de9737f59e1965db2de11c90cf1fdd426db322a7205c935a3e55150287b02f
+md5: 560abd550c097e0d0af2e201b335f53d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 286342
+timestamp: 1761151056217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+sha256: 162742dd773c8a163de6ffdf0e14820b5708b9e1041d4491762c05e00f6be614
+md5: 849a8fcdb5e1d98a3917a7c652c322df
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 679411
+timestamp: 1757649050426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+sha256: a4869bf14ad791c8a5cb48fd0575faa3cdb7b07692cb4b473809c261f584fa45
+md5: 9a48d2e7fdc93937c60481c06d40e6ba
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 234305
+timestamp: 1770387131912
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+sha256: b3f281041ecff2d4a9f40073ad5e7ec6fa7e0c841068ce85c550bcce0ff8938d
+md5: 807ef77a70fc5156f830d6c683d07a29
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 629867
+timestamp: 1758149763203
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+sha256: fda425435a533e86da5f0fc89cf45c9f889a4e6f1e2ed536ca23662a8461602c
+md5: 40a5fdd06c7e7880758a021cf2df6c12
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 27236
+timestamp: 1757447537447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
+sha256: 691d08f590099bb8cf4042a3af57b742775e02e4272df80dea5388c20e340116
+md5: 2021f458379120ae0d21189bee7e30cc
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.3,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 135276
+timestamp: 1758095801346
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
+md5: ced57d920bed79382f382a24a4425ef7
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-crosstalk
+- r-data.table
+- r-digest
+- r-dplyr
+- r-ggplot2 >=3.0.0
+- r-hexbin
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httr
+- r-jsonlite >=1.6
+- r-lazyeval >=0.2.0
+- r-magrittr
+- r-promises
+- r-purrr
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-tibble
+- r-tidyr
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 3587131
+timestamp: 1769337109792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
+sha256: 353d5945d242b03c47ab0d051cf9058b4459303c96455dba9442100628a0bde1
+md5: 255fec0919919b14789eb30cc448ed20
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.0
+license: MIT
+license_family: MIT
+size: 787537
+timestamp: 1757441721952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
+sha256: 7f69cd631f28279b4c706fe2341d8ffbd13cc10ed98e648d0c214ceecce4f877
+md5: c38b8f68cbe321dd5b819d397b2b5061
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-ps >=1.2.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 411030
+timestamp: 1776865706038
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+sha256: 684dba5d20aae8da37868d603b662014e1944f5568e5f737e42d9d485892a26e
+md5: b2c1b6ef8f12894fd2694b285fe8989a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-fastmap >=1.1.0
+- r-later
+- r-lifecycle
+- r-magrittr >=1.5
+- r-otel >=0.2.0
+- r-r6
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1597704
+timestamp: 1762426228446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ps-1.9.3-r45h54b55ab_0.conda
+sha256: 598576cd282f2b9c8280696c77b3a9e05d52a8f688174d6c6ed1b3bdad57bcdf
+md5: d4c22257df8cca28d50e604110e68e90
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 414722
+timestamp: 1777148019201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.2.2-r45h54b55ab_0.conda
+sha256: dc5f0ace59844125b92304324000770c7e2e466bab442826cee50a32eef731bf
+md5: dc14c484a0415f43dc1b90b518beb41a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 547035
+timestamp: 1775853612539
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-qap-0.1_2-r45heaba542_5.conda
+sha256: cd5b1706f125067986e083ba343ff6f20f79747c18e801fb6014481ec273964e
+md5: d64850fa9345afe8dbe58b371c32792d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 396309
+timestamp: 1757635813587
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+sha256: bd92e91332eba5f0c689583e80adec85ef272c4e0d0b36ee17cb7c11b5693cf2
+md5: 750802806d7d640c286ed8491bb395dc
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 95073
+timestamp: 1757447661037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rappdirs-0.3.4-r45h54b55ab_0.conda
+sha256: a9778d5fa6777ce286815eb0abef625ff54693532795ef48a1bc319967e0ecb4
+md5: 9fa763ece102dca3e50892bad36896ff
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 54376
+timestamp: 1768747300036
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+sha256: ddd4e63616ee475bdf9dc63a0b16a89017237121e927d83fbdee07d5a5ccc890
+md5: d8fa238420cb6de47d463b7345a761eb
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68005
+timestamp: 1757452462302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.1.2-r45h3697838_0.conda
+sha256: dabb73c4d43f352a3154067a20a46cbda1e1027636e72d133010f6f052e8d260
+md5: 1d6e2e4764de896f03fb73e28614022e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 2122066
+timestamp: 1783264478653
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpptoml-0.2.3-r45h3697838_1.conda
+sha256: 8e10fa6f550c83cdc99175443ecc92db178369e82a7dcb743e1fe7ce87d39530
+md5: 707ba8dabbbffd03f5907406a0fe8368
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.5
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 227793
+timestamp: 1757490566643
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+sha256: 68f01b65843f873b01bff24f61f27298667797aa3ad01d4406a62ae72e7c08c5
+md5: 1a99d6f9dfe5f6e8dc5275d49852cd66
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 208380
+timestamp: 1757507980343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-renv-1.2.3-r45h54b55ab_0.conda
+sha256: d88af05b70ac871598c7fda5e04c7d024f1011fcc047eeb18d9541ef9b03bea7
+md5: 378f0ed999e77fe5e276ef811d783d96
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 2469798
+timestamp: 1778972824711
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.5-r45h3697838_0.conda
+sha256: ffec1e0396849fab33c12bcc580fe71f90818c83da645146c165449ee9a6e799
+md5: 169cd9281096cd54a29072a2d7eea2a9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-plyr >=1.8.1
+- r-rcpp
+- r-stringr
+license: MIT
+license_family: MIT
+size: 127756
+timestamp: 1762975657971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.3.0-r45h3697838_0.conda
+sha256: 13aed8664cbf46946eed067d1708ee1a8dcbd7cf32d361c7a03a9bf3f83ac425
+md5: afa49304f86d922c157d08e9e9d9ceb8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1593782
+timestamp: 1783260208298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+sha256: b3735a4e75eca023b24678251da041854b94a8b96588d81b605928d6ecf74f11
+md5: 25b9dbf0ff990b8b3111774878e3bb07
+depends:
+- pandoc >=1.14
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.2.5.1
+- r-evaluate >=0.13
+- r-fontawesome >=0.5.0
+- r-htmltools >=0.5.1
+- r-jquerylib
+- r-jsonlite
+- r-knitr >=1.43
+- r-tinytex >=0.31
+- r-xfun >=0.36
+- r-yaml >=2.1.19
+license: GPL-3.0-only
+license_family: GPL3
+size: 2085382
+timestamp: 1774555006202
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+sha256: 5f9aa168f5c43f1d3ddbacc701370085fcead3956e2d5879af7fcd9e086a0a0b
+md5: 62f09532f225c86d27e954b36682add5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-digest
+- r-httr2
+- r-jsonlite
+- r-lifecycle
+- r-openssl >=2.0.0
+- r-packrat >=0.6
+- r-pki
+- r-renv >=1.0.0
+- r-rlang >=1.0.0
+- r-rstudioapi >=0.5
+- r-snowflakeauth
+- r-yaml >=2.1.5
+license: GPL-2.0-only
+license_family: GPL2
+size: 830390
+timestamp: 1783503525234
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+sha256: 896aeea3aa679a9dbd0277d10ef8dcfd011e45a1717129180a9877c1fd828f2a
+md5: 5f1b6b899fa3204ab77403e75b9df5fd
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 357140
+timestamp: 1781250782889
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-s7-0.2.2-r45h54b55ab_0.conda
+sha256: fae29c4af16617a17fea40c5e484e4350a6fe5d9fad40266f95cf3cb13e7019b
+md5: 598ca5290f9be9b22804436295471201
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 311525
+timestamp: 1776861444903
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sass-0.4.10-r45h3697838_1.conda
+sha256: 4d6d7db9d0187a9ede70d6d48278a8ba2b3160e823f5de239b86a6108f23172e
+md5: a3ccf52eefa448628535ee758c5a8a37
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-fs
+- r-htmltools
+- r-r6
+- r-rappdirs
+- r-rlang
+license: MIT
+license_family: MIT
+size: 2319704
+timestamp: 1757464682768
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+sha256: 260c384e952e5bd4d2c2de77b9e09b24ff1c1f680acd917c4657ab8c9e4e9a2f
+md5: 8bc81cc6fd130cef963bc9e082726a14
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-farver >=2.0.0
+- r-labeling
+- r-lifecycle
+- r-munsell >=0.5
+- r-r6
+- r-rcolorbrewer
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 777793
+timestamp: 1757487539496
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+sha256: bcde368cbf5a2c83b9c1fb8b3ba0722787af759f68d08bac6a82e966adbf999f
+md5: ba820689c02638c807f83e6ab5c53142
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 370745
+timestamp: 1771995271935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-seriation-1.5.8-r45heaba542_1.conda
+sha256: ce65e9dfe250a2d142acb7f7c2fec1ebd9e1527c66c5ce1212f0f18a3f2a415a
+md5: 9252542af85ee0c48a0a94ea103181e5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-ca
+- r-cluster
+- r-colorspace
+- r-foreach
+- r-gclus
+- r-mass
+- r-qap
+- r-registry
+- r-tsp
+- r-vegan
+license: GPL-3.0-only
+license_family: GPL
+size: 1372264
+timestamp: 1757660945261
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+sha256: ef0042ae1c3926ef9bee6c21cf761d7cf441eae61dceca7df143f3b9dc4c6f04
+md5: 2fb0e1ea59dd281487be303b1b7c6607
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.6.0
+- r-cachem >=1.1.0
+- r-commonmark >=1.7
+- r-crayon
+- r-fastmap >=1.1.1
+- r-fontawesome >=0.4.0
+- r-glue >=1.3.2
+- r-htmltools >=0.5.4
+- r-httpuv >=1.5.2
+- r-jsonlite >=0.9.16
+- r-later >=1.0.0
+- r-lifecycle >=0.2.0
+- r-mime >=0.3
+- r-promises >=1.1.0
+- r-r6 >=2.0
+- r-rlang >=0.4.10
+- r-sourcetools
+- r-withr
+- r-xtable
+license: GPL-3.0-only
+license_family: GPL3
+size: 3789417
+timestamp: 1782070586086
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+sha256: c3ea3d60226ed56e4a40b622b8e4721d257a9fb4ca8502ce89314f48a63a0090
+md5: b5da9b58b4f8137a7f2e14102bc230c9
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-glue
+- r-shiny
+license: MIT
+license_family: MIT
+size: 344724
+timestamp: 1757870156008
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+sha256: 9493d6cbf09850206f5904ccde65643de86bb9bd6add685548331c408e99610a
+md5: 3929f109451367912b4570480f4c572d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest >=0.6.8
+- r-jsonlite
+- r-shiny >=1.0.0
+license: MIT
+license_family: MIT
+size: 1018291
+timestamp: 1768513288077
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
+md5: 7382af8530d082191feb0c8da5f8a41b
+depends:
+- bioconductor-limma
+- bioconductor-summarizedexperiment
+- r-base >=4.5,<4.6.0a0
+- r-biocmanager
+- r-bslib >=0.9.0
+- r-cluster
+- r-dplyr
+- r-dt >=0.2
+- r-ggbeeswarm
+- r-ggdendro
+- r-ggplot2
+- r-heatmaply
+- r-htmltools
+- r-htmlwidgets
+- r-markdown
+- r-matrixstats
+- r-optparse
+- r-plotly >=4.8.0
+- r-rcolorbrewer
+- r-rsconnect
+- r-scatterplot3d
+- r-shiny >=1.7.0
+- r-shinycssloaders
+- r-shinyjs
+- r-viridislite
+- r-yaml
+license: AGPL-3.0
+license_family: AGPL
+size: 3448797
+timestamp: 1784579537432
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
+md5: 1d38994c8bfe421d621d9b3705c37b58
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-jose
+- r-jsonlite
+- r-openssl
+- r-rcpptoml
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76170
+timestamp: 1772133448445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
+sha256: 885a784f4258b491e48947dbed71bd18b2e2e7da0f0b53ee1dcfed93cfdcd48a
+md5: 1bd0042c176bde3dd1971eac76497219
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 54650
+timestamp: 1774682292388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
+sha256: 3095c4e59616a46480533f2e545136e25b1cb20d7ec6535d4a7f0938c48ff789
+md5: 377126a1601c75ff75c2c8c277e55a81
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 325043
+timestamp: 1779038241839
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.7-r45h3d52c89_2.conda
+sha256: 6d0d8d6f1465b3486996edaef7ccd1020cb2fcca1e69b543fc52dbad5262079b
+md5: c7ce6f26b92398224c78b92c653b94c1
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.2,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: FOSS
+license_family: OTHER
+size: 939928
+timestamp: 1772032511209
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+sha256: dea2a7676dd03ed93fa0ec961883c5075c361c8522659a1bc1e6b5c16525cb24
+md5: 8db438d8aa370726ee1ce8bf458f2e6d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 319328
+timestamp: 1762269757617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sys-3.4.3-r45h54b55ab_1.conda
+sha256: 0cf3a7af31b0396d5a2e1c932fffa360472f92a2b373a696f523b0b53ad1d682
+md5: f23bbac61ab0536f59f4caa4c2ebdf88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 50436
+timestamp: 1757441793835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.1-r45h54b55ab_0.conda
+sha256: 256d782fb5773d678f29b88a2c987eb47065e2393a080ca16f400b0256de65bb
+md5: ad28f67cbb0b10a5beaa7bf968761cad
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 589666
+timestamp: 1768139121744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.2-r45h3697838_0.conda
+sha256: 8c4560d92c1adfce9a37da2f963596a369688b0d5f44d1fa2f0fbfecb486d99f
+md5: e571d4d42233dd2aa3bdb0057ffbdc63
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127263
+timestamp: 1766142073696
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+sha256: fca09d6b9940f1e1cda0425a0f55716bba202d6f55d6bd25fedec391006c7dc7
+md5: 15aa0f323385403fe182e46a1d095e1b
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 220192
+timestamp: 1757475791328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+sha256: 1fad4d08756ca2d7db04cfaf88e9df797da95a5f7f4b8aabc165eee36faddafc
+md5: 5ee226c1449c66d1cd2399d942faa04d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.48
+license: MIT
+license_family: MIT
+size: 158240
+timestamp: 1782203211628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tsp-1.2.7-r45h54b55ab_0.conda
+sha256: 54c19b952897b97228f00ff3ae8def7e7af2194c0ed3419737a8fe04a988cd41
+md5: 4518075e6efc2a5c9714751a92bfc73e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-foreach
+license: GPL-3.0-only
+license_family: GPL3
+size: 736826
+timestamp: 1774389996066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r45h54b55ab_1.conda
+sha256: 97186abdf7c29872e012c9fe05ec16c019b58c43ac7b778baa480a8acae9c914
+md5: 75cb2540ac930ea879e92d99e00e97c3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 147244
+timestamp: 1757424673681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.7.3-r45h3697838_0.conda
+sha256: 73b0cdea9f85496b80e75ffa20f94aa4ab746f4b7af566742e22381bffa6772d
+md5: 372cefc1b05a567d1fbe19633766ab0c
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1805012
+timestamp: 1775897999712
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vegan-2.7_5-r45h11cdb10_0.conda
+sha256: b6245a77003ec655ca972e81d25771652991326ed9d7f3514951954565198e94
+md5: 81c256938ff8b33054afde06c7851e4e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+- r-lattice
+- r-mass
+- r-mgcv
+- r-permute >=0.9_0
+license: GPL-2.0-only
+license_family: GPL2
+size: 3049688
+timestamp: 1779956688681
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+sha256: 859729e8cd04bb92ec144b21a8abfdb2bec9cbac9deaa41ba0cc2add13d088a0
+md5: e605ce527e381c5577d57649e393cb87
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4508304
+timestamp: 1757669044129
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+sha256: 884896b59133b948646b0d1441106120f7b320e9fac827ccb9d44bbe80dda8f2
+md5: e841095941c40142bdad834299b95a30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=1.0.1
+- r-gridextra
+- r-viridislite >=0.4.0
+license: MIT
+license_family: MIT
+size: 2988605
+timestamp: 1757516440048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+sha256: b9ec9606562f0f6bdefc237bbc6163eb1cb022f9d699c80771bc84af0ae37269
+md5: bcadc0a3726e2191e51449f67fa5e0a9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1305542
+timestamp: 1770191459321
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+sha256: e79e366895dfdf79fe92986fe42d0695e3fcacc25411506c48b9db92742eb99c
+md5: e021e3d936f57ea9b35eb099999d6800
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-callr
+- r-jsonlite
+- r-magrittr
+license: GPL-2.0-only
+license_family: GPL2
+size: 206060
+timestamp: 1757520337073
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+sha256: 56f318c90bfc74f01339c83f0e1d0817c1b762ea46cd9e527fec9dcf244c5900
+md5: 388d25e67f93a5fec2aebe56d6a0a1d9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 235287
+timestamp: 1781856624720
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xfun-0.60-r45h54b55ab_0.conda
+sha256: dca6e2c57e1b038682879e793338683f25058362a8f3ca2a88f753e5de085cf0
+md5: 1d3e32dcae994197a303942b6654e577
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 651306
+timestamp: 1784103319293
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+sha256: 972923364cfd616ccf38768477c435677cfe1ea18a72016f90344ea920e4fea5
+md5: e18fda0821f0fdc1c34276c5e0acdc92
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL (>= 2)
+license_family: GPL3
+size: 744345
+timestamp: 1771859982217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-yaml-2.3.12-r45h54b55ab_0.conda
+sha256: f8944d47eccfdb2c04e27fd65797de7468ccc5d9f3fc3d9af296da613d75d79c
+md5: d0d07c6f14b640a98cf6a5e3e4e2e723
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 124461
+timestamp: 1765372968808
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 345073
+timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+sha256: b013d2085ce4ac01daec7b30472e9f3b6c2d69eb3a3a85a6cee3e01a3cb4f61a
+md5: e4a1ff2e59a5d9b38be71d15c93cf1bd
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 268482
+timestamp: 1776859422619
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+md5: 13dc3adbc692664cd3beabd216434749
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-64 4.18.0 he073ed8_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 24008591
+timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+build_number: 103
+sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+md5: 48a1049e710857572fc2a832aa394d9f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3550916
+timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+sha256: 3e20b2f2902a1f402ef2420ce2b9e8c91f9e02748d55530894ac1f640561fdd0
+md5: 72628f56d7a99b86efa435a0b97a4b47
+depends:
+- tk
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- tk >=8.6.13,<8.7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 102544
+timestamp: 1773732786017
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+sha256: 2bf9a40d86d29fd5c30d0febec99d06398143ddeece9ebb175cc5a6d20279943
+md5: f16d4aec5e8135e8e7bba02ef600149e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 38560
+timestamp: 1779439547766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+md5: fb901ff28063514abb6046c9ec2c4a45
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 58628
+timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+md5: 1c74ff8c35dcadf952a16f752ca5aa49
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 27590
+timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 839652
+timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+md5: b2895afaf55bf96a8c8282a2e47a5de0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 15321
+timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+md5: 1dafce8548e38671bea82e3f5c6ce22f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 20591
+timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+md5: 34e54f03dfea3e7a2dcf1453a85f1085
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+license: MIT
+license_family: MIT
+size: 50326
+timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+md5: 96d57aba173e878a2089d5638016dc5e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 33005
+timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+md5: 279b0de5f6ba95457190a1c459a64e31
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 379686
+timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 601375
+timestamp: 1764777111296

--- a/modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
+++ b/modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
@@ -1,0 +1,3175 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-aarch64:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.46.1-default_hf1166c9_102.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-biobase-2.70.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-delayedarray-0.36.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-genomicranges-1.62.1-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-iranges-2.44.0-r45hbd662d2_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-limma-3.66.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4arrays-1.10.1-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4vectors-0.48.0-r45hbd662d2_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-sparsearray-1.10.8-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-xvector-0.50.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h3530432_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-15.2.0-h2d9b6d1_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gsl-2.7-h294027d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h7c59cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-14.2.1-h3a99ef3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-devel-14.2.1-h3a99ef3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandoc-3.10-h8af1aa0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-askpass-1.2.1-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.5.3-h269e6ae_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base64enc-0.1_6-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-beeswarm-0.4.0-r45hf488e41_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cachem-1.1.0-r45h0557e7b_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.6-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cluster-2.1.8.2-r45h6df9e4a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-colorspace-2.1_3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-commonmark-2.0.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-curl-7.1.0-r45hd8a8d9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-data.table-1.18.4-r45hbf3bb9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-digest-0.6.39-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.2.1-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.7-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-farver-2.1.2-r45h08b74da_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fastmap-1.2.0-r45h08b74da_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fs-2.1.0-r45hd601667_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.1-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-hexbin-1.28.5-r45h6df9e4a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-htmltools-0.5.9-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-httpuv-1.6.17-r45hb62f08c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-isoband-0.3.0-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-jsonlite-2.0.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-later-1.4.8-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lattice-0.22_9-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lazyeval-0.2.3-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.5-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mass-7.3_66-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrix-1.7_5-r45h9301183_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrixstats-1.5.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mgcv-1.9_4-r45h8b2cba9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mime-0.13-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-nlme-3.1_170-r45ha85219e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-openssl-2.4.2-r45h37c386a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ps-1.9.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.2.2-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-qap-0.1_2-r45ha85219e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rappdirs-0.3.4-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpp-1.1.2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpptoml-0.2.3-r45hd601667_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-renv-1.2.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-reshape2-1.4.5-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.3.0-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-s7-0.2.2-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sass-0.4.10-r45h08b74da_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-seriation-1.5.8-r45ha85219e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.7-r45h1ddd0e6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sys-3.4.3-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.1-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tsp-1.2.7-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.7.3-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vegan-2.7_5-r45ha2e3c6d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-xfun-0.60-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-yaml-2.3.12-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h5f05d98_8.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: a2527b1d81792a0ccd2c05850960df119c2b6d8f5fdec97f2db7d25dc23b1068
+md5: 468fd3bb9e1f671d36c2cbc677e56f1d
+depends:
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28926
+timestamp: 1770939656741
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+sha256: eebe159bf600943552e4319ff4ce27b6a2dadf0dcc5443e76dcee9259a408e11
+md5: 58f37d76b8234c69dbf2939d511bea0b
+depends:
+- ld_impl_linux-aarch64 2.46.1 default_h1979696_102
+- sysroot_linux-aarch64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 4677171
+timestamp: 1784214549910
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.46.1-default_hf1166c9_102.conda
+sha256: d41099a3fe2809a3ab3e4c718ecff4d5f8879e7949f3c8e8efa97fa06a90248c
+md5: 9a340123cb7217eae51c5cae24484631
+depends:
+- binutils_impl_linux-aarch64 2.46.1 default_h5f4c503_102
+license: GPL-3.0-only
+license_family: GPL
+size: 36196
+timestamp: 1784214578949
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-biobase-2.70.0-r45hbd662d2_0.conda
+sha256: 144892eb6a1caeb15ca70a90e9502130ad5d4fb11cb3bfcf23944c540b6fc8c2
+md5: 8256b8838a2ed279aa68d6a74c64f2ae
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2359182
+timestamp: 1770502613668
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+sha256: 97221eda3007381c0a6498608baaebdcec6047f7f26b121c19149fd56aabf032
+md5: 27556377d159490ea87696727ae41808
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-generics
+license: Artistic-2.0
+size: 653523
+timestamp: 1770415244399
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-delayedarray-0.36.0-r45hbd662d2_0.conda
+sha256: a35e3f96ec640cf7665d74954c96c9dd94acec8c2d3b07773496917465891990
+md5: a539d17dd563adecc5716d832336d257
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-sparsearray >=1.10.0,<1.11.0
+- bioconductor-sparsearray >=1.10.8,<1.11.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 2203445
+timestamp: 1770580775191
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-genomicranges-1.62.1-r45hbd662d2_0.conda
+sha256: 55b5f4217dab83ed83c37669b166d3145eb3d844360f53cbe940b48fad58febd
+md5: 73f836e70629719f303b19c6f88e089e
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2307173
+timestamp: 1770634322279
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-iranges-2.44.0-r45hbd662d2_1.conda
+sha256: 7167ede80515e1b5d88fcfda2c16c01e7e6a39698d1b9824a3a0416b0bed6e1e
+md5: 82dc872dc3591e32ca8e8c051ef0d619
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2354429
+timestamp: 1770538530102
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-limma-3.66.0-r45hbd662d2_0.conda
+sha256: b6c0c4229c65102dbf5135421cdeda72c77bb84a574eb3ad6a017feda47843fe
+md5: 04a2febf68754954062a79fdfc4674df
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-statmod
+license: GPL (>=2)
+size: 3099160
+timestamp: 1770499849646
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+sha256: 169809ca754b2c07f7356f1fc4f365b7d5154fd66229543584f69008fa347c5a
+md5: cdf0406fc3caa814ff7b7876a42973a5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-matrixstats >=1.4.1
+license: Artistic-2.0
+size: 449898
+timestamp: 1770417102301
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4arrays-1.10.1-r45hbd662d2_0.conda
+sha256: 3e69df7fbd051d165364424a5b87ad1c902c68b2d4d04e7feffbfe11079bd90b
+md5: b7a8cb11e73c5031c3d6da65845c60b4
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-abind
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1027295
+timestamp: 1770573305521
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4vectors-0.48.0-r45hbd662d2_1.conda
+sha256: 714d17a1e87e49a3cb25b42794bb30ffba91921f6d5d7d37c6e80945aa036ef7
+md5: 82884abd1721c6c3fbe6024c7b627174
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2068293
+timestamp: 1770501459310
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+sha256: 875f5be76bc3b83766ec0cfacf888570d529907412519a537c5f7a318e489976
+md5: cfe7c256532f9a4fc87ec3be955bb9e6
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 598298
+timestamp: 1770628899171
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-sparsearray-1.10.8-r45hbd662d2_0.conda
+sha256: 6d45e717b4a44b4dc5209cc931301be4571db91b0219905d55d110edd3ef145b
+md5: 42802d5b7d809a31cf6e364b4c52a20b
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-xvector >=0.50.0,<0.51.0
+- bioconductor-xvector >=0.50.0,<0.51.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-matrixstats
+license: Artistic-2.0
+size: 1678434
+timestamp: 1770579674417
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+sha256: b8ade9f2ab8cc2835357653f5a9bc840323c05f7656659dfb40d20e5623f8ebd
+md5: 74eb95090e807c18f5bc81cb9fb39b3c
+depends:
+- bioconductor-biobase >=2.70.0,<2.71.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-delayedarray >=0.36.0,<0.37.0
+- bioconductor-genomicranges >=1.62.0,<1.63.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1416452
+timestamp: 1772218138703
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-xvector-0.50.0-r45hbd662d2_0.conda
+sha256: 961ac8875597fae63a4efc98917e2be0f58b0299700339ffbf8cdfbdc7cf4beb
+md5: 461fc07891c8587fbe1f870f67f98e91
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 644057
+timestamp: 1770573790622
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+sha256: d9def28d376d13033e0e78d731091a85a49a2297bf5efe15f0ef0d4533a6adeb
+md5: 585e14e544be02d0baceffecd31c7882
+depends:
+- tk
+license: TCL
+size: 129724
+timestamp: 1750262711538
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+sha256: b3495077889dde6bb370938e7db82be545c73e8589696ad0843a32221520ad4c
+md5: 840d8fc0d7b3209be93080bc20e07f2d
+depends:
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 192412
+timestamp: 1771350241232
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
+sha256: 24f78776eda069a6c1566fd6d65379e45747d0a7cce9f864686690806543c408
+md5: a8a5833ef43f9b31a4d548071ea5ba75
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 220677
+timestamp: 1784091035199
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+md5: a9965dd99f683c5f444428f896635716
+depends:
+- __unix
+license: ISC
+size: 128866
+timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
+md5: 043c13ed3a18396994be9b4fab6572ad
+depends:
+- fontconfig >=2.15.0,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.1,<79.0a0
+- libexpat >=2.7.3,<3.0a0
+- libfreetype >=2.14.1
+- libfreetype6 >=2.14.1
+- libgcc >=14
+- libglib >=2.86.3,<3.0a0
+- libpng >=1.6.53,<1.7.0a0
+- libstdcxx >=14
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 927045
+timestamp: 1766416003626
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
+sha256: a36ed82bbaebdc59e205d399d6e898bcb20fbcd5aaebb162cdf690ba97173ef5
+md5: a06d829c51a365e8daf0b2a3d4f06d9d
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 h7c59cd8_2
+- libgcc >=14
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 201305
+timestamp: 1782911743345
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
+md5: f4d29a0cd77104a683607319a542ac7e
+depends:
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 290522
+timestamp: 1780450108132
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+sha256: 1112c56bc19cbce233b30d9d31ce8eb6fcc100c9baa5145315aaa1e3a25b5178
+md5: 5e8e88bfb3fbb0df0f9f8bb890721e07
+depends:
+- libfreetype 2.14.3 h8af1aa0_1
+- libfreetype6 2.14.3 hdae7a39_1
+license: GPL-2.0-only OR FTL
+size: 174060
+timestamp: 1780933507786
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+sha256: 1bfcd715bcb49a0b22d5d1899a22c6ff884b06f8e141eb746f3949752469a422
+md5: f3ac54914f7d3e1d68cb8d891765e5f9
+depends:
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 62909
+timestamp: 1757438620177
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h3530432_19.conda
+sha256: cd23829b5fb7f3ff5f44eab2da1a993e06bdf759b681a0a7a73bb5783755b6b3
+md5: 66dfb62e7a47e2b511f9c5ee0ff1abf3
+depends:
+- binutils_impl_linux-aarch64 >=2.45
+- libgcc >=15.2.0
+- libgcc-devel_linux-aarch64 15.2.0 h55c397f_119
+- libgomp >=15.2.0
+- libsanitizer 15.2.0 he19c465_19
+- libstdcxx >=15.2.0
+- libstdcxx-devel_linux-aarch64 15.2.0 ha7b1723_119
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 73237372
+timestamp: 1778268860495
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+sha256: 2450913611189cc3c26062a43a97a93501159335d4d314cca5e2678fb5f4d3b6
+md5: 619b8a05f89220fa8c9536dcfeeddd5b
+depends:
+- gcc_impl_linux-aarch64 15.2.0.*
+- binutils_linux-aarch64
+- sysroot_linux-aarch64
+license: BSD-3-Clause
+license_family: BSD
+size: 29074
+timestamp: 1781279974207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-15.2.0-h2d9b6d1_19.conda
+sha256: eb531f1a37c2efa431fb3104842d98aba271c55ef3de8c2741e9d575bd3cb762
+md5: c8fc81db8eef1e0f76778e8f91ab8ff3
+depends:
+- gcc_impl_linux-aarch64 >=15.2.0
+- libgcc >=15.2.0
+- libgfortran5 >=15.2.0
+- libstdcxx >=15.2.0
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16043253
+timestamp: 1778269041546
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+sha256: 3e529c517a76a1f4497c51eeedeeb927d33f732dcdb48055a020a83eb3e4e95c
+md5: 4db044857ab1d09b2e8f0013c65387c1
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 103119
+timestamp: 1780455096710
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gsl-2.7-h294027d_0.tar.bz2
+sha256: be506a418cc648996bf3376a626826cbe0fa5d9de913598c4d3965a61ddc7a7b
+md5: 8b9533e21be7fa232ab64e85f184e0b3
+depends:
+- libblas >=3.8.0,<4.0a0
+- libcblas >=3.8.0,<4.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3890901
+timestamp: 1626369614424
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
+sha256: afb0fc36b93539a8e43a8063c8d3e1b4bace38a5a0c3c9e1978c72792d633c62
+md5: 7214ae8a8aade7b48a2bfd8bbb4d9e79
+depends:
+- gcc_impl_linux-aarch64 15.2.0 h3530432_19
+- libstdcxx-devel_linux-aarch64 15.2.0 ha7b1723_119
+- sysroot_linux-aarch64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 14640001
+timestamp: 1778269082840
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
+sha256: f4bc63d467e2c48c255bc8d2886fb11f6a8d09c1251a6f5b25628abee1768693
+md5: ea51d6df068bee183ff667f75bfdc2f6
+depends:
+- gxx_impl_linux-aarch64 15.2.0.*
+- gcc_linux-aarch64 ==15.2.0 h0bf4bd8_27
+- binutils_linux-aarch64
+- sysroot_linux-aarch64
+license: BSD-3-Clause
+license_family: BSD
+size: 27620
+timestamp: 1781279974207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
+sha256: 57b157674ecee4d16e2873a3624095b4ed1859ce8c574b161e0d9c1723788733
+md5: 41198d1dd71d97c1507e6bd17edd10c7
+depends:
+- libharfbuzz-devel 14.2.1 h3a99ef3_1
+license: MIT
+license_family: MIT
+size: 11079
+timestamp: 1782800518091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
+md5: 546da38c2fa9efacf203e2ad3f987c59
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 12837286
+timestamp: 1773822650615
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
+md5: bb3b7cad9005f2cbf9d169fb30263f3e
+constrains:
+- sysroot_linux-aarch64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1248134
+timestamp: 1765578613607
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+sha256: 5ce830ca274b67de11a7075430a72020c1fb7d486161a82839be15c2b84e9988
+md5: e7df0aab10b9cbb73ab2a467ebfaf8c7
+depends:
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 129048
+timestamp: 1754906002667
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+sha256: b644718416a22b5d57c1194ea7207b7f8d33d6a2b42775763782d76cd7457aea
+md5: 5fd2304064ef6199d1f91ec60ee7b820
+depends:
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1518484
+timestamp: 1781859412954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+sha256: 2c4901f4227b0850328ed0c69f958b30ad2cd18982f7a31c7c1f911827004d08
+md5: 489444d0acb2a579d2a002d85a08c059
+depends:
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-aarch64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 905305
+timestamp: 1784214534868
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+sha256: 8957fd460c1c132c8031f65fd5f56ec3807fd71b7cab2c5e2b0937b13404ab36
+md5: d13423b06447113a90b5b1366d4da171
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 240444
+timestamp: 1773114901155
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+build_number: 8
+sha256: c897399c943168c646f659952f73a9154f9122d7e9b151649dbe075dfdcd484b
+md5: 8b44dad125760faa2b3925f5a6e3112d
+depends:
+- libopenblas >=0.3.33,<0.3.34.0a0
+- libopenblas >=0.3.33,<1.0a0
+constrains:
+- libcblas   3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+- mkl <2027
+- blas 2.308   openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18843
+timestamp: 1779859042591
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+build_number: 8
+sha256: 3ba039f0705022939d90e36c1ed2fcbafd7f5bb77563e3702202ae796b32f4d2
+md5: 76242b7ad6e43809afa8671dd609b4ed
+depends:
+- libblas 3.11.0 8_haddc8a3_openblas
+constrains:
+- liblapack  3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+- blas 2.308   openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18817
+timestamp: 1779859049133
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h7c59cd8_2.conda
+sha256: 5846fa724f4b8eb23751e347fc8b31775c0a28a7a34d1e44f081651613470512
+md5: 0a187db240c503afc7eb5bd865c7ff04
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 505957
+timestamp: 1782911738398
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+sha256: 48814b73bd462da6eed2e697e30c060ae16af21e9fbed30d64feaf0aad9da392
+md5: a9138815598fe6b91a1d6782ca657b0c
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 71117
+timestamp: 1761979776756
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+sha256: c0b27546aa3a23d47919226b3a1635fccdb4f24b94e72e206a751b33f46fd8d6
+md5: fb640d776fc92b682a14e001980825b1
+depends:
+- ncurses
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 148125
+timestamp: 1738479808948
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+md5: a9a13cb143bbaa477b1ebaefbe47a302
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 115123
+timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+sha256: 20a5726bc8705d91437c9e6ef83b30da64a1719b869656d20a1ee818333ea5ac
+md5: fac3b65a605cd253037fdf3daf2de8d9
+depends:
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77649
+timestamp: 1781203572523
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+sha256: 3df4c539449aabc3443bbe8c492c01d401eea894603087fca2917aa4e1c2dea9
+md5: 2f364feefb6a7c00423e80dcb12db62a
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 55952
+timestamp: 1769456078358
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+sha256: db75d0fc080992dc67db8e24d7bb2a2f2a0b25bfce8870fa45a82a4b5f6111a2
+md5: a13e600f9d18488b1fd1257344dbfdaa
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8381
+timestamp: 1780933505754
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+sha256: 34fe8276befd6c42956c4acd969caeddbdc7ea8e6ed054b8388709b6c3e94ba4
+md5: 426cc33f8745ce11a73baf73db3954a7
+depends:
+- libgcc >=14
+- libpng >=1.6.58,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 424236
+timestamp: 1780933505195
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+sha256: 4592b096e553f67799ae70d4b6167eeda3ec74587d68c7aecbf4e7b1df136681
+md5: f35b3f52d0a2ec4ffe3c89ba135cdb9a
+depends:
+- _openmp_mutex >=4.5
+constrains:
+- libgomp 15.2.0 h8acb6b2_19
+- libgcc-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 622462
+timestamp: 1778268755949
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
+sha256: fe600a63a39281e6994e27fe79360cd6bd8e576c3ce1af32ce8673b011f46c21
+md5: 18ad0f0b94071d91fa962a1bf3983a78
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2353893
+timestamp: 1778268665954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+sha256: 1137f93f477f56199ded24117430045a0c02cbe8b10031beac3b9ad2138539d3
+md5: 770cf892e5530f43e63cadc673e85653
+depends:
+- libgcc 15.2.0 h8acb6b2_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27738
+timestamp: 1778268759211
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+sha256: e5ad94be72634233510b33ba792a3339921bd468f0b8bc6961ea05eded251d9b
+md5: c7a5b5decf969ead5ecada83654164cf
+depends:
+- libgfortran5 15.2.0 h1b7bec0_19
+constrains:
+- libgfortran-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27728
+timestamp: 1778268784621
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+sha256: af8e9bdcaa77f133a8ee4c1ef57ef564d9c45aa262abf9f5ef9b50eb99d96407
+md5: 779dbb494de6d3d6477cab52eb34285a
+depends:
+- libgcc >=15.2.0
+constrains:
+- libgfortran 15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1487244
+timestamp: 1778268767295
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+sha256: 6a13152a81513117b8d41bf64dea56c731d877bcced5a24fab738e3c0f9ac58c
+md5: 31d404d8c0755d0f9062a4459f5a1084
+depends:
+- libgcc >=14
+- libffi >=3.5.2,<3.6.0a0
+- pcre2 >=10.47,<10.48.0a0
+- libzlib >=1.3.2,<2.0a0
+- libiconv >=1.18,<2.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4943441
+timestamp: 1782464048865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+sha256: 2370ef0ffcbae5bede3c4bf136add4abc257245eb91f724c99bb4a43116c5a83
+md5: c5e8a379c4a2ec2aea4ba22758c001d9
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 587387
+timestamp: 1778268674393
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-14.2.1-h3a99ef3_1.conda
+sha256: ae1d16dd62f626c4dab1240a49f6b04e14e4f30140e5fb26bb835821dba114b6
+md5: 655cedd9626545089b9e9ead153cf619
+depends:
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1334601
+timestamp: 1782800489368
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-devel-14.2.1-h3a99ef3_1.conda
+sha256: 866b0132df7d080a7b2e3c44e4c79723f007db6c035b1e751612d29db698859b
+md5: b6762f2c0386ba4606d5b2cba1e41ca8
+depends:
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libharfbuzz 14.2.1 h3a99ef3_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 2050496
+timestamp: 1782800511879
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+sha256: 1473451cd282b48d24515795a595801c9b65b567fe399d7e12d50b2d6cdb04d9
+md5: 5a86bf847b9b926f3a4f203339748d78
+depends:
+- libgcc >=14
+license: LGPL-2.1-only
+size: 791226
+timestamp: 1754910975665
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_0.conda
+sha256: da3e45974c1f23c76264d6358463861236862052ca156e34b502ef3c27e36fb8
+md5: de0780a3690bffe75ac3fa70db84596d
+depends:
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 714602
+timestamp: 1783731816001
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+build_number: 8
+sha256: d269a684afa0b2fdb44d6b60167f854f30410cdb5ee49a7275c026f6b10c8d05
+md5: 3af3f2aa755abc5e91351114ae214f55
+depends:
+- libblas 3.11.0 8_haddc8a3_openblas
+constrains:
+- libcblas   3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+- blas 2.308   openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18828
+timestamp: 1779859055749
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+sha256: d61962b9cd54c3554361550203c64d5b65b71e3058a285b66e4b04b9769f0a5c
+md5: 76298a9e6d71ee6e832a8d0d7373b261
+depends:
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 126102
+timestamp: 1775828008518
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+sha256: 13782715b9eeebc4ad16d36e84ca569d1495e3516aea3fe546a32caa0a597d82
+md5: be5f0f007a4500a226ef001115535a3d
+depends:
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 726928
+timestamp: 1773854039807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+sha256: b018ecfb05e75a8eea3f21f6b5c5c2a54b5178bdcf19e2e2df2735740214a8c8
+md5: 58a66cd95e9692f08abe89f55a6f3f12
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.33,<0.3.34.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5121336
+timestamp: 1776993423004
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
+md5: f51503ac45a4888bce71af9027a2ecc9
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 341202
+timestamp: 1776315188425
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+sha256: 15ec553e784f2b8601c3df58e1dbe723309303c5ed405bc671bffae722c81023
+md5: f8f91448e5ba30051ceb17b45b31da9b
+depends:
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 71121
+timestamp: 1783936885865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_19.conda
+sha256: 8115604f113fe2b7be95b2d22183a4dda5779c1cc6db4b826af800581498b4b3
+md5: 95210a1edbd7fc6e12afc9f8276f450a
+depends:
+- libgcc >=15.2.0
+- libstdcxx >=15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7067965
+timestamp: 1778268796086
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+sha256: 1e289bcce4ee6a5817a19c66e296f3c644dcfa6e562e5c1cba807270798814e7
+md5: eecc495bcfdd9da8058969656f916cc2
+depends:
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 311396
+timestamp: 1745609845915
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
+md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
+depends:
+- libgcc 15.2.0 h8acb6b2_19
+constrains:
+- libstdcxx-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 5546559
+timestamp: 1778268777463
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
+sha256: 6f7ceee16070781b7d642a37a35ffdf09c66796d3df105c919526210ce220443
+md5: 61da34d67f58dd4cf16683f6cdcb06c8
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 17627362
+timestamp: 1778268687968
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+sha256: ef1006578ef7e3f7c420e89d87846213ceb3fdcef2626af2558cbede53d36839
+md5: 20166e2297c1cac346b544d5f6197440
+depends:
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 508982
+timestamp: 1783084925965
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+sha256: 7663489f97c104ae3814db10f384932c74b439f3c1fd4247e4fe3599830c090a
+md5: 58fa42bc4bc71fc329889497ec15effb
+depends:
+- libgcc >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 43248
+timestamp: 1781625528371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+sha256: 3e2ead35f47d01364031f323f1be984018c8f19a3a264f952ddcd043685a1c86
+md5: ac7bcbd2c77691cd6d1ede8c029e8c8a
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 456627
+timestamp: 1779396031450
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+sha256: b03700a1f741554e8e5712f9b06dd67e76f5301292958cd3cb1ac8c6fdd9ed25
+md5: 24e92d0942c799db387f5c9d7b81f1af
+depends:
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 359496
+timestamp: 1752160685488
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
+md5: cd14ee5cca2464a425b1dbfc24d90db2
+depends:
+- libgcc >=13
+- pthread-stubs
+- xorg-libxau >=1.0.11,<2.0a0
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 397493
+timestamp: 1727280745441
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+sha256: eb111e32e5a7313a5bf799c7fb2419051fa2fe7eff74769fac8d5a448b309f7f
+md5: 502006882cf5461adced436e410046d1
+constrains:
+- zlib 1.3.2 *_2
+license: Zlib
+license_family: Other
+size: 69833
+timestamp: 1774072605429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+sha256: d243aea768e6fa360b7eda598340f43d2a41c9fc169d9f97f505410be68815f8
+md5: 5983ffb12d09efc45c4a3b74cd890137
+depends:
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 528318
+timestamp: 1727801707353
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+sha256: 369db85c5cd8d99dde364ce70725d76511d9c8199e5b820c740414091bf5bcca
+md5: b2a43456aa56fe80c2477a5094899eff
+depends:
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 960036
+timestamp: 1777422174534
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+sha256: da4a5df42614166b69c2f6d8602fc1425f7aaa699f77c3bafb5c7fe69b3d9fb7
+md5: fa6260b3e6eababf6ca85a7eb3336383
+depends:
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3704664
+timestamp: 1781069675555
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandoc-3.10-h8af1aa0_0.conda
+sha256: 8427cd22ccc4104d1348fe028e130e800328060e3b6f3607ce97f5188c68b835
+md5: 648f4bde42b8c5d708296ca6106c377d
+license: GPL-2.0-or-later
+license_family: GPL
+size: 23565468
+timestamp: 1780595445519
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+sha256: d209c8b0d53c441ee0bc0d8fce0fcae8e7e05755e51b13b6b9da02c7aa032f98
+md5: 3fc7cc25bba3381e77b753578058e3b0
+depends:
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.17.1,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- harfbuzz >=13.2.0
+- libexpat >=2.7.4,<3.0a0
+- libfreetype >=2.14.2
+- libfreetype6 >=2.14.2
+- libgcc >=14
+- libglib >=2.86.4,<3.0a0
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 470441
+timestamp: 1774284032397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+sha256: 04df2cee95feba440387f33f878e9f655521e69f4be33a0cd637f07d3d81f0f9
+md5: 1a30c42e32ca0ea216bd0bfe6f842f0b
+depends:
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1166552
+timestamp: 1763655534263
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_2.conda
+sha256: 414acad3e460cfcf6bf3a764c4b4837359bda9fdc350a85b560e344a9e2306a5
+md5: af8ab93369e53542b135dab29eca49e8
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 304146
+timestamp: 1784286832656
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+sha256: e9cbcbc94e151ada3d6dc365380aaaf591f65012c16d9a2abaea4b9b90adc402
+md5: ab7288cc39545556d1bc5e71ab2df9a9
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 636733
+timestamp: 1769712412683
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
+md5: bb5a90c93e3bac3d5690acf76b4a6386
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 8342
+timestamp: 1726803319942
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+sha256: 5055913d786b82f33a14f493f32945b3b2b5d528ea2f52856ca02b296f6511eb
+md5: dde4691fe168112a90efba6aaa08f13d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: LGPL (>= 2)
+license_family: LGPL
+size: 82526
+timestamp: 1757460261392
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-askpass-1.2.1-r45h0557e7b_1.conda
+sha256: e6d37a7c16ca9693a1dee6ab71778c78f6539508ca59934f38c97ff2a5129565
+md5: 6dd9985ca467090a3ce338ea95da715c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-sys >=2.1
+license: MIT
+license_family: MIT
+size: 33005
+timestamp: 1758383588821
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+sha256: 90e7ae8aa427274d7d2e510060b68925e60e897ecaa5ea135bb33afa7eb12134
+md5: b5291c60f52b43108a2973ba6f5885d1
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 72543
+timestamp: 1757447376176
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.5.3-h269e6ae_3.conda
+sha256: 27649f8b9717afec0d32b3ddd2537f08948321a5b311d8ed49bedfd4dde6b718
+md5: bd35d2e5e6972908b398aaf340861ff1
+depends:
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.18.4,<2.0a0
+- curl
+- gcc_linux-aarch64 >=14
+- gfortran_impl_linux-aarch64
+- gsl >=2.7,<2.8.0a0
+- gxx_linux-aarch64 >=14
+- icu >=78.3,<79.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libglib >=2.88.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- make
+- pango >=1.56.4,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- readline >=8.3,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- tzdata >=2024a
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxt >=1.3.1,<2.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 27596006
+timestamp: 1781523590403
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base64enc-0.1_6-r45h0557e7b_0.conda
+sha256: 2172b3db2c71520fd5018cac6e7db1659a43054b71f331573e30e0c30acbec20
+md5: 8b5fb4c68b8c612747adcf9ef27e397c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 50459
+timestamp: 1770027826952
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-beeswarm-0.4.0-r45hf488e41_5.conda
+sha256: 5284e4fd8982aa2e63d73f1b8bd760462311b5e9a853a341f5b872cd0c22d463
+md5: a0429d68e95c279c95760fa4da3ea648
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 89962
+timestamp: 1757584938658
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+sha256: 177f262fda25552b8ce3e7685220deefba1625314575a892cd4abca06ddf06a4
+md5: f1b6b9a4e77b21df8a6949102db4f468
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 644936
+timestamp: 1763112090227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+sha256: fafc7a0acb8fc595b8fd89e75ec0b1d7d5af71b2b493570fa05e1f5612d299c2
+md5: dae60c429ab933e549832bc223e95639
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-cachem
+- r-htmltools >=0.5.7
+- r-jquerylib >=0.1.3
+- r-jsonlite
+- r-lifecycle
+- r-memoise >=2.0.1
+- r-mime
+- r-rlang
+- r-sass >=0.4.0
+license: MIT
+license_family: MIT
+size: 5538377
+timestamp: 1778923739710
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+sha256: 20dd6e4aa94d2d5ea97419add6bcac50f81400d297e9933659ff35da41fe2f6d
+md5: c922b0a6584376d3587d8cb3670f5cac
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 256017
+timestamp: 1757560386979
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cachem-1.1.0-r45h0557e7b_2.conda
+sha256: c8fd2712d1a19d32feabf471fd4f5e01d8d9a622a08f76b1c3cf638f4ab1dccb
+md5: 7ac09a862af4168c7e6ca6f018464c55
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fastmap
+- r-rlang
+license: MIT
+license_family: MIT
+size: 77756
+timestamp: 1757441578494
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+sha256: f9f49b2b845f279af84a33c8af19a915b2731c0bd892c608205cbad8a34f423d
+md5: a5cc8a8d0dc08dc769c65a13b3573739
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-processx >=3.4.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 454090
+timestamp: 1757475635573
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.6-r45h08b74da_0.conda
+sha256: 5416a041dbc61d4d3b74c0c888295aaf7cb71262236a4fc09242c18711ed00ff
+md5: 196fedd5e490165a94ee856d727aa247
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1346019
+timestamp: 1775733744341
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cluster-2.1.8.2-r45h6df9e4a_0.conda
+sha256: bf4a9118958688ef6a7b06267fb0aa7006fa97ec37d400f194c48175ff5df3f7
+md5: 5b08c25df4a50c12c8bfdfe65d191ce8
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 595768
+timestamp: 1770285735470
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+sha256: aec327dd836824278a2adf006f426a58d834828de74de7f8348f2f5f068de702
+md5: 8e9e5b14f74a6040c77e0b9c8bfa84ca
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 109200
+timestamp: 1757452164030
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-colorspace-2.1_3-r45h0557e7b_0.conda
+sha256: d78a45f9c58a3182ba17a3851017b7adaa6d0ecebcee872998bb41e6cc312782
+md5: 01eaba8437d8c23d0dea562c29e406a8
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2546382
+timestamp: 1784283306550
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-commonmark-2.0.0-r45h0557e7b_1.conda
+sha256: 1382bc1e64063f49fdc406d0ce92a815c43b9be9cb098d8e65f7059f97117535
+md5: 4f0d0c8eeeaad3aab64c7bee16426a28
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 144114
+timestamp: 1757422195437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+sha256: 5993a1b5c08c78a35cdbcf20376773eb7c4def2d28615e49f96008b43a4c05c0
+md5: 71c68a3993a696b6b75f7a6550b3750f
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 246247
+timestamp: 1778089270609
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+sha256: 9126a0408696133893e674549ca7aef317768dba503765a7ed032616aabe5b49
+md5: 4f111ce078b9690abaad6248b831a370
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 168201
+timestamp: 1757452410374
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+sha256: 217e5e210501b7fa611d6c6c46ae1551f443e2359e27164240da5a1219b2551a
+md5: 523a15023a79bd6f0dcb95ba6756ceed
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.3.6
+- r-jsonlite
+- r-lazyeval
+- r-r6
+license: MIT
+license_family: MIT
+size: 382037
+timestamp: 1757479275516
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-curl-7.1.0-r45hd8a8d9c_0.conda
+sha256: 91fce711e5bacf578c37e9c5012563d60d1dbe5a05dcf0f2a8080d3be2a938bf
+md5: 328d250136cafc6b644b5174767dbea4
+depends:
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 477493
+timestamp: 1777147747989
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-data.table-1.18.4-r45hbf3bb9c_0.conda
+sha256: d4a19f503b0705d9662ce3e9d81753aa720202c5c87e0f64869599dcfa9e84d7
+md5: 8f3b2a953fcbc5eb2dadb5dab1f0d5b6
+depends:
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MPL-2.0
+license_family: OTHER
+size: 2644344
+timestamp: 1783428401576
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+sha256: 1edafb4e01397265da1816f3164a451d36f02546f2589c5f45051886ab9f91a8
+md5: f69bda3cb40132707f6efff4c749ce09
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-magrittr >=1.0.1
+- r-viridis
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4839264
+timestamp: 1757633933010
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-digest-0.6.39-r45h08b74da_0.conda
+sha256: 2cf79b6af8cdd8215ffed899d016c1554935cab5cc419a9390cc6931cdf49513
+md5: c5109e71b8b0a7dcdddcc4f6fa21605d
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 225830
+timestamp: 1763566824454
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.2.1-r45h08b74da_0.conda
+sha256: c7a33bc92936537648e29cb70b0912deaa4a79cc4d8f30f4e4dd213723eb00a0
+md5: 93bb33f64dce6cdcd5251d8d2234bac7
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1449577
+timestamp: 1775207129641
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+sha256: 38eee3a12260e5fff1e2af04250f6b67091b01c694f101ae6448da12c3fcca09
+md5: b78224895a1ad7fb52311ab071c2ec00
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-crosstalk
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httpuv
+- r-jquerylib
+- r-jsonlite >=0.9.16
+- r-magrittr
+- r-promises
+license: GPL-3.0-only
+license_family: GPL3
+size: 1439901
+timestamp: 1757566758266
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+sha256: ec00c0162d803af3c8059e9504d1d0c8b60cabe805c347a4a20300f2cce9e700
+md5: 6ac48e7c4c46b6c0538a779d0a43008a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-gridextra >=2.3
+- r-gtable
+license: GPL-3
+license_family: GPL3
+size: 950098
+timestamp: 1757760318911
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.3-r45h0557e7b_0.conda
+sha256: cdd63168ef461c582d26b5a8bcd7e5378575a20068e61ab119cdbb544329f5a4
+md5: a52d33523179da32a3c9d11ff27b730d
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 34061
+timestamp: 1775287261756
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+sha256: d3accfeab1416151515c37e5edc94b18868998db4936183459f8040117d5c83c
+md5: 4e0c71ab78d7292372a89d4daecb49af
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 111914
+timestamp: 1757447684244
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.7-r45h0557e7b_0.conda
+sha256: 9a8c13e87085007face8d9576ca4675ac2187e4b2082f195199b6b6af67c45c6
+md5: a0702b7eb11d1a382527a02baf1fd0bc
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 339732
+timestamp: 1763566140258
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-farver-2.1.2-r45h08b74da_2.conda
+sha256: bad9c13ce006e7e972cd3b240efc2ab457557acfec2a5566c85b91f6f354cd8f
+md5: e3468d0fb1e32edf11badd5dcdb847e4
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1401937
+timestamp: 1757441349828
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fastmap-1.2.0-r45h08b74da_2.conda
+sha256: 3bff61e00966863ab1febada7f64a9618db330aa97dd527b0d2719990993e1a3
+md5: 679225ca2785ed02ffd33b5cd998e514
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 74243
+timestamp: 1757421537458
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+sha256: 865df12d8cdd8cf577abc8f785a0aa4ee50b4f8751256dffe4676a350943d591
+md5: e9fccb3617ec9776569c6496fa254e64
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.1.1
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 1335664
+timestamp: 1757461248044
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+sha256: c95d1e61946bf81128be213dea7a07b5196c6e13caf9c6452c38145da8d2dfb1
+md5: 5abe392c8f8c5b954ebdc5fe46fcc709
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-codetools
+- r-iterators
+license: Apache-2.0
+license_family: APACHE
+size: 140909
+timestamp: 1757490449004
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fs-2.1.0-r45hd601667_0.conda
+sha256: 305a53e9e768366f5a143376ad618c5c08f67ac96242d747ec7bd6a0db71d1c2
+md5: 87df8bfe7e48c5b0537cc534f8a5b3a3
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 244508
+timestamp: 1777152716131
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+sha256: 196d29aa2d809d9115dce27236470219e1057d394654b5d73182f0e9d117f2fa
+md5: 4a667a55fc37e12dcbe510262ca61d19
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 424919
+timestamp: 1757627324320
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+sha256: 88a5cf4bac0a553943996bc930b1ea28f2635c262c1b2c5a42b026b69f227f02
+md5: f19c9493b80f63a41fa017ec3b27bc2e
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 88225
+timestamp: 1757455977192
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+sha256: 20c4ea52e72cb2e50907f9e5a446f16b0fce467fec4edab236eeb3b46890f3dd
+md5: b3a121ed6a71f3b674859ccbb15ad56b
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 67477
+timestamp: 1777325952298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+sha256: f8c0982d1579b810fc24cb702f8922794fce7bdfb9d3bf96867a4b038205b045
+md5: 9be31d2adf526d3c38b78a05333ddf30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-beeswarm
+- r-ggplot2 >=3.3.0
+- r-lifecycle
+- r-vipor
+license: GPL-3.0-or-later
+license_family: GPL3
+size: 1761662
+timestamp: 1764399956063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+sha256: 4e0401174fac5b54f124a8e7e418995a74918e8cd52a456a82db3fc5a373f0e0
+md5: bcdfec44c6bf587e65f56de61334a413
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=0.9.2
+- r-mass
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 221547
+timestamp: 1757758420492
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+sha256: 3a91d5334b7d99bc247386eaf0d331e119852e381e769e266f70df20eab22689
+md5: 866fbbf3f356140922d618f26f2b889c
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-gtable >=0.3.6
+- r-isoband
+- r-lifecycle >=1.0.1
+- r-rlang >=1.1.0
+- r-s7
+- r-scales >=1.4.0
+- r-vctrs >=0.6.0
+- r-withr >=2.5.0
+license: MIT
+license_family: MIT
+size: 7812326
+timestamp: 1776860393567
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.1-r45h0557e7b_0.conda
+sha256: 02f33f91373217832525d722f7e3be2ac47a1b8f9e1e65a33a03622180ff2360
+md5: a410160f41fb5192efccd33986aced38
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 172828
+timestamp: 1776413622694
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+sha256: e82d7e308a7e6d3eb90d9ea33d1f56d24bd69804995db2dacd5b20b7a20c34e4
+md5: aad2c473bf6f930833d0dc881811cf62
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-gtable
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 529159
+timestamp: 1782547830828
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+sha256: fcd2601af8213f39af6f720e22c8f858b3451f8e3d93cbc9e6aedb2d6f88483e
+md5: f686123cfba49e6299fae7e029a40266
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-lifecycle
+- r-rlang
+license: MIT
+license_family: MIT
+size: 228864
+timestamp: 1757463478042
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+sha256: 2d26e9b5c0e688cc76d33d81f8f62c59de9dc2f0695fd7b110991fa222db5524
+md5: d0bd1b5a09e5d631b8de31949ea19ece
+depends:
+- r-assertthat
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+- r-dendextend >=1.12.0
+- r-egg
+- r-ggplot2 >=2.2.0
+- r-htmlwidgets
+- r-magrittr >=1.0.1
+- r-plotly >=4.7.1
+- r-rcolorbrewer
+- r-reshape2
+- r-scales
+- r-seriation
+- r-viridis
+- r-webshot
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1693764
+timestamp: 1758426737719
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-hexbin-1.28.5-r45h6df9e4a_1.conda
+sha256: 1b589435aaf7c11bb23d6877f077a61f387a696fdeb7fd4d8307b5e4e5fcbebe
+md5: a7e475f65cbe95ff5193d520cdd5196c
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-only
+license_family: GPL2
+size: 1594883
+timestamp: 1757483340587
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+sha256: e676112aac0dbfe123fcb3108cce376782211a096c898a3af46fdf32a37e12e9
+md5: 0b5902d6af02a23bda1794d46090db42
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.18
+license: GPL-2.0-or-later
+license_family: GPL
+size: 57308
+timestamp: 1772794436225
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-htmltools-0.5.9-r45h08b74da_0.conda
+sha256: 71fb50fb947fc5209e6abc3ea4a7e388e32f564f306a4771c46b26dcf7474369
+md5: bd128ae05e4cb14baa66ff86ad9b3126
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-digest
+- r-ellipsis
+- r-fastmap >=1.1.0
+- r-rlang >=0.4.10
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 368214
+timestamp: 1764860572792
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+sha256: 4c3998ce4b4882429e52eed5c6c53d59056814d8fbc34a41ba79b990fdec1441
+md5: 6f767715f90e7caf17af72959bfcb11e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.7
+- r-jsonlite >=0.9.16
+- r-knitr >=1.8
+- r-rmarkdown
+- r-yaml
+license: MIT
+license_family: MIT
+size: 426023
+timestamp: 1757552859817
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-httpuv-1.6.17-r45hb62f08c_0.conda
+sha256: f80c025e58243755b5a66d125fff21aff8f081fee0428a9254c62ee9cde6dc65
+md5: d1e3db0a93a2074799a0659080178b8e
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-later >=0.8.0
+- r-promises
+- r-r6
+- r-rcpp >=1.0.7
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 553429
+timestamp: 1773825488822
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+sha256: 4adb565d2b3365108d7efb926c2acdc68c11ef2ad32ed03d1108a3005cf8cdd8
+md5: 259658089c383f2915b167da3e7890aa
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-curl >=0.9.1
+- r-jsonlite
+- r-mime
+- r-openssl >=0.8
+- r-r6
+license: MIT
+license_family: MIT
+size: 474019
+timestamp: 1771005817336
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+sha256: dcc78f60308390c6549e25308fb2437421e8fcaeeb45378b6fbe3a49e3d3cd0b
+md5: b240e3c0e61de35f1f43729f4ea2888e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.0.0
+- r-curl >=5.1.0
+- r-glue
+- r-lifecycle
+- r-magrittr
+- r-openssl
+- r-r6
+- r-rappdirs
+- r-rlang >=1.1.0
+- r-vctrs >=0.6.3
+- r-withr
+license: MIT
+license_family: MIT
+size: 935264
+timestamp: 1784022303810
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-isoband-0.3.0-r45h08b74da_0.conda
+sha256: e70c9f8bb4b0100ac45e9aeed982c2a72357c4b8ca529fa2927cbc917e283c4c
+md5: 04efe7d434cd3e6f5a69e4799eb6cbbd
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-cpp11
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1660497
+timestamp: 1766530417757
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+sha256: c90d0faa668d2753db9da9458ca085891a3030c6537f5675fe0c1a1b5af2103c
+md5: 7746a41a4cb97cec59db2d5a2cac0701
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 350171
+timestamp: 1757459846270
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+sha256: abb2cd923ed271df8774e696f2e455f8c641532cc984fd770b87852a0017d7ab
+md5: 7113381f500ebcc8a33b61101817d120
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-jsonlite
+- r-openssl >=1.2.1
+license: MIT
+license_family: MIT
+size: 248113
+timestamp: 1776846446837
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+sha256: 3b98f72bb32d4758854805b664b4404602a583da32c9b96026536f5676f41812
+md5: 49a9ed6ed01f4ae6067ead552795bfce
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools
+license: MIT
+license_family: MIT
+size: 307113
+timestamp: 1757459485295
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-jsonlite-2.0.0-r45h0557e7b_1.conda
+sha256: cd484854182eca0e62cacf6f5dfdc3d11106d4ab0307d41361c772247e9ae283
+md5: 0c7d7b8541f5619f09dd9334deb7dbf7
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 645626
+timestamp: 1757419590460
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+sha256: e2184f1cb58aedacd94d1dbe6e8b5dfa3508151f454e80f6bd49486bdb90625c
+md5: 35b31b96aa7bc052ad6347322a1481f1
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-evaluate >=0.15
+- r-highr >=0.11
+- r-xfun >=0.52
+- r-yaml >=2.1.19
+license: GPL-2.0-or-later
+license_family: GPL
+size: 988526
+timestamp: 1766309267127
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+sha256: 42a06b7c346d6e4550dca1024bbf89e3c22962d568cfe4e8b8be824dea326110
+md5: a41490fdf607381035aa0304c21407c9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 70182
+timestamp: 1757456007088
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-later-1.4.8-r45h08b74da_0.conda
+sha256: b7c530de9a38fcf30ae63c92cd60fb0d23567e6567f70694d350ff2adeec88e0
+md5: 3601ce2112d41114cdb6ed340ee44442
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.12.9
+- r-rlang
+license: MIT
+license_family: MIT
+size: 155668
+timestamp: 1772707321535
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lattice-0.22_9-r45h0557e7b_0.conda
+sha256: a6f30211a8b3511e27c2aac99b499cdb4751a950fe5595a48672a38de8ecc28d
+md5: 2049f7981874aefa34b2b5b53af007eb
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1418137
+timestamp: 1770694138040
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lazyeval-0.2.3-r45hf488e41_0.conda
+sha256: c9f7bb66c064e813d5aa82e60b70ab4fb1f0b6acda05a43cbbb3615bd2c71899
+md5: 2a54efbd48368966f65e6500198574e7
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang
+license: GPL-3.0-only
+license_family: GPL3
+size: 195208
+timestamp: 1775429446648
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+sha256: b7a4d8d98a96d17d18c80fb7e1c8e6cb09b9bd2542e74d91a7f483afccb30ee6
+md5: 5f8369dfbdff08878e58bf15529fca3a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 132636
+timestamp: 1767865665455
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+sha256: 1f594c5be675a53caef3368ea85c048b8bcbc4385e2bd582e977981a1edd5e3e
+md5: b936b3596737a3a1d513e1258d5d0355
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-commonmark >=2.0.0
+- r-xfun >=0.55
+license: MIT
+license_family: MIT
+size: 392980
+timestamp: 1784144498175
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.5-r45h0557e7b_0.conda
+sha256: 0a4dbbb3acc77222d0119e1d9c47c94359e5a05290a514b5ac345512e6d5d125
+md5: e61a28ac3cbd3f76f96f9aef579ae6ef
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 212064
+timestamp: 1775298634467
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+sha256: 5f27ccd93b39c2435ed6e9b8302ae50d51eb5b6058d7d11edba403e9723f48c6
+md5: 755b46b2896c8526a18074b3b651dfbc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-litedown >=0.6
+- r-xfun
+license: MIT
+license_family: MIT
+size: 72190
+timestamp: 1757496654397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mass-7.3_66-r45hf488e41_0.conda
+sha256: cadc1e7cb74ec9999a2393b5225bca8f39da162f5ea1719783c4186dffd5d223
+md5: 615cb3f4dc69d374da874553f58cc61c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1143006
+timestamp: 1784201763856
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrix-1.7_5-r45h9301183_0.conda
+sha256: 0671e1595f283ed8f5a67f6006821b90b58a954c095d230cf0c3543d45aa6e1f
+md5: dbc4de669537f1b65a8f63e92d01c0de
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4492870
+timestamp: 1774809348312
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrixstats-1.5.0-r45h0557e7b_1.conda
+sha256: cc732696567fd2e79cf48cb9ae19cfed65d2a547ef7657b847ea6e52ab29cef0
+md5: 28f5371af404b055c4e8fda252343eff
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 508907
+timestamp: 1757442506110
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+sha256: 91b0eedec5cf5de195b442b97eda508f22fdedbdbc487f74e3868d3e95380fdd
+md5: 2b04206ff6ea5a92e8e36bdaa5feb3cc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cachem
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 57750
+timestamp: 1757456335587
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mgcv-1.9_4-r45h8b2cba9_0.conda
+sha256: deb54e1594e6cff5fa5c1851b6ba9b8e9ddb663fc2a5bd0a770bd7348fca0740
+md5: 3f3684540a7cf2f8aba9bd7419b86182
+depends:
+- _openmp_mutex >=4.5
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-nlme >=3.1_64
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 3663168
+timestamp: 1762539639167
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mime-0.13-r45h0557e7b_1.conda
+sha256: 7ebc8c9727a9841e9c0ac408d67dda73618105a6741e6ee2764d3b5838006adc
+md5: a18f44c7e30f17a25dae01a2ebdd64ac
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 65881
+timestamp: 1757441504988
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+sha256: 97d463c2146c483992a25fe497755e9cf714f95ca611a93d8adbb41c068e9e74
+md5: c78bd534986cde8fc0cb08cc9a1a2cc6
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+license: MIT
+license_family: MIT
+size: 247241
+timestamp: 1757455926748
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-nlme-3.1_170-r45ha85219e_0.conda
+sha256: 5a665d1c57741a6ad27b09c26a5c70c1e8b2600b99c1ca70850b01e67981aba1
+md5: 9d56b3fd30b35e8511816cd727b71c75
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 2364152
+timestamp: 1784288181817
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-openssl-2.4.2-r45h37c386a_0.conda
+sha256: 0b1010bcebef6d666733f422ede62662c408bd21d35a1a6a415a56469641ff98
+md5: b835aaead878405731f2cd4f92f253ff
+depends:
+- libgcc >=14
+- openssl >=3.5.6,<4.0a0
+- r-askpass
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 683534
+timestamp: 1781024877810
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+sha256: 09df5e8326b04412a26b6c4d896e04adbceba45194457c6d30f370d5ccb4b397
+md5: 0c015ba0c5444777a683c05e4a000f21
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-getopt >=1.20.2
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 119289
+timestamp: 1776419503742
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+sha256: f5de9737f59e1965db2de11c90cf1fdd426db322a7205c935a3e55150287b02f
+md5: 560abd550c097e0d0af2e201b335f53d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 286342
+timestamp: 1761151056217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+sha256: 162742dd773c8a163de6ffdf0e14820b5708b9e1041d4491762c05e00f6be614
+md5: 849a8fcdb5e1d98a3917a7c652c322df
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 679411
+timestamp: 1757649050426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+sha256: a4869bf14ad791c8a5cb48fd0575faa3cdb7b07692cb4b473809c261f584fa45
+md5: 9a48d2e7fdc93937c60481c06d40e6ba
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 234305
+timestamp: 1770387131912
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+sha256: b3f281041ecff2d4a9f40073ad5e7ec6fa7e0c841068ce85c550bcce0ff8938d
+md5: 807ef77a70fc5156f830d6c683d07a29
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 629867
+timestamp: 1758149763203
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+sha256: fda425435a533e86da5f0fc89cf45c9f889a4e6f1e2ed536ca23662a8461602c
+md5: 40a5fdd06c7e7880758a021cf2df6c12
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 27236
+timestamp: 1757447537447
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
+sha256: c27913720e29845540e0f20507cdd43ea2beff02e7a73b1e2f51e4e929c42859
+md5: 51ad52cc7fa715ca7739245162bfab8f
+depends:
+- libgcc >=14
+- openssl >=3.5.3,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 137458
+timestamp: 1758095884906
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
+md5: ced57d920bed79382f382a24a4425ef7
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-crosstalk
+- r-data.table
+- r-digest
+- r-dplyr
+- r-ggplot2 >=3.0.0
+- r-hexbin
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httr
+- r-jsonlite >=1.6
+- r-lazyeval >=0.2.0
+- r-magrittr
+- r-promises
+- r-purrr
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-tibble
+- r-tidyr
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 3587131
+timestamp: 1769337109792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
+sha256: 0150b0ff5b1f10d44d8340697dc75308d000af7173e06a7bd6bbc52662435647
+md5: b5287e844eb29138a9bbac2204c34938
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.0
+license: MIT
+license_family: MIT
+size: 787646
+timestamp: 1757441825154
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
+sha256: 0795c4803d0c96906f1f509db1b444bedbcd49efcf563fa67e34056f155f4944
+md5: 6002b6697d4f3a7aa2112d75938215df
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-ps >=1.2.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 416233
+timestamp: 1776865727437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+sha256: 684dba5d20aae8da37868d603b662014e1944f5568e5f737e42d9d485892a26e
+md5: b2c1b6ef8f12894fd2694b285fe8989a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-fastmap >=1.1.0
+- r-later
+- r-lifecycle
+- r-magrittr >=1.5
+- r-otel >=0.2.0
+- r-r6
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1597704
+timestamp: 1762426228446
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ps-1.9.3-r45h0557e7b_0.conda
+sha256: 9806dc2cd51b90600c0cfaa9414bf037359b48e4409a3e848c714f7fd202e326
+md5: 110a8db7f8f7d81dc6499717e3518901
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 415719
+timestamp: 1777148053343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.2.2-r45h0557e7b_0.conda
+sha256: 132601f0cf01c5472b5808479e92290c4a1764202d8eb370a568c0c8cc42e509
+md5: 9418ed4bd8e6c1f7daa1d86fde8d4bca
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 551426
+timestamp: 1775853641796
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-qap-0.1_2-r45ha85219e_5.conda
+sha256: 130ad15a31352cac447a5d5121df7703a77775be465967816193fadf522ec604
+md5: 0783f6d35f1229fd9476bbd89ebb36e2
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 397185
+timestamp: 1757637123693
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+sha256: bd92e91332eba5f0c689583e80adec85ef272c4e0d0b36ee17cb7c11b5693cf2
+md5: 750802806d7d640c286ed8491bb395dc
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 95073
+timestamp: 1757447661037
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rappdirs-0.3.4-r45h0557e7b_0.conda
+sha256: 86b48f6a5648dab19677da07eb4360ab9f1df1957ab1a5bd7499c14284303fe4
+md5: 37552103a31471f0dd255110017d4397
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 55042
+timestamp: 1768747329339
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+sha256: ddd4e63616ee475bdf9dc63a0b16a89017237121e927d83fbdee07d5a5ccc890
+md5: d8fa238420cb6de47d463b7345a761eb
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68005
+timestamp: 1757452462302
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpp-1.1.2-r45h08b74da_0.conda
+sha256: 4a2c9002ff0360803ab644577bbac5a2277dab69a7cb58c23218d39e84d3371a
+md5: 6cc0478a5eda6092486e4f6fb2de570b
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 2121146
+timestamp: 1783264524840
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpptoml-0.2.3-r45hd601667_1.conda
+sha256: 0481dc92f2c896ce9e25ea69b53c8bfe7ddb76c6e3fc7baaf4cdda8351c385e5
+md5: f68ce5a7d961bf5047a1635c013d5ce2
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.5
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 229676
+timestamp: 1757491689154
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+sha256: 68f01b65843f873b01bff24f61f27298667797aa3ad01d4406a62ae72e7c08c5
+md5: 1a99d6f9dfe5f6e8dc5275d49852cd66
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 208380
+timestamp: 1757507980343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-renv-1.2.3-r45h0557e7b_0.conda
+sha256: 10a562d51e1c0286aeec2a9146e2038b809391bb1aa63700c9ccfb3362e9e372
+md5: 8dfb98a9c08d53deb71fc9f861aedefb
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 2469153
+timestamp: 1778972869359
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-reshape2-1.4.5-r45h08b74da_0.conda
+sha256: 963e97c3784e971a8f6a42efe7734123da1e5de0cea2cef876b0ffc46b303eed
+md5: 1f0843cf4a39b71ae3bb80d11c0d19f1
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-plyr >=1.8.1
+- r-rcpp
+- r-stringr
+license: MIT
+license_family: MIT
+size: 126686
+timestamp: 1762975693066
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.3.0-r45h08b74da_0.conda
+sha256: 074cbdc062065520aa129ac3390dd1dd2ac792a151c0a2441890290f2dc2351f
+md5: c41e2c86ee4633b25d88036ff33b1cdc
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1625093
+timestamp: 1783260250227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+sha256: b3735a4e75eca023b24678251da041854b94a8b96588d81b605928d6ecf74f11
+md5: 25b9dbf0ff990b8b3111774878e3bb07
+depends:
+- pandoc >=1.14
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.2.5.1
+- r-evaluate >=0.13
+- r-fontawesome >=0.5.0
+- r-htmltools >=0.5.1
+- r-jquerylib
+- r-jsonlite
+- r-knitr >=1.43
+- r-tinytex >=0.31
+- r-xfun >=0.36
+- r-yaml >=2.1.19
+license: GPL-3.0-only
+license_family: GPL3
+size: 2085382
+timestamp: 1774555006202
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+sha256: 5f9aa168f5c43f1d3ddbacc701370085fcead3956e2d5879af7fcd9e086a0a0b
+md5: 62f09532f225c86d27e954b36682add5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-digest
+- r-httr2
+- r-jsonlite
+- r-lifecycle
+- r-openssl >=2.0.0
+- r-packrat >=0.6
+- r-pki
+- r-renv >=1.0.0
+- r-rlang >=1.0.0
+- r-rstudioapi >=0.5
+- r-snowflakeauth
+- r-yaml >=2.1.5
+license: GPL-2.0-only
+license_family: GPL2
+size: 830390
+timestamp: 1783503525234
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+sha256: 896aeea3aa679a9dbd0277d10ef8dcfd011e45a1717129180a9877c1fd828f2a
+md5: 5f1b6b899fa3204ab77403e75b9df5fd
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 357140
+timestamp: 1781250782889
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-s7-0.2.2-r45hf488e41_0.conda
+sha256: 1c1be6985179ebd4eefbfc6939f014a4841e3a5b4738a667c0b1575f7bc2d1d1
+md5: 04cc16d1447a6e6cdaebe06e23d46d50
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 312811
+timestamp: 1776861400477
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sass-0.4.10-r45h08b74da_1.conda
+sha256: a318466958e737c4b214299b99974398e769961347cfad85c585e7bc7a959749
+md5: 6a543a95d37cfaa08a3f17dc3e46e8f6
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-fs
+- r-htmltools
+- r-r6
+- r-rappdirs
+- r-rlang
+license: MIT
+license_family: MIT
+size: 2245202
+timestamp: 1757464676590
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+sha256: 260c384e952e5bd4d2c2de77b9e09b24ff1c1f680acd917c4657ab8c9e4e9a2f
+md5: 8bc81cc6fd130cef963bc9e082726a14
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-farver >=2.0.0
+- r-labeling
+- r-lifecycle
+- r-munsell >=0.5
+- r-r6
+- r-rcolorbrewer
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 777793
+timestamp: 1757487539496
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+sha256: bcde368cbf5a2c83b9c1fb8b3ba0722787af759f68d08bac6a82e966adbf999f
+md5: ba820689c02638c807f83e6ab5c53142
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 370745
+timestamp: 1771995271935
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-seriation-1.5.8-r45ha85219e_1.conda
+sha256: e59663a8f5dbd9c6748a353e508f49f85e99622d4adce539cd2b1aef21186624
+md5: 60eaa5984a3efa5d4a7cf167dfe18d75
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-ca
+- r-cluster
+- r-colorspace
+- r-foreach
+- r-gclus
+- r-mass
+- r-qap
+- r-registry
+- r-tsp
+- r-vegan
+license: GPL-3.0-only
+license_family: GPL
+size: 1373552
+timestamp: 1757662510748
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+sha256: ef0042ae1c3926ef9bee6c21cf761d7cf441eae61dceca7df143f3b9dc4c6f04
+md5: 2fb0e1ea59dd281487be303b1b7c6607
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.6.0
+- r-cachem >=1.1.0
+- r-commonmark >=1.7
+- r-crayon
+- r-fastmap >=1.1.1
+- r-fontawesome >=0.4.0
+- r-glue >=1.3.2
+- r-htmltools >=0.5.4
+- r-httpuv >=1.5.2
+- r-jsonlite >=0.9.16
+- r-later >=1.0.0
+- r-lifecycle >=0.2.0
+- r-mime >=0.3
+- r-promises >=1.1.0
+- r-r6 >=2.0
+- r-rlang >=0.4.10
+- r-sourcetools
+- r-withr
+- r-xtable
+license: GPL-3.0-only
+license_family: GPL3
+size: 3789417
+timestamp: 1782070586086
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+sha256: c3ea3d60226ed56e4a40b622b8e4721d257a9fb4ca8502ce89314f48a63a0090
+md5: b5da9b58b4f8137a7f2e14102bc230c9
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-glue
+- r-shiny
+license: MIT
+license_family: MIT
+size: 344724
+timestamp: 1757870156008
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+sha256: 9493d6cbf09850206f5904ccde65643de86bb9bd6add685548331c408e99610a
+md5: 3929f109451367912b4570480f4c572d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest >=0.6.8
+- r-jsonlite
+- r-shiny >=1.0.0
+license: MIT
+license_family: MIT
+size: 1018291
+timestamp: 1768513288077
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
+md5: 7382af8530d082191feb0c8da5f8a41b
+depends:
+- bioconductor-limma
+- bioconductor-summarizedexperiment
+- r-base >=4.5,<4.6.0a0
+- r-biocmanager
+- r-bslib >=0.9.0
+- r-cluster
+- r-dplyr
+- r-dt >=0.2
+- r-ggbeeswarm
+- r-ggdendro
+- r-ggplot2
+- r-heatmaply
+- r-htmltools
+- r-htmlwidgets
+- r-markdown
+- r-matrixstats
+- r-optparse
+- r-plotly >=4.8.0
+- r-rcolorbrewer
+- r-rsconnect
+- r-scatterplot3d
+- r-shiny >=1.7.0
+- r-shinycssloaders
+- r-shinyjs
+- r-viridislite
+- r-yaml
+license: AGPL-3.0
+license_family: AGPL
+size: 3448797
+timestamp: 1784579537432
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
+md5: 1d38994c8bfe421d621d9b3705c37b58
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-jose
+- r-jsonlite
+- r-openssl
+- r-rcpptoml
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76170
+timestamp: 1772133448445
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
+sha256: e0425d3fc2508397001a828f83de7b9057b26bf674f3ad031154c6d3ff737010
+md5: 6df66556d9813139f613a3d5d80aefa3
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 57378
+timestamp: 1774682311091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
+sha256: 72aaa65e6c8aecf46e62493fd569d756ad5f655dfc35e8b65fb32f903e42fac3
+md5: 896cc6b4f51281019f0112a291f2e4b0
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 326784
+timestamp: 1779038275497
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.7-r45h1ddd0e6_2.conda
+sha256: 683aecd70c89afc99c9d1a5358502091d58c5515637839a174170b5270864473
+md5: f70959e59600d520abb4fc5eff09b6b7
+depends:
+- icu >=78.2,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: FOSS
+license_family: OTHER
+size: 948766
+timestamp: 1772037526007
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+sha256: dea2a7676dd03ed93fa0ec961883c5075c361c8522659a1bc1e6b5c16525cb24
+md5: 8db438d8aa370726ee1ce8bf458f2e6d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 319328
+timestamp: 1762269757617
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sys-3.4.3-r45h0557e7b_1.conda
+sha256: 2615aa5617553d22835183a060a13b19a7fd6b006d5570d3dc7d4d0a9a18ffd1
+md5: 902062b1b024b2cf50bcebbdc3f14a33
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 51531
+timestamp: 1757441776397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.1-r45h0557e7b_0.conda
+sha256: 9ef8d3a7e5862ffe7921129d77c0e640eed11233c8c93c03ebbd38c5a7bdfc9b
+md5: 672f703f5dba8c08fe08bd5d6d462b81
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 591468
+timestamp: 1768139158745
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.2-r45h08b74da_0.conda
+sha256: cdceeab30bdc7648b9b037f884d91fafff5e3663b87a72cf9d6c4ee6e68e86d1
+md5: 0757fb6415a03dd46697bcbc836562b0
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127523
+timestamp: 1766142060375
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+sha256: fca09d6b9940f1e1cda0425a0f55716bba202d6f55d6bd25fedec391006c7dc7
+md5: 15aa0f323385403fe182e46a1d095e1b
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 220192
+timestamp: 1757475791328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+sha256: 1fad4d08756ca2d7db04cfaf88e9df797da95a5f7f4b8aabc165eee36faddafc
+md5: 5ee226c1449c66d1cd2399d942faa04d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.48
+license: MIT
+license_family: MIT
+size: 158240
+timestamp: 1782203211628
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tsp-1.2.7-r45hf488e41_0.conda
+sha256: 76b17a4cb143f1441fd91b78d1e05d537dc3fb21ae4c2b0a8247f032f249249d
+md5: d266cd3851cb11b2f619c80ff9adf6f5
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-foreach
+license: GPL-3.0-only
+license_family: GPL3
+size: 737125
+timestamp: 1774391402905
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r45h0557e7b_1.conda
+sha256: c98cdf9a46680cf5e415e37c037cab774b8df2b9b3182f15ece4d740fc0c697b
+md5: a526af0f22a5ac7a3835f1710b63e5b5
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 152455
+timestamp: 1757424718278
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.7.3-r45h08b74da_0.conda
+sha256: 10235170aad63b8412ce99dd1756d250175cf5a3ea987379fea98f0bd9224e82
+md5: f43335c24a9f3fd0920d2a9e721f2845
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1854267
+timestamp: 1775898029394
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vegan-2.7_5-r45ha2e3c6d_0.conda
+sha256: f114cf641e03f2d087d55b37f0826910bdd1e6481c1b18dbcf5d343b84178435
+md5: 5da6b73699a8bb6b0d8f60a9419983e8
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+- r-lattice
+- r-mass
+- r-mgcv
+- r-permute >=0.9_0
+license: GPL-2.0-only
+license_family: GPL2
+size: 3050073
+timestamp: 1779956718513
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+sha256: 859729e8cd04bb92ec144b21a8abfdb2bec9cbac9deaa41ba0cc2add13d088a0
+md5: e605ce527e381c5577d57649e393cb87
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4508304
+timestamp: 1757669044129
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+sha256: 884896b59133b948646b0d1441106120f7b320e9fac827ccb9d44bbe80dda8f2
+md5: e841095941c40142bdad834299b95a30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=1.0.1
+- r-gridextra
+- r-viridislite >=0.4.0
+license: MIT
+license_family: MIT
+size: 2988605
+timestamp: 1757516440048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+sha256: b9ec9606562f0f6bdefc237bbc6163eb1cb022f9d699c80771bc84af0ae37269
+md5: bcadc0a3726e2191e51449f67fa5e0a9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1305542
+timestamp: 1770191459321
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+sha256: e79e366895dfdf79fe92986fe42d0695e3fcacc25411506c48b9db92742eb99c
+md5: e021e3d936f57ea9b35eb099999d6800
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-callr
+- r-jsonlite
+- r-magrittr
+license: GPL-2.0-only
+license_family: GPL2
+size: 206060
+timestamp: 1757520337073
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+sha256: 56f318c90bfc74f01339c83f0e1d0817c1b762ea46cd9e527fec9dcf244c5900
+md5: 388d25e67f93a5fec2aebe56d6a0a1d9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 235287
+timestamp: 1781856624720
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-xfun-0.60-r45hf488e41_0.conda
+sha256: adde9f62c5c7a48edd241547d778f4ff6016970ac4334f34977032394088f12f
+md5: ec03ae90ca44079179679287542be5af
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 651144
+timestamp: 1784103302558
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+sha256: 972923364cfd616ccf38768477c435677cfe1ea18a72016f90344ea920e4fea5
+md5: e18fda0821f0fdc1c34276c5e0acdc92
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL (>= 2)
+license_family: GPL3
+size: 744345
+timestamp: 1771859982217
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-yaml-2.3.12-r45h0557e7b_0.conda
+sha256: 85b3323f76adf8862ad3a52b42270425309a875983da261faa738ed9f7e52586
+md5: 9885e008c928a67e48cd521a98f666d4
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 128431
+timestamp: 1765372892689
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+sha256: fe695f9d215e9a2e3dd0ca7f56435ab4df24f5504b83865e3d295df36e88d216
+md5: 3d49cad61f829f4f0e0611547a9cda12
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 357597
+timestamp: 1765815673644
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+sha256: 7b2d9835a79bd67c0b2966cedf246c85bf650dc961125c8e31f073646d4ac797
+md5: 59f2c90c66b956d9bc3e625df3ad8a0a
+depends:
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 288685
+timestamp: 1776861726084
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+sha256: 1bd2db6b2e451247bab103e4a0128cf6c7595dd72cb26d70f7fadd9edd1d1bc3
+md5: fdf07ab944a222ff28c754914fdb0740
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-aarch64 4.18.0 h05a177a_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 23644746
+timestamp: 1765578629426
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+build_number: 103
+sha256: cd51fbda051a9f3679d10ef4a94cd1ff38c10533b82845dadce8ba87245ba4ce
+md5: 89e78452e06563964e419059ee45584a
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3683040
+timestamp: 1784229053797
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h5f05d98_8.conda
+sha256: 06e25e5026e0058a085be2cbcc55e7ef8cda1263c15bc7e72525c0eb8bb44d5e
+md5: 40266bd074925af4a396250d222d2188
+depends:
+- tk
+- libgcc >=14
+- tk >=8.6.13,<8.7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 106646
+timestamp: 1773733124596
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+sha256: 720691eb59b86f11ceb21b236b9402d59c47d156183375d2b24c53a201dd874b
+md5: 6dc4b55fc391a3d51ff12a6fed979562
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 40249
+timestamp: 1779439555623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+sha256: a2ba1864403c7eb4194dacbfe2777acf3d596feae43aada8d1b478617ce45031
+md5: c8d8ec3e00cd0fd8a231789b91a7c5b7
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 60433
+timestamp: 1734229908988
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+sha256: b86a819cd16f90c01d9d81892155126d01555a20dabd5f3091da59d6309afd0a
+md5: 2d1409c50882819cb1af2de82e2b7208
+depends:
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 28701
+timestamp: 1741897678254
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+sha256: cf886160e2ff580d77f7eb8ec1a77c41c2c5b05343e329bc35f0ddf40b8d92ab
+md5: 22dd10425ef181e80e130db50675d615
+depends:
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 869058
+timestamp: 1770819244991
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+sha256: e9f6e931feeb2f40e1fdbafe41d3b665f1ab6cb39c5880a1fcf9f79a3f3c84a5
+md5: 1c246e1105000c3660558459e2fd6d43
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 16317
+timestamp: 1762977521691
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+sha256: 128d72f36bcc8d2b4cdbec07507542e437c7d67f677b7d77b71ed9eeac7d6df1
+md5: bff06dcde4a707339d66d45d96ceb2e2
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 21039
+timestamp: 1762979038025
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+sha256: db2188bc0d844d4e9747bac7f6c1d067e390bd769c5ad897c93f1df759dc5dba
+md5: fb42b683034619915863d68dd9df03a3
+depends:
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+license: MIT
+license_family: MIT
+size: 52409
+timestamp: 1769446753771
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+sha256: ffd77ee860c9635a28cfda46163dcfe9224dc6248c62404c544ae6b564a0be1f
+md5: ae2c2dd0e2d38d249887727db2af960e
+depends:
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 33649
+timestamp: 1734229123157
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+sha256: 7c109792b60720809a580612aba7f8eb2a0bd425b9fc078748a9d6ffc97cbfa8
+md5: a9e4852c8e0b68ee783e7240030b696f
+depends:
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.9,<2.0a0
+license: MIT
+license_family: MIT
+size: 384752
+timestamp: 1731860572314
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+sha256: 569990cf12e46f9df540275146da567d9c618c1e9c7a0bc9d9cfefadaed20b75
+md5: c3655f82dcea2aa179b291e7099c1fcc
+depends:
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 614429
+timestamp: 1764777145593

--- a/modules/nf-core/shinyngs/app/environment.yml
+++ b/modules/nf-core/shinyngs/app/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=2.4.0
+  - bioconda::r-shinyngs=3.1.1

--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -13,9 +13,9 @@ process SHINYNGS_APP {
     // Those values must then be set in your Nextflow secrets.
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d7/d782b4f11adf8f3cad6af74ea585468decd873a171da1dae0e4a24a82bb29020/data' :
-        'community.wave.seqera.io/library/r-shinyngs:2.4.0--709fc6932be670a5' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d'}"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)    // Experiment-level info

--- a/modules/nf-core/shinyngs/app/meta.yml
+++ b/modules/nf-core/shinyngs/app/meta.yml
@@ -1,6 +1,5 @@
 name: "shinyngs_app"
-description: build and deploy Shiny apps for interactively mining differential abundance
-  data
+description: build and deploy Shiny apps for interactively mining differential abundance data
 keywords:
   - differential
   - expression
@@ -8,8 +7,7 @@ keywords:
   - deseq2
 tools:
   - "shinyngs":
-      description: "Provides Shiny applications for various array and NGS applications.
-        Currently very RNA-seq centric, with plans for expansion."
+      description: "Provides Shiny applications for various array and NGS applications. Currently very RNA-seq centric, with plans for expansion."
       homepage: "https://github.com/pinin4fjords/shinyngs"
       documentation: "https://rawgit.com/pinin4fjords/shinyngs/master/vignettes/shinyngs.html"
       tool_dev_url: "https://github.com/pinin4fjords/shinyngs"
@@ -102,3 +100,27 @@ authors:
   - "@pinin4fjords"
 maintainers:
   - "@pinin4fjords"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d
+      build_id: bd-b5595b301bfbfd4d_2
+      scan_id: sc-73b4cbdd1930464e_1
+    linux/arm64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--4d71a4d10942e43f
+      build_id: bd-4d71a4d10942e43f_2
+      scan_id: sc-72596f6b93ff3200_1
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--791778d7e2758322
+      build_id: bd-791778d7e2758322_2
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--60831a2d7cd7ae94
+      build_id: bd-60831a2d7cd7ae94_2
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6fff209824ab2042c6f09b68d257d59ae4e0ea7410dad923089db9c5c0dbd683/data
+  conda:
+    linux/amd64:
+      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+    linux/arm64:
+      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt

--- a/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
@@ -8,55 +8,55 @@
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:21:39.140663074",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:46:04.599962"
     },
     "mouse - multi matrix": {
         "content": [
             "data.rds",
-            "app.R:md5,bedcfc45b6cdcc2b8fe3627987e2b17a",
+            "app.R:md5,2706f3949cd8e1ab20ef8021a58f8e84",
             {
                 "versions_shinyngs": [
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:21:09.728388372",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:43:56.866763"
     },
     "mouse - single matrix": {
         "content": [
             "data.rds",
-            "app.R:md5,bedcfc45b6cdcc2b8fe3627987e2b17a",
+            "app.R:md5,2706f3949cd8e1ab20ef8021a58f8e84",
             {
                 "versions_shinyngs": [
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:21:26.989003371",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:45:19.325048"
     }
 }

--- a/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+++ b/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
@@ -1,0 +1,3302 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-64:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-biobase-2.70.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-delayedarray-0.36.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-genomicranges-1.62.1-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-iranges-2.44.0-r45h01b2380_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-limma-3.66.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4arrays-1.10.1-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4vectors-0.48.0-r45h01b2380_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-sparsearray-1.10.8-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-xvector-0.50.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.2.0-h281d09f_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-askpass-1.2.1-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.5.3-h502d0c9_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base64enc-0.1_6-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-beeswarm-0.4.0-r45h54b55ab_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cachem-1.1.0-r45h54b55ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.6-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.2-r45heaba542_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-commonmark-2.0.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-curl-7.1.0-r45h10955f1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.18.4-r45h1c8cec4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.39-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.2.1-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.7-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r45h3697838_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fastmap-1.2.0-r45h3697838_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fs-2.1.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.1-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-hexbin-1.28.5-r45heaba542_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-htmltools-0.5.9-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-httpuv-1.6.17-r45h6d565e7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.3.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-jsonlite-2.0.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-later-1.4.8-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_9-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lazyeval-0.2.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.5-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_66-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.7_5-r45h0e4624f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_4-r45h0e4624f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mime-0.13-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_170-r45heaba542_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-openssl-2.4.2-r45h68c19f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ps-1.9.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.2.2-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-qap-0.1_2-r45heaba542_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rappdirs-0.3.4-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.1.2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpptoml-0.2.3-r45h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-renv-1.2.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.5-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.3.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-s7-0.2.2-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sass-0.4.10-r45h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-seriation-1.5.8-r45heaba542_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.7-r45h3d52c89_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sys-3.4.3-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.1-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tsp-1.2.7-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.7.3-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vegan-2.7_5-r45h11cdb10_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xfun-0.60-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-yaml-2.3.12-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+md5: a9f577daf3de00bca7c3c76c0ecbd1de
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28948
+timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+depends:
+- ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+- sysroot_linux-64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 3713752
+timestamp: 1784214522814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+sha256: 08d7238663fc408ba2ab60b02fa3d06a7ca9d872962e03e90c7e0fdecb7ed1d0
+md5: 32fd07abe84eb14f17c7f5cc6fa8df82
+depends:
+- binutils_impl_linux-64 2.46.1 default_hfdba357_102
+license: GPL-3.0-only
+license_family: GPL
+size: 36337
+timestamp: 1784214551894
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-biobase-2.70.0-r45h01b2380_0.conda
+sha256: d23fb8b3abab1d8241a9172fc1a4ca586c31d18cb2c4fb5152c53a6cd659777a
+md5: 782edae8ecb3df45c26652d215977957
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2355711
+timestamp: 1770509543214
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+sha256: 97221eda3007381c0a6498608baaebdcec6047f7f26b121c19149fd56aabf032
+md5: 27556377d159490ea87696727ae41808
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-generics
+license: Artistic-2.0
+size: 653523
+timestamp: 1770415244399
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-delayedarray-0.36.0-r45h01b2380_0.conda
+sha256: 1f1fd7027ffffebeaca5c416f05d91bcd3a05cf1d043ee347fffbcdde6978c01
+md5: 8a5b2ea0550afcb925ff5f267ff741ea
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-sparsearray >=1.10.0,<1.11.0
+- bioconductor-sparsearray >=1.10.8,<1.11.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 2204619
+timestamp: 1772123650559
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-genomicranges-1.62.1-r45h01b2380_0.conda
+sha256: 0d5ea1e661e10cfeecf763a7466efebc616ca55a2c9f6ce33cbe41c7eb1a0a4b
+md5: 5dd6ca03e419938e6e4e3bc6b7796b45
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2306994
+timestamp: 1772108656670
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-iranges-2.44.0-r45h01b2380_1.conda
+sha256: 964697eeaeb946ecfe076f3b43eec9bafa018ef21d2dc3555d6c28ca817e4d79
+md5: d6811165f0b3db78b08fdc2c4938bc4e
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2344215
+timestamp: 1770546527540
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-limma-3.66.0-r45h01b2380_0.conda
+sha256: c8dcbf3abfc0c1cf4ff6e68c828e0c59052c2b65dd3dd15aa1d39dbca679991e
+md5: 54dbec67b82ef291760cb0c2927c5002
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-statmod
+license: GPL-2.0-or-later
+size: 3099884
+timestamp: 1770417840293
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+sha256: 169809ca754b2c07f7356f1fc4f365b7d5154fd66229543584f69008fa347c5a
+md5: cdf0406fc3caa814ff7b7876a42973a5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-matrixstats >=1.4.1
+license: Artistic-2.0
+size: 449898
+timestamp: 1770417102301
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4arrays-1.10.1-r45h01b2380_0.conda
+sha256: 0b8729dc75999ab80ff333242f1052de1642f2f5653d344c06a652143b1326bd
+md5: 0b2ad083cc4002a36926c7c31be1c5c8
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-abind
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1027424
+timestamp: 1770628251018
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4vectors-0.48.0-r45h01b2380_1.conda
+sha256: d6ffd7388683d03ab6133a3f8efdb69d917718a54c3d08b744c1b4910b876e82
+md5: db7c8f69c137a9a97a11518ce59ca149
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2061150
+timestamp: 1770508921246
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+sha256: 875f5be76bc3b83766ec0cfacf888570d529907412519a537c5f7a318e489976
+md5: cfe7c256532f9a4fc87ec3be955bb9e6
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 598298
+timestamp: 1770628899171
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-sparsearray-1.10.8-r45h01b2380_0.conda
+sha256: 7f1f2c6012e51daa1d5ea291b7928e396763dd073ebef228f2352118d4287096
+md5: 2b73e1653c675b4ba118bb085862771c
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-xvector >=0.50.0,<0.51.0
+- bioconductor-xvector >=0.50.0,<0.51.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-matrixstats
+license: Artistic-2.0
+size: 1636745
+timestamp: 1772107896548
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+sha256: b8ade9f2ab8cc2835357653f5a9bc840323c05f7656659dfb40d20e5623f8ebd
+md5: 74eb95090e807c18f5bc81cb9fb39b3c
+depends:
+- bioconductor-biobase >=2.70.0,<2.71.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-delayedarray >=0.36.0,<0.37.0
+- bioconductor-genomicranges >=1.62.0,<1.63.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1416452
+timestamp: 1772218138703
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-xvector-0.50.0-r45h01b2380_0.conda
+sha256: c0921f72138df07e69bdae7c16cc1b35deebfaf0fa93e16dfa731838a6c358b7
+md5: ec982ddb97e04a6b40454395fd2dd229
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 641687
+timestamp: 1770628594641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+sha256: c88dd33c89b33409ebcd558d78fdc66a63c18f8b06e04d170668ffb6c8ecfabd
+md5: 983b92277d78c0d0ec498e460caa0e6d
+depends:
+- tk
+license: TCL
+size: 129594
+timestamp: 1750261567920
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+md5: d2ffd7602c02f2b316fd921d39876885
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 260182
+timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+sha256: dee93a82d045f9aa8277829aa465224afa3c7a6ac18388de66099b2be7f705e7
+md5: 6130ad6705adc993b5d8482b7f66e01f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 210929
+timestamp: 1784091008551
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+md5: a9965dd99f683c5f444428f896635716
+depends:
+- __unix
+license: ISC
+size: 128866
+timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
+md5: bb6c4808bfa69d6f7f6b07e5846ced37
+depends:
+- __glibc >=2.17,<3.0.a0
+- fontconfig >=2.15.0,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.1,<79.0a0
+- libexpat >=2.7.3,<3.0a0
+- libfreetype >=2.14.1
+- libfreetype6 >=2.14.1
+- libgcc >=14
+- libglib >=2.86.3,<3.0a0
+- libpng >=1.6.53,<1.7.0a0
+- libstdcxx >=14
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 989514
+timestamp: 1766415934926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
+sha256: ae0b83efb7545ea40845253b76bbfeb12349bd32001728b8f58d726cd532d467
+md5: d09779693563f4a1a0bdb0f715ba2bf0
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 hae6b9f4_2
+- libgcc >=14
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 194776
+timestamp: 1782911792708
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
+md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 281880
+timestamp: 1780450077431
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
+md5: 8462b5322567212beeb025f3519fb3e2
+depends:
+- libfreetype 2.14.3 ha770c72_0
+- libfreetype6 2.14.3 h73754d4_0
+license: GPL-2.0-only OR FTL
+size: 173839
+timestamp: 1774298173462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
+md5: f9f81ea472684d75b9dd8d0b328cf655
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 61244
+timestamp: 1757438574066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+sha256: a48400ec4b73369c1c59babe4ad35821b63a88bba0ec40a80cea5f8c53a26b83
+md5: e3be72048d3c4a78b8e27ec48ba06252
+depends:
+- binutils_impl_linux-64 >=2.45
+- libgcc >=15.2.0
+- libgcc-devel_linux-64 15.2.0 hcc6f6b0_119
+- libgomp >=15.2.0
+- libsanitizer 15.2.0 h90f66d4_19
+- libstdcxx >=15.2.0
+- libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 81180457
+timestamp: 1778269124617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+sha256: b24b13d467898a9b9a17a868a2686412a98f8935dc7cc51547dd90645d4e8436
+md5: 28bc49875f9c38e2401696b3e48d0798
+depends:
+- gcc_impl_linux-64 15.2.0.*
+- binutils_linux-64
+- sysroot_linux-64
+license: BSD-3-Clause
+license_family: BSD
+size: 29330
+timestamp: 1781279944230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.2.0-h281d09f_19.conda
+sha256: 2f6a962bfcb74b8262dc0af5cf0716acbd96f769a0443dd231d1041c222b0ca6
+md5: 5d4fdb7935b8aa1cdb2e22ef8958101e
+depends:
+- gcc_impl_linux-64 >=15.2.0
+- libgcc >=15.2.0
+- libgfortran5 >=15.2.0
+- libstdcxx >=15.2.0
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 20041854
+timestamp: 1778269291096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
+md5: cf09e9fc938518e91d0706572cadf17a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 100054
+timestamp: 1780454302233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+sha256: 132a918b676dd1f533d7c6f95e567abf7081a6ea3251c3280de35ef600e0da87
+md5: fec079ba39c9cca093bf4c00001825de
+depends:
+- libblas >=3.8.0,<4.0a0
+- libcblas >=3.8.0,<4.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3376423
+timestamp: 1626369596591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+sha256: 3f5288346b9fe233352443b3c2e31f1fde845e39d3e96475fc05ec2e782af158
+md5: 9d41f3899b512199af0a4bb939b83e21
+depends:
+- gcc_impl_linux-64 15.2.0 he0086c7_19
+- libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+- sysroot_linux-64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16356816
+timestamp: 1778269332159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
+sha256: f78da7a8b49943a6ce48372a5bc85ab741ac86666f1040e8876545065ec1096e
+md5: 5e194579a5f72c70102f342aa362f5f9
+depends:
+- gxx_impl_linux-64 15.2.0.*
+- gcc_linux-64 ==15.2.0 h7be306e_27
+- binutils_linux-64
+- sysroot_linux-64
+license: BSD-3-Clause
+license_family: BSD
+size: 27848
+timestamp: 1781279944230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
+md5: 72e956a71241633d8c80aa198fd08784
+depends:
+- libharfbuzz-devel 14.2.1 h17a8019_1
+license: MIT
+license_family: MIT
+size: 11039
+timestamp: 1782800611635
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+md5: c80d8a3b84358cb967fa81e7075fbc8a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 12723451
+timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+md5: 86d9cba083cd041bfbf242a01a7a1999
+constrains:
+- sysroot_linux-64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1278712
+timestamp: 1765578681495
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+md5: b38117a3c920364aff79f870c984b4a3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 134088
+timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+depends:
+- __glibc >=2.17,<3.0.a0
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1388990
+timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+md5: 449500f2c089da11c40f5c21312e3e07
+depends:
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 745303
+timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
+md5: a752488c68f2e7c456bcbd8f16eec275
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 261513
+timestamp: 1773113328888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+build_number: 8
+sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+md5: 00fc660ab1b2f5ca07e92b4900d10c79
+depends:
+- libopenblas >=0.3.33,<0.3.34.0a0
+- libopenblas >=0.3.33,<1.0a0
+constrains:
+- blas 2.308   openblas
+- mkl <2027
+- libcblas   3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18804
+timestamp: 1779859100675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+build_number: 8
+sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+md5: 33a413f1095f8325e5c30fde3b0d2445
+depends:
+- libblas 3.11.0 8_h4a7cf45_openblas
+constrains:
+- blas 2.308   openblas
+- liblapacke 3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18778
+timestamp: 1779859107964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
+md5: f9c59d277a16ec8f272b2d5dd2ec3335
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 480327
+timestamp: 1782911787190
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+md5: 6c77a605a7a689d17d4819c0f8ac9a00
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 73490
+timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+depends:
+- ncurses
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 134676
+timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+md5: 172bf1cd1ff8629f2b1179945ed45055
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 112766
+timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+md5: b24d3c612f71e7aa74158d92106318b2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77856
+timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+md5: a360c33a5abe61c07959e449fa1453eb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 58592
+timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
+md5: e289f3d17880e44b633ba911d57a321b
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8049
+timestamp: 1774298163029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
+md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 384575
+timestamp: 1774298162622
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+constrains:
+- libgcc-ng ==15.2.0=*_19
+- libgomp 15.2.0 he0feb66_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1041084
+timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+sha256: 38a557eba305468ac1f90ac85e50d8defd76141cb0b8a43b2fc1aca71dd5d5f2
+md5: 683fcb168e1df9a21fa80d5aa2d9330b
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 3095909
+timestamp: 1778268932148
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+md5: 331ee9b72b9dff570d56b1302c5ab37d
+depends:
+- libgcc 15.2.0 he0feb66_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27694
+timestamp: 1778269016987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
+md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
+depends:
+- libgfortran5 15.2.0 h68bc16d_19
+constrains:
+- libgfortran-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27655
+timestamp: 1778269042954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
+md5: 85072b0ad177c966294f129b7c04a2d5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15.2.0
+constrains:
+- libgfortran 15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2483673
+timestamp: 1778269025089
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
+md5: 889febc66cd9e4190f80ef9718fa239b
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libiconv >=1.18,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- libffi >=3.5.2,<3.6.0a0
+- pcre2 >=10.47,<10.48.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4754220
+timestamp: 1782463895250
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+md5: faac990cb7aedc7f3a2224f2c9b0c26c
+depends:
+- __glibc >=2.17,<3.0.a0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 603817
+timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+md5: fb4669c3990b94ea32fbb81f433e9aa6
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1297668
+timestamp: 1782800580119
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+md5: 99cf21100441e51272f1cd6fe0632a20
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libharfbuzz 14.2.1 h17a8019_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1970690
+timestamp: 1782800603897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+md5: 915f5995e94f60e9a4826e0b0920ee88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-only
+size: 790176
+timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+sha256: 716332fd31b3808da7a4235a05212a9e9da05e854864c3def2dea0b5d2bf7610
+md5: 466badda5536d85ddc63ee9404f29735
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 652868
+timestamp: 1783731886811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+build_number: 8
+sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+md5: 809be8ba8712c77bc7d44c2d99390dc4
+depends:
+- libblas 3.11.0 8_h4a7cf45_openblas
+constrains:
+- blas 2.308   openblas
+- libcblas   3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18790
+timestamp: 1779859115086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+md5: b88d90cad08e6bc8ad540cb310a761fb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 113478
+timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+md5: 2a45e7f8af083626f009645a6481f12d
+depends:
+- __glibc >=2.17,<3.0.a0
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 663344
+timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
+md5: 2d3278b721e40468295ca755c3b84070
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.33,<0.3.34.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5931919
+timestamp: 1776993658641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+md5: eba48a68a1a2b9d3c0d9511548db85db
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 317729
+timestamp: 1776315175087
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+sha256: 71118885feab91c61bea4e9532ec46e0653b24f02e563681f822915aee8435bb
+md5: af5ddfb52ad25d833c70c7511478d4eb
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 70092
+timestamp: 1783936855082
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+sha256: 7a58892a52739ce4c0f7109de9e91b4353104748eb04fc6441d88e8af444ba99
+md5: 67eef12ce33f7ff99900c212d7076fc2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15.2.0
+- libstdcxx >=15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7930689
+timestamp: 1778269054623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+md5: eecce068c7e4eddeb169591baac20ac4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 304790
+timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+md5: 5794b3bdc38177caf969dabd3af08549
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc 15.2.0 he0feb66_19
+constrains:
+- libstdcxx-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 5852044
+timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+sha256: a2385f3611d5cd25378f9cf2367183320731709c067ddd08d43330d3170f15b8
+md5: bcfe7eae40158c3e355d2f9d3ed41230
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 20765069
+timestamp: 1778268963689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
+md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
+depends:
+- __glibc >=2.17,<3.0.a0
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 452337
+timestamp: 1783084902636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+md5: 01bb81d12c957de066ea7362007df642
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-3-Clause
+license_family: BSD
+size: 40017
+timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+sha256: e28e4519223f78b3163599ca89c3f2d80bfb53e907e7fc74e806e60d1efa578b
+md5: 4e33d49bf4fc853855a3b00643aa5484
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 419935
+timestamp: 1779396012261
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+md5: aea31d2e5b1091feca96fcfe945c3cf9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 429011
+timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+md5: 92ed62436b625154323d40d5f2f11dd7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- pthread-stubs
+- xorg-libxau >=1.0.11,<2.0a0
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 395888
+timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+md5: d87ff7921124eccd67248aa483c23fec
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- zlib 1.3.2 *_2
+license: Zlib
+license_family: Other
+size: 63629
+timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+sha256: d652c7bd4d3b6f82b0f6d063b0d8df6f54cc47531092d7ff008e780f3261bdda
+md5: 33405d2a66b1411db9f7242c8b97c9e7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 513088
+timestamp: 1727801714848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+md5: fc21868a1a5aacc937e7a18747acb8a5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 918956
+timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+md5: 79dd2074b5cd5c5c6b2930514a11e22d
+depends:
+- __glibc >=2.17,<3.0.a0
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3159683
+timestamp: 1781069855778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+sha256: 2f17a165a04833bd249215336b00df912bad7f03ae445a36765b47593df34057
+md5: a4b80dd6e9e0784ba48e6803bef1e17a
+license: GPL-2.0-or-later
+license_family: GPL
+size: 22516793
+timestamp: 1780595446569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
+md5: d53ffc0edc8eabf4253508008493c5bc
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.17.1,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- harfbuzz >=13.2.1
+- libexpat >=2.7.4,<3.0a0
+- libfreetype >=2.14.2
+- libfreetype6 >=2.14.2
+- libgcc >=14
+- libglib >=2.86.4,<3.0a0
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 458036
+timestamp: 1774281947855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+md5: 7a3bff861a6583f1889021facefc08b1
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1222481
+timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+sha256: 9e5b5be056820ade8b09ef73cf9f4bea037eb9887145d0297ac99e0add88878d
+md5: 7cd77fef4da3e1ca9484394616cb71f1
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 376220
+timestamp: 1784286827180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+sha256: 4ce2e1ee31a6217998f78c31ce7dc0a3e0557d9238b51d49dd20c52d467a126d
+md5: f2c23a77b25efcad57d377b34bd84941
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 593603
+timestamp: 1769710381284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+md5: b3c17d95b5a10c6e64a21fa17573e70e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 8252
+timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+sha256: 5055913d786b82f33a14f493f32945b3b2b5d528ea2f52856ca02b296f6511eb
+md5: dde4691fe168112a90efba6aaa08f13d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: LGPL (>= 2)
+license_family: LGPL
+size: 82526
+timestamp: 1757460261392
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-askpass-1.2.1-r45h54b55ab_1.conda
+sha256: 5c4d2bcc1beba7703acbfe1610a846ce2a4010456714705dfa63989cee722a00
+md5: 1ae3c72e90c6a3871c594448d3e152e4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-sys >=2.1
+license: MIT
+license_family: MIT
+size: 31983
+timestamp: 1758383536121
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+sha256: 90e7ae8aa427274d7d2e510060b68925e60e897ecaa5ea135bb33afa7eb12134
+md5: b5291c60f52b43108a2973ba6f5885d1
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 72543
+timestamp: 1757447376176
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.5.3-h502d0c9_3.conda
+sha256: e6fa14f597334a5178e5ea0ce2290e1bcb5d165d36f6dbcf41a516cba3176dff
+md5: 8e584ef995c58d546ca1b2642fa4deae
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.18.4,<2.0a0
+- curl
+- gcc_linux-64 >=14
+- gfortran_impl_linux-64
+- gsl >=2.7,<2.8.0a0
+- gxx_linux-64 >=14
+- icu >=78.3,<79.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libglib >=2.88.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- make
+- pango >=1.56.4,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- readline >=8.3,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- tzdata >=2024a
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxt >=1.3.1,<2.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 27369225
+timestamp: 1781522577217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base64enc-0.1_6-r45h54b55ab_0.conda
+sha256: 7a3751a340766ee25380a51df70c8356a64cfeb6ac3d982a86e92eb99fec2943
+md5: e573dc135976197e7f819eec202c93f1
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 48616
+timestamp: 1770027796335
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-beeswarm-0.4.0-r45h54b55ab_5.conda
+sha256: 0b1e86ec24e2acc3eae1020cc5b19f9f7e172df8871b4f042fbca11d0fc2e0a6
+md5: 787c18b3e1532606bf796a360cf2ea39
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 89369
+timestamp: 1757583631217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+sha256: 177f262fda25552b8ce3e7685220deefba1625314575a892cd4abca06ddf06a4
+md5: f1b6b9a4e77b21df8a6949102db4f468
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 644936
+timestamp: 1763112090227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+sha256: fafc7a0acb8fc595b8fd89e75ec0b1d7d5af71b2b493570fa05e1f5612d299c2
+md5: dae60c429ab933e549832bc223e95639
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-cachem
+- r-htmltools >=0.5.7
+- r-jquerylib >=0.1.3
+- r-jsonlite
+- r-lifecycle
+- r-memoise >=2.0.1
+- r-mime
+- r-rlang
+- r-sass >=0.4.0
+license: MIT
+license_family: MIT
+size: 5538377
+timestamp: 1778923739710
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+sha256: 20dd6e4aa94d2d5ea97419add6bcac50f81400d297e9933659ff35da41fe2f6d
+md5: c922b0a6584376d3587d8cb3670f5cac
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 256017
+timestamp: 1757560386979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cachem-1.1.0-r45h54b55ab_2.conda
+sha256: 75a21c955abf03fa1804d47c94f5091cd772b614e074b63b02347a23f5649a53
+md5: 42617e710293f0b76ccc08855e0edbc4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fastmap
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76879
+timestamp: 1757441544326
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+sha256: f9f49b2b845f279af84a33c8af19a915b2731c0bd892c608205cbad8a34f423d
+md5: a5cc8a8d0dc08dc769c65a13b3573739
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-processx >=3.4.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 454090
+timestamp: 1757475635573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.6-r45h3697838_0.conda
+sha256: a894e558a680a31444090de217b73f8fc06a3f4c07746d2cde4b6f86acdae0b1
+md5: ed8dcbbe9d66e9093ba58891e3b6065a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1323795
+timestamp: 1775733704549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.2-r45heaba542_0.conda
+sha256: 521cb81e41e3a63717ec7cf317598b8a793969e60c57328b7d382bfea4178b5d
+md5: 421758eee50879a9a7ff122543e38e14
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 592267
+timestamp: 1770285739523
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+sha256: aec327dd836824278a2adf006f426a58d834828de74de7f8348f2f5f068de702
+md5: 8e9e5b14f74a6040c77e0b9c8bfa84ca
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 109200
+timestamp: 1757452164030
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_3-r45h54b55ab_0.conda
+sha256: 16bbbc7347aaee2c73d132584711f42cf612de501197e154385247818018b7a0
+md5: 472eadbb95c9103963bae1631ec23b0f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2542148
+timestamp: 1784283276786
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-commonmark-2.0.0-r45h54b55ab_1.conda
+sha256: 211423381b2e832619cdb964e7fe3833b09871d0140066ca90fd3e91eb86231b
+md5: 769e161acb18575460780ab99acc454e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 139818
+timestamp: 1757422097696
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+sha256: 5993a1b5c08c78a35cdbcf20376773eb7c4def2d28615e49f96008b43a4c05c0
+md5: 71c68a3993a696b6b75f7a6550b3750f
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 246247
+timestamp: 1778089270609
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+sha256: 9126a0408696133893e674549ca7aef317768dba503765a7ed032616aabe5b49
+md5: 4f111ce078b9690abaad6248b831a370
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 168201
+timestamp: 1757452410374
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+sha256: 217e5e210501b7fa611d6c6c46ae1551f443e2359e27164240da5a1219b2551a
+md5: 523a15023a79bd6f0dcb95ba6756ceed
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.3.6
+- r-jsonlite
+- r-lazyeval
+- r-r6
+license: MIT
+license_family: MIT
+size: 382037
+timestamp: 1757479275516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-curl-7.1.0-r45h10955f1_0.conda
+sha256: f2185d7bb29d869cc0d8e65a1913ab715e4f976666f94c18931cfa6b51b12821
+md5: dbfb442102b495d7bfc9f50321410a42
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 473709
+timestamp: 1777147706848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.18.4-r45h1c8cec4_0.conda
+sha256: fc5c6970d5ebbb92ccb61313efab7160869ae2851e48105e5dfff10f939a4bf6
+md5: 141a897d44a6a63b43dc6c1776ba7136
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MPL-2.0
+license_family: OTHER
+size: 2566399
+timestamp: 1783428409426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+sha256: 1edafb4e01397265da1816f3164a451d36f02546f2589c5f45051886ab9f91a8
+md5: f69bda3cb40132707f6efff4c749ce09
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-magrittr >=1.0.1
+- r-viridis
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4839264
+timestamp: 1757633933010
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.39-r45h3697838_0.conda
+sha256: 33ce40552bc1810252c4445082392638ff2fb883147cf36c3e4017e9b0dc5474
+md5: a0e856537aa7d62a6835e3a528d29517
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 218412
+timestamp: 1763566744987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.2.1-r45h3697838_0.conda
+sha256: 42067805b0742b933de7e1ca4311645797ac687cee6aacd630d9d4c585dfa830
+md5: 7c8e643f764769a184f0d0d06ac0e789
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1445950
+timestamp: 1775207093582
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+sha256: 38eee3a12260e5fff1e2af04250f6b67091b01c694f101ae6448da12c3fcca09
+md5: b78224895a1ad7fb52311ab071c2ec00
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-crosstalk
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httpuv
+- r-jquerylib
+- r-jsonlite >=0.9.16
+- r-magrittr
+- r-promises
+license: GPL-3.0-only
+license_family: GPL3
+size: 1439901
+timestamp: 1757566758266
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+sha256: ec00c0162d803af3c8059e9504d1d0c8b60cabe805c347a4a20300f2cce9e700
+md5: 6ac48e7c4c46b6c0538a779d0a43008a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-gridextra >=2.3
+- r-gtable
+license: GPL-3
+license_family: GPL3
+size: 950098
+timestamp: 1757760318911
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.3-r45h54b55ab_0.conda
+sha256: 19d03273f9d5e1aa41302e1cf080dcb95ced5b955bc978df39eee71a9686a86c
+md5: e43b3e7101a90ac57f58a21da67c99a4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 33411
+timestamp: 1775287239478
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+sha256: d3accfeab1416151515c37e5edc94b18868998db4936183459f8040117d5c83c
+md5: 4e0c71ab78d7292372a89d4daecb49af
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 111914
+timestamp: 1757447684244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.7-r45h54b55ab_0.conda
+sha256: 68dcc5aa6fc4408f9cac5aeaa03a7e6a5d127a949fc72b3fed31fd1af3bbeee5
+md5: 309740f1b6a2d4cb16d395be786c85c5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 329435
+timestamp: 1763566090233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r45h3697838_2.conda
+sha256: 06c5e73ed5c9c15e7ca944e3a5fabfbcabd9f4aec71804404ecf51c56f78fd8f
+md5: 7896efcfd50f8c1f207acce5d4ab1cc0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1429269
+timestamp: 1757441256046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fastmap-1.2.0-r45h3697838_2.conda
+sha256: bfec10cec03b434d9010690c61d43a0be79418f67a0713ce31da207a40e1570c
+md5: 245526991ad3b8a1dc97f2dcb5031065
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 73870
+timestamp: 1757421441326
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+sha256: 865df12d8cdd8cf577abc8f785a0aa4ee50b4f8751256dffe4676a350943d591
+md5: e9fccb3617ec9776569c6496fa254e64
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.1.1
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 1335664
+timestamp: 1757461248044
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+sha256: c95d1e61946bf81128be213dea7a07b5196c6e13caf9c6452c38145da8d2dfb1
+md5: 5abe392c8f8c5b954ebdc5fe46fcc709
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-codetools
+- r-iterators
+license: Apache-2.0
+license_family: APACHE
+size: 140909
+timestamp: 1757490449004
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fs-2.1.0-r45h3697838_0.conda
+sha256: 748304679610fe9f5d078f5b9be7c8693858ff5f66db55e43fb98d0e4e07d375
+md5: 67c48aad5ce921ad990b951a1f194f42
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 243286
+timestamp: 1777152733514
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+sha256: 196d29aa2d809d9115dce27236470219e1057d394654b5d73182f0e9d117f2fa
+md5: 4a667a55fc37e12dcbe510262ca61d19
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 424919
+timestamp: 1757627324320
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+sha256: 88a5cf4bac0a553943996bc930b1ea28f2635c262c1b2c5a42b026b69f227f02
+md5: f19c9493b80f63a41fa017ec3b27bc2e
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 88225
+timestamp: 1757455977192
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+sha256: 20c4ea52e72cb2e50907f9e5a446f16b0fce467fec4edab236eeb3b46890f3dd
+md5: b3a121ed6a71f3b674859ccbb15ad56b
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 67477
+timestamp: 1777325952298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+sha256: f8c0982d1579b810fc24cb702f8922794fce7bdfb9d3bf96867a4b038205b045
+md5: 9be31d2adf526d3c38b78a05333ddf30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-beeswarm
+- r-ggplot2 >=3.3.0
+- r-lifecycle
+- r-vipor
+license: GPL-3.0-or-later
+license_family: GPL3
+size: 1761662
+timestamp: 1764399956063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+sha256: 4e0401174fac5b54f124a8e7e418995a74918e8cd52a456a82db3fc5a373f0e0
+md5: bcdfec44c6bf587e65f56de61334a413
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=0.9.2
+- r-mass
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 221547
+timestamp: 1757758420492
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+sha256: 3a91d5334b7d99bc247386eaf0d331e119852e381e769e266f70df20eab22689
+md5: 866fbbf3f356140922d618f26f2b889c
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-gtable >=0.3.6
+- r-isoband
+- r-lifecycle >=1.0.1
+- r-rlang >=1.1.0
+- r-s7
+- r-scales >=1.4.0
+- r-vctrs >=0.6.0
+- r-withr >=2.5.0
+license: MIT
+license_family: MIT
+size: 7812326
+timestamp: 1776860393567
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.1-r45h54b55ab_0.conda
+sha256: c2760270ffabd95e9d0a0caa9cc705c5a0370ad119ace5495acc043b1a35d198
+md5: 65911c2e9cac35ea0235d3d6d4aa9625
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 171639
+timestamp: 1776413601349
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+sha256: e82d7e308a7e6d3eb90d9ea33d1f56d24bd69804995db2dacd5b20b7a20c34e4
+md5: aad2c473bf6f930833d0dc881811cf62
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-gtable
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 529159
+timestamp: 1782547830828
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+sha256: fcd2601af8213f39af6f720e22c8f858b3451f8e3d93cbc9e6aedb2d6f88483e
+md5: f686123cfba49e6299fae7e029a40266
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-lifecycle
+- r-rlang
+license: MIT
+license_family: MIT
+size: 228864
+timestamp: 1757463478042
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+sha256: 2d26e9b5c0e688cc76d33d81f8f62c59de9dc2f0695fd7b110991fa222db5524
+md5: d0bd1b5a09e5d631b8de31949ea19ece
+depends:
+- r-assertthat
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+- r-dendextend >=1.12.0
+- r-egg
+- r-ggplot2 >=2.2.0
+- r-htmlwidgets
+- r-magrittr >=1.0.1
+- r-plotly >=4.7.1
+- r-rcolorbrewer
+- r-reshape2
+- r-scales
+- r-seriation
+- r-viridis
+- r-webshot
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1693764
+timestamp: 1758426737719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-hexbin-1.28.5-r45heaba542_1.conda
+sha256: d3fa5cfc23220d3e279526a36ebcdc375ed2fc6cd45086248bd64a34c6be43d5
+md5: d622c8377663b5d7bdf5da48069f76cb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-only
+license_family: GPL2
+size: 1594722
+timestamp: 1757483295739
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+sha256: e676112aac0dbfe123fcb3108cce376782211a096c898a3af46fdf32a37e12e9
+md5: 0b5902d6af02a23bda1794d46090db42
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.18
+license: GPL-2.0-or-later
+license_family: GPL
+size: 57308
+timestamp: 1772794436225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-htmltools-0.5.9-r45h3697838_0.conda
+sha256: 1fa1fcdf980d0da17a583e41810da190eb9caf586c3fdf36312d045d9bb812e7
+md5: 2a2297687ae137e7fa90d3c996895e61
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-digest
+- r-ellipsis
+- r-fastmap >=1.1.0
+- r-rlang >=0.4.10
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 367095
+timestamp: 1764860550376
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+sha256: 4c3998ce4b4882429e52eed5c6c53d59056814d8fbc34a41ba79b990fdec1441
+md5: 6f767715f90e7caf17af72959bfcb11e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.7
+- r-jsonlite >=0.9.16
+- r-knitr >=1.8
+- r-rmarkdown
+- r-yaml
+license: MIT
+license_family: MIT
+size: 426023
+timestamp: 1757552859817
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-httpuv-1.6.17-r45h6d565e7_0.conda
+sha256: f0755cf37e28f0e1a142eef051918c90c9e8fece46edb5e40191a7898d8cb217
+md5: 1be1d81542b9c87b4d5197a41dbd0da9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-later >=0.8.0
+- r-promises
+- r-r6
+- r-rcpp >=1.0.7
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 553922
+timestamp: 1773825458255
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+sha256: 4adb565d2b3365108d7efb926c2acdc68c11ef2ad32ed03d1108a3005cf8cdd8
+md5: 259658089c383f2915b167da3e7890aa
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-curl >=0.9.1
+- r-jsonlite
+- r-mime
+- r-openssl >=0.8
+- r-r6
+license: MIT
+license_family: MIT
+size: 474019
+timestamp: 1771005817336
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+sha256: dcc78f60308390c6549e25308fb2437421e8fcaeeb45378b6fbe3a49e3d3cd0b
+md5: b240e3c0e61de35f1f43729f4ea2888e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.0.0
+- r-curl >=5.1.0
+- r-glue
+- r-lifecycle
+- r-magrittr
+- r-openssl
+- r-r6
+- r-rappdirs
+- r-rlang >=1.1.0
+- r-vctrs >=0.6.3
+- r-withr
+license: MIT
+license_family: MIT
+size: 935264
+timestamp: 1784022303810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.3.0-r45h3697838_0.conda
+sha256: a09a6f2f37890560217117463f0722283f8939af945b3e616b9791f2429325b0
+md5: fb538d0b46d6a44aa1ff666b15422ba6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-cpp11
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1657523
+timestamp: 1766530500097
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+sha256: c90d0faa668d2753db9da9458ca085891a3030c6537f5675fe0c1a1b5af2103c
+md5: 7746a41a4cb97cec59db2d5a2cac0701
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 350171
+timestamp: 1757459846270
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+sha256: abb2cd923ed271df8774e696f2e455f8c641532cc984fd770b87852a0017d7ab
+md5: 7113381f500ebcc8a33b61101817d120
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-jsonlite
+- r-openssl >=1.2.1
+license: MIT
+license_family: MIT
+size: 248113
+timestamp: 1776846446837
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+sha256: 3b98f72bb32d4758854805b664b4404602a583da32c9b96026536f5676f41812
+md5: 49a9ed6ed01f4ae6067ead552795bfce
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools
+license: MIT
+license_family: MIT
+size: 307113
+timestamp: 1757459485295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-jsonlite-2.0.0-r45h54b55ab_1.conda
+sha256: bd24c57226192b0decdcddd6fd5fa74db1f29685904e4aff87f2c16eb6493416
+md5: 026c72026f431daf8a5719e09e704faa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 638574
+timestamp: 1757419590757
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+sha256: e2184f1cb58aedacd94d1dbe6e8b5dfa3508151f454e80f6bd49486bdb90625c
+md5: 35b31b96aa7bc052ad6347322a1481f1
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-evaluate >=0.15
+- r-highr >=0.11
+- r-xfun >=0.52
+- r-yaml >=2.1.19
+license: GPL-2.0-or-later
+license_family: GPL
+size: 988526
+timestamp: 1766309267127
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+sha256: 42a06b7c346d6e4550dca1024bbf89e3c22962d568cfe4e8b8be824dea326110
+md5: a41490fdf607381035aa0304c21407c9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 70182
+timestamp: 1757456007088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-later-1.4.8-r45h3697838_0.conda
+sha256: 895f18dfc5a0521c22ad9e38619ea6cf170e38d54aaa4596fb1d0dad7845703b
+md5: a6b2c9882bb1d700f9108bc93c2c12a8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.12.9
+- r-rlang
+license: MIT
+license_family: MIT
+size: 153472
+timestamp: 1772707291964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_9-r45h54b55ab_0.conda
+sha256: ee233422c029d7b341dd05604d133db6f698ec1cdd4ad8690a312d0f7d958793
+md5: 234365e95fa3cf27bd7946f208d1ed0b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1416943
+timestamp: 1770694116947
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lazyeval-0.2.3-r45h54b55ab_0.conda
+sha256: 581fec2d1215b6d7b6d35ce9588271ba4bd89c75b0f131c04a718b79cbe2180f
+md5: 5634c3ee3e3c77f7462047a70ed35321
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang
+license: GPL-3.0-only
+license_family: GPL3
+size: 192307
+timestamp: 1775429492578
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+sha256: b7a4d8d98a96d17d18c80fb7e1c8e6cb09b9bd2542e74d91a7f483afccb30ee6
+md5: 5f8369dfbdff08878e58bf15529fca3a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 132636
+timestamp: 1767865665455
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+sha256: 1f594c5be675a53caef3368ea85c048b8bcbc4385e2bd582e977981a1edd5e3e
+md5: b936b3596737a3a1d513e1258d5d0355
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-commonmark >=2.0.0
+- r-xfun >=0.55
+license: MIT
+license_family: MIT
+size: 392980
+timestamp: 1784144498175
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.5-r45h54b55ab_0.conda
+sha256: 5b09fdee8ef5426082844d17d360756922ba74f9e3c428f501373295a5e9228d
+md5: 2e26e018edc1f198aa72a8f2127fab00
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 211086
+timestamp: 1775298609420
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+sha256: 5f27ccd93b39c2435ed6e9b8302ae50d51eb5b6058d7d11edba403e9723f48c6
+md5: 755b46b2896c8526a18074b3b651dfbc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-litedown >=0.6
+- r-xfun
+license: MIT
+license_family: MIT
+size: 72190
+timestamp: 1757496654397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_66-r45h54b55ab_0.conda
+sha256: 89218d4083593e5eae881fe5136befa358333d90a7de1a0ede13e8cd7bb5244e
+md5: 700d7bffd1c317597b574b218b567017
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1141176
+timestamp: 1784201795136
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.7_5-r45h0e4624f_0.conda
+sha256: de3447368ff93fb293c022d4a1eb8bcffe9044f52baf65c19218d6966815b88d
+md5: ca378a648cfa47523266acd1a0251729
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4301827
+timestamp: 1774809406103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r45h54b55ab_1.conda
+sha256: 06177df6c2f39df0a90b456557d226c2ffa9eaf55505b35d0ca9a81fe793dc49
+md5: 3deafa947ef32bf21d87b57e74d3711b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 484755
+timestamp: 1757442394466
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+sha256: 91b0eedec5cf5de195b442b97eda508f22fdedbdbc487f74e3868d3e95380fdd
+md5: 2b04206ff6ea5a92e8e36bdaa5feb3cc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cachem
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 57750
+timestamp: 1757456335587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_4-r45h0e4624f_0.conda
+sha256: 83a5233b6162c55f5021dea34464bd64d87f18b7815e738c42d06a046780e594
+md5: e33882c93c191f5d9a9b346431f02b43
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-nlme >=3.1_64
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 3644492
+timestamp: 1762539595584
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mime-0.13-r45h54b55ab_1.conda
+sha256: 03116d6a8db71492d036c6c052d6cfbf5a98c06da071e42aedb5c740920d6b61
+md5: 26aa2fa52d4caed58336f2b4887916d6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 64912
+timestamp: 1757441376534
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+sha256: 97d463c2146c483992a25fe497755e9cf714f95ca611a93d8adbb41c068e9e74
+md5: c78bd534986cde8fc0cb08cc9a1a2cc6
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+license: MIT
+license_family: MIT
+size: 247241
+timestamp: 1757455926748
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_170-r45heaba542_0.conda
+sha256: 83964b5b1ea49ed78be1fd7606650cf1ea68b92febe3d0bbdb9fda1be30f2d5b
+md5: 17487ca56832572cb95f9cc1314ddabb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 2356999
+timestamp: 1784288204943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-openssl-2.4.2-r45h68c19f5_0.conda
+sha256: 2796cf7768c939a58344157fcddec88dbdadf9cabd3ab0b24d9bbaf7916b9ebd
+md5: 6568a5797c9d74e89ef94b82724665aa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.6,<4.0a0
+- r-askpass
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 680716
+timestamp: 1781024845749
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+sha256: 09df5e8326b04412a26b6c4d896e04adbceba45194457c6d30f370d5ccb4b397
+md5: 0c015ba0c5444777a683c05e4a000f21
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-getopt >=1.20.2
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 119289
+timestamp: 1776419503742
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+sha256: f5de9737f59e1965db2de11c90cf1fdd426db322a7205c935a3e55150287b02f
+md5: 560abd550c097e0d0af2e201b335f53d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 286342
+timestamp: 1761151056217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+sha256: 162742dd773c8a163de6ffdf0e14820b5708b9e1041d4491762c05e00f6be614
+md5: 849a8fcdb5e1d98a3917a7c652c322df
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 679411
+timestamp: 1757649050426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+sha256: a4869bf14ad791c8a5cb48fd0575faa3cdb7b07692cb4b473809c261f584fa45
+md5: 9a48d2e7fdc93937c60481c06d40e6ba
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 234305
+timestamp: 1770387131912
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+sha256: b3f281041ecff2d4a9f40073ad5e7ec6fa7e0c841068ce85c550bcce0ff8938d
+md5: 807ef77a70fc5156f830d6c683d07a29
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 629867
+timestamp: 1758149763203
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+sha256: fda425435a533e86da5f0fc89cf45c9f889a4e6f1e2ed536ca23662a8461602c
+md5: 40a5fdd06c7e7880758a021cf2df6c12
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 27236
+timestamp: 1757447537447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
+sha256: 691d08f590099bb8cf4042a3af57b742775e02e4272df80dea5388c20e340116
+md5: 2021f458379120ae0d21189bee7e30cc
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.3,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 135276
+timestamp: 1758095801346
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
+md5: ced57d920bed79382f382a24a4425ef7
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-crosstalk
+- r-data.table
+- r-digest
+- r-dplyr
+- r-ggplot2 >=3.0.0
+- r-hexbin
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httr
+- r-jsonlite >=1.6
+- r-lazyeval >=0.2.0
+- r-magrittr
+- r-promises
+- r-purrr
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-tibble
+- r-tidyr
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 3587131
+timestamp: 1769337109792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
+sha256: 353d5945d242b03c47ab0d051cf9058b4459303c96455dba9442100628a0bde1
+md5: 255fec0919919b14789eb30cc448ed20
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.0
+license: MIT
+license_family: MIT
+size: 787537
+timestamp: 1757441721952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
+sha256: 7f69cd631f28279b4c706fe2341d8ffbd13cc10ed98e648d0c214ceecce4f877
+md5: c38b8f68cbe321dd5b819d397b2b5061
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-ps >=1.2.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 411030
+timestamp: 1776865706038
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+sha256: 684dba5d20aae8da37868d603b662014e1944f5568e5f737e42d9d485892a26e
+md5: b2c1b6ef8f12894fd2694b285fe8989a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-fastmap >=1.1.0
+- r-later
+- r-lifecycle
+- r-magrittr >=1.5
+- r-otel >=0.2.0
+- r-r6
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1597704
+timestamp: 1762426228446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ps-1.9.3-r45h54b55ab_0.conda
+sha256: 598576cd282f2b9c8280696c77b3a9e05d52a8f688174d6c6ed1b3bdad57bcdf
+md5: d4c22257df8cca28d50e604110e68e90
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 414722
+timestamp: 1777148019201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.2.2-r45h54b55ab_0.conda
+sha256: dc5f0ace59844125b92304324000770c7e2e466bab442826cee50a32eef731bf
+md5: dc14c484a0415f43dc1b90b518beb41a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 547035
+timestamp: 1775853612539
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-qap-0.1_2-r45heaba542_5.conda
+sha256: cd5b1706f125067986e083ba343ff6f20f79747c18e801fb6014481ec273964e
+md5: d64850fa9345afe8dbe58b371c32792d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 396309
+timestamp: 1757635813587
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+sha256: bd92e91332eba5f0c689583e80adec85ef272c4e0d0b36ee17cb7c11b5693cf2
+md5: 750802806d7d640c286ed8491bb395dc
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 95073
+timestamp: 1757447661037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rappdirs-0.3.4-r45h54b55ab_0.conda
+sha256: a9778d5fa6777ce286815eb0abef625ff54693532795ef48a1bc319967e0ecb4
+md5: 9fa763ece102dca3e50892bad36896ff
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 54376
+timestamp: 1768747300036
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+sha256: ddd4e63616ee475bdf9dc63a0b16a89017237121e927d83fbdee07d5a5ccc890
+md5: d8fa238420cb6de47d463b7345a761eb
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68005
+timestamp: 1757452462302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.1.2-r45h3697838_0.conda
+sha256: dabb73c4d43f352a3154067a20a46cbda1e1027636e72d133010f6f052e8d260
+md5: 1d6e2e4764de896f03fb73e28614022e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 2122066
+timestamp: 1783264478653
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpptoml-0.2.3-r45h3697838_1.conda
+sha256: 8e10fa6f550c83cdc99175443ecc92db178369e82a7dcb743e1fe7ce87d39530
+md5: 707ba8dabbbffd03f5907406a0fe8368
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.5
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 227793
+timestamp: 1757490566643
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+sha256: 68f01b65843f873b01bff24f61f27298667797aa3ad01d4406a62ae72e7c08c5
+md5: 1a99d6f9dfe5f6e8dc5275d49852cd66
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 208380
+timestamp: 1757507980343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-renv-1.2.3-r45h54b55ab_0.conda
+sha256: d88af05b70ac871598c7fda5e04c7d024f1011fcc047eeb18d9541ef9b03bea7
+md5: 378f0ed999e77fe5e276ef811d783d96
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 2469798
+timestamp: 1778972824711
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.5-r45h3697838_0.conda
+sha256: ffec1e0396849fab33c12bcc580fe71f90818c83da645146c165449ee9a6e799
+md5: 169cd9281096cd54a29072a2d7eea2a9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-plyr >=1.8.1
+- r-rcpp
+- r-stringr
+license: MIT
+license_family: MIT
+size: 127756
+timestamp: 1762975657971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.3.0-r45h3697838_0.conda
+sha256: 13aed8664cbf46946eed067d1708ee1a8dcbd7cf32d361c7a03a9bf3f83ac425
+md5: afa49304f86d922c157d08e9e9d9ceb8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1593782
+timestamp: 1783260208298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+sha256: b3735a4e75eca023b24678251da041854b94a8b96588d81b605928d6ecf74f11
+md5: 25b9dbf0ff990b8b3111774878e3bb07
+depends:
+- pandoc >=1.14
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.2.5.1
+- r-evaluate >=0.13
+- r-fontawesome >=0.5.0
+- r-htmltools >=0.5.1
+- r-jquerylib
+- r-jsonlite
+- r-knitr >=1.43
+- r-tinytex >=0.31
+- r-xfun >=0.36
+- r-yaml >=2.1.19
+license: GPL-3.0-only
+license_family: GPL3
+size: 2085382
+timestamp: 1774555006202
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+sha256: 5f9aa168f5c43f1d3ddbacc701370085fcead3956e2d5879af7fcd9e086a0a0b
+md5: 62f09532f225c86d27e954b36682add5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-digest
+- r-httr2
+- r-jsonlite
+- r-lifecycle
+- r-openssl >=2.0.0
+- r-packrat >=0.6
+- r-pki
+- r-renv >=1.0.0
+- r-rlang >=1.0.0
+- r-rstudioapi >=0.5
+- r-snowflakeauth
+- r-yaml >=2.1.5
+license: GPL-2.0-only
+license_family: GPL2
+size: 830390
+timestamp: 1783503525234
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+sha256: 896aeea3aa679a9dbd0277d10ef8dcfd011e45a1717129180a9877c1fd828f2a
+md5: 5f1b6b899fa3204ab77403e75b9df5fd
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 357140
+timestamp: 1781250782889
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-s7-0.2.2-r45h54b55ab_0.conda
+sha256: fae29c4af16617a17fea40c5e484e4350a6fe5d9fad40266f95cf3cb13e7019b
+md5: 598ca5290f9be9b22804436295471201
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 311525
+timestamp: 1776861444903
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sass-0.4.10-r45h3697838_1.conda
+sha256: 4d6d7db9d0187a9ede70d6d48278a8ba2b3160e823f5de239b86a6108f23172e
+md5: a3ccf52eefa448628535ee758c5a8a37
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-fs
+- r-htmltools
+- r-r6
+- r-rappdirs
+- r-rlang
+license: MIT
+license_family: MIT
+size: 2319704
+timestamp: 1757464682768
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+sha256: 260c384e952e5bd4d2c2de77b9e09b24ff1c1f680acd917c4657ab8c9e4e9a2f
+md5: 8bc81cc6fd130cef963bc9e082726a14
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-farver >=2.0.0
+- r-labeling
+- r-lifecycle
+- r-munsell >=0.5
+- r-r6
+- r-rcolorbrewer
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 777793
+timestamp: 1757487539496
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+sha256: bcde368cbf5a2c83b9c1fb8b3ba0722787af759f68d08bac6a82e966adbf999f
+md5: ba820689c02638c807f83e6ab5c53142
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 370745
+timestamp: 1771995271935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-seriation-1.5.8-r45heaba542_1.conda
+sha256: ce65e9dfe250a2d142acb7f7c2fec1ebd9e1527c66c5ce1212f0f18a3f2a415a
+md5: 9252542af85ee0c48a0a94ea103181e5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-ca
+- r-cluster
+- r-colorspace
+- r-foreach
+- r-gclus
+- r-mass
+- r-qap
+- r-registry
+- r-tsp
+- r-vegan
+license: GPL-3.0-only
+license_family: GPL
+size: 1372264
+timestamp: 1757660945261
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+sha256: ef0042ae1c3926ef9bee6c21cf761d7cf441eae61dceca7df143f3b9dc4c6f04
+md5: 2fb0e1ea59dd281487be303b1b7c6607
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.6.0
+- r-cachem >=1.1.0
+- r-commonmark >=1.7
+- r-crayon
+- r-fastmap >=1.1.1
+- r-fontawesome >=0.4.0
+- r-glue >=1.3.2
+- r-htmltools >=0.5.4
+- r-httpuv >=1.5.2
+- r-jsonlite >=0.9.16
+- r-later >=1.0.0
+- r-lifecycle >=0.2.0
+- r-mime >=0.3
+- r-promises >=1.1.0
+- r-r6 >=2.0
+- r-rlang >=0.4.10
+- r-sourcetools
+- r-withr
+- r-xtable
+license: GPL-3.0-only
+license_family: GPL3
+size: 3789417
+timestamp: 1782070586086
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+sha256: c3ea3d60226ed56e4a40b622b8e4721d257a9fb4ca8502ce89314f48a63a0090
+md5: b5da9b58b4f8137a7f2e14102bc230c9
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-glue
+- r-shiny
+license: MIT
+license_family: MIT
+size: 344724
+timestamp: 1757870156008
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+sha256: 9493d6cbf09850206f5904ccde65643de86bb9bd6add685548331c408e99610a
+md5: 3929f109451367912b4570480f4c572d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest >=0.6.8
+- r-jsonlite
+- r-shiny >=1.0.0
+license: MIT
+license_family: MIT
+size: 1018291
+timestamp: 1768513288077
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
+md5: 7382af8530d082191feb0c8da5f8a41b
+depends:
+- bioconductor-limma
+- bioconductor-summarizedexperiment
+- r-base >=4.5,<4.6.0a0
+- r-biocmanager
+- r-bslib >=0.9.0
+- r-cluster
+- r-dplyr
+- r-dt >=0.2
+- r-ggbeeswarm
+- r-ggdendro
+- r-ggplot2
+- r-heatmaply
+- r-htmltools
+- r-htmlwidgets
+- r-markdown
+- r-matrixstats
+- r-optparse
+- r-plotly >=4.8.0
+- r-rcolorbrewer
+- r-rsconnect
+- r-scatterplot3d
+- r-shiny >=1.7.0
+- r-shinycssloaders
+- r-shinyjs
+- r-viridislite
+- r-yaml
+license: AGPL-3.0
+license_family: AGPL
+size: 3448797
+timestamp: 1784579537432
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
+md5: 1d38994c8bfe421d621d9b3705c37b58
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-jose
+- r-jsonlite
+- r-openssl
+- r-rcpptoml
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76170
+timestamp: 1772133448445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
+sha256: 885a784f4258b491e48947dbed71bd18b2e2e7da0f0b53ee1dcfed93cfdcd48a
+md5: 1bd0042c176bde3dd1971eac76497219
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 54650
+timestamp: 1774682292388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
+sha256: 3095c4e59616a46480533f2e545136e25b1cb20d7ec6535d4a7f0938c48ff789
+md5: 377126a1601c75ff75c2c8c277e55a81
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 325043
+timestamp: 1779038241839
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.7-r45h3d52c89_2.conda
+sha256: 6d0d8d6f1465b3486996edaef7ccd1020cb2fcca1e69b543fc52dbad5262079b
+md5: c7ce6f26b92398224c78b92c653b94c1
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.2,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: FOSS
+license_family: OTHER
+size: 939928
+timestamp: 1772032511209
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+sha256: dea2a7676dd03ed93fa0ec961883c5075c361c8522659a1bc1e6b5c16525cb24
+md5: 8db438d8aa370726ee1ce8bf458f2e6d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 319328
+timestamp: 1762269757617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sys-3.4.3-r45h54b55ab_1.conda
+sha256: 0cf3a7af31b0396d5a2e1c932fffa360472f92a2b373a696f523b0b53ad1d682
+md5: f23bbac61ab0536f59f4caa4c2ebdf88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 50436
+timestamp: 1757441793835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.1-r45h54b55ab_0.conda
+sha256: 256d782fb5773d678f29b88a2c987eb47065e2393a080ca16f400b0256de65bb
+md5: ad28f67cbb0b10a5beaa7bf968761cad
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 589666
+timestamp: 1768139121744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.2-r45h3697838_0.conda
+sha256: 8c4560d92c1adfce9a37da2f963596a369688b0d5f44d1fa2f0fbfecb486d99f
+md5: e571d4d42233dd2aa3bdb0057ffbdc63
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127263
+timestamp: 1766142073696
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+sha256: fca09d6b9940f1e1cda0425a0f55716bba202d6f55d6bd25fedec391006c7dc7
+md5: 15aa0f323385403fe182e46a1d095e1b
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 220192
+timestamp: 1757475791328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+sha256: 1fad4d08756ca2d7db04cfaf88e9df797da95a5f7f4b8aabc165eee36faddafc
+md5: 5ee226c1449c66d1cd2399d942faa04d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.48
+license: MIT
+license_family: MIT
+size: 158240
+timestamp: 1782203211628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tsp-1.2.7-r45h54b55ab_0.conda
+sha256: 54c19b952897b97228f00ff3ae8def7e7af2194c0ed3419737a8fe04a988cd41
+md5: 4518075e6efc2a5c9714751a92bfc73e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-foreach
+license: GPL-3.0-only
+license_family: GPL3
+size: 736826
+timestamp: 1774389996066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r45h54b55ab_1.conda
+sha256: 97186abdf7c29872e012c9fe05ec16c019b58c43ac7b778baa480a8acae9c914
+md5: 75cb2540ac930ea879e92d99e00e97c3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 147244
+timestamp: 1757424673681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.7.3-r45h3697838_0.conda
+sha256: 73b0cdea9f85496b80e75ffa20f94aa4ab746f4b7af566742e22381bffa6772d
+md5: 372cefc1b05a567d1fbe19633766ab0c
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1805012
+timestamp: 1775897999712
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vegan-2.7_5-r45h11cdb10_0.conda
+sha256: b6245a77003ec655ca972e81d25771652991326ed9d7f3514951954565198e94
+md5: 81c256938ff8b33054afde06c7851e4e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+- r-lattice
+- r-mass
+- r-mgcv
+- r-permute >=0.9_0
+license: GPL-2.0-only
+license_family: GPL2
+size: 3049688
+timestamp: 1779956688681
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+sha256: 859729e8cd04bb92ec144b21a8abfdb2bec9cbac9deaa41ba0cc2add13d088a0
+md5: e605ce527e381c5577d57649e393cb87
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4508304
+timestamp: 1757669044129
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+sha256: 884896b59133b948646b0d1441106120f7b320e9fac827ccb9d44bbe80dda8f2
+md5: e841095941c40142bdad834299b95a30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=1.0.1
+- r-gridextra
+- r-viridislite >=0.4.0
+license: MIT
+license_family: MIT
+size: 2988605
+timestamp: 1757516440048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+sha256: b9ec9606562f0f6bdefc237bbc6163eb1cb022f9d699c80771bc84af0ae37269
+md5: bcadc0a3726e2191e51449f67fa5e0a9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1305542
+timestamp: 1770191459321
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+sha256: e79e366895dfdf79fe92986fe42d0695e3fcacc25411506c48b9db92742eb99c
+md5: e021e3d936f57ea9b35eb099999d6800
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-callr
+- r-jsonlite
+- r-magrittr
+license: GPL-2.0-only
+license_family: GPL2
+size: 206060
+timestamp: 1757520337073
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+sha256: 56f318c90bfc74f01339c83f0e1d0817c1b762ea46cd9e527fec9dcf244c5900
+md5: 388d25e67f93a5fec2aebe56d6a0a1d9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 235287
+timestamp: 1781856624720
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xfun-0.60-r45h54b55ab_0.conda
+sha256: dca6e2c57e1b038682879e793338683f25058362a8f3ca2a88f753e5de085cf0
+md5: 1d3e32dcae994197a303942b6654e577
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 651306
+timestamp: 1784103319293
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+sha256: 972923364cfd616ccf38768477c435677cfe1ea18a72016f90344ea920e4fea5
+md5: e18fda0821f0fdc1c34276c5e0acdc92
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL (>= 2)
+license_family: GPL3
+size: 744345
+timestamp: 1771859982217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-yaml-2.3.12-r45h54b55ab_0.conda
+sha256: f8944d47eccfdb2c04e27fd65797de7468ccc5d9f3fc3d9af296da613d75d79c
+md5: d0d07c6f14b640a98cf6a5e3e4e2e723
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 124461
+timestamp: 1765372968808
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 345073
+timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+sha256: b013d2085ce4ac01daec7b30472e9f3b6c2d69eb3a3a85a6cee3e01a3cb4f61a
+md5: e4a1ff2e59a5d9b38be71d15c93cf1bd
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 268482
+timestamp: 1776859422619
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+md5: 13dc3adbc692664cd3beabd216434749
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-64 4.18.0 he073ed8_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 24008591
+timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+build_number: 103
+sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+md5: 48a1049e710857572fc2a832aa394d9f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3550916
+timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+sha256: 3e20b2f2902a1f402ef2420ce2b9e8c91f9e02748d55530894ac1f640561fdd0
+md5: 72628f56d7a99b86efa435a0b97a4b47
+depends:
+- tk
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- tk >=8.6.13,<8.7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 102544
+timestamp: 1773732786017
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+sha256: 2bf9a40d86d29fd5c30d0febec99d06398143ddeece9ebb175cc5a6d20279943
+md5: f16d4aec5e8135e8e7bba02ef600149e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 38560
+timestamp: 1779439547766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+md5: fb901ff28063514abb6046c9ec2c4a45
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 58628
+timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+md5: 1c74ff8c35dcadf952a16f752ca5aa49
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 27590
+timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 839652
+timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+md5: b2895afaf55bf96a8c8282a2e47a5de0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 15321
+timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+md5: 1dafce8548e38671bea82e3f5c6ce22f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 20591
+timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+md5: 34e54f03dfea3e7a2dcf1453a85f1085
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+license: MIT
+license_family: MIT
+size: 50326
+timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+md5: 96d57aba173e878a2089d5638016dc5e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 33005
+timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+md5: 279b0de5f6ba95457190a1c459a64e31
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 379686
+timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 601375
+timestamp: 1764777111296

--- a/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
+++ b/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
@@ -1,0 +1,3175 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-aarch64:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.46.1-default_hf1166c9_102.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-biobase-2.70.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-delayedarray-0.36.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-genomicranges-1.62.1-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-iranges-2.44.0-r45hbd662d2_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-limma-3.66.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4arrays-1.10.1-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4vectors-0.48.0-r45hbd662d2_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-sparsearray-1.10.8-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-xvector-0.50.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h3530432_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-15.2.0-h2d9b6d1_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gsl-2.7-h294027d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h7c59cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-14.2.1-h3a99ef3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-devel-14.2.1-h3a99ef3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandoc-3.10-h8af1aa0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-askpass-1.2.1-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.5.3-h269e6ae_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base64enc-0.1_6-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-beeswarm-0.4.0-r45hf488e41_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cachem-1.1.0-r45h0557e7b_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.6-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cluster-2.1.8.2-r45h6df9e4a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-colorspace-2.1_3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-commonmark-2.0.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-curl-7.1.0-r45hd8a8d9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-data.table-1.18.4-r45hbf3bb9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-digest-0.6.39-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.2.1-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.7-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-farver-2.1.2-r45h08b74da_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fastmap-1.2.0-r45h08b74da_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fs-2.1.0-r45hd601667_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.1-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-hexbin-1.28.5-r45h6df9e4a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-htmltools-0.5.9-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-httpuv-1.6.17-r45hb62f08c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-isoband-0.3.0-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-jsonlite-2.0.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-later-1.4.8-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lattice-0.22_9-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lazyeval-0.2.3-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.5-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mass-7.3_66-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrix-1.7_5-r45h9301183_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrixstats-1.5.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mgcv-1.9_4-r45h8b2cba9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mime-0.13-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-nlme-3.1_170-r45ha85219e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-openssl-2.4.2-r45h37c386a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ps-1.9.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.2.2-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-qap-0.1_2-r45ha85219e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rappdirs-0.3.4-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpp-1.1.2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpptoml-0.2.3-r45hd601667_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-renv-1.2.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-reshape2-1.4.5-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.3.0-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-s7-0.2.2-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sass-0.4.10-r45h08b74da_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-seriation-1.5.8-r45ha85219e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.7-r45h1ddd0e6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sys-3.4.3-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.1-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tsp-1.2.7-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.7.3-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vegan-2.7_5-r45ha2e3c6d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-xfun-0.60-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-yaml-2.3.12-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h5f05d98_8.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: a2527b1d81792a0ccd2c05850960df119c2b6d8f5fdec97f2db7d25dc23b1068
+md5: 468fd3bb9e1f671d36c2cbc677e56f1d
+depends:
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28926
+timestamp: 1770939656741
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+sha256: eebe159bf600943552e4319ff4ce27b6a2dadf0dcc5443e76dcee9259a408e11
+md5: 58f37d76b8234c69dbf2939d511bea0b
+depends:
+- ld_impl_linux-aarch64 2.46.1 default_h1979696_102
+- sysroot_linux-aarch64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 4677171
+timestamp: 1784214549910
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.46.1-default_hf1166c9_102.conda
+sha256: d41099a3fe2809a3ab3e4c718ecff4d5f8879e7949f3c8e8efa97fa06a90248c
+md5: 9a340123cb7217eae51c5cae24484631
+depends:
+- binutils_impl_linux-aarch64 2.46.1 default_h5f4c503_102
+license: GPL-3.0-only
+license_family: GPL
+size: 36196
+timestamp: 1784214578949
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-biobase-2.70.0-r45hbd662d2_0.conda
+sha256: 144892eb6a1caeb15ca70a90e9502130ad5d4fb11cb3bfcf23944c540b6fc8c2
+md5: 8256b8838a2ed279aa68d6a74c64f2ae
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2359182
+timestamp: 1770502613668
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+sha256: 97221eda3007381c0a6498608baaebdcec6047f7f26b121c19149fd56aabf032
+md5: 27556377d159490ea87696727ae41808
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-generics
+license: Artistic-2.0
+size: 653523
+timestamp: 1770415244399
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-delayedarray-0.36.0-r45hbd662d2_0.conda
+sha256: a35e3f96ec640cf7665d74954c96c9dd94acec8c2d3b07773496917465891990
+md5: a539d17dd563adecc5716d832336d257
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-sparsearray >=1.10.0,<1.11.0
+- bioconductor-sparsearray >=1.10.8,<1.11.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 2203445
+timestamp: 1770580775191
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-genomicranges-1.62.1-r45hbd662d2_0.conda
+sha256: 55b5f4217dab83ed83c37669b166d3145eb3d844360f53cbe940b48fad58febd
+md5: 73f836e70629719f303b19c6f88e089e
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2307173
+timestamp: 1770634322279
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-iranges-2.44.0-r45hbd662d2_1.conda
+sha256: 7167ede80515e1b5d88fcfda2c16c01e7e6a39698d1b9824a3a0416b0bed6e1e
+md5: 82dc872dc3591e32ca8e8c051ef0d619
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2354429
+timestamp: 1770538530102
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-limma-3.66.0-r45hbd662d2_0.conda
+sha256: b6c0c4229c65102dbf5135421cdeda72c77bb84a574eb3ad6a017feda47843fe
+md5: 04a2febf68754954062a79fdfc4674df
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-statmod
+license: GPL (>=2)
+size: 3099160
+timestamp: 1770499849646
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+sha256: 169809ca754b2c07f7356f1fc4f365b7d5154fd66229543584f69008fa347c5a
+md5: cdf0406fc3caa814ff7b7876a42973a5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-matrixstats >=1.4.1
+license: Artistic-2.0
+size: 449898
+timestamp: 1770417102301
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4arrays-1.10.1-r45hbd662d2_0.conda
+sha256: 3e69df7fbd051d165364424a5b87ad1c902c68b2d4d04e7feffbfe11079bd90b
+md5: b7a8cb11e73c5031c3d6da65845c60b4
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-abind
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1027295
+timestamp: 1770573305521
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4vectors-0.48.0-r45hbd662d2_1.conda
+sha256: 714d17a1e87e49a3cb25b42794bb30ffba91921f6d5d7d37c6e80945aa036ef7
+md5: 82884abd1721c6c3fbe6024c7b627174
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2068293
+timestamp: 1770501459310
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+sha256: 875f5be76bc3b83766ec0cfacf888570d529907412519a537c5f7a318e489976
+md5: cfe7c256532f9a4fc87ec3be955bb9e6
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 598298
+timestamp: 1770628899171
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-sparsearray-1.10.8-r45hbd662d2_0.conda
+sha256: 6d45e717b4a44b4dc5209cc931301be4571db91b0219905d55d110edd3ef145b
+md5: 42802d5b7d809a31cf6e364b4c52a20b
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-xvector >=0.50.0,<0.51.0
+- bioconductor-xvector >=0.50.0,<0.51.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-matrixstats
+license: Artistic-2.0
+size: 1678434
+timestamp: 1770579674417
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+sha256: b8ade9f2ab8cc2835357653f5a9bc840323c05f7656659dfb40d20e5623f8ebd
+md5: 74eb95090e807c18f5bc81cb9fb39b3c
+depends:
+- bioconductor-biobase >=2.70.0,<2.71.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-delayedarray >=0.36.0,<0.37.0
+- bioconductor-genomicranges >=1.62.0,<1.63.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1416452
+timestamp: 1772218138703
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-xvector-0.50.0-r45hbd662d2_0.conda
+sha256: 961ac8875597fae63a4efc98917e2be0f58b0299700339ffbf8cdfbdc7cf4beb
+md5: 461fc07891c8587fbe1f870f67f98e91
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 644057
+timestamp: 1770573790622
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+sha256: d9def28d376d13033e0e78d731091a85a49a2297bf5efe15f0ef0d4533a6adeb
+md5: 585e14e544be02d0baceffecd31c7882
+depends:
+- tk
+license: TCL
+size: 129724
+timestamp: 1750262711538
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+sha256: b3495077889dde6bb370938e7db82be545c73e8589696ad0843a32221520ad4c
+md5: 840d8fc0d7b3209be93080bc20e07f2d
+depends:
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 192412
+timestamp: 1771350241232
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
+sha256: 24f78776eda069a6c1566fd6d65379e45747d0a7cce9f864686690806543c408
+md5: a8a5833ef43f9b31a4d548071ea5ba75
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 220677
+timestamp: 1784091035199
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+md5: a9965dd99f683c5f444428f896635716
+depends:
+- __unix
+license: ISC
+size: 128866
+timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
+md5: 043c13ed3a18396994be9b4fab6572ad
+depends:
+- fontconfig >=2.15.0,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.1,<79.0a0
+- libexpat >=2.7.3,<3.0a0
+- libfreetype >=2.14.1
+- libfreetype6 >=2.14.1
+- libgcc >=14
+- libglib >=2.86.3,<3.0a0
+- libpng >=1.6.53,<1.7.0a0
+- libstdcxx >=14
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 927045
+timestamp: 1766416003626
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
+sha256: a36ed82bbaebdc59e205d399d6e898bcb20fbcd5aaebb162cdf690ba97173ef5
+md5: a06d829c51a365e8daf0b2a3d4f06d9d
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 h7c59cd8_2
+- libgcc >=14
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 201305
+timestamp: 1782911743345
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
+md5: f4d29a0cd77104a683607319a542ac7e
+depends:
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 290522
+timestamp: 1780450108132
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+sha256: 1112c56bc19cbce233b30d9d31ce8eb6fcc100c9baa5145315aaa1e3a25b5178
+md5: 5e8e88bfb3fbb0df0f9f8bb890721e07
+depends:
+- libfreetype 2.14.3 h8af1aa0_1
+- libfreetype6 2.14.3 hdae7a39_1
+license: GPL-2.0-only OR FTL
+size: 174060
+timestamp: 1780933507786
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+sha256: 1bfcd715bcb49a0b22d5d1899a22c6ff884b06f8e141eb746f3949752469a422
+md5: f3ac54914f7d3e1d68cb8d891765e5f9
+depends:
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 62909
+timestamp: 1757438620177
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h3530432_19.conda
+sha256: cd23829b5fb7f3ff5f44eab2da1a993e06bdf759b681a0a7a73bb5783755b6b3
+md5: 66dfb62e7a47e2b511f9c5ee0ff1abf3
+depends:
+- binutils_impl_linux-aarch64 >=2.45
+- libgcc >=15.2.0
+- libgcc-devel_linux-aarch64 15.2.0 h55c397f_119
+- libgomp >=15.2.0
+- libsanitizer 15.2.0 he19c465_19
+- libstdcxx >=15.2.0
+- libstdcxx-devel_linux-aarch64 15.2.0 ha7b1723_119
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 73237372
+timestamp: 1778268860495
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+sha256: 2450913611189cc3c26062a43a97a93501159335d4d314cca5e2678fb5f4d3b6
+md5: 619b8a05f89220fa8c9536dcfeeddd5b
+depends:
+- gcc_impl_linux-aarch64 15.2.0.*
+- binutils_linux-aarch64
+- sysroot_linux-aarch64
+license: BSD-3-Clause
+license_family: BSD
+size: 29074
+timestamp: 1781279974207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-15.2.0-h2d9b6d1_19.conda
+sha256: eb531f1a37c2efa431fb3104842d98aba271c55ef3de8c2741e9d575bd3cb762
+md5: c8fc81db8eef1e0f76778e8f91ab8ff3
+depends:
+- gcc_impl_linux-aarch64 >=15.2.0
+- libgcc >=15.2.0
+- libgfortran5 >=15.2.0
+- libstdcxx >=15.2.0
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16043253
+timestamp: 1778269041546
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+sha256: 3e529c517a76a1f4497c51eeedeeb927d33f732dcdb48055a020a83eb3e4e95c
+md5: 4db044857ab1d09b2e8f0013c65387c1
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 103119
+timestamp: 1780455096710
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gsl-2.7-h294027d_0.tar.bz2
+sha256: be506a418cc648996bf3376a626826cbe0fa5d9de913598c4d3965a61ddc7a7b
+md5: 8b9533e21be7fa232ab64e85f184e0b3
+depends:
+- libblas >=3.8.0,<4.0a0
+- libcblas >=3.8.0,<4.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3890901
+timestamp: 1626369614424
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
+sha256: afb0fc36b93539a8e43a8063c8d3e1b4bace38a5a0c3c9e1978c72792d633c62
+md5: 7214ae8a8aade7b48a2bfd8bbb4d9e79
+depends:
+- gcc_impl_linux-aarch64 15.2.0 h3530432_19
+- libstdcxx-devel_linux-aarch64 15.2.0 ha7b1723_119
+- sysroot_linux-aarch64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 14640001
+timestamp: 1778269082840
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
+sha256: f4bc63d467e2c48c255bc8d2886fb11f6a8d09c1251a6f5b25628abee1768693
+md5: ea51d6df068bee183ff667f75bfdc2f6
+depends:
+- gxx_impl_linux-aarch64 15.2.0.*
+- gcc_linux-aarch64 ==15.2.0 h0bf4bd8_27
+- binutils_linux-aarch64
+- sysroot_linux-aarch64
+license: BSD-3-Clause
+license_family: BSD
+size: 27620
+timestamp: 1781279974207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
+sha256: 57b157674ecee4d16e2873a3624095b4ed1859ce8c574b161e0d9c1723788733
+md5: 41198d1dd71d97c1507e6bd17edd10c7
+depends:
+- libharfbuzz-devel 14.2.1 h3a99ef3_1
+license: MIT
+license_family: MIT
+size: 11079
+timestamp: 1782800518091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
+md5: 546da38c2fa9efacf203e2ad3f987c59
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 12837286
+timestamp: 1773822650615
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
+md5: bb3b7cad9005f2cbf9d169fb30263f3e
+constrains:
+- sysroot_linux-aarch64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1248134
+timestamp: 1765578613607
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+sha256: 5ce830ca274b67de11a7075430a72020c1fb7d486161a82839be15c2b84e9988
+md5: e7df0aab10b9cbb73ab2a467ebfaf8c7
+depends:
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 129048
+timestamp: 1754906002667
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+sha256: b644718416a22b5d57c1194ea7207b7f8d33d6a2b42775763782d76cd7457aea
+md5: 5fd2304064ef6199d1f91ec60ee7b820
+depends:
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1518484
+timestamp: 1781859412954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+sha256: 2c4901f4227b0850328ed0c69f958b30ad2cd18982f7a31c7c1f911827004d08
+md5: 489444d0acb2a579d2a002d85a08c059
+depends:
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-aarch64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 905305
+timestamp: 1784214534868
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+sha256: 8957fd460c1c132c8031f65fd5f56ec3807fd71b7cab2c5e2b0937b13404ab36
+md5: d13423b06447113a90b5b1366d4da171
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 240444
+timestamp: 1773114901155
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+build_number: 8
+sha256: c897399c943168c646f659952f73a9154f9122d7e9b151649dbe075dfdcd484b
+md5: 8b44dad125760faa2b3925f5a6e3112d
+depends:
+- libopenblas >=0.3.33,<0.3.34.0a0
+- libopenblas >=0.3.33,<1.0a0
+constrains:
+- libcblas   3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+- mkl <2027
+- blas 2.308   openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18843
+timestamp: 1779859042591
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+build_number: 8
+sha256: 3ba039f0705022939d90e36c1ed2fcbafd7f5bb77563e3702202ae796b32f4d2
+md5: 76242b7ad6e43809afa8671dd609b4ed
+depends:
+- libblas 3.11.0 8_haddc8a3_openblas
+constrains:
+- liblapack  3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+- blas 2.308   openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18817
+timestamp: 1779859049133
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h7c59cd8_2.conda
+sha256: 5846fa724f4b8eb23751e347fc8b31775c0a28a7a34d1e44f081651613470512
+md5: 0a187db240c503afc7eb5bd865c7ff04
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 505957
+timestamp: 1782911738398
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+sha256: 48814b73bd462da6eed2e697e30c060ae16af21e9fbed30d64feaf0aad9da392
+md5: a9138815598fe6b91a1d6782ca657b0c
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 71117
+timestamp: 1761979776756
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+sha256: c0b27546aa3a23d47919226b3a1635fccdb4f24b94e72e206a751b33f46fd8d6
+md5: fb640d776fc92b682a14e001980825b1
+depends:
+- ncurses
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 148125
+timestamp: 1738479808948
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+md5: a9a13cb143bbaa477b1ebaefbe47a302
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 115123
+timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+sha256: 20a5726bc8705d91437c9e6ef83b30da64a1719b869656d20a1ee818333ea5ac
+md5: fac3b65a605cd253037fdf3daf2de8d9
+depends:
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77649
+timestamp: 1781203572523
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+sha256: 3df4c539449aabc3443bbe8c492c01d401eea894603087fca2917aa4e1c2dea9
+md5: 2f364feefb6a7c00423e80dcb12db62a
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 55952
+timestamp: 1769456078358
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+sha256: db75d0fc080992dc67db8e24d7bb2a2f2a0b25bfce8870fa45a82a4b5f6111a2
+md5: a13e600f9d18488b1fd1257344dbfdaa
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8381
+timestamp: 1780933505754
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+sha256: 34fe8276befd6c42956c4acd969caeddbdc7ea8e6ed054b8388709b6c3e94ba4
+md5: 426cc33f8745ce11a73baf73db3954a7
+depends:
+- libgcc >=14
+- libpng >=1.6.58,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 424236
+timestamp: 1780933505195
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+sha256: 4592b096e553f67799ae70d4b6167eeda3ec74587d68c7aecbf4e7b1df136681
+md5: f35b3f52d0a2ec4ffe3c89ba135cdb9a
+depends:
+- _openmp_mutex >=4.5
+constrains:
+- libgomp 15.2.0 h8acb6b2_19
+- libgcc-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 622462
+timestamp: 1778268755949
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
+sha256: fe600a63a39281e6994e27fe79360cd6bd8e576c3ce1af32ce8673b011f46c21
+md5: 18ad0f0b94071d91fa962a1bf3983a78
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2353893
+timestamp: 1778268665954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+sha256: 1137f93f477f56199ded24117430045a0c02cbe8b10031beac3b9ad2138539d3
+md5: 770cf892e5530f43e63cadc673e85653
+depends:
+- libgcc 15.2.0 h8acb6b2_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27738
+timestamp: 1778268759211
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+sha256: e5ad94be72634233510b33ba792a3339921bd468f0b8bc6961ea05eded251d9b
+md5: c7a5b5decf969ead5ecada83654164cf
+depends:
+- libgfortran5 15.2.0 h1b7bec0_19
+constrains:
+- libgfortran-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27728
+timestamp: 1778268784621
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+sha256: af8e9bdcaa77f133a8ee4c1ef57ef564d9c45aa262abf9f5ef9b50eb99d96407
+md5: 779dbb494de6d3d6477cab52eb34285a
+depends:
+- libgcc >=15.2.0
+constrains:
+- libgfortran 15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1487244
+timestamp: 1778268767295
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+sha256: 6a13152a81513117b8d41bf64dea56c731d877bcced5a24fab738e3c0f9ac58c
+md5: 31d404d8c0755d0f9062a4459f5a1084
+depends:
+- libgcc >=14
+- libffi >=3.5.2,<3.6.0a0
+- pcre2 >=10.47,<10.48.0a0
+- libzlib >=1.3.2,<2.0a0
+- libiconv >=1.18,<2.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4943441
+timestamp: 1782464048865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+sha256: 2370ef0ffcbae5bede3c4bf136add4abc257245eb91f724c99bb4a43116c5a83
+md5: c5e8a379c4a2ec2aea4ba22758c001d9
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 587387
+timestamp: 1778268674393
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-14.2.1-h3a99ef3_1.conda
+sha256: ae1d16dd62f626c4dab1240a49f6b04e14e4f30140e5fb26bb835821dba114b6
+md5: 655cedd9626545089b9e9ead153cf619
+depends:
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1334601
+timestamp: 1782800489368
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-devel-14.2.1-h3a99ef3_1.conda
+sha256: 866b0132df7d080a7b2e3c44e4c79723f007db6c035b1e751612d29db698859b
+md5: b6762f2c0386ba4606d5b2cba1e41ca8
+depends:
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libharfbuzz 14.2.1 h3a99ef3_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 2050496
+timestamp: 1782800511879
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+sha256: 1473451cd282b48d24515795a595801c9b65b567fe399d7e12d50b2d6cdb04d9
+md5: 5a86bf847b9b926f3a4f203339748d78
+depends:
+- libgcc >=14
+license: LGPL-2.1-only
+size: 791226
+timestamp: 1754910975665
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_0.conda
+sha256: da3e45974c1f23c76264d6358463861236862052ca156e34b502ef3c27e36fb8
+md5: de0780a3690bffe75ac3fa70db84596d
+depends:
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 714602
+timestamp: 1783731816001
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+build_number: 8
+sha256: d269a684afa0b2fdb44d6b60167f854f30410cdb5ee49a7275c026f6b10c8d05
+md5: 3af3f2aa755abc5e91351114ae214f55
+depends:
+- libblas 3.11.0 8_haddc8a3_openblas
+constrains:
+- libcblas   3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+- blas 2.308   openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18828
+timestamp: 1779859055749
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+sha256: d61962b9cd54c3554361550203c64d5b65b71e3058a285b66e4b04b9769f0a5c
+md5: 76298a9e6d71ee6e832a8d0d7373b261
+depends:
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 126102
+timestamp: 1775828008518
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+sha256: 13782715b9eeebc4ad16d36e84ca569d1495e3516aea3fe546a32caa0a597d82
+md5: be5f0f007a4500a226ef001115535a3d
+depends:
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 726928
+timestamp: 1773854039807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+sha256: b018ecfb05e75a8eea3f21f6b5c5c2a54b5178bdcf19e2e2df2735740214a8c8
+md5: 58a66cd95e9692f08abe89f55a6f3f12
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.33,<0.3.34.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5121336
+timestamp: 1776993423004
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
+md5: f51503ac45a4888bce71af9027a2ecc9
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 341202
+timestamp: 1776315188425
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+sha256: 15ec553e784f2b8601c3df58e1dbe723309303c5ed405bc671bffae722c81023
+md5: f8f91448e5ba30051ceb17b45b31da9b
+depends:
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 71121
+timestamp: 1783936885865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_19.conda
+sha256: 8115604f113fe2b7be95b2d22183a4dda5779c1cc6db4b826af800581498b4b3
+md5: 95210a1edbd7fc6e12afc9f8276f450a
+depends:
+- libgcc >=15.2.0
+- libstdcxx >=15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7067965
+timestamp: 1778268796086
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+sha256: 1e289bcce4ee6a5817a19c66e296f3c644dcfa6e562e5c1cba807270798814e7
+md5: eecc495bcfdd9da8058969656f916cc2
+depends:
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 311396
+timestamp: 1745609845915
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
+md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
+depends:
+- libgcc 15.2.0 h8acb6b2_19
+constrains:
+- libstdcxx-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 5546559
+timestamp: 1778268777463
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
+sha256: 6f7ceee16070781b7d642a37a35ffdf09c66796d3df105c919526210ce220443
+md5: 61da34d67f58dd4cf16683f6cdcb06c8
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 17627362
+timestamp: 1778268687968
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+sha256: ef1006578ef7e3f7c420e89d87846213ceb3fdcef2626af2558cbede53d36839
+md5: 20166e2297c1cac346b544d5f6197440
+depends:
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 508982
+timestamp: 1783084925965
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+sha256: 7663489f97c104ae3814db10f384932c74b439f3c1fd4247e4fe3599830c090a
+md5: 58fa42bc4bc71fc329889497ec15effb
+depends:
+- libgcc >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 43248
+timestamp: 1781625528371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+sha256: 3e2ead35f47d01364031f323f1be984018c8f19a3a264f952ddcd043685a1c86
+md5: ac7bcbd2c77691cd6d1ede8c029e8c8a
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 456627
+timestamp: 1779396031450
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+sha256: b03700a1f741554e8e5712f9b06dd67e76f5301292958cd3cb1ac8c6fdd9ed25
+md5: 24e92d0942c799db387f5c9d7b81f1af
+depends:
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 359496
+timestamp: 1752160685488
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
+md5: cd14ee5cca2464a425b1dbfc24d90db2
+depends:
+- libgcc >=13
+- pthread-stubs
+- xorg-libxau >=1.0.11,<2.0a0
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 397493
+timestamp: 1727280745441
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+sha256: eb111e32e5a7313a5bf799c7fb2419051fa2fe7eff74769fac8d5a448b309f7f
+md5: 502006882cf5461adced436e410046d1
+constrains:
+- zlib 1.3.2 *_2
+license: Zlib
+license_family: Other
+size: 69833
+timestamp: 1774072605429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+sha256: d243aea768e6fa360b7eda598340f43d2a41c9fc169d9f97f505410be68815f8
+md5: 5983ffb12d09efc45c4a3b74cd890137
+depends:
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 528318
+timestamp: 1727801707353
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+sha256: 369db85c5cd8d99dde364ce70725d76511d9c8199e5b820c740414091bf5bcca
+md5: b2a43456aa56fe80c2477a5094899eff
+depends:
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 960036
+timestamp: 1777422174534
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+sha256: da4a5df42614166b69c2f6d8602fc1425f7aaa699f77c3bafb5c7fe69b3d9fb7
+md5: fa6260b3e6eababf6ca85a7eb3336383
+depends:
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3704664
+timestamp: 1781069675555
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandoc-3.10-h8af1aa0_0.conda
+sha256: 8427cd22ccc4104d1348fe028e130e800328060e3b6f3607ce97f5188c68b835
+md5: 648f4bde42b8c5d708296ca6106c377d
+license: GPL-2.0-or-later
+license_family: GPL
+size: 23565468
+timestamp: 1780595445519
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+sha256: d209c8b0d53c441ee0bc0d8fce0fcae8e7e05755e51b13b6b9da02c7aa032f98
+md5: 3fc7cc25bba3381e77b753578058e3b0
+depends:
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.17.1,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- harfbuzz >=13.2.0
+- libexpat >=2.7.4,<3.0a0
+- libfreetype >=2.14.2
+- libfreetype6 >=2.14.2
+- libgcc >=14
+- libglib >=2.86.4,<3.0a0
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 470441
+timestamp: 1774284032397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+sha256: 04df2cee95feba440387f33f878e9f655521e69f4be33a0cd637f07d3d81f0f9
+md5: 1a30c42e32ca0ea216bd0bfe6f842f0b
+depends:
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1166552
+timestamp: 1763655534263
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_2.conda
+sha256: 414acad3e460cfcf6bf3a764c4b4837359bda9fdc350a85b560e344a9e2306a5
+md5: af8ab93369e53542b135dab29eca49e8
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 304146
+timestamp: 1784286832656
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+sha256: e9cbcbc94e151ada3d6dc365380aaaf591f65012c16d9a2abaea4b9b90adc402
+md5: ab7288cc39545556d1bc5e71ab2df9a9
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 636733
+timestamp: 1769712412683
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
+md5: bb5a90c93e3bac3d5690acf76b4a6386
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 8342
+timestamp: 1726803319942
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+sha256: 5055913d786b82f33a14f493f32945b3b2b5d528ea2f52856ca02b296f6511eb
+md5: dde4691fe168112a90efba6aaa08f13d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: LGPL (>= 2)
+license_family: LGPL
+size: 82526
+timestamp: 1757460261392
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-askpass-1.2.1-r45h0557e7b_1.conda
+sha256: e6d37a7c16ca9693a1dee6ab71778c78f6539508ca59934f38c97ff2a5129565
+md5: 6dd9985ca467090a3ce338ea95da715c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-sys >=2.1
+license: MIT
+license_family: MIT
+size: 33005
+timestamp: 1758383588821
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+sha256: 90e7ae8aa427274d7d2e510060b68925e60e897ecaa5ea135bb33afa7eb12134
+md5: b5291c60f52b43108a2973ba6f5885d1
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 72543
+timestamp: 1757447376176
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.5.3-h269e6ae_3.conda
+sha256: 27649f8b9717afec0d32b3ddd2537f08948321a5b311d8ed49bedfd4dde6b718
+md5: bd35d2e5e6972908b398aaf340861ff1
+depends:
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.18.4,<2.0a0
+- curl
+- gcc_linux-aarch64 >=14
+- gfortran_impl_linux-aarch64
+- gsl >=2.7,<2.8.0a0
+- gxx_linux-aarch64 >=14
+- icu >=78.3,<79.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libglib >=2.88.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- make
+- pango >=1.56.4,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- readline >=8.3,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- tzdata >=2024a
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxt >=1.3.1,<2.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 27596006
+timestamp: 1781523590403
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base64enc-0.1_6-r45h0557e7b_0.conda
+sha256: 2172b3db2c71520fd5018cac6e7db1659a43054b71f331573e30e0c30acbec20
+md5: 8b5fb4c68b8c612747adcf9ef27e397c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 50459
+timestamp: 1770027826952
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-beeswarm-0.4.0-r45hf488e41_5.conda
+sha256: 5284e4fd8982aa2e63d73f1b8bd760462311b5e9a853a341f5b872cd0c22d463
+md5: a0429d68e95c279c95760fa4da3ea648
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 89962
+timestamp: 1757584938658
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+sha256: 177f262fda25552b8ce3e7685220deefba1625314575a892cd4abca06ddf06a4
+md5: f1b6b9a4e77b21df8a6949102db4f468
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 644936
+timestamp: 1763112090227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+sha256: fafc7a0acb8fc595b8fd89e75ec0b1d7d5af71b2b493570fa05e1f5612d299c2
+md5: dae60c429ab933e549832bc223e95639
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-cachem
+- r-htmltools >=0.5.7
+- r-jquerylib >=0.1.3
+- r-jsonlite
+- r-lifecycle
+- r-memoise >=2.0.1
+- r-mime
+- r-rlang
+- r-sass >=0.4.0
+license: MIT
+license_family: MIT
+size: 5538377
+timestamp: 1778923739710
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+sha256: 20dd6e4aa94d2d5ea97419add6bcac50f81400d297e9933659ff35da41fe2f6d
+md5: c922b0a6584376d3587d8cb3670f5cac
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 256017
+timestamp: 1757560386979
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cachem-1.1.0-r45h0557e7b_2.conda
+sha256: c8fd2712d1a19d32feabf471fd4f5e01d8d9a622a08f76b1c3cf638f4ab1dccb
+md5: 7ac09a862af4168c7e6ca6f018464c55
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fastmap
+- r-rlang
+license: MIT
+license_family: MIT
+size: 77756
+timestamp: 1757441578494
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+sha256: f9f49b2b845f279af84a33c8af19a915b2731c0bd892c608205cbad8a34f423d
+md5: a5cc8a8d0dc08dc769c65a13b3573739
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-processx >=3.4.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 454090
+timestamp: 1757475635573
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.6-r45h08b74da_0.conda
+sha256: 5416a041dbc61d4d3b74c0c888295aaf7cb71262236a4fc09242c18711ed00ff
+md5: 196fedd5e490165a94ee856d727aa247
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1346019
+timestamp: 1775733744341
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cluster-2.1.8.2-r45h6df9e4a_0.conda
+sha256: bf4a9118958688ef6a7b06267fb0aa7006fa97ec37d400f194c48175ff5df3f7
+md5: 5b08c25df4a50c12c8bfdfe65d191ce8
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 595768
+timestamp: 1770285735470
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+sha256: aec327dd836824278a2adf006f426a58d834828de74de7f8348f2f5f068de702
+md5: 8e9e5b14f74a6040c77e0b9c8bfa84ca
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 109200
+timestamp: 1757452164030
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-colorspace-2.1_3-r45h0557e7b_0.conda
+sha256: d78a45f9c58a3182ba17a3851017b7adaa6d0ecebcee872998bb41e6cc312782
+md5: 01eaba8437d8c23d0dea562c29e406a8
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2546382
+timestamp: 1784283306550
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-commonmark-2.0.0-r45h0557e7b_1.conda
+sha256: 1382bc1e64063f49fdc406d0ce92a815c43b9be9cb098d8e65f7059f97117535
+md5: 4f0d0c8eeeaad3aab64c7bee16426a28
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 144114
+timestamp: 1757422195437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+sha256: 5993a1b5c08c78a35cdbcf20376773eb7c4def2d28615e49f96008b43a4c05c0
+md5: 71c68a3993a696b6b75f7a6550b3750f
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 246247
+timestamp: 1778089270609
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+sha256: 9126a0408696133893e674549ca7aef317768dba503765a7ed032616aabe5b49
+md5: 4f111ce078b9690abaad6248b831a370
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 168201
+timestamp: 1757452410374
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+sha256: 217e5e210501b7fa611d6c6c46ae1551f443e2359e27164240da5a1219b2551a
+md5: 523a15023a79bd6f0dcb95ba6756ceed
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.3.6
+- r-jsonlite
+- r-lazyeval
+- r-r6
+license: MIT
+license_family: MIT
+size: 382037
+timestamp: 1757479275516
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-curl-7.1.0-r45hd8a8d9c_0.conda
+sha256: 91fce711e5bacf578c37e9c5012563d60d1dbe5a05dcf0f2a8080d3be2a938bf
+md5: 328d250136cafc6b644b5174767dbea4
+depends:
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 477493
+timestamp: 1777147747989
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-data.table-1.18.4-r45hbf3bb9c_0.conda
+sha256: d4a19f503b0705d9662ce3e9d81753aa720202c5c87e0f64869599dcfa9e84d7
+md5: 8f3b2a953fcbc5eb2dadb5dab1f0d5b6
+depends:
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MPL-2.0
+license_family: OTHER
+size: 2644344
+timestamp: 1783428401576
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+sha256: 1edafb4e01397265da1816f3164a451d36f02546f2589c5f45051886ab9f91a8
+md5: f69bda3cb40132707f6efff4c749ce09
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-magrittr >=1.0.1
+- r-viridis
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4839264
+timestamp: 1757633933010
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-digest-0.6.39-r45h08b74da_0.conda
+sha256: 2cf79b6af8cdd8215ffed899d016c1554935cab5cc419a9390cc6931cdf49513
+md5: c5109e71b8b0a7dcdddcc4f6fa21605d
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 225830
+timestamp: 1763566824454
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.2.1-r45h08b74da_0.conda
+sha256: c7a33bc92936537648e29cb70b0912deaa4a79cc4d8f30f4e4dd213723eb00a0
+md5: 93bb33f64dce6cdcd5251d8d2234bac7
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1449577
+timestamp: 1775207129641
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+sha256: 38eee3a12260e5fff1e2af04250f6b67091b01c694f101ae6448da12c3fcca09
+md5: b78224895a1ad7fb52311ab071c2ec00
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-crosstalk
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httpuv
+- r-jquerylib
+- r-jsonlite >=0.9.16
+- r-magrittr
+- r-promises
+license: GPL-3.0-only
+license_family: GPL3
+size: 1439901
+timestamp: 1757566758266
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+sha256: ec00c0162d803af3c8059e9504d1d0c8b60cabe805c347a4a20300f2cce9e700
+md5: 6ac48e7c4c46b6c0538a779d0a43008a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-gridextra >=2.3
+- r-gtable
+license: GPL-3
+license_family: GPL3
+size: 950098
+timestamp: 1757760318911
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.3-r45h0557e7b_0.conda
+sha256: cdd63168ef461c582d26b5a8bcd7e5378575a20068e61ab119cdbb544329f5a4
+md5: a52d33523179da32a3c9d11ff27b730d
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 34061
+timestamp: 1775287261756
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+sha256: d3accfeab1416151515c37e5edc94b18868998db4936183459f8040117d5c83c
+md5: 4e0c71ab78d7292372a89d4daecb49af
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 111914
+timestamp: 1757447684244
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.7-r45h0557e7b_0.conda
+sha256: 9a8c13e87085007face8d9576ca4675ac2187e4b2082f195199b6b6af67c45c6
+md5: a0702b7eb11d1a382527a02baf1fd0bc
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 339732
+timestamp: 1763566140258
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-farver-2.1.2-r45h08b74da_2.conda
+sha256: bad9c13ce006e7e972cd3b240efc2ab457557acfec2a5566c85b91f6f354cd8f
+md5: e3468d0fb1e32edf11badd5dcdb847e4
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1401937
+timestamp: 1757441349828
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fastmap-1.2.0-r45h08b74da_2.conda
+sha256: 3bff61e00966863ab1febada7f64a9618db330aa97dd527b0d2719990993e1a3
+md5: 679225ca2785ed02ffd33b5cd998e514
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 74243
+timestamp: 1757421537458
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+sha256: 865df12d8cdd8cf577abc8f785a0aa4ee50b4f8751256dffe4676a350943d591
+md5: e9fccb3617ec9776569c6496fa254e64
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.1.1
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 1335664
+timestamp: 1757461248044
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+sha256: c95d1e61946bf81128be213dea7a07b5196c6e13caf9c6452c38145da8d2dfb1
+md5: 5abe392c8f8c5b954ebdc5fe46fcc709
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-codetools
+- r-iterators
+license: Apache-2.0
+license_family: APACHE
+size: 140909
+timestamp: 1757490449004
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fs-2.1.0-r45hd601667_0.conda
+sha256: 305a53e9e768366f5a143376ad618c5c08f67ac96242d747ec7bd6a0db71d1c2
+md5: 87df8bfe7e48c5b0537cc534f8a5b3a3
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 244508
+timestamp: 1777152716131
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+sha256: 196d29aa2d809d9115dce27236470219e1057d394654b5d73182f0e9d117f2fa
+md5: 4a667a55fc37e12dcbe510262ca61d19
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 424919
+timestamp: 1757627324320
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+sha256: 88a5cf4bac0a553943996bc930b1ea28f2635c262c1b2c5a42b026b69f227f02
+md5: f19c9493b80f63a41fa017ec3b27bc2e
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 88225
+timestamp: 1757455977192
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+sha256: 20c4ea52e72cb2e50907f9e5a446f16b0fce467fec4edab236eeb3b46890f3dd
+md5: b3a121ed6a71f3b674859ccbb15ad56b
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 67477
+timestamp: 1777325952298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+sha256: f8c0982d1579b810fc24cb702f8922794fce7bdfb9d3bf96867a4b038205b045
+md5: 9be31d2adf526d3c38b78a05333ddf30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-beeswarm
+- r-ggplot2 >=3.3.0
+- r-lifecycle
+- r-vipor
+license: GPL-3.0-or-later
+license_family: GPL3
+size: 1761662
+timestamp: 1764399956063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+sha256: 4e0401174fac5b54f124a8e7e418995a74918e8cd52a456a82db3fc5a373f0e0
+md5: bcdfec44c6bf587e65f56de61334a413
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=0.9.2
+- r-mass
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 221547
+timestamp: 1757758420492
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+sha256: 3a91d5334b7d99bc247386eaf0d331e119852e381e769e266f70df20eab22689
+md5: 866fbbf3f356140922d618f26f2b889c
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-gtable >=0.3.6
+- r-isoband
+- r-lifecycle >=1.0.1
+- r-rlang >=1.1.0
+- r-s7
+- r-scales >=1.4.0
+- r-vctrs >=0.6.0
+- r-withr >=2.5.0
+license: MIT
+license_family: MIT
+size: 7812326
+timestamp: 1776860393567
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.1-r45h0557e7b_0.conda
+sha256: 02f33f91373217832525d722f7e3be2ac47a1b8f9e1e65a33a03622180ff2360
+md5: a410160f41fb5192efccd33986aced38
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 172828
+timestamp: 1776413622694
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+sha256: e82d7e308a7e6d3eb90d9ea33d1f56d24bd69804995db2dacd5b20b7a20c34e4
+md5: aad2c473bf6f930833d0dc881811cf62
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-gtable
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 529159
+timestamp: 1782547830828
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+sha256: fcd2601af8213f39af6f720e22c8f858b3451f8e3d93cbc9e6aedb2d6f88483e
+md5: f686123cfba49e6299fae7e029a40266
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-lifecycle
+- r-rlang
+license: MIT
+license_family: MIT
+size: 228864
+timestamp: 1757463478042
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+sha256: 2d26e9b5c0e688cc76d33d81f8f62c59de9dc2f0695fd7b110991fa222db5524
+md5: d0bd1b5a09e5d631b8de31949ea19ece
+depends:
+- r-assertthat
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+- r-dendextend >=1.12.0
+- r-egg
+- r-ggplot2 >=2.2.0
+- r-htmlwidgets
+- r-magrittr >=1.0.1
+- r-plotly >=4.7.1
+- r-rcolorbrewer
+- r-reshape2
+- r-scales
+- r-seriation
+- r-viridis
+- r-webshot
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1693764
+timestamp: 1758426737719
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-hexbin-1.28.5-r45h6df9e4a_1.conda
+sha256: 1b589435aaf7c11bb23d6877f077a61f387a696fdeb7fd4d8307b5e4e5fcbebe
+md5: a7e475f65cbe95ff5193d520cdd5196c
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-only
+license_family: GPL2
+size: 1594883
+timestamp: 1757483340587
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+sha256: e676112aac0dbfe123fcb3108cce376782211a096c898a3af46fdf32a37e12e9
+md5: 0b5902d6af02a23bda1794d46090db42
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.18
+license: GPL-2.0-or-later
+license_family: GPL
+size: 57308
+timestamp: 1772794436225
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-htmltools-0.5.9-r45h08b74da_0.conda
+sha256: 71fb50fb947fc5209e6abc3ea4a7e388e32f564f306a4771c46b26dcf7474369
+md5: bd128ae05e4cb14baa66ff86ad9b3126
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-digest
+- r-ellipsis
+- r-fastmap >=1.1.0
+- r-rlang >=0.4.10
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 368214
+timestamp: 1764860572792
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+sha256: 4c3998ce4b4882429e52eed5c6c53d59056814d8fbc34a41ba79b990fdec1441
+md5: 6f767715f90e7caf17af72959bfcb11e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.7
+- r-jsonlite >=0.9.16
+- r-knitr >=1.8
+- r-rmarkdown
+- r-yaml
+license: MIT
+license_family: MIT
+size: 426023
+timestamp: 1757552859817
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-httpuv-1.6.17-r45hb62f08c_0.conda
+sha256: f80c025e58243755b5a66d125fff21aff8f081fee0428a9254c62ee9cde6dc65
+md5: d1e3db0a93a2074799a0659080178b8e
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-later >=0.8.0
+- r-promises
+- r-r6
+- r-rcpp >=1.0.7
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 553429
+timestamp: 1773825488822
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+sha256: 4adb565d2b3365108d7efb926c2acdc68c11ef2ad32ed03d1108a3005cf8cdd8
+md5: 259658089c383f2915b167da3e7890aa
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-curl >=0.9.1
+- r-jsonlite
+- r-mime
+- r-openssl >=0.8
+- r-r6
+license: MIT
+license_family: MIT
+size: 474019
+timestamp: 1771005817336
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+sha256: dcc78f60308390c6549e25308fb2437421e8fcaeeb45378b6fbe3a49e3d3cd0b
+md5: b240e3c0e61de35f1f43729f4ea2888e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.0.0
+- r-curl >=5.1.0
+- r-glue
+- r-lifecycle
+- r-magrittr
+- r-openssl
+- r-r6
+- r-rappdirs
+- r-rlang >=1.1.0
+- r-vctrs >=0.6.3
+- r-withr
+license: MIT
+license_family: MIT
+size: 935264
+timestamp: 1784022303810
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-isoband-0.3.0-r45h08b74da_0.conda
+sha256: e70c9f8bb4b0100ac45e9aeed982c2a72357c4b8ca529fa2927cbc917e283c4c
+md5: 04efe7d434cd3e6f5a69e4799eb6cbbd
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-cpp11
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1660497
+timestamp: 1766530417757
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+sha256: c90d0faa668d2753db9da9458ca085891a3030c6537f5675fe0c1a1b5af2103c
+md5: 7746a41a4cb97cec59db2d5a2cac0701
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 350171
+timestamp: 1757459846270
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+sha256: abb2cd923ed271df8774e696f2e455f8c641532cc984fd770b87852a0017d7ab
+md5: 7113381f500ebcc8a33b61101817d120
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-jsonlite
+- r-openssl >=1.2.1
+license: MIT
+license_family: MIT
+size: 248113
+timestamp: 1776846446837
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+sha256: 3b98f72bb32d4758854805b664b4404602a583da32c9b96026536f5676f41812
+md5: 49a9ed6ed01f4ae6067ead552795bfce
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools
+license: MIT
+license_family: MIT
+size: 307113
+timestamp: 1757459485295
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-jsonlite-2.0.0-r45h0557e7b_1.conda
+sha256: cd484854182eca0e62cacf6f5dfdc3d11106d4ab0307d41361c772247e9ae283
+md5: 0c7d7b8541f5619f09dd9334deb7dbf7
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 645626
+timestamp: 1757419590460
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+sha256: e2184f1cb58aedacd94d1dbe6e8b5dfa3508151f454e80f6bd49486bdb90625c
+md5: 35b31b96aa7bc052ad6347322a1481f1
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-evaluate >=0.15
+- r-highr >=0.11
+- r-xfun >=0.52
+- r-yaml >=2.1.19
+license: GPL-2.0-or-later
+license_family: GPL
+size: 988526
+timestamp: 1766309267127
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+sha256: 42a06b7c346d6e4550dca1024bbf89e3c22962d568cfe4e8b8be824dea326110
+md5: a41490fdf607381035aa0304c21407c9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 70182
+timestamp: 1757456007088
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-later-1.4.8-r45h08b74da_0.conda
+sha256: b7c530de9a38fcf30ae63c92cd60fb0d23567e6567f70694d350ff2adeec88e0
+md5: 3601ce2112d41114cdb6ed340ee44442
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.12.9
+- r-rlang
+license: MIT
+license_family: MIT
+size: 155668
+timestamp: 1772707321535
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lattice-0.22_9-r45h0557e7b_0.conda
+sha256: a6f30211a8b3511e27c2aac99b499cdb4751a950fe5595a48672a38de8ecc28d
+md5: 2049f7981874aefa34b2b5b53af007eb
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1418137
+timestamp: 1770694138040
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lazyeval-0.2.3-r45hf488e41_0.conda
+sha256: c9f7bb66c064e813d5aa82e60b70ab4fb1f0b6acda05a43cbbb3615bd2c71899
+md5: 2a54efbd48368966f65e6500198574e7
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang
+license: GPL-3.0-only
+license_family: GPL3
+size: 195208
+timestamp: 1775429446648
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+sha256: b7a4d8d98a96d17d18c80fb7e1c8e6cb09b9bd2542e74d91a7f483afccb30ee6
+md5: 5f8369dfbdff08878e58bf15529fca3a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 132636
+timestamp: 1767865665455
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+sha256: 1f594c5be675a53caef3368ea85c048b8bcbc4385e2bd582e977981a1edd5e3e
+md5: b936b3596737a3a1d513e1258d5d0355
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-commonmark >=2.0.0
+- r-xfun >=0.55
+license: MIT
+license_family: MIT
+size: 392980
+timestamp: 1784144498175
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.5-r45h0557e7b_0.conda
+sha256: 0a4dbbb3acc77222d0119e1d9c47c94359e5a05290a514b5ac345512e6d5d125
+md5: e61a28ac3cbd3f76f96f9aef579ae6ef
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 212064
+timestamp: 1775298634467
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+sha256: 5f27ccd93b39c2435ed6e9b8302ae50d51eb5b6058d7d11edba403e9723f48c6
+md5: 755b46b2896c8526a18074b3b651dfbc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-litedown >=0.6
+- r-xfun
+license: MIT
+license_family: MIT
+size: 72190
+timestamp: 1757496654397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mass-7.3_66-r45hf488e41_0.conda
+sha256: cadc1e7cb74ec9999a2393b5225bca8f39da162f5ea1719783c4186dffd5d223
+md5: 615cb3f4dc69d374da874553f58cc61c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1143006
+timestamp: 1784201763856
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrix-1.7_5-r45h9301183_0.conda
+sha256: 0671e1595f283ed8f5a67f6006821b90b58a954c095d230cf0c3543d45aa6e1f
+md5: dbc4de669537f1b65a8f63e92d01c0de
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4492870
+timestamp: 1774809348312
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrixstats-1.5.0-r45h0557e7b_1.conda
+sha256: cc732696567fd2e79cf48cb9ae19cfed65d2a547ef7657b847ea6e52ab29cef0
+md5: 28f5371af404b055c4e8fda252343eff
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 508907
+timestamp: 1757442506110
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+sha256: 91b0eedec5cf5de195b442b97eda508f22fdedbdbc487f74e3868d3e95380fdd
+md5: 2b04206ff6ea5a92e8e36bdaa5feb3cc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cachem
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 57750
+timestamp: 1757456335587
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mgcv-1.9_4-r45h8b2cba9_0.conda
+sha256: deb54e1594e6cff5fa5c1851b6ba9b8e9ddb663fc2a5bd0a770bd7348fca0740
+md5: 3f3684540a7cf2f8aba9bd7419b86182
+depends:
+- _openmp_mutex >=4.5
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-nlme >=3.1_64
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 3663168
+timestamp: 1762539639167
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mime-0.13-r45h0557e7b_1.conda
+sha256: 7ebc8c9727a9841e9c0ac408d67dda73618105a6741e6ee2764d3b5838006adc
+md5: a18f44c7e30f17a25dae01a2ebdd64ac
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 65881
+timestamp: 1757441504988
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+sha256: 97d463c2146c483992a25fe497755e9cf714f95ca611a93d8adbb41c068e9e74
+md5: c78bd534986cde8fc0cb08cc9a1a2cc6
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+license: MIT
+license_family: MIT
+size: 247241
+timestamp: 1757455926748
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-nlme-3.1_170-r45ha85219e_0.conda
+sha256: 5a665d1c57741a6ad27b09c26a5c70c1e8b2600b99c1ca70850b01e67981aba1
+md5: 9d56b3fd30b35e8511816cd727b71c75
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 2364152
+timestamp: 1784288181817
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-openssl-2.4.2-r45h37c386a_0.conda
+sha256: 0b1010bcebef6d666733f422ede62662c408bd21d35a1a6a415a56469641ff98
+md5: b835aaead878405731f2cd4f92f253ff
+depends:
+- libgcc >=14
+- openssl >=3.5.6,<4.0a0
+- r-askpass
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 683534
+timestamp: 1781024877810
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+sha256: 09df5e8326b04412a26b6c4d896e04adbceba45194457c6d30f370d5ccb4b397
+md5: 0c015ba0c5444777a683c05e4a000f21
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-getopt >=1.20.2
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 119289
+timestamp: 1776419503742
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+sha256: f5de9737f59e1965db2de11c90cf1fdd426db322a7205c935a3e55150287b02f
+md5: 560abd550c097e0d0af2e201b335f53d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 286342
+timestamp: 1761151056217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+sha256: 162742dd773c8a163de6ffdf0e14820b5708b9e1041d4491762c05e00f6be614
+md5: 849a8fcdb5e1d98a3917a7c652c322df
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 679411
+timestamp: 1757649050426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+sha256: a4869bf14ad791c8a5cb48fd0575faa3cdb7b07692cb4b473809c261f584fa45
+md5: 9a48d2e7fdc93937c60481c06d40e6ba
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 234305
+timestamp: 1770387131912
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+sha256: b3f281041ecff2d4a9f40073ad5e7ec6fa7e0c841068ce85c550bcce0ff8938d
+md5: 807ef77a70fc5156f830d6c683d07a29
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 629867
+timestamp: 1758149763203
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+sha256: fda425435a533e86da5f0fc89cf45c9f889a4e6f1e2ed536ca23662a8461602c
+md5: 40a5fdd06c7e7880758a021cf2df6c12
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 27236
+timestamp: 1757447537447
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
+sha256: c27913720e29845540e0f20507cdd43ea2beff02e7a73b1e2f51e4e929c42859
+md5: 51ad52cc7fa715ca7739245162bfab8f
+depends:
+- libgcc >=14
+- openssl >=3.5.3,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 137458
+timestamp: 1758095884906
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
+md5: ced57d920bed79382f382a24a4425ef7
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-crosstalk
+- r-data.table
+- r-digest
+- r-dplyr
+- r-ggplot2 >=3.0.0
+- r-hexbin
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httr
+- r-jsonlite >=1.6
+- r-lazyeval >=0.2.0
+- r-magrittr
+- r-promises
+- r-purrr
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-tibble
+- r-tidyr
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 3587131
+timestamp: 1769337109792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
+sha256: 0150b0ff5b1f10d44d8340697dc75308d000af7173e06a7bd6bbc52662435647
+md5: b5287e844eb29138a9bbac2204c34938
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.0
+license: MIT
+license_family: MIT
+size: 787646
+timestamp: 1757441825154
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
+sha256: 0795c4803d0c96906f1f509db1b444bedbcd49efcf563fa67e34056f155f4944
+md5: 6002b6697d4f3a7aa2112d75938215df
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-ps >=1.2.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 416233
+timestamp: 1776865727437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+sha256: 684dba5d20aae8da37868d603b662014e1944f5568e5f737e42d9d485892a26e
+md5: b2c1b6ef8f12894fd2694b285fe8989a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-fastmap >=1.1.0
+- r-later
+- r-lifecycle
+- r-magrittr >=1.5
+- r-otel >=0.2.0
+- r-r6
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1597704
+timestamp: 1762426228446
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ps-1.9.3-r45h0557e7b_0.conda
+sha256: 9806dc2cd51b90600c0cfaa9414bf037359b48e4409a3e848c714f7fd202e326
+md5: 110a8db7f8f7d81dc6499717e3518901
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 415719
+timestamp: 1777148053343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.2.2-r45h0557e7b_0.conda
+sha256: 132601f0cf01c5472b5808479e92290c4a1764202d8eb370a568c0c8cc42e509
+md5: 9418ed4bd8e6c1f7daa1d86fde8d4bca
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 551426
+timestamp: 1775853641796
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-qap-0.1_2-r45ha85219e_5.conda
+sha256: 130ad15a31352cac447a5d5121df7703a77775be465967816193fadf522ec604
+md5: 0783f6d35f1229fd9476bbd89ebb36e2
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 397185
+timestamp: 1757637123693
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+sha256: bd92e91332eba5f0c689583e80adec85ef272c4e0d0b36ee17cb7c11b5693cf2
+md5: 750802806d7d640c286ed8491bb395dc
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 95073
+timestamp: 1757447661037
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rappdirs-0.3.4-r45h0557e7b_0.conda
+sha256: 86b48f6a5648dab19677da07eb4360ab9f1df1957ab1a5bd7499c14284303fe4
+md5: 37552103a31471f0dd255110017d4397
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 55042
+timestamp: 1768747329339
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+sha256: ddd4e63616ee475bdf9dc63a0b16a89017237121e927d83fbdee07d5a5ccc890
+md5: d8fa238420cb6de47d463b7345a761eb
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68005
+timestamp: 1757452462302
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpp-1.1.2-r45h08b74da_0.conda
+sha256: 4a2c9002ff0360803ab644577bbac5a2277dab69a7cb58c23218d39e84d3371a
+md5: 6cc0478a5eda6092486e4f6fb2de570b
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 2121146
+timestamp: 1783264524840
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpptoml-0.2.3-r45hd601667_1.conda
+sha256: 0481dc92f2c896ce9e25ea69b53c8bfe7ddb76c6e3fc7baaf4cdda8351c385e5
+md5: f68ce5a7d961bf5047a1635c013d5ce2
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.5
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 229676
+timestamp: 1757491689154
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+sha256: 68f01b65843f873b01bff24f61f27298667797aa3ad01d4406a62ae72e7c08c5
+md5: 1a99d6f9dfe5f6e8dc5275d49852cd66
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 208380
+timestamp: 1757507980343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-renv-1.2.3-r45h0557e7b_0.conda
+sha256: 10a562d51e1c0286aeec2a9146e2038b809391bb1aa63700c9ccfb3362e9e372
+md5: 8dfb98a9c08d53deb71fc9f861aedefb
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 2469153
+timestamp: 1778972869359
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-reshape2-1.4.5-r45h08b74da_0.conda
+sha256: 963e97c3784e971a8f6a42efe7734123da1e5de0cea2cef876b0ffc46b303eed
+md5: 1f0843cf4a39b71ae3bb80d11c0d19f1
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-plyr >=1.8.1
+- r-rcpp
+- r-stringr
+license: MIT
+license_family: MIT
+size: 126686
+timestamp: 1762975693066
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.3.0-r45h08b74da_0.conda
+sha256: 074cbdc062065520aa129ac3390dd1dd2ac792a151c0a2441890290f2dc2351f
+md5: c41e2c86ee4633b25d88036ff33b1cdc
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1625093
+timestamp: 1783260250227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+sha256: b3735a4e75eca023b24678251da041854b94a8b96588d81b605928d6ecf74f11
+md5: 25b9dbf0ff990b8b3111774878e3bb07
+depends:
+- pandoc >=1.14
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.2.5.1
+- r-evaluate >=0.13
+- r-fontawesome >=0.5.0
+- r-htmltools >=0.5.1
+- r-jquerylib
+- r-jsonlite
+- r-knitr >=1.43
+- r-tinytex >=0.31
+- r-xfun >=0.36
+- r-yaml >=2.1.19
+license: GPL-3.0-only
+license_family: GPL3
+size: 2085382
+timestamp: 1774555006202
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+sha256: 5f9aa168f5c43f1d3ddbacc701370085fcead3956e2d5879af7fcd9e086a0a0b
+md5: 62f09532f225c86d27e954b36682add5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-digest
+- r-httr2
+- r-jsonlite
+- r-lifecycle
+- r-openssl >=2.0.0
+- r-packrat >=0.6
+- r-pki
+- r-renv >=1.0.0
+- r-rlang >=1.0.0
+- r-rstudioapi >=0.5
+- r-snowflakeauth
+- r-yaml >=2.1.5
+license: GPL-2.0-only
+license_family: GPL2
+size: 830390
+timestamp: 1783503525234
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+sha256: 896aeea3aa679a9dbd0277d10ef8dcfd011e45a1717129180a9877c1fd828f2a
+md5: 5f1b6b899fa3204ab77403e75b9df5fd
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 357140
+timestamp: 1781250782889
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-s7-0.2.2-r45hf488e41_0.conda
+sha256: 1c1be6985179ebd4eefbfc6939f014a4841e3a5b4738a667c0b1575f7bc2d1d1
+md5: 04cc16d1447a6e6cdaebe06e23d46d50
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 312811
+timestamp: 1776861400477
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sass-0.4.10-r45h08b74da_1.conda
+sha256: a318466958e737c4b214299b99974398e769961347cfad85c585e7bc7a959749
+md5: 6a543a95d37cfaa08a3f17dc3e46e8f6
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-fs
+- r-htmltools
+- r-r6
+- r-rappdirs
+- r-rlang
+license: MIT
+license_family: MIT
+size: 2245202
+timestamp: 1757464676590
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+sha256: 260c384e952e5bd4d2c2de77b9e09b24ff1c1f680acd917c4657ab8c9e4e9a2f
+md5: 8bc81cc6fd130cef963bc9e082726a14
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-farver >=2.0.0
+- r-labeling
+- r-lifecycle
+- r-munsell >=0.5
+- r-r6
+- r-rcolorbrewer
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 777793
+timestamp: 1757487539496
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+sha256: bcde368cbf5a2c83b9c1fb8b3ba0722787af759f68d08bac6a82e966adbf999f
+md5: ba820689c02638c807f83e6ab5c53142
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 370745
+timestamp: 1771995271935
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-seriation-1.5.8-r45ha85219e_1.conda
+sha256: e59663a8f5dbd9c6748a353e508f49f85e99622d4adce539cd2b1aef21186624
+md5: 60eaa5984a3efa5d4a7cf167dfe18d75
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-ca
+- r-cluster
+- r-colorspace
+- r-foreach
+- r-gclus
+- r-mass
+- r-qap
+- r-registry
+- r-tsp
+- r-vegan
+license: GPL-3.0-only
+license_family: GPL
+size: 1373552
+timestamp: 1757662510748
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+sha256: ef0042ae1c3926ef9bee6c21cf761d7cf441eae61dceca7df143f3b9dc4c6f04
+md5: 2fb0e1ea59dd281487be303b1b7c6607
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.6.0
+- r-cachem >=1.1.0
+- r-commonmark >=1.7
+- r-crayon
+- r-fastmap >=1.1.1
+- r-fontawesome >=0.4.0
+- r-glue >=1.3.2
+- r-htmltools >=0.5.4
+- r-httpuv >=1.5.2
+- r-jsonlite >=0.9.16
+- r-later >=1.0.0
+- r-lifecycle >=0.2.0
+- r-mime >=0.3
+- r-promises >=1.1.0
+- r-r6 >=2.0
+- r-rlang >=0.4.10
+- r-sourcetools
+- r-withr
+- r-xtable
+license: GPL-3.0-only
+license_family: GPL3
+size: 3789417
+timestamp: 1782070586086
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+sha256: c3ea3d60226ed56e4a40b622b8e4721d257a9fb4ca8502ce89314f48a63a0090
+md5: b5da9b58b4f8137a7f2e14102bc230c9
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-glue
+- r-shiny
+license: MIT
+license_family: MIT
+size: 344724
+timestamp: 1757870156008
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+sha256: 9493d6cbf09850206f5904ccde65643de86bb9bd6add685548331c408e99610a
+md5: 3929f109451367912b4570480f4c572d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest >=0.6.8
+- r-jsonlite
+- r-shiny >=1.0.0
+license: MIT
+license_family: MIT
+size: 1018291
+timestamp: 1768513288077
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
+md5: 7382af8530d082191feb0c8da5f8a41b
+depends:
+- bioconductor-limma
+- bioconductor-summarizedexperiment
+- r-base >=4.5,<4.6.0a0
+- r-biocmanager
+- r-bslib >=0.9.0
+- r-cluster
+- r-dplyr
+- r-dt >=0.2
+- r-ggbeeswarm
+- r-ggdendro
+- r-ggplot2
+- r-heatmaply
+- r-htmltools
+- r-htmlwidgets
+- r-markdown
+- r-matrixstats
+- r-optparse
+- r-plotly >=4.8.0
+- r-rcolorbrewer
+- r-rsconnect
+- r-scatterplot3d
+- r-shiny >=1.7.0
+- r-shinycssloaders
+- r-shinyjs
+- r-viridislite
+- r-yaml
+license: AGPL-3.0
+license_family: AGPL
+size: 3448797
+timestamp: 1784579537432
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
+md5: 1d38994c8bfe421d621d9b3705c37b58
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-jose
+- r-jsonlite
+- r-openssl
+- r-rcpptoml
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76170
+timestamp: 1772133448445
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
+sha256: e0425d3fc2508397001a828f83de7b9057b26bf674f3ad031154c6d3ff737010
+md5: 6df66556d9813139f613a3d5d80aefa3
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 57378
+timestamp: 1774682311091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
+sha256: 72aaa65e6c8aecf46e62493fd569d756ad5f655dfc35e8b65fb32f903e42fac3
+md5: 896cc6b4f51281019f0112a291f2e4b0
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 326784
+timestamp: 1779038275497
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.7-r45h1ddd0e6_2.conda
+sha256: 683aecd70c89afc99c9d1a5358502091d58c5515637839a174170b5270864473
+md5: f70959e59600d520abb4fc5eff09b6b7
+depends:
+- icu >=78.2,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: FOSS
+license_family: OTHER
+size: 948766
+timestamp: 1772037526007
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+sha256: dea2a7676dd03ed93fa0ec961883c5075c361c8522659a1bc1e6b5c16525cb24
+md5: 8db438d8aa370726ee1ce8bf458f2e6d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 319328
+timestamp: 1762269757617
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sys-3.4.3-r45h0557e7b_1.conda
+sha256: 2615aa5617553d22835183a060a13b19a7fd6b006d5570d3dc7d4d0a9a18ffd1
+md5: 902062b1b024b2cf50bcebbdc3f14a33
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 51531
+timestamp: 1757441776397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.1-r45h0557e7b_0.conda
+sha256: 9ef8d3a7e5862ffe7921129d77c0e640eed11233c8c93c03ebbd38c5a7bdfc9b
+md5: 672f703f5dba8c08fe08bd5d6d462b81
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 591468
+timestamp: 1768139158745
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.2-r45h08b74da_0.conda
+sha256: cdceeab30bdc7648b9b037f884d91fafff5e3663b87a72cf9d6c4ee6e68e86d1
+md5: 0757fb6415a03dd46697bcbc836562b0
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127523
+timestamp: 1766142060375
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+sha256: fca09d6b9940f1e1cda0425a0f55716bba202d6f55d6bd25fedec391006c7dc7
+md5: 15aa0f323385403fe182e46a1d095e1b
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 220192
+timestamp: 1757475791328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+sha256: 1fad4d08756ca2d7db04cfaf88e9df797da95a5f7f4b8aabc165eee36faddafc
+md5: 5ee226c1449c66d1cd2399d942faa04d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.48
+license: MIT
+license_family: MIT
+size: 158240
+timestamp: 1782203211628
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tsp-1.2.7-r45hf488e41_0.conda
+sha256: 76b17a4cb143f1441fd91b78d1e05d537dc3fb21ae4c2b0a8247f032f249249d
+md5: d266cd3851cb11b2f619c80ff9adf6f5
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-foreach
+license: GPL-3.0-only
+license_family: GPL3
+size: 737125
+timestamp: 1774391402905
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r45h0557e7b_1.conda
+sha256: c98cdf9a46680cf5e415e37c037cab774b8df2b9b3182f15ece4d740fc0c697b
+md5: a526af0f22a5ac7a3835f1710b63e5b5
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 152455
+timestamp: 1757424718278
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.7.3-r45h08b74da_0.conda
+sha256: 10235170aad63b8412ce99dd1756d250175cf5a3ea987379fea98f0bd9224e82
+md5: f43335c24a9f3fd0920d2a9e721f2845
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1854267
+timestamp: 1775898029394
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vegan-2.7_5-r45ha2e3c6d_0.conda
+sha256: f114cf641e03f2d087d55b37f0826910bdd1e6481c1b18dbcf5d343b84178435
+md5: 5da6b73699a8bb6b0d8f60a9419983e8
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+- r-lattice
+- r-mass
+- r-mgcv
+- r-permute >=0.9_0
+license: GPL-2.0-only
+license_family: GPL2
+size: 3050073
+timestamp: 1779956718513
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+sha256: 859729e8cd04bb92ec144b21a8abfdb2bec9cbac9deaa41ba0cc2add13d088a0
+md5: e605ce527e381c5577d57649e393cb87
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4508304
+timestamp: 1757669044129
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+sha256: 884896b59133b948646b0d1441106120f7b320e9fac827ccb9d44bbe80dda8f2
+md5: e841095941c40142bdad834299b95a30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=1.0.1
+- r-gridextra
+- r-viridislite >=0.4.0
+license: MIT
+license_family: MIT
+size: 2988605
+timestamp: 1757516440048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+sha256: b9ec9606562f0f6bdefc237bbc6163eb1cb022f9d699c80771bc84af0ae37269
+md5: bcadc0a3726e2191e51449f67fa5e0a9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1305542
+timestamp: 1770191459321
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+sha256: e79e366895dfdf79fe92986fe42d0695e3fcacc25411506c48b9db92742eb99c
+md5: e021e3d936f57ea9b35eb099999d6800
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-callr
+- r-jsonlite
+- r-magrittr
+license: GPL-2.0-only
+license_family: GPL2
+size: 206060
+timestamp: 1757520337073
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+sha256: 56f318c90bfc74f01339c83f0e1d0817c1b762ea46cd9e527fec9dcf244c5900
+md5: 388d25e67f93a5fec2aebe56d6a0a1d9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 235287
+timestamp: 1781856624720
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-xfun-0.60-r45hf488e41_0.conda
+sha256: adde9f62c5c7a48edd241547d778f4ff6016970ac4334f34977032394088f12f
+md5: ec03ae90ca44079179679287542be5af
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 651144
+timestamp: 1784103302558
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+sha256: 972923364cfd616ccf38768477c435677cfe1ea18a72016f90344ea920e4fea5
+md5: e18fda0821f0fdc1c34276c5e0acdc92
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL (>= 2)
+license_family: GPL3
+size: 744345
+timestamp: 1771859982217
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-yaml-2.3.12-r45h0557e7b_0.conda
+sha256: 85b3323f76adf8862ad3a52b42270425309a875983da261faa738ed9f7e52586
+md5: 9885e008c928a67e48cd521a98f666d4
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 128431
+timestamp: 1765372892689
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+sha256: fe695f9d215e9a2e3dd0ca7f56435ab4df24f5504b83865e3d295df36e88d216
+md5: 3d49cad61f829f4f0e0611547a9cda12
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 357597
+timestamp: 1765815673644
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+sha256: 7b2d9835a79bd67c0b2966cedf246c85bf650dc961125c8e31f073646d4ac797
+md5: 59f2c90c66b956d9bc3e625df3ad8a0a
+depends:
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 288685
+timestamp: 1776861726084
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+sha256: 1bd2db6b2e451247bab103e4a0128cf6c7595dd72cb26d70f7fadd9edd1d1bc3
+md5: fdf07ab944a222ff28c754914fdb0740
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-aarch64 4.18.0 h05a177a_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 23644746
+timestamp: 1765578629426
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+build_number: 103
+sha256: cd51fbda051a9f3679d10ef4a94cd1ff38c10533b82845dadce8ba87245ba4ce
+md5: 89e78452e06563964e419059ee45584a
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3683040
+timestamp: 1784229053797
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h5f05d98_8.conda
+sha256: 06e25e5026e0058a085be2cbcc55e7ef8cda1263c15bc7e72525c0eb8bb44d5e
+md5: 40266bd074925af4a396250d222d2188
+depends:
+- tk
+- libgcc >=14
+- tk >=8.6.13,<8.7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 106646
+timestamp: 1773733124596
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+sha256: 720691eb59b86f11ceb21b236b9402d59c47d156183375d2b24c53a201dd874b
+md5: 6dc4b55fc391a3d51ff12a6fed979562
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 40249
+timestamp: 1779439555623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+sha256: a2ba1864403c7eb4194dacbfe2777acf3d596feae43aada8d1b478617ce45031
+md5: c8d8ec3e00cd0fd8a231789b91a7c5b7
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 60433
+timestamp: 1734229908988
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+sha256: b86a819cd16f90c01d9d81892155126d01555a20dabd5f3091da59d6309afd0a
+md5: 2d1409c50882819cb1af2de82e2b7208
+depends:
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 28701
+timestamp: 1741897678254
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+sha256: cf886160e2ff580d77f7eb8ec1a77c41c2c5b05343e329bc35f0ddf40b8d92ab
+md5: 22dd10425ef181e80e130db50675d615
+depends:
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 869058
+timestamp: 1770819244991
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+sha256: e9f6e931feeb2f40e1fdbafe41d3b665f1ab6cb39c5880a1fcf9f79a3f3c84a5
+md5: 1c246e1105000c3660558459e2fd6d43
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 16317
+timestamp: 1762977521691
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+sha256: 128d72f36bcc8d2b4cdbec07507542e437c7d67f677b7d77b71ed9eeac7d6df1
+md5: bff06dcde4a707339d66d45d96ceb2e2
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 21039
+timestamp: 1762979038025
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+sha256: db2188bc0d844d4e9747bac7f6c1d067e390bd769c5ad897c93f1df759dc5dba
+md5: fb42b683034619915863d68dd9df03a3
+depends:
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+license: MIT
+license_family: MIT
+size: 52409
+timestamp: 1769446753771
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+sha256: ffd77ee860c9635a28cfda46163dcfe9224dc6248c62404c544ae6b564a0be1f
+md5: ae2c2dd0e2d38d249887727db2af960e
+depends:
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 33649
+timestamp: 1734229123157
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+sha256: 7c109792b60720809a580612aba7f8eb2a0bd425b9fc078748a9d6ffc97cbfa8
+md5: a9e4852c8e0b68ee783e7240030b696f
+depends:
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.9,<2.0a0
+license: MIT
+license_family: MIT
+size: 384752
+timestamp: 1731860572314
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+sha256: 569990cf12e46f9df540275146da567d9c618c1e9c7a0bc9d9cfefadaed20b75
+md5: c3655f82dcea2aa179b291e7099c1fcc
+depends:
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 614429
+timestamp: 1764777145593

--- a/modules/nf-core/shinyngs/staticdifferential/environment.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=2.4.0
+  - bioconda::r-shinyngs=3.1.1

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -3,9 +3,9 @@ process SHINYNGS_STATICDIFFERENTIAL {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d7/d782b4f11adf8f3cad6af74ea585468decd873a171da1dae0e4a24a82bb29020/data' :
-        'community.wave.seqera.io/library/r-shinyngs:2.4.0--709fc6932be670a5' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d'}"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticdifferential/meta.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/meta.yml
@@ -7,8 +7,7 @@ keywords:
   - shinyngs
 tools:
   - "shinyngs":
-      description: "Provides Shiny applications for various array and NGS applications.
-        Currently very RNA-seq centric, with plans for expansion."
+      description: "Provides Shiny applications for various array and NGS applications. Currently very RNA-seq centric, with plans for expansion."
       homepage: "https://github.com/pinin4fjords/shinyngs"
       documentation: "https://rawgit.com/pinin4fjords/shinyngs/master/vignettes/shinyngs.html"
       tool_dev_url: "https://github.com/pinin4fjords/shinyngs"
@@ -99,3 +98,27 @@ authors:
   - "@pinin4fjords"
 maintainers:
   - "@pinin4fjords"
+containers:
+  docker:
+    linux/arm64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--4d71a4d10942e43f
+      build_id: bd-4d71a4d10942e43f_2
+      scan_id: sc-72596f6b93ff3200_1
+    linux/amd64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d
+      build_id: bd-b5595b301bfbfd4d_2
+      scan_id: sc-73b4cbdd1930464e_1
+  singularity:
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--60831a2d7cd7ae94
+      build_id: bd-60831a2d7cd7ae94_2
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6fff209824ab2042c6f09b68d257d59ae4e0ea7410dad923089db9c5c0dbd683/data
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--791778d7e2758322
+      build_id: bd-791778d7e2758322_2
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data
+  conda:
+    linux/amd64:
+      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+    linux/arm64:
+      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt

--- a/modules/nf-core/shinyngs/staticdifferential/tests/main.nf.test
+++ b/modules/nf-core/shinyngs/staticdifferential/tests/main.nf.test
@@ -33,7 +33,7 @@ nextflow_process {
                     "--diff_feature_id_col \"${params.differential_feature_id_column}\"",
                     "--fold_change_threshold \"${params.differential_min_fold_change}\"",
                     "--p_value_threshold \"${params.differential_max_qval}\"",
-                    "--unlog_foldchanges \"${params.differential_foldchanges_logged}\"",
+                    params.differential_foldchanges_logged ? "--unlog_foldchanges" : "",
                     "--palette_name \"${params.differential_palette_name}\""
                 ].join(' ').trim()
             }
@@ -94,7 +94,7 @@ nextflow_process {
                     "--diff_feature_id_col \"${params.differential_feature_id_column}\"",
                     "--fold_change_threshold \"${params.differential_min_fold_change}\"",
                     "--p_value_threshold \"${params.differential_max_qval}\"",
-                    "--unlog_foldchanges \"${params.differential_foldchanges_logged}\"",
+                    params.differential_foldchanges_logged ? "--unlog_foldchanges" : "",
                     "--palette_name \"${params.differential_palette_name}\""
                 ].join(' ').trim()
             }

--- a/modules/nf-core/shinyngs/staticdifferential/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/staticdifferential/tests/main.nf.test.snap
@@ -10,16 +10,16 @@
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:22:01.222412911",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:47:46.296759"
     },
     "stub": {
         "content": [
@@ -52,14 +52,14 @@
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ],
                 "versions_shinyngs": [
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ],
                 "volcanos_html": [
@@ -88,10 +88,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:22:14.145006911",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:48:32.900666"
     }
 }

--- a/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+++ b/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
@@ -1,0 +1,3302 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-64:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-biobase-2.70.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-delayedarray-0.36.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-genomicranges-1.62.1-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-iranges-2.44.0-r45h01b2380_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-limma-3.66.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4arrays-1.10.1-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4vectors-0.48.0-r45h01b2380_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-sparsearray-1.10.8-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-xvector-0.50.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.2.0-h281d09f_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-askpass-1.2.1-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.5.3-h502d0c9_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base64enc-0.1_6-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-beeswarm-0.4.0-r45h54b55ab_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cachem-1.1.0-r45h54b55ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.6-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.2-r45heaba542_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-commonmark-2.0.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-curl-7.1.0-r45h10955f1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.18.4-r45h1c8cec4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.39-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.2.1-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.7-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r45h3697838_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fastmap-1.2.0-r45h3697838_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fs-2.1.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.1-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-hexbin-1.28.5-r45heaba542_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-htmltools-0.5.9-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-httpuv-1.6.17-r45h6d565e7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.3.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-jsonlite-2.0.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-later-1.4.8-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_9-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lazyeval-0.2.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.5-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_66-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.7_5-r45h0e4624f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_4-r45h0e4624f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mime-0.13-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_170-r45heaba542_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-openssl-2.4.2-r45h68c19f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ps-1.9.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.2.2-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-qap-0.1_2-r45heaba542_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rappdirs-0.3.4-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.1.2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpptoml-0.2.3-r45h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-renv-1.2.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.5-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.3.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-s7-0.2.2-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sass-0.4.10-r45h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-seriation-1.5.8-r45heaba542_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.7-r45h3d52c89_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sys-3.4.3-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.1-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tsp-1.2.7-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.7.3-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vegan-2.7_5-r45h11cdb10_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xfun-0.60-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-yaml-2.3.12-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+md5: a9f577daf3de00bca7c3c76c0ecbd1de
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28948
+timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+depends:
+- ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+- sysroot_linux-64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 3713752
+timestamp: 1784214522814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+sha256: 08d7238663fc408ba2ab60b02fa3d06a7ca9d872962e03e90c7e0fdecb7ed1d0
+md5: 32fd07abe84eb14f17c7f5cc6fa8df82
+depends:
+- binutils_impl_linux-64 2.46.1 default_hfdba357_102
+license: GPL-3.0-only
+license_family: GPL
+size: 36337
+timestamp: 1784214551894
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-biobase-2.70.0-r45h01b2380_0.conda
+sha256: d23fb8b3abab1d8241a9172fc1a4ca586c31d18cb2c4fb5152c53a6cd659777a
+md5: 782edae8ecb3df45c26652d215977957
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2355711
+timestamp: 1770509543214
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+sha256: 97221eda3007381c0a6498608baaebdcec6047f7f26b121c19149fd56aabf032
+md5: 27556377d159490ea87696727ae41808
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-generics
+license: Artistic-2.0
+size: 653523
+timestamp: 1770415244399
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-delayedarray-0.36.0-r45h01b2380_0.conda
+sha256: 1f1fd7027ffffebeaca5c416f05d91bcd3a05cf1d043ee347fffbcdde6978c01
+md5: 8a5b2ea0550afcb925ff5f267ff741ea
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-sparsearray >=1.10.0,<1.11.0
+- bioconductor-sparsearray >=1.10.8,<1.11.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 2204619
+timestamp: 1772123650559
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-genomicranges-1.62.1-r45h01b2380_0.conda
+sha256: 0d5ea1e661e10cfeecf763a7466efebc616ca55a2c9f6ce33cbe41c7eb1a0a4b
+md5: 5dd6ca03e419938e6e4e3bc6b7796b45
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2306994
+timestamp: 1772108656670
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-iranges-2.44.0-r45h01b2380_1.conda
+sha256: 964697eeaeb946ecfe076f3b43eec9bafa018ef21d2dc3555d6c28ca817e4d79
+md5: d6811165f0b3db78b08fdc2c4938bc4e
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2344215
+timestamp: 1770546527540
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-limma-3.66.0-r45h01b2380_0.conda
+sha256: c8dcbf3abfc0c1cf4ff6e68c828e0c59052c2b65dd3dd15aa1d39dbca679991e
+md5: 54dbec67b82ef291760cb0c2927c5002
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-statmod
+license: GPL-2.0-or-later
+size: 3099884
+timestamp: 1770417840293
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+sha256: 169809ca754b2c07f7356f1fc4f365b7d5154fd66229543584f69008fa347c5a
+md5: cdf0406fc3caa814ff7b7876a42973a5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-matrixstats >=1.4.1
+license: Artistic-2.0
+size: 449898
+timestamp: 1770417102301
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4arrays-1.10.1-r45h01b2380_0.conda
+sha256: 0b8729dc75999ab80ff333242f1052de1642f2f5653d344c06a652143b1326bd
+md5: 0b2ad083cc4002a36926c7c31be1c5c8
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-abind
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1027424
+timestamp: 1770628251018
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4vectors-0.48.0-r45h01b2380_1.conda
+sha256: d6ffd7388683d03ab6133a3f8efdb69d917718a54c3d08b744c1b4910b876e82
+md5: db7c8f69c137a9a97a11518ce59ca149
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2061150
+timestamp: 1770508921246
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+sha256: 875f5be76bc3b83766ec0cfacf888570d529907412519a537c5f7a318e489976
+md5: cfe7c256532f9a4fc87ec3be955bb9e6
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 598298
+timestamp: 1770628899171
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-sparsearray-1.10.8-r45h01b2380_0.conda
+sha256: 7f1f2c6012e51daa1d5ea291b7928e396763dd073ebef228f2352118d4287096
+md5: 2b73e1653c675b4ba118bb085862771c
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-xvector >=0.50.0,<0.51.0
+- bioconductor-xvector >=0.50.0,<0.51.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-matrixstats
+license: Artistic-2.0
+size: 1636745
+timestamp: 1772107896548
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+sha256: b8ade9f2ab8cc2835357653f5a9bc840323c05f7656659dfb40d20e5623f8ebd
+md5: 74eb95090e807c18f5bc81cb9fb39b3c
+depends:
+- bioconductor-biobase >=2.70.0,<2.71.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-delayedarray >=0.36.0,<0.37.0
+- bioconductor-genomicranges >=1.62.0,<1.63.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1416452
+timestamp: 1772218138703
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-xvector-0.50.0-r45h01b2380_0.conda
+sha256: c0921f72138df07e69bdae7c16cc1b35deebfaf0fa93e16dfa731838a6c358b7
+md5: ec982ddb97e04a6b40454395fd2dd229
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 641687
+timestamp: 1770628594641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+sha256: c88dd33c89b33409ebcd558d78fdc66a63c18f8b06e04d170668ffb6c8ecfabd
+md5: 983b92277d78c0d0ec498e460caa0e6d
+depends:
+- tk
+license: TCL
+size: 129594
+timestamp: 1750261567920
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+md5: d2ffd7602c02f2b316fd921d39876885
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 260182
+timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+sha256: dee93a82d045f9aa8277829aa465224afa3c7a6ac18388de66099b2be7f705e7
+md5: 6130ad6705adc993b5d8482b7f66e01f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 210929
+timestamp: 1784091008551
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+md5: a9965dd99f683c5f444428f896635716
+depends:
+- __unix
+license: ISC
+size: 128866
+timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
+md5: bb6c4808bfa69d6f7f6b07e5846ced37
+depends:
+- __glibc >=2.17,<3.0.a0
+- fontconfig >=2.15.0,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.1,<79.0a0
+- libexpat >=2.7.3,<3.0a0
+- libfreetype >=2.14.1
+- libfreetype6 >=2.14.1
+- libgcc >=14
+- libglib >=2.86.3,<3.0a0
+- libpng >=1.6.53,<1.7.0a0
+- libstdcxx >=14
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 989514
+timestamp: 1766415934926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
+sha256: ae0b83efb7545ea40845253b76bbfeb12349bd32001728b8f58d726cd532d467
+md5: d09779693563f4a1a0bdb0f715ba2bf0
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 hae6b9f4_2
+- libgcc >=14
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 194776
+timestamp: 1782911792708
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
+md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 281880
+timestamp: 1780450077431
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
+md5: 8462b5322567212beeb025f3519fb3e2
+depends:
+- libfreetype 2.14.3 ha770c72_0
+- libfreetype6 2.14.3 h73754d4_0
+license: GPL-2.0-only OR FTL
+size: 173839
+timestamp: 1774298173462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
+md5: f9f81ea472684d75b9dd8d0b328cf655
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 61244
+timestamp: 1757438574066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+sha256: a48400ec4b73369c1c59babe4ad35821b63a88bba0ec40a80cea5f8c53a26b83
+md5: e3be72048d3c4a78b8e27ec48ba06252
+depends:
+- binutils_impl_linux-64 >=2.45
+- libgcc >=15.2.0
+- libgcc-devel_linux-64 15.2.0 hcc6f6b0_119
+- libgomp >=15.2.0
+- libsanitizer 15.2.0 h90f66d4_19
+- libstdcxx >=15.2.0
+- libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 81180457
+timestamp: 1778269124617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+sha256: b24b13d467898a9b9a17a868a2686412a98f8935dc7cc51547dd90645d4e8436
+md5: 28bc49875f9c38e2401696b3e48d0798
+depends:
+- gcc_impl_linux-64 15.2.0.*
+- binutils_linux-64
+- sysroot_linux-64
+license: BSD-3-Clause
+license_family: BSD
+size: 29330
+timestamp: 1781279944230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.2.0-h281d09f_19.conda
+sha256: 2f6a962bfcb74b8262dc0af5cf0716acbd96f769a0443dd231d1041c222b0ca6
+md5: 5d4fdb7935b8aa1cdb2e22ef8958101e
+depends:
+- gcc_impl_linux-64 >=15.2.0
+- libgcc >=15.2.0
+- libgfortran5 >=15.2.0
+- libstdcxx >=15.2.0
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 20041854
+timestamp: 1778269291096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
+md5: cf09e9fc938518e91d0706572cadf17a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 100054
+timestamp: 1780454302233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+sha256: 132a918b676dd1f533d7c6f95e567abf7081a6ea3251c3280de35ef600e0da87
+md5: fec079ba39c9cca093bf4c00001825de
+depends:
+- libblas >=3.8.0,<4.0a0
+- libcblas >=3.8.0,<4.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3376423
+timestamp: 1626369596591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+sha256: 3f5288346b9fe233352443b3c2e31f1fde845e39d3e96475fc05ec2e782af158
+md5: 9d41f3899b512199af0a4bb939b83e21
+depends:
+- gcc_impl_linux-64 15.2.0 he0086c7_19
+- libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+- sysroot_linux-64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16356816
+timestamp: 1778269332159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
+sha256: f78da7a8b49943a6ce48372a5bc85ab741ac86666f1040e8876545065ec1096e
+md5: 5e194579a5f72c70102f342aa362f5f9
+depends:
+- gxx_impl_linux-64 15.2.0.*
+- gcc_linux-64 ==15.2.0 h7be306e_27
+- binutils_linux-64
+- sysroot_linux-64
+license: BSD-3-Clause
+license_family: BSD
+size: 27848
+timestamp: 1781279944230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
+md5: 72e956a71241633d8c80aa198fd08784
+depends:
+- libharfbuzz-devel 14.2.1 h17a8019_1
+license: MIT
+license_family: MIT
+size: 11039
+timestamp: 1782800611635
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+md5: c80d8a3b84358cb967fa81e7075fbc8a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 12723451
+timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+md5: 86d9cba083cd041bfbf242a01a7a1999
+constrains:
+- sysroot_linux-64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1278712
+timestamp: 1765578681495
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+md5: b38117a3c920364aff79f870c984b4a3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 134088
+timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+depends:
+- __glibc >=2.17,<3.0.a0
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1388990
+timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+md5: 449500f2c089da11c40f5c21312e3e07
+depends:
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 745303
+timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
+md5: a752488c68f2e7c456bcbd8f16eec275
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 261513
+timestamp: 1773113328888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+build_number: 8
+sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+md5: 00fc660ab1b2f5ca07e92b4900d10c79
+depends:
+- libopenblas >=0.3.33,<0.3.34.0a0
+- libopenblas >=0.3.33,<1.0a0
+constrains:
+- blas 2.308   openblas
+- mkl <2027
+- libcblas   3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18804
+timestamp: 1779859100675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+build_number: 8
+sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+md5: 33a413f1095f8325e5c30fde3b0d2445
+depends:
+- libblas 3.11.0 8_h4a7cf45_openblas
+constrains:
+- blas 2.308   openblas
+- liblapacke 3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18778
+timestamp: 1779859107964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
+md5: f9c59d277a16ec8f272b2d5dd2ec3335
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 480327
+timestamp: 1782911787190
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+md5: 6c77a605a7a689d17d4819c0f8ac9a00
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 73490
+timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+depends:
+- ncurses
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 134676
+timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+md5: 172bf1cd1ff8629f2b1179945ed45055
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 112766
+timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+md5: b24d3c612f71e7aa74158d92106318b2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77856
+timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+md5: a360c33a5abe61c07959e449fa1453eb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 58592
+timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
+md5: e289f3d17880e44b633ba911d57a321b
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8049
+timestamp: 1774298163029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
+md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 384575
+timestamp: 1774298162622
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+constrains:
+- libgcc-ng ==15.2.0=*_19
+- libgomp 15.2.0 he0feb66_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1041084
+timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+sha256: 38a557eba305468ac1f90ac85e50d8defd76141cb0b8a43b2fc1aca71dd5d5f2
+md5: 683fcb168e1df9a21fa80d5aa2d9330b
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 3095909
+timestamp: 1778268932148
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+md5: 331ee9b72b9dff570d56b1302c5ab37d
+depends:
+- libgcc 15.2.0 he0feb66_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27694
+timestamp: 1778269016987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
+md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
+depends:
+- libgfortran5 15.2.0 h68bc16d_19
+constrains:
+- libgfortran-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27655
+timestamp: 1778269042954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
+md5: 85072b0ad177c966294f129b7c04a2d5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15.2.0
+constrains:
+- libgfortran 15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2483673
+timestamp: 1778269025089
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
+md5: 889febc66cd9e4190f80ef9718fa239b
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libiconv >=1.18,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- libffi >=3.5.2,<3.6.0a0
+- pcre2 >=10.47,<10.48.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4754220
+timestamp: 1782463895250
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+md5: faac990cb7aedc7f3a2224f2c9b0c26c
+depends:
+- __glibc >=2.17,<3.0.a0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 603817
+timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+md5: fb4669c3990b94ea32fbb81f433e9aa6
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1297668
+timestamp: 1782800580119
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+md5: 99cf21100441e51272f1cd6fe0632a20
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libharfbuzz 14.2.1 h17a8019_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1970690
+timestamp: 1782800603897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+md5: 915f5995e94f60e9a4826e0b0920ee88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-only
+size: 790176
+timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+sha256: 716332fd31b3808da7a4235a05212a9e9da05e854864c3def2dea0b5d2bf7610
+md5: 466badda5536d85ddc63ee9404f29735
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 652868
+timestamp: 1783731886811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+build_number: 8
+sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+md5: 809be8ba8712c77bc7d44c2d99390dc4
+depends:
+- libblas 3.11.0 8_h4a7cf45_openblas
+constrains:
+- blas 2.308   openblas
+- libcblas   3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18790
+timestamp: 1779859115086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+md5: b88d90cad08e6bc8ad540cb310a761fb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 113478
+timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+md5: 2a45e7f8af083626f009645a6481f12d
+depends:
+- __glibc >=2.17,<3.0.a0
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 663344
+timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
+md5: 2d3278b721e40468295ca755c3b84070
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.33,<0.3.34.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5931919
+timestamp: 1776993658641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+md5: eba48a68a1a2b9d3c0d9511548db85db
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 317729
+timestamp: 1776315175087
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+sha256: 71118885feab91c61bea4e9532ec46e0653b24f02e563681f822915aee8435bb
+md5: af5ddfb52ad25d833c70c7511478d4eb
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 70092
+timestamp: 1783936855082
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+sha256: 7a58892a52739ce4c0f7109de9e91b4353104748eb04fc6441d88e8af444ba99
+md5: 67eef12ce33f7ff99900c212d7076fc2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15.2.0
+- libstdcxx >=15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7930689
+timestamp: 1778269054623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+md5: eecce068c7e4eddeb169591baac20ac4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 304790
+timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+md5: 5794b3bdc38177caf969dabd3af08549
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc 15.2.0 he0feb66_19
+constrains:
+- libstdcxx-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 5852044
+timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+sha256: a2385f3611d5cd25378f9cf2367183320731709c067ddd08d43330d3170f15b8
+md5: bcfe7eae40158c3e355d2f9d3ed41230
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 20765069
+timestamp: 1778268963689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
+md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
+depends:
+- __glibc >=2.17,<3.0.a0
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 452337
+timestamp: 1783084902636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+md5: 01bb81d12c957de066ea7362007df642
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-3-Clause
+license_family: BSD
+size: 40017
+timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+sha256: e28e4519223f78b3163599ca89c3f2d80bfb53e907e7fc74e806e60d1efa578b
+md5: 4e33d49bf4fc853855a3b00643aa5484
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 419935
+timestamp: 1779396012261
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+md5: aea31d2e5b1091feca96fcfe945c3cf9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 429011
+timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+md5: 92ed62436b625154323d40d5f2f11dd7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- pthread-stubs
+- xorg-libxau >=1.0.11,<2.0a0
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 395888
+timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+md5: d87ff7921124eccd67248aa483c23fec
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- zlib 1.3.2 *_2
+license: Zlib
+license_family: Other
+size: 63629
+timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+sha256: d652c7bd4d3b6f82b0f6d063b0d8df6f54cc47531092d7ff008e780f3261bdda
+md5: 33405d2a66b1411db9f7242c8b97c9e7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 513088
+timestamp: 1727801714848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+md5: fc21868a1a5aacc937e7a18747acb8a5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 918956
+timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+md5: 79dd2074b5cd5c5c6b2930514a11e22d
+depends:
+- __glibc >=2.17,<3.0.a0
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3159683
+timestamp: 1781069855778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+sha256: 2f17a165a04833bd249215336b00df912bad7f03ae445a36765b47593df34057
+md5: a4b80dd6e9e0784ba48e6803bef1e17a
+license: GPL-2.0-or-later
+license_family: GPL
+size: 22516793
+timestamp: 1780595446569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
+md5: d53ffc0edc8eabf4253508008493c5bc
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.17.1,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- harfbuzz >=13.2.1
+- libexpat >=2.7.4,<3.0a0
+- libfreetype >=2.14.2
+- libfreetype6 >=2.14.2
+- libgcc >=14
+- libglib >=2.86.4,<3.0a0
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 458036
+timestamp: 1774281947855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+md5: 7a3bff861a6583f1889021facefc08b1
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1222481
+timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+sha256: 9e5b5be056820ade8b09ef73cf9f4bea037eb9887145d0297ac99e0add88878d
+md5: 7cd77fef4da3e1ca9484394616cb71f1
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 376220
+timestamp: 1784286827180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+sha256: 4ce2e1ee31a6217998f78c31ce7dc0a3e0557d9238b51d49dd20c52d467a126d
+md5: f2c23a77b25efcad57d377b34bd84941
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 593603
+timestamp: 1769710381284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+md5: b3c17d95b5a10c6e64a21fa17573e70e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 8252
+timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+sha256: 5055913d786b82f33a14f493f32945b3b2b5d528ea2f52856ca02b296f6511eb
+md5: dde4691fe168112a90efba6aaa08f13d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: LGPL (>= 2)
+license_family: LGPL
+size: 82526
+timestamp: 1757460261392
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-askpass-1.2.1-r45h54b55ab_1.conda
+sha256: 5c4d2bcc1beba7703acbfe1610a846ce2a4010456714705dfa63989cee722a00
+md5: 1ae3c72e90c6a3871c594448d3e152e4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-sys >=2.1
+license: MIT
+license_family: MIT
+size: 31983
+timestamp: 1758383536121
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+sha256: 90e7ae8aa427274d7d2e510060b68925e60e897ecaa5ea135bb33afa7eb12134
+md5: b5291c60f52b43108a2973ba6f5885d1
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 72543
+timestamp: 1757447376176
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.5.3-h502d0c9_3.conda
+sha256: e6fa14f597334a5178e5ea0ce2290e1bcb5d165d36f6dbcf41a516cba3176dff
+md5: 8e584ef995c58d546ca1b2642fa4deae
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.18.4,<2.0a0
+- curl
+- gcc_linux-64 >=14
+- gfortran_impl_linux-64
+- gsl >=2.7,<2.8.0a0
+- gxx_linux-64 >=14
+- icu >=78.3,<79.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libglib >=2.88.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- make
+- pango >=1.56.4,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- readline >=8.3,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- tzdata >=2024a
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxt >=1.3.1,<2.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 27369225
+timestamp: 1781522577217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base64enc-0.1_6-r45h54b55ab_0.conda
+sha256: 7a3751a340766ee25380a51df70c8356a64cfeb6ac3d982a86e92eb99fec2943
+md5: e573dc135976197e7f819eec202c93f1
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 48616
+timestamp: 1770027796335
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-beeswarm-0.4.0-r45h54b55ab_5.conda
+sha256: 0b1e86ec24e2acc3eae1020cc5b19f9f7e172df8871b4f042fbca11d0fc2e0a6
+md5: 787c18b3e1532606bf796a360cf2ea39
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 89369
+timestamp: 1757583631217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+sha256: 177f262fda25552b8ce3e7685220deefba1625314575a892cd4abca06ddf06a4
+md5: f1b6b9a4e77b21df8a6949102db4f468
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 644936
+timestamp: 1763112090227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+sha256: fafc7a0acb8fc595b8fd89e75ec0b1d7d5af71b2b493570fa05e1f5612d299c2
+md5: dae60c429ab933e549832bc223e95639
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-cachem
+- r-htmltools >=0.5.7
+- r-jquerylib >=0.1.3
+- r-jsonlite
+- r-lifecycle
+- r-memoise >=2.0.1
+- r-mime
+- r-rlang
+- r-sass >=0.4.0
+license: MIT
+license_family: MIT
+size: 5538377
+timestamp: 1778923739710
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+sha256: 20dd6e4aa94d2d5ea97419add6bcac50f81400d297e9933659ff35da41fe2f6d
+md5: c922b0a6584376d3587d8cb3670f5cac
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 256017
+timestamp: 1757560386979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cachem-1.1.0-r45h54b55ab_2.conda
+sha256: 75a21c955abf03fa1804d47c94f5091cd772b614e074b63b02347a23f5649a53
+md5: 42617e710293f0b76ccc08855e0edbc4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fastmap
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76879
+timestamp: 1757441544326
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+sha256: f9f49b2b845f279af84a33c8af19a915b2731c0bd892c608205cbad8a34f423d
+md5: a5cc8a8d0dc08dc769c65a13b3573739
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-processx >=3.4.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 454090
+timestamp: 1757475635573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.6-r45h3697838_0.conda
+sha256: a894e558a680a31444090de217b73f8fc06a3f4c07746d2cde4b6f86acdae0b1
+md5: ed8dcbbe9d66e9093ba58891e3b6065a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1323795
+timestamp: 1775733704549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.2-r45heaba542_0.conda
+sha256: 521cb81e41e3a63717ec7cf317598b8a793969e60c57328b7d382bfea4178b5d
+md5: 421758eee50879a9a7ff122543e38e14
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 592267
+timestamp: 1770285739523
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+sha256: aec327dd836824278a2adf006f426a58d834828de74de7f8348f2f5f068de702
+md5: 8e9e5b14f74a6040c77e0b9c8bfa84ca
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 109200
+timestamp: 1757452164030
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_3-r45h54b55ab_0.conda
+sha256: 16bbbc7347aaee2c73d132584711f42cf612de501197e154385247818018b7a0
+md5: 472eadbb95c9103963bae1631ec23b0f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2542148
+timestamp: 1784283276786
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-commonmark-2.0.0-r45h54b55ab_1.conda
+sha256: 211423381b2e832619cdb964e7fe3833b09871d0140066ca90fd3e91eb86231b
+md5: 769e161acb18575460780ab99acc454e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 139818
+timestamp: 1757422097696
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+sha256: 5993a1b5c08c78a35cdbcf20376773eb7c4def2d28615e49f96008b43a4c05c0
+md5: 71c68a3993a696b6b75f7a6550b3750f
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 246247
+timestamp: 1778089270609
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+sha256: 9126a0408696133893e674549ca7aef317768dba503765a7ed032616aabe5b49
+md5: 4f111ce078b9690abaad6248b831a370
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 168201
+timestamp: 1757452410374
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+sha256: 217e5e210501b7fa611d6c6c46ae1551f443e2359e27164240da5a1219b2551a
+md5: 523a15023a79bd6f0dcb95ba6756ceed
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.3.6
+- r-jsonlite
+- r-lazyeval
+- r-r6
+license: MIT
+license_family: MIT
+size: 382037
+timestamp: 1757479275516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-curl-7.1.0-r45h10955f1_0.conda
+sha256: f2185d7bb29d869cc0d8e65a1913ab715e4f976666f94c18931cfa6b51b12821
+md5: dbfb442102b495d7bfc9f50321410a42
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 473709
+timestamp: 1777147706848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.18.4-r45h1c8cec4_0.conda
+sha256: fc5c6970d5ebbb92ccb61313efab7160869ae2851e48105e5dfff10f939a4bf6
+md5: 141a897d44a6a63b43dc6c1776ba7136
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MPL-2.0
+license_family: OTHER
+size: 2566399
+timestamp: 1783428409426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+sha256: 1edafb4e01397265da1816f3164a451d36f02546f2589c5f45051886ab9f91a8
+md5: f69bda3cb40132707f6efff4c749ce09
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-magrittr >=1.0.1
+- r-viridis
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4839264
+timestamp: 1757633933010
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.39-r45h3697838_0.conda
+sha256: 33ce40552bc1810252c4445082392638ff2fb883147cf36c3e4017e9b0dc5474
+md5: a0e856537aa7d62a6835e3a528d29517
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 218412
+timestamp: 1763566744987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.2.1-r45h3697838_0.conda
+sha256: 42067805b0742b933de7e1ca4311645797ac687cee6aacd630d9d4c585dfa830
+md5: 7c8e643f764769a184f0d0d06ac0e789
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1445950
+timestamp: 1775207093582
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+sha256: 38eee3a12260e5fff1e2af04250f6b67091b01c694f101ae6448da12c3fcca09
+md5: b78224895a1ad7fb52311ab071c2ec00
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-crosstalk
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httpuv
+- r-jquerylib
+- r-jsonlite >=0.9.16
+- r-magrittr
+- r-promises
+license: GPL-3.0-only
+license_family: GPL3
+size: 1439901
+timestamp: 1757566758266
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+sha256: ec00c0162d803af3c8059e9504d1d0c8b60cabe805c347a4a20300f2cce9e700
+md5: 6ac48e7c4c46b6c0538a779d0a43008a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-gridextra >=2.3
+- r-gtable
+license: GPL-3
+license_family: GPL3
+size: 950098
+timestamp: 1757760318911
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.3-r45h54b55ab_0.conda
+sha256: 19d03273f9d5e1aa41302e1cf080dcb95ced5b955bc978df39eee71a9686a86c
+md5: e43b3e7101a90ac57f58a21da67c99a4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 33411
+timestamp: 1775287239478
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+sha256: d3accfeab1416151515c37e5edc94b18868998db4936183459f8040117d5c83c
+md5: 4e0c71ab78d7292372a89d4daecb49af
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 111914
+timestamp: 1757447684244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.7-r45h54b55ab_0.conda
+sha256: 68dcc5aa6fc4408f9cac5aeaa03a7e6a5d127a949fc72b3fed31fd1af3bbeee5
+md5: 309740f1b6a2d4cb16d395be786c85c5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 329435
+timestamp: 1763566090233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r45h3697838_2.conda
+sha256: 06c5e73ed5c9c15e7ca944e3a5fabfbcabd9f4aec71804404ecf51c56f78fd8f
+md5: 7896efcfd50f8c1f207acce5d4ab1cc0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1429269
+timestamp: 1757441256046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fastmap-1.2.0-r45h3697838_2.conda
+sha256: bfec10cec03b434d9010690c61d43a0be79418f67a0713ce31da207a40e1570c
+md5: 245526991ad3b8a1dc97f2dcb5031065
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 73870
+timestamp: 1757421441326
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+sha256: 865df12d8cdd8cf577abc8f785a0aa4ee50b4f8751256dffe4676a350943d591
+md5: e9fccb3617ec9776569c6496fa254e64
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.1.1
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 1335664
+timestamp: 1757461248044
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+sha256: c95d1e61946bf81128be213dea7a07b5196c6e13caf9c6452c38145da8d2dfb1
+md5: 5abe392c8f8c5b954ebdc5fe46fcc709
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-codetools
+- r-iterators
+license: Apache-2.0
+license_family: APACHE
+size: 140909
+timestamp: 1757490449004
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fs-2.1.0-r45h3697838_0.conda
+sha256: 748304679610fe9f5d078f5b9be7c8693858ff5f66db55e43fb98d0e4e07d375
+md5: 67c48aad5ce921ad990b951a1f194f42
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 243286
+timestamp: 1777152733514
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+sha256: 196d29aa2d809d9115dce27236470219e1057d394654b5d73182f0e9d117f2fa
+md5: 4a667a55fc37e12dcbe510262ca61d19
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 424919
+timestamp: 1757627324320
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+sha256: 88a5cf4bac0a553943996bc930b1ea28f2635c262c1b2c5a42b026b69f227f02
+md5: f19c9493b80f63a41fa017ec3b27bc2e
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 88225
+timestamp: 1757455977192
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+sha256: 20c4ea52e72cb2e50907f9e5a446f16b0fce467fec4edab236eeb3b46890f3dd
+md5: b3a121ed6a71f3b674859ccbb15ad56b
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 67477
+timestamp: 1777325952298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+sha256: f8c0982d1579b810fc24cb702f8922794fce7bdfb9d3bf96867a4b038205b045
+md5: 9be31d2adf526d3c38b78a05333ddf30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-beeswarm
+- r-ggplot2 >=3.3.0
+- r-lifecycle
+- r-vipor
+license: GPL-3.0-or-later
+license_family: GPL3
+size: 1761662
+timestamp: 1764399956063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+sha256: 4e0401174fac5b54f124a8e7e418995a74918e8cd52a456a82db3fc5a373f0e0
+md5: bcdfec44c6bf587e65f56de61334a413
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=0.9.2
+- r-mass
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 221547
+timestamp: 1757758420492
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+sha256: 3a91d5334b7d99bc247386eaf0d331e119852e381e769e266f70df20eab22689
+md5: 866fbbf3f356140922d618f26f2b889c
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-gtable >=0.3.6
+- r-isoband
+- r-lifecycle >=1.0.1
+- r-rlang >=1.1.0
+- r-s7
+- r-scales >=1.4.0
+- r-vctrs >=0.6.0
+- r-withr >=2.5.0
+license: MIT
+license_family: MIT
+size: 7812326
+timestamp: 1776860393567
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.1-r45h54b55ab_0.conda
+sha256: c2760270ffabd95e9d0a0caa9cc705c5a0370ad119ace5495acc043b1a35d198
+md5: 65911c2e9cac35ea0235d3d6d4aa9625
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 171639
+timestamp: 1776413601349
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+sha256: e82d7e308a7e6d3eb90d9ea33d1f56d24bd69804995db2dacd5b20b7a20c34e4
+md5: aad2c473bf6f930833d0dc881811cf62
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-gtable
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 529159
+timestamp: 1782547830828
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+sha256: fcd2601af8213f39af6f720e22c8f858b3451f8e3d93cbc9e6aedb2d6f88483e
+md5: f686123cfba49e6299fae7e029a40266
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-lifecycle
+- r-rlang
+license: MIT
+license_family: MIT
+size: 228864
+timestamp: 1757463478042
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+sha256: 2d26e9b5c0e688cc76d33d81f8f62c59de9dc2f0695fd7b110991fa222db5524
+md5: d0bd1b5a09e5d631b8de31949ea19ece
+depends:
+- r-assertthat
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+- r-dendextend >=1.12.0
+- r-egg
+- r-ggplot2 >=2.2.0
+- r-htmlwidgets
+- r-magrittr >=1.0.1
+- r-plotly >=4.7.1
+- r-rcolorbrewer
+- r-reshape2
+- r-scales
+- r-seriation
+- r-viridis
+- r-webshot
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1693764
+timestamp: 1758426737719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-hexbin-1.28.5-r45heaba542_1.conda
+sha256: d3fa5cfc23220d3e279526a36ebcdc375ed2fc6cd45086248bd64a34c6be43d5
+md5: d622c8377663b5d7bdf5da48069f76cb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-only
+license_family: GPL2
+size: 1594722
+timestamp: 1757483295739
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+sha256: e676112aac0dbfe123fcb3108cce376782211a096c898a3af46fdf32a37e12e9
+md5: 0b5902d6af02a23bda1794d46090db42
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.18
+license: GPL-2.0-or-later
+license_family: GPL
+size: 57308
+timestamp: 1772794436225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-htmltools-0.5.9-r45h3697838_0.conda
+sha256: 1fa1fcdf980d0da17a583e41810da190eb9caf586c3fdf36312d045d9bb812e7
+md5: 2a2297687ae137e7fa90d3c996895e61
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-digest
+- r-ellipsis
+- r-fastmap >=1.1.0
+- r-rlang >=0.4.10
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 367095
+timestamp: 1764860550376
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+sha256: 4c3998ce4b4882429e52eed5c6c53d59056814d8fbc34a41ba79b990fdec1441
+md5: 6f767715f90e7caf17af72959bfcb11e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.7
+- r-jsonlite >=0.9.16
+- r-knitr >=1.8
+- r-rmarkdown
+- r-yaml
+license: MIT
+license_family: MIT
+size: 426023
+timestamp: 1757552859817
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-httpuv-1.6.17-r45h6d565e7_0.conda
+sha256: f0755cf37e28f0e1a142eef051918c90c9e8fece46edb5e40191a7898d8cb217
+md5: 1be1d81542b9c87b4d5197a41dbd0da9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-later >=0.8.0
+- r-promises
+- r-r6
+- r-rcpp >=1.0.7
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 553922
+timestamp: 1773825458255
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+sha256: 4adb565d2b3365108d7efb926c2acdc68c11ef2ad32ed03d1108a3005cf8cdd8
+md5: 259658089c383f2915b167da3e7890aa
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-curl >=0.9.1
+- r-jsonlite
+- r-mime
+- r-openssl >=0.8
+- r-r6
+license: MIT
+license_family: MIT
+size: 474019
+timestamp: 1771005817336
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+sha256: dcc78f60308390c6549e25308fb2437421e8fcaeeb45378b6fbe3a49e3d3cd0b
+md5: b240e3c0e61de35f1f43729f4ea2888e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.0.0
+- r-curl >=5.1.0
+- r-glue
+- r-lifecycle
+- r-magrittr
+- r-openssl
+- r-r6
+- r-rappdirs
+- r-rlang >=1.1.0
+- r-vctrs >=0.6.3
+- r-withr
+license: MIT
+license_family: MIT
+size: 935264
+timestamp: 1784022303810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.3.0-r45h3697838_0.conda
+sha256: a09a6f2f37890560217117463f0722283f8939af945b3e616b9791f2429325b0
+md5: fb538d0b46d6a44aa1ff666b15422ba6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-cpp11
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1657523
+timestamp: 1766530500097
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+sha256: c90d0faa668d2753db9da9458ca085891a3030c6537f5675fe0c1a1b5af2103c
+md5: 7746a41a4cb97cec59db2d5a2cac0701
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 350171
+timestamp: 1757459846270
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+sha256: abb2cd923ed271df8774e696f2e455f8c641532cc984fd770b87852a0017d7ab
+md5: 7113381f500ebcc8a33b61101817d120
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-jsonlite
+- r-openssl >=1.2.1
+license: MIT
+license_family: MIT
+size: 248113
+timestamp: 1776846446837
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+sha256: 3b98f72bb32d4758854805b664b4404602a583da32c9b96026536f5676f41812
+md5: 49a9ed6ed01f4ae6067ead552795bfce
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools
+license: MIT
+license_family: MIT
+size: 307113
+timestamp: 1757459485295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-jsonlite-2.0.0-r45h54b55ab_1.conda
+sha256: bd24c57226192b0decdcddd6fd5fa74db1f29685904e4aff87f2c16eb6493416
+md5: 026c72026f431daf8a5719e09e704faa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 638574
+timestamp: 1757419590757
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+sha256: e2184f1cb58aedacd94d1dbe6e8b5dfa3508151f454e80f6bd49486bdb90625c
+md5: 35b31b96aa7bc052ad6347322a1481f1
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-evaluate >=0.15
+- r-highr >=0.11
+- r-xfun >=0.52
+- r-yaml >=2.1.19
+license: GPL-2.0-or-later
+license_family: GPL
+size: 988526
+timestamp: 1766309267127
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+sha256: 42a06b7c346d6e4550dca1024bbf89e3c22962d568cfe4e8b8be824dea326110
+md5: a41490fdf607381035aa0304c21407c9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 70182
+timestamp: 1757456007088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-later-1.4.8-r45h3697838_0.conda
+sha256: 895f18dfc5a0521c22ad9e38619ea6cf170e38d54aaa4596fb1d0dad7845703b
+md5: a6b2c9882bb1d700f9108bc93c2c12a8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.12.9
+- r-rlang
+license: MIT
+license_family: MIT
+size: 153472
+timestamp: 1772707291964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_9-r45h54b55ab_0.conda
+sha256: ee233422c029d7b341dd05604d133db6f698ec1cdd4ad8690a312d0f7d958793
+md5: 234365e95fa3cf27bd7946f208d1ed0b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1416943
+timestamp: 1770694116947
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lazyeval-0.2.3-r45h54b55ab_0.conda
+sha256: 581fec2d1215b6d7b6d35ce9588271ba4bd89c75b0f131c04a718b79cbe2180f
+md5: 5634c3ee3e3c77f7462047a70ed35321
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang
+license: GPL-3.0-only
+license_family: GPL3
+size: 192307
+timestamp: 1775429492578
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+sha256: b7a4d8d98a96d17d18c80fb7e1c8e6cb09b9bd2542e74d91a7f483afccb30ee6
+md5: 5f8369dfbdff08878e58bf15529fca3a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 132636
+timestamp: 1767865665455
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+sha256: 1f594c5be675a53caef3368ea85c048b8bcbc4385e2bd582e977981a1edd5e3e
+md5: b936b3596737a3a1d513e1258d5d0355
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-commonmark >=2.0.0
+- r-xfun >=0.55
+license: MIT
+license_family: MIT
+size: 392980
+timestamp: 1784144498175
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.5-r45h54b55ab_0.conda
+sha256: 5b09fdee8ef5426082844d17d360756922ba74f9e3c428f501373295a5e9228d
+md5: 2e26e018edc1f198aa72a8f2127fab00
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 211086
+timestamp: 1775298609420
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+sha256: 5f27ccd93b39c2435ed6e9b8302ae50d51eb5b6058d7d11edba403e9723f48c6
+md5: 755b46b2896c8526a18074b3b651dfbc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-litedown >=0.6
+- r-xfun
+license: MIT
+license_family: MIT
+size: 72190
+timestamp: 1757496654397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_66-r45h54b55ab_0.conda
+sha256: 89218d4083593e5eae881fe5136befa358333d90a7de1a0ede13e8cd7bb5244e
+md5: 700d7bffd1c317597b574b218b567017
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1141176
+timestamp: 1784201795136
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.7_5-r45h0e4624f_0.conda
+sha256: de3447368ff93fb293c022d4a1eb8bcffe9044f52baf65c19218d6966815b88d
+md5: ca378a648cfa47523266acd1a0251729
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4301827
+timestamp: 1774809406103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r45h54b55ab_1.conda
+sha256: 06177df6c2f39df0a90b456557d226c2ffa9eaf55505b35d0ca9a81fe793dc49
+md5: 3deafa947ef32bf21d87b57e74d3711b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 484755
+timestamp: 1757442394466
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+sha256: 91b0eedec5cf5de195b442b97eda508f22fdedbdbc487f74e3868d3e95380fdd
+md5: 2b04206ff6ea5a92e8e36bdaa5feb3cc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cachem
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 57750
+timestamp: 1757456335587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_4-r45h0e4624f_0.conda
+sha256: 83a5233b6162c55f5021dea34464bd64d87f18b7815e738c42d06a046780e594
+md5: e33882c93c191f5d9a9b346431f02b43
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-nlme >=3.1_64
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 3644492
+timestamp: 1762539595584
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mime-0.13-r45h54b55ab_1.conda
+sha256: 03116d6a8db71492d036c6c052d6cfbf5a98c06da071e42aedb5c740920d6b61
+md5: 26aa2fa52d4caed58336f2b4887916d6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 64912
+timestamp: 1757441376534
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+sha256: 97d463c2146c483992a25fe497755e9cf714f95ca611a93d8adbb41c068e9e74
+md5: c78bd534986cde8fc0cb08cc9a1a2cc6
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+license: MIT
+license_family: MIT
+size: 247241
+timestamp: 1757455926748
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_170-r45heaba542_0.conda
+sha256: 83964b5b1ea49ed78be1fd7606650cf1ea68b92febe3d0bbdb9fda1be30f2d5b
+md5: 17487ca56832572cb95f9cc1314ddabb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 2356999
+timestamp: 1784288204943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-openssl-2.4.2-r45h68c19f5_0.conda
+sha256: 2796cf7768c939a58344157fcddec88dbdadf9cabd3ab0b24d9bbaf7916b9ebd
+md5: 6568a5797c9d74e89ef94b82724665aa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.6,<4.0a0
+- r-askpass
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 680716
+timestamp: 1781024845749
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+sha256: 09df5e8326b04412a26b6c4d896e04adbceba45194457c6d30f370d5ccb4b397
+md5: 0c015ba0c5444777a683c05e4a000f21
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-getopt >=1.20.2
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 119289
+timestamp: 1776419503742
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+sha256: f5de9737f59e1965db2de11c90cf1fdd426db322a7205c935a3e55150287b02f
+md5: 560abd550c097e0d0af2e201b335f53d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 286342
+timestamp: 1761151056217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+sha256: 162742dd773c8a163de6ffdf0e14820b5708b9e1041d4491762c05e00f6be614
+md5: 849a8fcdb5e1d98a3917a7c652c322df
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 679411
+timestamp: 1757649050426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+sha256: a4869bf14ad791c8a5cb48fd0575faa3cdb7b07692cb4b473809c261f584fa45
+md5: 9a48d2e7fdc93937c60481c06d40e6ba
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 234305
+timestamp: 1770387131912
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+sha256: b3f281041ecff2d4a9f40073ad5e7ec6fa7e0c841068ce85c550bcce0ff8938d
+md5: 807ef77a70fc5156f830d6c683d07a29
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 629867
+timestamp: 1758149763203
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+sha256: fda425435a533e86da5f0fc89cf45c9f889a4e6f1e2ed536ca23662a8461602c
+md5: 40a5fdd06c7e7880758a021cf2df6c12
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 27236
+timestamp: 1757447537447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
+sha256: 691d08f590099bb8cf4042a3af57b742775e02e4272df80dea5388c20e340116
+md5: 2021f458379120ae0d21189bee7e30cc
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.3,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 135276
+timestamp: 1758095801346
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
+md5: ced57d920bed79382f382a24a4425ef7
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-crosstalk
+- r-data.table
+- r-digest
+- r-dplyr
+- r-ggplot2 >=3.0.0
+- r-hexbin
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httr
+- r-jsonlite >=1.6
+- r-lazyeval >=0.2.0
+- r-magrittr
+- r-promises
+- r-purrr
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-tibble
+- r-tidyr
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 3587131
+timestamp: 1769337109792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
+sha256: 353d5945d242b03c47ab0d051cf9058b4459303c96455dba9442100628a0bde1
+md5: 255fec0919919b14789eb30cc448ed20
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.0
+license: MIT
+license_family: MIT
+size: 787537
+timestamp: 1757441721952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
+sha256: 7f69cd631f28279b4c706fe2341d8ffbd13cc10ed98e648d0c214ceecce4f877
+md5: c38b8f68cbe321dd5b819d397b2b5061
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-ps >=1.2.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 411030
+timestamp: 1776865706038
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+sha256: 684dba5d20aae8da37868d603b662014e1944f5568e5f737e42d9d485892a26e
+md5: b2c1b6ef8f12894fd2694b285fe8989a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-fastmap >=1.1.0
+- r-later
+- r-lifecycle
+- r-magrittr >=1.5
+- r-otel >=0.2.0
+- r-r6
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1597704
+timestamp: 1762426228446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ps-1.9.3-r45h54b55ab_0.conda
+sha256: 598576cd282f2b9c8280696c77b3a9e05d52a8f688174d6c6ed1b3bdad57bcdf
+md5: d4c22257df8cca28d50e604110e68e90
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 414722
+timestamp: 1777148019201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.2.2-r45h54b55ab_0.conda
+sha256: dc5f0ace59844125b92304324000770c7e2e466bab442826cee50a32eef731bf
+md5: dc14c484a0415f43dc1b90b518beb41a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 547035
+timestamp: 1775853612539
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-qap-0.1_2-r45heaba542_5.conda
+sha256: cd5b1706f125067986e083ba343ff6f20f79747c18e801fb6014481ec273964e
+md5: d64850fa9345afe8dbe58b371c32792d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 396309
+timestamp: 1757635813587
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+sha256: bd92e91332eba5f0c689583e80adec85ef272c4e0d0b36ee17cb7c11b5693cf2
+md5: 750802806d7d640c286ed8491bb395dc
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 95073
+timestamp: 1757447661037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rappdirs-0.3.4-r45h54b55ab_0.conda
+sha256: a9778d5fa6777ce286815eb0abef625ff54693532795ef48a1bc319967e0ecb4
+md5: 9fa763ece102dca3e50892bad36896ff
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 54376
+timestamp: 1768747300036
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+sha256: ddd4e63616ee475bdf9dc63a0b16a89017237121e927d83fbdee07d5a5ccc890
+md5: d8fa238420cb6de47d463b7345a761eb
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68005
+timestamp: 1757452462302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.1.2-r45h3697838_0.conda
+sha256: dabb73c4d43f352a3154067a20a46cbda1e1027636e72d133010f6f052e8d260
+md5: 1d6e2e4764de896f03fb73e28614022e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 2122066
+timestamp: 1783264478653
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpptoml-0.2.3-r45h3697838_1.conda
+sha256: 8e10fa6f550c83cdc99175443ecc92db178369e82a7dcb743e1fe7ce87d39530
+md5: 707ba8dabbbffd03f5907406a0fe8368
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.5
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 227793
+timestamp: 1757490566643
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+sha256: 68f01b65843f873b01bff24f61f27298667797aa3ad01d4406a62ae72e7c08c5
+md5: 1a99d6f9dfe5f6e8dc5275d49852cd66
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 208380
+timestamp: 1757507980343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-renv-1.2.3-r45h54b55ab_0.conda
+sha256: d88af05b70ac871598c7fda5e04c7d024f1011fcc047eeb18d9541ef9b03bea7
+md5: 378f0ed999e77fe5e276ef811d783d96
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 2469798
+timestamp: 1778972824711
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.5-r45h3697838_0.conda
+sha256: ffec1e0396849fab33c12bcc580fe71f90818c83da645146c165449ee9a6e799
+md5: 169cd9281096cd54a29072a2d7eea2a9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-plyr >=1.8.1
+- r-rcpp
+- r-stringr
+license: MIT
+license_family: MIT
+size: 127756
+timestamp: 1762975657971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.3.0-r45h3697838_0.conda
+sha256: 13aed8664cbf46946eed067d1708ee1a8dcbd7cf32d361c7a03a9bf3f83ac425
+md5: afa49304f86d922c157d08e9e9d9ceb8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1593782
+timestamp: 1783260208298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+sha256: b3735a4e75eca023b24678251da041854b94a8b96588d81b605928d6ecf74f11
+md5: 25b9dbf0ff990b8b3111774878e3bb07
+depends:
+- pandoc >=1.14
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.2.5.1
+- r-evaluate >=0.13
+- r-fontawesome >=0.5.0
+- r-htmltools >=0.5.1
+- r-jquerylib
+- r-jsonlite
+- r-knitr >=1.43
+- r-tinytex >=0.31
+- r-xfun >=0.36
+- r-yaml >=2.1.19
+license: GPL-3.0-only
+license_family: GPL3
+size: 2085382
+timestamp: 1774555006202
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+sha256: 5f9aa168f5c43f1d3ddbacc701370085fcead3956e2d5879af7fcd9e086a0a0b
+md5: 62f09532f225c86d27e954b36682add5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-digest
+- r-httr2
+- r-jsonlite
+- r-lifecycle
+- r-openssl >=2.0.0
+- r-packrat >=0.6
+- r-pki
+- r-renv >=1.0.0
+- r-rlang >=1.0.0
+- r-rstudioapi >=0.5
+- r-snowflakeauth
+- r-yaml >=2.1.5
+license: GPL-2.0-only
+license_family: GPL2
+size: 830390
+timestamp: 1783503525234
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+sha256: 896aeea3aa679a9dbd0277d10ef8dcfd011e45a1717129180a9877c1fd828f2a
+md5: 5f1b6b899fa3204ab77403e75b9df5fd
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 357140
+timestamp: 1781250782889
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-s7-0.2.2-r45h54b55ab_0.conda
+sha256: fae29c4af16617a17fea40c5e484e4350a6fe5d9fad40266f95cf3cb13e7019b
+md5: 598ca5290f9be9b22804436295471201
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 311525
+timestamp: 1776861444903
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sass-0.4.10-r45h3697838_1.conda
+sha256: 4d6d7db9d0187a9ede70d6d48278a8ba2b3160e823f5de239b86a6108f23172e
+md5: a3ccf52eefa448628535ee758c5a8a37
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-fs
+- r-htmltools
+- r-r6
+- r-rappdirs
+- r-rlang
+license: MIT
+license_family: MIT
+size: 2319704
+timestamp: 1757464682768
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+sha256: 260c384e952e5bd4d2c2de77b9e09b24ff1c1f680acd917c4657ab8c9e4e9a2f
+md5: 8bc81cc6fd130cef963bc9e082726a14
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-farver >=2.0.0
+- r-labeling
+- r-lifecycle
+- r-munsell >=0.5
+- r-r6
+- r-rcolorbrewer
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 777793
+timestamp: 1757487539496
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+sha256: bcde368cbf5a2c83b9c1fb8b3ba0722787af759f68d08bac6a82e966adbf999f
+md5: ba820689c02638c807f83e6ab5c53142
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 370745
+timestamp: 1771995271935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-seriation-1.5.8-r45heaba542_1.conda
+sha256: ce65e9dfe250a2d142acb7f7c2fec1ebd9e1527c66c5ce1212f0f18a3f2a415a
+md5: 9252542af85ee0c48a0a94ea103181e5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-ca
+- r-cluster
+- r-colorspace
+- r-foreach
+- r-gclus
+- r-mass
+- r-qap
+- r-registry
+- r-tsp
+- r-vegan
+license: GPL-3.0-only
+license_family: GPL
+size: 1372264
+timestamp: 1757660945261
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+sha256: ef0042ae1c3926ef9bee6c21cf761d7cf441eae61dceca7df143f3b9dc4c6f04
+md5: 2fb0e1ea59dd281487be303b1b7c6607
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.6.0
+- r-cachem >=1.1.0
+- r-commonmark >=1.7
+- r-crayon
+- r-fastmap >=1.1.1
+- r-fontawesome >=0.4.0
+- r-glue >=1.3.2
+- r-htmltools >=0.5.4
+- r-httpuv >=1.5.2
+- r-jsonlite >=0.9.16
+- r-later >=1.0.0
+- r-lifecycle >=0.2.0
+- r-mime >=0.3
+- r-promises >=1.1.0
+- r-r6 >=2.0
+- r-rlang >=0.4.10
+- r-sourcetools
+- r-withr
+- r-xtable
+license: GPL-3.0-only
+license_family: GPL3
+size: 3789417
+timestamp: 1782070586086
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+sha256: c3ea3d60226ed56e4a40b622b8e4721d257a9fb4ca8502ce89314f48a63a0090
+md5: b5da9b58b4f8137a7f2e14102bc230c9
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-glue
+- r-shiny
+license: MIT
+license_family: MIT
+size: 344724
+timestamp: 1757870156008
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+sha256: 9493d6cbf09850206f5904ccde65643de86bb9bd6add685548331c408e99610a
+md5: 3929f109451367912b4570480f4c572d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest >=0.6.8
+- r-jsonlite
+- r-shiny >=1.0.0
+license: MIT
+license_family: MIT
+size: 1018291
+timestamp: 1768513288077
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
+md5: 7382af8530d082191feb0c8da5f8a41b
+depends:
+- bioconductor-limma
+- bioconductor-summarizedexperiment
+- r-base >=4.5,<4.6.0a0
+- r-biocmanager
+- r-bslib >=0.9.0
+- r-cluster
+- r-dplyr
+- r-dt >=0.2
+- r-ggbeeswarm
+- r-ggdendro
+- r-ggplot2
+- r-heatmaply
+- r-htmltools
+- r-htmlwidgets
+- r-markdown
+- r-matrixstats
+- r-optparse
+- r-plotly >=4.8.0
+- r-rcolorbrewer
+- r-rsconnect
+- r-scatterplot3d
+- r-shiny >=1.7.0
+- r-shinycssloaders
+- r-shinyjs
+- r-viridislite
+- r-yaml
+license: AGPL-3.0
+license_family: AGPL
+size: 3448797
+timestamp: 1784579537432
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
+md5: 1d38994c8bfe421d621d9b3705c37b58
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-jose
+- r-jsonlite
+- r-openssl
+- r-rcpptoml
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76170
+timestamp: 1772133448445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
+sha256: 885a784f4258b491e48947dbed71bd18b2e2e7da0f0b53ee1dcfed93cfdcd48a
+md5: 1bd0042c176bde3dd1971eac76497219
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 54650
+timestamp: 1774682292388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
+sha256: 3095c4e59616a46480533f2e545136e25b1cb20d7ec6535d4a7f0938c48ff789
+md5: 377126a1601c75ff75c2c8c277e55a81
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 325043
+timestamp: 1779038241839
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.7-r45h3d52c89_2.conda
+sha256: 6d0d8d6f1465b3486996edaef7ccd1020cb2fcca1e69b543fc52dbad5262079b
+md5: c7ce6f26b92398224c78b92c653b94c1
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.2,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: FOSS
+license_family: OTHER
+size: 939928
+timestamp: 1772032511209
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+sha256: dea2a7676dd03ed93fa0ec961883c5075c361c8522659a1bc1e6b5c16525cb24
+md5: 8db438d8aa370726ee1ce8bf458f2e6d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 319328
+timestamp: 1762269757617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sys-3.4.3-r45h54b55ab_1.conda
+sha256: 0cf3a7af31b0396d5a2e1c932fffa360472f92a2b373a696f523b0b53ad1d682
+md5: f23bbac61ab0536f59f4caa4c2ebdf88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 50436
+timestamp: 1757441793835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.1-r45h54b55ab_0.conda
+sha256: 256d782fb5773d678f29b88a2c987eb47065e2393a080ca16f400b0256de65bb
+md5: ad28f67cbb0b10a5beaa7bf968761cad
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 589666
+timestamp: 1768139121744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.2-r45h3697838_0.conda
+sha256: 8c4560d92c1adfce9a37da2f963596a369688b0d5f44d1fa2f0fbfecb486d99f
+md5: e571d4d42233dd2aa3bdb0057ffbdc63
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127263
+timestamp: 1766142073696
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+sha256: fca09d6b9940f1e1cda0425a0f55716bba202d6f55d6bd25fedec391006c7dc7
+md5: 15aa0f323385403fe182e46a1d095e1b
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 220192
+timestamp: 1757475791328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+sha256: 1fad4d08756ca2d7db04cfaf88e9df797da95a5f7f4b8aabc165eee36faddafc
+md5: 5ee226c1449c66d1cd2399d942faa04d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.48
+license: MIT
+license_family: MIT
+size: 158240
+timestamp: 1782203211628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tsp-1.2.7-r45h54b55ab_0.conda
+sha256: 54c19b952897b97228f00ff3ae8def7e7af2194c0ed3419737a8fe04a988cd41
+md5: 4518075e6efc2a5c9714751a92bfc73e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-foreach
+license: GPL-3.0-only
+license_family: GPL3
+size: 736826
+timestamp: 1774389996066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r45h54b55ab_1.conda
+sha256: 97186abdf7c29872e012c9fe05ec16c019b58c43ac7b778baa480a8acae9c914
+md5: 75cb2540ac930ea879e92d99e00e97c3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 147244
+timestamp: 1757424673681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.7.3-r45h3697838_0.conda
+sha256: 73b0cdea9f85496b80e75ffa20f94aa4ab746f4b7af566742e22381bffa6772d
+md5: 372cefc1b05a567d1fbe19633766ab0c
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1805012
+timestamp: 1775897999712
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vegan-2.7_5-r45h11cdb10_0.conda
+sha256: b6245a77003ec655ca972e81d25771652991326ed9d7f3514951954565198e94
+md5: 81c256938ff8b33054afde06c7851e4e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+- r-lattice
+- r-mass
+- r-mgcv
+- r-permute >=0.9_0
+license: GPL-2.0-only
+license_family: GPL2
+size: 3049688
+timestamp: 1779956688681
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+sha256: 859729e8cd04bb92ec144b21a8abfdb2bec9cbac9deaa41ba0cc2add13d088a0
+md5: e605ce527e381c5577d57649e393cb87
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4508304
+timestamp: 1757669044129
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+sha256: 884896b59133b948646b0d1441106120f7b320e9fac827ccb9d44bbe80dda8f2
+md5: e841095941c40142bdad834299b95a30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=1.0.1
+- r-gridextra
+- r-viridislite >=0.4.0
+license: MIT
+license_family: MIT
+size: 2988605
+timestamp: 1757516440048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+sha256: b9ec9606562f0f6bdefc237bbc6163eb1cb022f9d699c80771bc84af0ae37269
+md5: bcadc0a3726e2191e51449f67fa5e0a9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1305542
+timestamp: 1770191459321
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+sha256: e79e366895dfdf79fe92986fe42d0695e3fcacc25411506c48b9db92742eb99c
+md5: e021e3d936f57ea9b35eb099999d6800
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-callr
+- r-jsonlite
+- r-magrittr
+license: GPL-2.0-only
+license_family: GPL2
+size: 206060
+timestamp: 1757520337073
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+sha256: 56f318c90bfc74f01339c83f0e1d0817c1b762ea46cd9e527fec9dcf244c5900
+md5: 388d25e67f93a5fec2aebe56d6a0a1d9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 235287
+timestamp: 1781856624720
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xfun-0.60-r45h54b55ab_0.conda
+sha256: dca6e2c57e1b038682879e793338683f25058362a8f3ca2a88f753e5de085cf0
+md5: 1d3e32dcae994197a303942b6654e577
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 651306
+timestamp: 1784103319293
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+sha256: 972923364cfd616ccf38768477c435677cfe1ea18a72016f90344ea920e4fea5
+md5: e18fda0821f0fdc1c34276c5e0acdc92
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL (>= 2)
+license_family: GPL3
+size: 744345
+timestamp: 1771859982217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-yaml-2.3.12-r45h54b55ab_0.conda
+sha256: f8944d47eccfdb2c04e27fd65797de7468ccc5d9f3fc3d9af296da613d75d79c
+md5: d0d07c6f14b640a98cf6a5e3e4e2e723
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 124461
+timestamp: 1765372968808
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 345073
+timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+sha256: b013d2085ce4ac01daec7b30472e9f3b6c2d69eb3a3a85a6cee3e01a3cb4f61a
+md5: e4a1ff2e59a5d9b38be71d15c93cf1bd
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 268482
+timestamp: 1776859422619
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+md5: 13dc3adbc692664cd3beabd216434749
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-64 4.18.0 he073ed8_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 24008591
+timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+build_number: 103
+sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+md5: 48a1049e710857572fc2a832aa394d9f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3550916
+timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+sha256: 3e20b2f2902a1f402ef2420ce2b9e8c91f9e02748d55530894ac1f640561fdd0
+md5: 72628f56d7a99b86efa435a0b97a4b47
+depends:
+- tk
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- tk >=8.6.13,<8.7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 102544
+timestamp: 1773732786017
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+sha256: 2bf9a40d86d29fd5c30d0febec99d06398143ddeece9ebb175cc5a6d20279943
+md5: f16d4aec5e8135e8e7bba02ef600149e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 38560
+timestamp: 1779439547766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+md5: fb901ff28063514abb6046c9ec2c4a45
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 58628
+timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+md5: 1c74ff8c35dcadf952a16f752ca5aa49
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 27590
+timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 839652
+timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+md5: b2895afaf55bf96a8c8282a2e47a5de0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 15321
+timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+md5: 1dafce8548e38671bea82e3f5c6ce22f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 20591
+timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+md5: 34e54f03dfea3e7a2dcf1453a85f1085
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+license: MIT
+license_family: MIT
+size: 50326
+timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+md5: 96d57aba173e878a2089d5638016dc5e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 33005
+timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+md5: 279b0de5f6ba95457190a1c459a64e31
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 379686
+timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 601375
+timestamp: 1764777111296

--- a/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
+++ b/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
@@ -1,0 +1,3175 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-aarch64:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.46.1-default_hf1166c9_102.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-biobase-2.70.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-delayedarray-0.36.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-genomicranges-1.62.1-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-iranges-2.44.0-r45hbd662d2_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-limma-3.66.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4arrays-1.10.1-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4vectors-0.48.0-r45hbd662d2_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-sparsearray-1.10.8-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-xvector-0.50.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h3530432_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-15.2.0-h2d9b6d1_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gsl-2.7-h294027d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h7c59cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-14.2.1-h3a99ef3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-devel-14.2.1-h3a99ef3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandoc-3.10-h8af1aa0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-askpass-1.2.1-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.5.3-h269e6ae_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base64enc-0.1_6-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-beeswarm-0.4.0-r45hf488e41_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cachem-1.1.0-r45h0557e7b_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.6-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cluster-2.1.8.2-r45h6df9e4a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-colorspace-2.1_3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-commonmark-2.0.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-curl-7.1.0-r45hd8a8d9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-data.table-1.18.4-r45hbf3bb9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-digest-0.6.39-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.2.1-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.7-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-farver-2.1.2-r45h08b74da_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fastmap-1.2.0-r45h08b74da_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fs-2.1.0-r45hd601667_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.1-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-hexbin-1.28.5-r45h6df9e4a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-htmltools-0.5.9-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-httpuv-1.6.17-r45hb62f08c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-isoband-0.3.0-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-jsonlite-2.0.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-later-1.4.8-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lattice-0.22_9-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lazyeval-0.2.3-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.5-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mass-7.3_66-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrix-1.7_5-r45h9301183_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrixstats-1.5.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mgcv-1.9_4-r45h8b2cba9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mime-0.13-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-nlme-3.1_170-r45ha85219e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-openssl-2.4.2-r45h37c386a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ps-1.9.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.2.2-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-qap-0.1_2-r45ha85219e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rappdirs-0.3.4-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpp-1.1.2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpptoml-0.2.3-r45hd601667_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-renv-1.2.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-reshape2-1.4.5-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.3.0-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-s7-0.2.2-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sass-0.4.10-r45h08b74da_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-seriation-1.5.8-r45ha85219e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.7-r45h1ddd0e6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sys-3.4.3-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.1-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tsp-1.2.7-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.7.3-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vegan-2.7_5-r45ha2e3c6d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-xfun-0.60-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-yaml-2.3.12-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h5f05d98_8.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: a2527b1d81792a0ccd2c05850960df119c2b6d8f5fdec97f2db7d25dc23b1068
+md5: 468fd3bb9e1f671d36c2cbc677e56f1d
+depends:
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28926
+timestamp: 1770939656741
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+sha256: eebe159bf600943552e4319ff4ce27b6a2dadf0dcc5443e76dcee9259a408e11
+md5: 58f37d76b8234c69dbf2939d511bea0b
+depends:
+- ld_impl_linux-aarch64 2.46.1 default_h1979696_102
+- sysroot_linux-aarch64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 4677171
+timestamp: 1784214549910
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.46.1-default_hf1166c9_102.conda
+sha256: d41099a3fe2809a3ab3e4c718ecff4d5f8879e7949f3c8e8efa97fa06a90248c
+md5: 9a340123cb7217eae51c5cae24484631
+depends:
+- binutils_impl_linux-aarch64 2.46.1 default_h5f4c503_102
+license: GPL-3.0-only
+license_family: GPL
+size: 36196
+timestamp: 1784214578949
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-biobase-2.70.0-r45hbd662d2_0.conda
+sha256: 144892eb6a1caeb15ca70a90e9502130ad5d4fb11cb3bfcf23944c540b6fc8c2
+md5: 8256b8838a2ed279aa68d6a74c64f2ae
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2359182
+timestamp: 1770502613668
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+sha256: 97221eda3007381c0a6498608baaebdcec6047f7f26b121c19149fd56aabf032
+md5: 27556377d159490ea87696727ae41808
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-generics
+license: Artistic-2.0
+size: 653523
+timestamp: 1770415244399
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-delayedarray-0.36.0-r45hbd662d2_0.conda
+sha256: a35e3f96ec640cf7665d74954c96c9dd94acec8c2d3b07773496917465891990
+md5: a539d17dd563adecc5716d832336d257
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-sparsearray >=1.10.0,<1.11.0
+- bioconductor-sparsearray >=1.10.8,<1.11.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 2203445
+timestamp: 1770580775191
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-genomicranges-1.62.1-r45hbd662d2_0.conda
+sha256: 55b5f4217dab83ed83c37669b166d3145eb3d844360f53cbe940b48fad58febd
+md5: 73f836e70629719f303b19c6f88e089e
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2307173
+timestamp: 1770634322279
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-iranges-2.44.0-r45hbd662d2_1.conda
+sha256: 7167ede80515e1b5d88fcfda2c16c01e7e6a39698d1b9824a3a0416b0bed6e1e
+md5: 82dc872dc3591e32ca8e8c051ef0d619
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2354429
+timestamp: 1770538530102
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-limma-3.66.0-r45hbd662d2_0.conda
+sha256: b6c0c4229c65102dbf5135421cdeda72c77bb84a574eb3ad6a017feda47843fe
+md5: 04a2febf68754954062a79fdfc4674df
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-statmod
+license: GPL (>=2)
+size: 3099160
+timestamp: 1770499849646
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+sha256: 169809ca754b2c07f7356f1fc4f365b7d5154fd66229543584f69008fa347c5a
+md5: cdf0406fc3caa814ff7b7876a42973a5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-matrixstats >=1.4.1
+license: Artistic-2.0
+size: 449898
+timestamp: 1770417102301
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4arrays-1.10.1-r45hbd662d2_0.conda
+sha256: 3e69df7fbd051d165364424a5b87ad1c902c68b2d4d04e7feffbfe11079bd90b
+md5: b7a8cb11e73c5031c3d6da65845c60b4
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-abind
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1027295
+timestamp: 1770573305521
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4vectors-0.48.0-r45hbd662d2_1.conda
+sha256: 714d17a1e87e49a3cb25b42794bb30ffba91921f6d5d7d37c6e80945aa036ef7
+md5: 82884abd1721c6c3fbe6024c7b627174
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2068293
+timestamp: 1770501459310
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+sha256: 875f5be76bc3b83766ec0cfacf888570d529907412519a537c5f7a318e489976
+md5: cfe7c256532f9a4fc87ec3be955bb9e6
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 598298
+timestamp: 1770628899171
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-sparsearray-1.10.8-r45hbd662d2_0.conda
+sha256: 6d45e717b4a44b4dc5209cc931301be4571db91b0219905d55d110edd3ef145b
+md5: 42802d5b7d809a31cf6e364b4c52a20b
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-xvector >=0.50.0,<0.51.0
+- bioconductor-xvector >=0.50.0,<0.51.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-matrixstats
+license: Artistic-2.0
+size: 1678434
+timestamp: 1770579674417
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+sha256: b8ade9f2ab8cc2835357653f5a9bc840323c05f7656659dfb40d20e5623f8ebd
+md5: 74eb95090e807c18f5bc81cb9fb39b3c
+depends:
+- bioconductor-biobase >=2.70.0,<2.71.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-delayedarray >=0.36.0,<0.37.0
+- bioconductor-genomicranges >=1.62.0,<1.63.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1416452
+timestamp: 1772218138703
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-xvector-0.50.0-r45hbd662d2_0.conda
+sha256: 961ac8875597fae63a4efc98917e2be0f58b0299700339ffbf8cdfbdc7cf4beb
+md5: 461fc07891c8587fbe1f870f67f98e91
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 644057
+timestamp: 1770573790622
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+sha256: d9def28d376d13033e0e78d731091a85a49a2297bf5efe15f0ef0d4533a6adeb
+md5: 585e14e544be02d0baceffecd31c7882
+depends:
+- tk
+license: TCL
+size: 129724
+timestamp: 1750262711538
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+sha256: b3495077889dde6bb370938e7db82be545c73e8589696ad0843a32221520ad4c
+md5: 840d8fc0d7b3209be93080bc20e07f2d
+depends:
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 192412
+timestamp: 1771350241232
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
+sha256: 24f78776eda069a6c1566fd6d65379e45747d0a7cce9f864686690806543c408
+md5: a8a5833ef43f9b31a4d548071ea5ba75
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 220677
+timestamp: 1784091035199
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+md5: a9965dd99f683c5f444428f896635716
+depends:
+- __unix
+license: ISC
+size: 128866
+timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
+md5: 043c13ed3a18396994be9b4fab6572ad
+depends:
+- fontconfig >=2.15.0,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.1,<79.0a0
+- libexpat >=2.7.3,<3.0a0
+- libfreetype >=2.14.1
+- libfreetype6 >=2.14.1
+- libgcc >=14
+- libglib >=2.86.3,<3.0a0
+- libpng >=1.6.53,<1.7.0a0
+- libstdcxx >=14
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 927045
+timestamp: 1766416003626
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
+sha256: a36ed82bbaebdc59e205d399d6e898bcb20fbcd5aaebb162cdf690ba97173ef5
+md5: a06d829c51a365e8daf0b2a3d4f06d9d
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 h7c59cd8_2
+- libgcc >=14
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 201305
+timestamp: 1782911743345
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
+md5: f4d29a0cd77104a683607319a542ac7e
+depends:
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 290522
+timestamp: 1780450108132
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+sha256: 1112c56bc19cbce233b30d9d31ce8eb6fcc100c9baa5145315aaa1e3a25b5178
+md5: 5e8e88bfb3fbb0df0f9f8bb890721e07
+depends:
+- libfreetype 2.14.3 h8af1aa0_1
+- libfreetype6 2.14.3 hdae7a39_1
+license: GPL-2.0-only OR FTL
+size: 174060
+timestamp: 1780933507786
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+sha256: 1bfcd715bcb49a0b22d5d1899a22c6ff884b06f8e141eb746f3949752469a422
+md5: f3ac54914f7d3e1d68cb8d891765e5f9
+depends:
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 62909
+timestamp: 1757438620177
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h3530432_19.conda
+sha256: cd23829b5fb7f3ff5f44eab2da1a993e06bdf759b681a0a7a73bb5783755b6b3
+md5: 66dfb62e7a47e2b511f9c5ee0ff1abf3
+depends:
+- binutils_impl_linux-aarch64 >=2.45
+- libgcc >=15.2.0
+- libgcc-devel_linux-aarch64 15.2.0 h55c397f_119
+- libgomp >=15.2.0
+- libsanitizer 15.2.0 he19c465_19
+- libstdcxx >=15.2.0
+- libstdcxx-devel_linux-aarch64 15.2.0 ha7b1723_119
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 73237372
+timestamp: 1778268860495
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+sha256: 2450913611189cc3c26062a43a97a93501159335d4d314cca5e2678fb5f4d3b6
+md5: 619b8a05f89220fa8c9536dcfeeddd5b
+depends:
+- gcc_impl_linux-aarch64 15.2.0.*
+- binutils_linux-aarch64
+- sysroot_linux-aarch64
+license: BSD-3-Clause
+license_family: BSD
+size: 29074
+timestamp: 1781279974207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-15.2.0-h2d9b6d1_19.conda
+sha256: eb531f1a37c2efa431fb3104842d98aba271c55ef3de8c2741e9d575bd3cb762
+md5: c8fc81db8eef1e0f76778e8f91ab8ff3
+depends:
+- gcc_impl_linux-aarch64 >=15.2.0
+- libgcc >=15.2.0
+- libgfortran5 >=15.2.0
+- libstdcxx >=15.2.0
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16043253
+timestamp: 1778269041546
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+sha256: 3e529c517a76a1f4497c51eeedeeb927d33f732dcdb48055a020a83eb3e4e95c
+md5: 4db044857ab1d09b2e8f0013c65387c1
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 103119
+timestamp: 1780455096710
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gsl-2.7-h294027d_0.tar.bz2
+sha256: be506a418cc648996bf3376a626826cbe0fa5d9de913598c4d3965a61ddc7a7b
+md5: 8b9533e21be7fa232ab64e85f184e0b3
+depends:
+- libblas >=3.8.0,<4.0a0
+- libcblas >=3.8.0,<4.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3890901
+timestamp: 1626369614424
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
+sha256: afb0fc36b93539a8e43a8063c8d3e1b4bace38a5a0c3c9e1978c72792d633c62
+md5: 7214ae8a8aade7b48a2bfd8bbb4d9e79
+depends:
+- gcc_impl_linux-aarch64 15.2.0 h3530432_19
+- libstdcxx-devel_linux-aarch64 15.2.0 ha7b1723_119
+- sysroot_linux-aarch64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 14640001
+timestamp: 1778269082840
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
+sha256: f4bc63d467e2c48c255bc8d2886fb11f6a8d09c1251a6f5b25628abee1768693
+md5: ea51d6df068bee183ff667f75bfdc2f6
+depends:
+- gxx_impl_linux-aarch64 15.2.0.*
+- gcc_linux-aarch64 ==15.2.0 h0bf4bd8_27
+- binutils_linux-aarch64
+- sysroot_linux-aarch64
+license: BSD-3-Clause
+license_family: BSD
+size: 27620
+timestamp: 1781279974207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
+sha256: 57b157674ecee4d16e2873a3624095b4ed1859ce8c574b161e0d9c1723788733
+md5: 41198d1dd71d97c1507e6bd17edd10c7
+depends:
+- libharfbuzz-devel 14.2.1 h3a99ef3_1
+license: MIT
+license_family: MIT
+size: 11079
+timestamp: 1782800518091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
+md5: 546da38c2fa9efacf203e2ad3f987c59
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 12837286
+timestamp: 1773822650615
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
+md5: bb3b7cad9005f2cbf9d169fb30263f3e
+constrains:
+- sysroot_linux-aarch64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1248134
+timestamp: 1765578613607
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+sha256: 5ce830ca274b67de11a7075430a72020c1fb7d486161a82839be15c2b84e9988
+md5: e7df0aab10b9cbb73ab2a467ebfaf8c7
+depends:
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 129048
+timestamp: 1754906002667
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+sha256: b644718416a22b5d57c1194ea7207b7f8d33d6a2b42775763782d76cd7457aea
+md5: 5fd2304064ef6199d1f91ec60ee7b820
+depends:
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1518484
+timestamp: 1781859412954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+sha256: 2c4901f4227b0850328ed0c69f958b30ad2cd18982f7a31c7c1f911827004d08
+md5: 489444d0acb2a579d2a002d85a08c059
+depends:
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-aarch64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 905305
+timestamp: 1784214534868
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+sha256: 8957fd460c1c132c8031f65fd5f56ec3807fd71b7cab2c5e2b0937b13404ab36
+md5: d13423b06447113a90b5b1366d4da171
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 240444
+timestamp: 1773114901155
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+build_number: 8
+sha256: c897399c943168c646f659952f73a9154f9122d7e9b151649dbe075dfdcd484b
+md5: 8b44dad125760faa2b3925f5a6e3112d
+depends:
+- libopenblas >=0.3.33,<0.3.34.0a0
+- libopenblas >=0.3.33,<1.0a0
+constrains:
+- libcblas   3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+- mkl <2027
+- blas 2.308   openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18843
+timestamp: 1779859042591
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+build_number: 8
+sha256: 3ba039f0705022939d90e36c1ed2fcbafd7f5bb77563e3702202ae796b32f4d2
+md5: 76242b7ad6e43809afa8671dd609b4ed
+depends:
+- libblas 3.11.0 8_haddc8a3_openblas
+constrains:
+- liblapack  3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+- blas 2.308   openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18817
+timestamp: 1779859049133
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h7c59cd8_2.conda
+sha256: 5846fa724f4b8eb23751e347fc8b31775c0a28a7a34d1e44f081651613470512
+md5: 0a187db240c503afc7eb5bd865c7ff04
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 505957
+timestamp: 1782911738398
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+sha256: 48814b73bd462da6eed2e697e30c060ae16af21e9fbed30d64feaf0aad9da392
+md5: a9138815598fe6b91a1d6782ca657b0c
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 71117
+timestamp: 1761979776756
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+sha256: c0b27546aa3a23d47919226b3a1635fccdb4f24b94e72e206a751b33f46fd8d6
+md5: fb640d776fc92b682a14e001980825b1
+depends:
+- ncurses
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 148125
+timestamp: 1738479808948
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+md5: a9a13cb143bbaa477b1ebaefbe47a302
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 115123
+timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+sha256: 20a5726bc8705d91437c9e6ef83b30da64a1719b869656d20a1ee818333ea5ac
+md5: fac3b65a605cd253037fdf3daf2de8d9
+depends:
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77649
+timestamp: 1781203572523
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+sha256: 3df4c539449aabc3443bbe8c492c01d401eea894603087fca2917aa4e1c2dea9
+md5: 2f364feefb6a7c00423e80dcb12db62a
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 55952
+timestamp: 1769456078358
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+sha256: db75d0fc080992dc67db8e24d7bb2a2f2a0b25bfce8870fa45a82a4b5f6111a2
+md5: a13e600f9d18488b1fd1257344dbfdaa
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8381
+timestamp: 1780933505754
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+sha256: 34fe8276befd6c42956c4acd969caeddbdc7ea8e6ed054b8388709b6c3e94ba4
+md5: 426cc33f8745ce11a73baf73db3954a7
+depends:
+- libgcc >=14
+- libpng >=1.6.58,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 424236
+timestamp: 1780933505195
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+sha256: 4592b096e553f67799ae70d4b6167eeda3ec74587d68c7aecbf4e7b1df136681
+md5: f35b3f52d0a2ec4ffe3c89ba135cdb9a
+depends:
+- _openmp_mutex >=4.5
+constrains:
+- libgomp 15.2.0 h8acb6b2_19
+- libgcc-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 622462
+timestamp: 1778268755949
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
+sha256: fe600a63a39281e6994e27fe79360cd6bd8e576c3ce1af32ce8673b011f46c21
+md5: 18ad0f0b94071d91fa962a1bf3983a78
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2353893
+timestamp: 1778268665954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+sha256: 1137f93f477f56199ded24117430045a0c02cbe8b10031beac3b9ad2138539d3
+md5: 770cf892e5530f43e63cadc673e85653
+depends:
+- libgcc 15.2.0 h8acb6b2_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27738
+timestamp: 1778268759211
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+sha256: e5ad94be72634233510b33ba792a3339921bd468f0b8bc6961ea05eded251d9b
+md5: c7a5b5decf969ead5ecada83654164cf
+depends:
+- libgfortran5 15.2.0 h1b7bec0_19
+constrains:
+- libgfortran-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27728
+timestamp: 1778268784621
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+sha256: af8e9bdcaa77f133a8ee4c1ef57ef564d9c45aa262abf9f5ef9b50eb99d96407
+md5: 779dbb494de6d3d6477cab52eb34285a
+depends:
+- libgcc >=15.2.0
+constrains:
+- libgfortran 15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1487244
+timestamp: 1778268767295
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+sha256: 6a13152a81513117b8d41bf64dea56c731d877bcced5a24fab738e3c0f9ac58c
+md5: 31d404d8c0755d0f9062a4459f5a1084
+depends:
+- libgcc >=14
+- libffi >=3.5.2,<3.6.0a0
+- pcre2 >=10.47,<10.48.0a0
+- libzlib >=1.3.2,<2.0a0
+- libiconv >=1.18,<2.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4943441
+timestamp: 1782464048865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+sha256: 2370ef0ffcbae5bede3c4bf136add4abc257245eb91f724c99bb4a43116c5a83
+md5: c5e8a379c4a2ec2aea4ba22758c001d9
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 587387
+timestamp: 1778268674393
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-14.2.1-h3a99ef3_1.conda
+sha256: ae1d16dd62f626c4dab1240a49f6b04e14e4f30140e5fb26bb835821dba114b6
+md5: 655cedd9626545089b9e9ead153cf619
+depends:
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1334601
+timestamp: 1782800489368
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-devel-14.2.1-h3a99ef3_1.conda
+sha256: 866b0132df7d080a7b2e3c44e4c79723f007db6c035b1e751612d29db698859b
+md5: b6762f2c0386ba4606d5b2cba1e41ca8
+depends:
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libharfbuzz 14.2.1 h3a99ef3_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 2050496
+timestamp: 1782800511879
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+sha256: 1473451cd282b48d24515795a595801c9b65b567fe399d7e12d50b2d6cdb04d9
+md5: 5a86bf847b9b926f3a4f203339748d78
+depends:
+- libgcc >=14
+license: LGPL-2.1-only
+size: 791226
+timestamp: 1754910975665
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_0.conda
+sha256: da3e45974c1f23c76264d6358463861236862052ca156e34b502ef3c27e36fb8
+md5: de0780a3690bffe75ac3fa70db84596d
+depends:
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 714602
+timestamp: 1783731816001
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+build_number: 8
+sha256: d269a684afa0b2fdb44d6b60167f854f30410cdb5ee49a7275c026f6b10c8d05
+md5: 3af3f2aa755abc5e91351114ae214f55
+depends:
+- libblas 3.11.0 8_haddc8a3_openblas
+constrains:
+- libcblas   3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+- blas 2.308   openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18828
+timestamp: 1779859055749
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+sha256: d61962b9cd54c3554361550203c64d5b65b71e3058a285b66e4b04b9769f0a5c
+md5: 76298a9e6d71ee6e832a8d0d7373b261
+depends:
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 126102
+timestamp: 1775828008518
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+sha256: 13782715b9eeebc4ad16d36e84ca569d1495e3516aea3fe546a32caa0a597d82
+md5: be5f0f007a4500a226ef001115535a3d
+depends:
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 726928
+timestamp: 1773854039807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+sha256: b018ecfb05e75a8eea3f21f6b5c5c2a54b5178bdcf19e2e2df2735740214a8c8
+md5: 58a66cd95e9692f08abe89f55a6f3f12
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.33,<0.3.34.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5121336
+timestamp: 1776993423004
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
+md5: f51503ac45a4888bce71af9027a2ecc9
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 341202
+timestamp: 1776315188425
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+sha256: 15ec553e784f2b8601c3df58e1dbe723309303c5ed405bc671bffae722c81023
+md5: f8f91448e5ba30051ceb17b45b31da9b
+depends:
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 71121
+timestamp: 1783936885865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_19.conda
+sha256: 8115604f113fe2b7be95b2d22183a4dda5779c1cc6db4b826af800581498b4b3
+md5: 95210a1edbd7fc6e12afc9f8276f450a
+depends:
+- libgcc >=15.2.0
+- libstdcxx >=15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7067965
+timestamp: 1778268796086
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+sha256: 1e289bcce4ee6a5817a19c66e296f3c644dcfa6e562e5c1cba807270798814e7
+md5: eecc495bcfdd9da8058969656f916cc2
+depends:
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 311396
+timestamp: 1745609845915
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
+md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
+depends:
+- libgcc 15.2.0 h8acb6b2_19
+constrains:
+- libstdcxx-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 5546559
+timestamp: 1778268777463
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
+sha256: 6f7ceee16070781b7d642a37a35ffdf09c66796d3df105c919526210ce220443
+md5: 61da34d67f58dd4cf16683f6cdcb06c8
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 17627362
+timestamp: 1778268687968
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+sha256: ef1006578ef7e3f7c420e89d87846213ceb3fdcef2626af2558cbede53d36839
+md5: 20166e2297c1cac346b544d5f6197440
+depends:
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 508982
+timestamp: 1783084925965
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+sha256: 7663489f97c104ae3814db10f384932c74b439f3c1fd4247e4fe3599830c090a
+md5: 58fa42bc4bc71fc329889497ec15effb
+depends:
+- libgcc >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 43248
+timestamp: 1781625528371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+sha256: 3e2ead35f47d01364031f323f1be984018c8f19a3a264f952ddcd043685a1c86
+md5: ac7bcbd2c77691cd6d1ede8c029e8c8a
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 456627
+timestamp: 1779396031450
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+sha256: b03700a1f741554e8e5712f9b06dd67e76f5301292958cd3cb1ac8c6fdd9ed25
+md5: 24e92d0942c799db387f5c9d7b81f1af
+depends:
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 359496
+timestamp: 1752160685488
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
+md5: cd14ee5cca2464a425b1dbfc24d90db2
+depends:
+- libgcc >=13
+- pthread-stubs
+- xorg-libxau >=1.0.11,<2.0a0
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 397493
+timestamp: 1727280745441
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+sha256: eb111e32e5a7313a5bf799c7fb2419051fa2fe7eff74769fac8d5a448b309f7f
+md5: 502006882cf5461adced436e410046d1
+constrains:
+- zlib 1.3.2 *_2
+license: Zlib
+license_family: Other
+size: 69833
+timestamp: 1774072605429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+sha256: d243aea768e6fa360b7eda598340f43d2a41c9fc169d9f97f505410be68815f8
+md5: 5983ffb12d09efc45c4a3b74cd890137
+depends:
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 528318
+timestamp: 1727801707353
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+sha256: 369db85c5cd8d99dde364ce70725d76511d9c8199e5b820c740414091bf5bcca
+md5: b2a43456aa56fe80c2477a5094899eff
+depends:
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 960036
+timestamp: 1777422174534
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+sha256: da4a5df42614166b69c2f6d8602fc1425f7aaa699f77c3bafb5c7fe69b3d9fb7
+md5: fa6260b3e6eababf6ca85a7eb3336383
+depends:
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3704664
+timestamp: 1781069675555
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandoc-3.10-h8af1aa0_0.conda
+sha256: 8427cd22ccc4104d1348fe028e130e800328060e3b6f3607ce97f5188c68b835
+md5: 648f4bde42b8c5d708296ca6106c377d
+license: GPL-2.0-or-later
+license_family: GPL
+size: 23565468
+timestamp: 1780595445519
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+sha256: d209c8b0d53c441ee0bc0d8fce0fcae8e7e05755e51b13b6b9da02c7aa032f98
+md5: 3fc7cc25bba3381e77b753578058e3b0
+depends:
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.17.1,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- harfbuzz >=13.2.0
+- libexpat >=2.7.4,<3.0a0
+- libfreetype >=2.14.2
+- libfreetype6 >=2.14.2
+- libgcc >=14
+- libglib >=2.86.4,<3.0a0
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 470441
+timestamp: 1774284032397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+sha256: 04df2cee95feba440387f33f878e9f655521e69f4be33a0cd637f07d3d81f0f9
+md5: 1a30c42e32ca0ea216bd0bfe6f842f0b
+depends:
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1166552
+timestamp: 1763655534263
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_2.conda
+sha256: 414acad3e460cfcf6bf3a764c4b4837359bda9fdc350a85b560e344a9e2306a5
+md5: af8ab93369e53542b135dab29eca49e8
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 304146
+timestamp: 1784286832656
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+sha256: e9cbcbc94e151ada3d6dc365380aaaf591f65012c16d9a2abaea4b9b90adc402
+md5: ab7288cc39545556d1bc5e71ab2df9a9
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 636733
+timestamp: 1769712412683
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
+md5: bb5a90c93e3bac3d5690acf76b4a6386
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 8342
+timestamp: 1726803319942
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+sha256: 5055913d786b82f33a14f493f32945b3b2b5d528ea2f52856ca02b296f6511eb
+md5: dde4691fe168112a90efba6aaa08f13d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: LGPL (>= 2)
+license_family: LGPL
+size: 82526
+timestamp: 1757460261392
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-askpass-1.2.1-r45h0557e7b_1.conda
+sha256: e6d37a7c16ca9693a1dee6ab71778c78f6539508ca59934f38c97ff2a5129565
+md5: 6dd9985ca467090a3ce338ea95da715c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-sys >=2.1
+license: MIT
+license_family: MIT
+size: 33005
+timestamp: 1758383588821
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+sha256: 90e7ae8aa427274d7d2e510060b68925e60e897ecaa5ea135bb33afa7eb12134
+md5: b5291c60f52b43108a2973ba6f5885d1
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 72543
+timestamp: 1757447376176
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.5.3-h269e6ae_3.conda
+sha256: 27649f8b9717afec0d32b3ddd2537f08948321a5b311d8ed49bedfd4dde6b718
+md5: bd35d2e5e6972908b398aaf340861ff1
+depends:
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.18.4,<2.0a0
+- curl
+- gcc_linux-aarch64 >=14
+- gfortran_impl_linux-aarch64
+- gsl >=2.7,<2.8.0a0
+- gxx_linux-aarch64 >=14
+- icu >=78.3,<79.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libglib >=2.88.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- make
+- pango >=1.56.4,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- readline >=8.3,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- tzdata >=2024a
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxt >=1.3.1,<2.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 27596006
+timestamp: 1781523590403
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base64enc-0.1_6-r45h0557e7b_0.conda
+sha256: 2172b3db2c71520fd5018cac6e7db1659a43054b71f331573e30e0c30acbec20
+md5: 8b5fb4c68b8c612747adcf9ef27e397c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 50459
+timestamp: 1770027826952
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-beeswarm-0.4.0-r45hf488e41_5.conda
+sha256: 5284e4fd8982aa2e63d73f1b8bd760462311b5e9a853a341f5b872cd0c22d463
+md5: a0429d68e95c279c95760fa4da3ea648
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 89962
+timestamp: 1757584938658
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+sha256: 177f262fda25552b8ce3e7685220deefba1625314575a892cd4abca06ddf06a4
+md5: f1b6b9a4e77b21df8a6949102db4f468
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 644936
+timestamp: 1763112090227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+sha256: fafc7a0acb8fc595b8fd89e75ec0b1d7d5af71b2b493570fa05e1f5612d299c2
+md5: dae60c429ab933e549832bc223e95639
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-cachem
+- r-htmltools >=0.5.7
+- r-jquerylib >=0.1.3
+- r-jsonlite
+- r-lifecycle
+- r-memoise >=2.0.1
+- r-mime
+- r-rlang
+- r-sass >=0.4.0
+license: MIT
+license_family: MIT
+size: 5538377
+timestamp: 1778923739710
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+sha256: 20dd6e4aa94d2d5ea97419add6bcac50f81400d297e9933659ff35da41fe2f6d
+md5: c922b0a6584376d3587d8cb3670f5cac
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 256017
+timestamp: 1757560386979
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cachem-1.1.0-r45h0557e7b_2.conda
+sha256: c8fd2712d1a19d32feabf471fd4f5e01d8d9a622a08f76b1c3cf638f4ab1dccb
+md5: 7ac09a862af4168c7e6ca6f018464c55
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fastmap
+- r-rlang
+license: MIT
+license_family: MIT
+size: 77756
+timestamp: 1757441578494
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+sha256: f9f49b2b845f279af84a33c8af19a915b2731c0bd892c608205cbad8a34f423d
+md5: a5cc8a8d0dc08dc769c65a13b3573739
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-processx >=3.4.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 454090
+timestamp: 1757475635573
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.6-r45h08b74da_0.conda
+sha256: 5416a041dbc61d4d3b74c0c888295aaf7cb71262236a4fc09242c18711ed00ff
+md5: 196fedd5e490165a94ee856d727aa247
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1346019
+timestamp: 1775733744341
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cluster-2.1.8.2-r45h6df9e4a_0.conda
+sha256: bf4a9118958688ef6a7b06267fb0aa7006fa97ec37d400f194c48175ff5df3f7
+md5: 5b08c25df4a50c12c8bfdfe65d191ce8
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 595768
+timestamp: 1770285735470
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+sha256: aec327dd836824278a2adf006f426a58d834828de74de7f8348f2f5f068de702
+md5: 8e9e5b14f74a6040c77e0b9c8bfa84ca
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 109200
+timestamp: 1757452164030
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-colorspace-2.1_3-r45h0557e7b_0.conda
+sha256: d78a45f9c58a3182ba17a3851017b7adaa6d0ecebcee872998bb41e6cc312782
+md5: 01eaba8437d8c23d0dea562c29e406a8
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2546382
+timestamp: 1784283306550
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-commonmark-2.0.0-r45h0557e7b_1.conda
+sha256: 1382bc1e64063f49fdc406d0ce92a815c43b9be9cb098d8e65f7059f97117535
+md5: 4f0d0c8eeeaad3aab64c7bee16426a28
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 144114
+timestamp: 1757422195437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+sha256: 5993a1b5c08c78a35cdbcf20376773eb7c4def2d28615e49f96008b43a4c05c0
+md5: 71c68a3993a696b6b75f7a6550b3750f
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 246247
+timestamp: 1778089270609
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+sha256: 9126a0408696133893e674549ca7aef317768dba503765a7ed032616aabe5b49
+md5: 4f111ce078b9690abaad6248b831a370
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 168201
+timestamp: 1757452410374
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+sha256: 217e5e210501b7fa611d6c6c46ae1551f443e2359e27164240da5a1219b2551a
+md5: 523a15023a79bd6f0dcb95ba6756ceed
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.3.6
+- r-jsonlite
+- r-lazyeval
+- r-r6
+license: MIT
+license_family: MIT
+size: 382037
+timestamp: 1757479275516
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-curl-7.1.0-r45hd8a8d9c_0.conda
+sha256: 91fce711e5bacf578c37e9c5012563d60d1dbe5a05dcf0f2a8080d3be2a938bf
+md5: 328d250136cafc6b644b5174767dbea4
+depends:
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 477493
+timestamp: 1777147747989
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-data.table-1.18.4-r45hbf3bb9c_0.conda
+sha256: d4a19f503b0705d9662ce3e9d81753aa720202c5c87e0f64869599dcfa9e84d7
+md5: 8f3b2a953fcbc5eb2dadb5dab1f0d5b6
+depends:
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MPL-2.0
+license_family: OTHER
+size: 2644344
+timestamp: 1783428401576
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+sha256: 1edafb4e01397265da1816f3164a451d36f02546f2589c5f45051886ab9f91a8
+md5: f69bda3cb40132707f6efff4c749ce09
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-magrittr >=1.0.1
+- r-viridis
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4839264
+timestamp: 1757633933010
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-digest-0.6.39-r45h08b74da_0.conda
+sha256: 2cf79b6af8cdd8215ffed899d016c1554935cab5cc419a9390cc6931cdf49513
+md5: c5109e71b8b0a7dcdddcc4f6fa21605d
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 225830
+timestamp: 1763566824454
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.2.1-r45h08b74da_0.conda
+sha256: c7a33bc92936537648e29cb70b0912deaa4a79cc4d8f30f4e4dd213723eb00a0
+md5: 93bb33f64dce6cdcd5251d8d2234bac7
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1449577
+timestamp: 1775207129641
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+sha256: 38eee3a12260e5fff1e2af04250f6b67091b01c694f101ae6448da12c3fcca09
+md5: b78224895a1ad7fb52311ab071c2ec00
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-crosstalk
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httpuv
+- r-jquerylib
+- r-jsonlite >=0.9.16
+- r-magrittr
+- r-promises
+license: GPL-3.0-only
+license_family: GPL3
+size: 1439901
+timestamp: 1757566758266
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+sha256: ec00c0162d803af3c8059e9504d1d0c8b60cabe805c347a4a20300f2cce9e700
+md5: 6ac48e7c4c46b6c0538a779d0a43008a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-gridextra >=2.3
+- r-gtable
+license: GPL-3
+license_family: GPL3
+size: 950098
+timestamp: 1757760318911
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.3-r45h0557e7b_0.conda
+sha256: cdd63168ef461c582d26b5a8bcd7e5378575a20068e61ab119cdbb544329f5a4
+md5: a52d33523179da32a3c9d11ff27b730d
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 34061
+timestamp: 1775287261756
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+sha256: d3accfeab1416151515c37e5edc94b18868998db4936183459f8040117d5c83c
+md5: 4e0c71ab78d7292372a89d4daecb49af
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 111914
+timestamp: 1757447684244
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.7-r45h0557e7b_0.conda
+sha256: 9a8c13e87085007face8d9576ca4675ac2187e4b2082f195199b6b6af67c45c6
+md5: a0702b7eb11d1a382527a02baf1fd0bc
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 339732
+timestamp: 1763566140258
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-farver-2.1.2-r45h08b74da_2.conda
+sha256: bad9c13ce006e7e972cd3b240efc2ab457557acfec2a5566c85b91f6f354cd8f
+md5: e3468d0fb1e32edf11badd5dcdb847e4
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1401937
+timestamp: 1757441349828
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fastmap-1.2.0-r45h08b74da_2.conda
+sha256: 3bff61e00966863ab1febada7f64a9618db330aa97dd527b0d2719990993e1a3
+md5: 679225ca2785ed02ffd33b5cd998e514
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 74243
+timestamp: 1757421537458
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+sha256: 865df12d8cdd8cf577abc8f785a0aa4ee50b4f8751256dffe4676a350943d591
+md5: e9fccb3617ec9776569c6496fa254e64
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.1.1
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 1335664
+timestamp: 1757461248044
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+sha256: c95d1e61946bf81128be213dea7a07b5196c6e13caf9c6452c38145da8d2dfb1
+md5: 5abe392c8f8c5b954ebdc5fe46fcc709
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-codetools
+- r-iterators
+license: Apache-2.0
+license_family: APACHE
+size: 140909
+timestamp: 1757490449004
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fs-2.1.0-r45hd601667_0.conda
+sha256: 305a53e9e768366f5a143376ad618c5c08f67ac96242d747ec7bd6a0db71d1c2
+md5: 87df8bfe7e48c5b0537cc534f8a5b3a3
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 244508
+timestamp: 1777152716131
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+sha256: 196d29aa2d809d9115dce27236470219e1057d394654b5d73182f0e9d117f2fa
+md5: 4a667a55fc37e12dcbe510262ca61d19
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 424919
+timestamp: 1757627324320
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+sha256: 88a5cf4bac0a553943996bc930b1ea28f2635c262c1b2c5a42b026b69f227f02
+md5: f19c9493b80f63a41fa017ec3b27bc2e
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 88225
+timestamp: 1757455977192
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+sha256: 20c4ea52e72cb2e50907f9e5a446f16b0fce467fec4edab236eeb3b46890f3dd
+md5: b3a121ed6a71f3b674859ccbb15ad56b
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 67477
+timestamp: 1777325952298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+sha256: f8c0982d1579b810fc24cb702f8922794fce7bdfb9d3bf96867a4b038205b045
+md5: 9be31d2adf526d3c38b78a05333ddf30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-beeswarm
+- r-ggplot2 >=3.3.0
+- r-lifecycle
+- r-vipor
+license: GPL-3.0-or-later
+license_family: GPL3
+size: 1761662
+timestamp: 1764399956063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+sha256: 4e0401174fac5b54f124a8e7e418995a74918e8cd52a456a82db3fc5a373f0e0
+md5: bcdfec44c6bf587e65f56de61334a413
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=0.9.2
+- r-mass
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 221547
+timestamp: 1757758420492
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+sha256: 3a91d5334b7d99bc247386eaf0d331e119852e381e769e266f70df20eab22689
+md5: 866fbbf3f356140922d618f26f2b889c
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-gtable >=0.3.6
+- r-isoband
+- r-lifecycle >=1.0.1
+- r-rlang >=1.1.0
+- r-s7
+- r-scales >=1.4.0
+- r-vctrs >=0.6.0
+- r-withr >=2.5.0
+license: MIT
+license_family: MIT
+size: 7812326
+timestamp: 1776860393567
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.1-r45h0557e7b_0.conda
+sha256: 02f33f91373217832525d722f7e3be2ac47a1b8f9e1e65a33a03622180ff2360
+md5: a410160f41fb5192efccd33986aced38
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 172828
+timestamp: 1776413622694
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+sha256: e82d7e308a7e6d3eb90d9ea33d1f56d24bd69804995db2dacd5b20b7a20c34e4
+md5: aad2c473bf6f930833d0dc881811cf62
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-gtable
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 529159
+timestamp: 1782547830828
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+sha256: fcd2601af8213f39af6f720e22c8f858b3451f8e3d93cbc9e6aedb2d6f88483e
+md5: f686123cfba49e6299fae7e029a40266
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-lifecycle
+- r-rlang
+license: MIT
+license_family: MIT
+size: 228864
+timestamp: 1757463478042
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+sha256: 2d26e9b5c0e688cc76d33d81f8f62c59de9dc2f0695fd7b110991fa222db5524
+md5: d0bd1b5a09e5d631b8de31949ea19ece
+depends:
+- r-assertthat
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+- r-dendextend >=1.12.0
+- r-egg
+- r-ggplot2 >=2.2.0
+- r-htmlwidgets
+- r-magrittr >=1.0.1
+- r-plotly >=4.7.1
+- r-rcolorbrewer
+- r-reshape2
+- r-scales
+- r-seriation
+- r-viridis
+- r-webshot
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1693764
+timestamp: 1758426737719
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-hexbin-1.28.5-r45h6df9e4a_1.conda
+sha256: 1b589435aaf7c11bb23d6877f077a61f387a696fdeb7fd4d8307b5e4e5fcbebe
+md5: a7e475f65cbe95ff5193d520cdd5196c
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-only
+license_family: GPL2
+size: 1594883
+timestamp: 1757483340587
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+sha256: e676112aac0dbfe123fcb3108cce376782211a096c898a3af46fdf32a37e12e9
+md5: 0b5902d6af02a23bda1794d46090db42
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.18
+license: GPL-2.0-or-later
+license_family: GPL
+size: 57308
+timestamp: 1772794436225
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-htmltools-0.5.9-r45h08b74da_0.conda
+sha256: 71fb50fb947fc5209e6abc3ea4a7e388e32f564f306a4771c46b26dcf7474369
+md5: bd128ae05e4cb14baa66ff86ad9b3126
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-digest
+- r-ellipsis
+- r-fastmap >=1.1.0
+- r-rlang >=0.4.10
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 368214
+timestamp: 1764860572792
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+sha256: 4c3998ce4b4882429e52eed5c6c53d59056814d8fbc34a41ba79b990fdec1441
+md5: 6f767715f90e7caf17af72959bfcb11e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.7
+- r-jsonlite >=0.9.16
+- r-knitr >=1.8
+- r-rmarkdown
+- r-yaml
+license: MIT
+license_family: MIT
+size: 426023
+timestamp: 1757552859817
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-httpuv-1.6.17-r45hb62f08c_0.conda
+sha256: f80c025e58243755b5a66d125fff21aff8f081fee0428a9254c62ee9cde6dc65
+md5: d1e3db0a93a2074799a0659080178b8e
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-later >=0.8.0
+- r-promises
+- r-r6
+- r-rcpp >=1.0.7
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 553429
+timestamp: 1773825488822
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+sha256: 4adb565d2b3365108d7efb926c2acdc68c11ef2ad32ed03d1108a3005cf8cdd8
+md5: 259658089c383f2915b167da3e7890aa
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-curl >=0.9.1
+- r-jsonlite
+- r-mime
+- r-openssl >=0.8
+- r-r6
+license: MIT
+license_family: MIT
+size: 474019
+timestamp: 1771005817336
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+sha256: dcc78f60308390c6549e25308fb2437421e8fcaeeb45378b6fbe3a49e3d3cd0b
+md5: b240e3c0e61de35f1f43729f4ea2888e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.0.0
+- r-curl >=5.1.0
+- r-glue
+- r-lifecycle
+- r-magrittr
+- r-openssl
+- r-r6
+- r-rappdirs
+- r-rlang >=1.1.0
+- r-vctrs >=0.6.3
+- r-withr
+license: MIT
+license_family: MIT
+size: 935264
+timestamp: 1784022303810
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-isoband-0.3.0-r45h08b74da_0.conda
+sha256: e70c9f8bb4b0100ac45e9aeed982c2a72357c4b8ca529fa2927cbc917e283c4c
+md5: 04efe7d434cd3e6f5a69e4799eb6cbbd
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-cpp11
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1660497
+timestamp: 1766530417757
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+sha256: c90d0faa668d2753db9da9458ca085891a3030c6537f5675fe0c1a1b5af2103c
+md5: 7746a41a4cb97cec59db2d5a2cac0701
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 350171
+timestamp: 1757459846270
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+sha256: abb2cd923ed271df8774e696f2e455f8c641532cc984fd770b87852a0017d7ab
+md5: 7113381f500ebcc8a33b61101817d120
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-jsonlite
+- r-openssl >=1.2.1
+license: MIT
+license_family: MIT
+size: 248113
+timestamp: 1776846446837
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+sha256: 3b98f72bb32d4758854805b664b4404602a583da32c9b96026536f5676f41812
+md5: 49a9ed6ed01f4ae6067ead552795bfce
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools
+license: MIT
+license_family: MIT
+size: 307113
+timestamp: 1757459485295
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-jsonlite-2.0.0-r45h0557e7b_1.conda
+sha256: cd484854182eca0e62cacf6f5dfdc3d11106d4ab0307d41361c772247e9ae283
+md5: 0c7d7b8541f5619f09dd9334deb7dbf7
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 645626
+timestamp: 1757419590460
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+sha256: e2184f1cb58aedacd94d1dbe6e8b5dfa3508151f454e80f6bd49486bdb90625c
+md5: 35b31b96aa7bc052ad6347322a1481f1
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-evaluate >=0.15
+- r-highr >=0.11
+- r-xfun >=0.52
+- r-yaml >=2.1.19
+license: GPL-2.0-or-later
+license_family: GPL
+size: 988526
+timestamp: 1766309267127
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+sha256: 42a06b7c346d6e4550dca1024bbf89e3c22962d568cfe4e8b8be824dea326110
+md5: a41490fdf607381035aa0304c21407c9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 70182
+timestamp: 1757456007088
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-later-1.4.8-r45h08b74da_0.conda
+sha256: b7c530de9a38fcf30ae63c92cd60fb0d23567e6567f70694d350ff2adeec88e0
+md5: 3601ce2112d41114cdb6ed340ee44442
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.12.9
+- r-rlang
+license: MIT
+license_family: MIT
+size: 155668
+timestamp: 1772707321535
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lattice-0.22_9-r45h0557e7b_0.conda
+sha256: a6f30211a8b3511e27c2aac99b499cdb4751a950fe5595a48672a38de8ecc28d
+md5: 2049f7981874aefa34b2b5b53af007eb
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1418137
+timestamp: 1770694138040
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lazyeval-0.2.3-r45hf488e41_0.conda
+sha256: c9f7bb66c064e813d5aa82e60b70ab4fb1f0b6acda05a43cbbb3615bd2c71899
+md5: 2a54efbd48368966f65e6500198574e7
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang
+license: GPL-3.0-only
+license_family: GPL3
+size: 195208
+timestamp: 1775429446648
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+sha256: b7a4d8d98a96d17d18c80fb7e1c8e6cb09b9bd2542e74d91a7f483afccb30ee6
+md5: 5f8369dfbdff08878e58bf15529fca3a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 132636
+timestamp: 1767865665455
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+sha256: 1f594c5be675a53caef3368ea85c048b8bcbc4385e2bd582e977981a1edd5e3e
+md5: b936b3596737a3a1d513e1258d5d0355
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-commonmark >=2.0.0
+- r-xfun >=0.55
+license: MIT
+license_family: MIT
+size: 392980
+timestamp: 1784144498175
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.5-r45h0557e7b_0.conda
+sha256: 0a4dbbb3acc77222d0119e1d9c47c94359e5a05290a514b5ac345512e6d5d125
+md5: e61a28ac3cbd3f76f96f9aef579ae6ef
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 212064
+timestamp: 1775298634467
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+sha256: 5f27ccd93b39c2435ed6e9b8302ae50d51eb5b6058d7d11edba403e9723f48c6
+md5: 755b46b2896c8526a18074b3b651dfbc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-litedown >=0.6
+- r-xfun
+license: MIT
+license_family: MIT
+size: 72190
+timestamp: 1757496654397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mass-7.3_66-r45hf488e41_0.conda
+sha256: cadc1e7cb74ec9999a2393b5225bca8f39da162f5ea1719783c4186dffd5d223
+md5: 615cb3f4dc69d374da874553f58cc61c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1143006
+timestamp: 1784201763856
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrix-1.7_5-r45h9301183_0.conda
+sha256: 0671e1595f283ed8f5a67f6006821b90b58a954c095d230cf0c3543d45aa6e1f
+md5: dbc4de669537f1b65a8f63e92d01c0de
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4492870
+timestamp: 1774809348312
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrixstats-1.5.0-r45h0557e7b_1.conda
+sha256: cc732696567fd2e79cf48cb9ae19cfed65d2a547ef7657b847ea6e52ab29cef0
+md5: 28f5371af404b055c4e8fda252343eff
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 508907
+timestamp: 1757442506110
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+sha256: 91b0eedec5cf5de195b442b97eda508f22fdedbdbc487f74e3868d3e95380fdd
+md5: 2b04206ff6ea5a92e8e36bdaa5feb3cc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cachem
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 57750
+timestamp: 1757456335587
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mgcv-1.9_4-r45h8b2cba9_0.conda
+sha256: deb54e1594e6cff5fa5c1851b6ba9b8e9ddb663fc2a5bd0a770bd7348fca0740
+md5: 3f3684540a7cf2f8aba9bd7419b86182
+depends:
+- _openmp_mutex >=4.5
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-nlme >=3.1_64
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 3663168
+timestamp: 1762539639167
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mime-0.13-r45h0557e7b_1.conda
+sha256: 7ebc8c9727a9841e9c0ac408d67dda73618105a6741e6ee2764d3b5838006adc
+md5: a18f44c7e30f17a25dae01a2ebdd64ac
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 65881
+timestamp: 1757441504988
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+sha256: 97d463c2146c483992a25fe497755e9cf714f95ca611a93d8adbb41c068e9e74
+md5: c78bd534986cde8fc0cb08cc9a1a2cc6
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+license: MIT
+license_family: MIT
+size: 247241
+timestamp: 1757455926748
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-nlme-3.1_170-r45ha85219e_0.conda
+sha256: 5a665d1c57741a6ad27b09c26a5c70c1e8b2600b99c1ca70850b01e67981aba1
+md5: 9d56b3fd30b35e8511816cd727b71c75
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 2364152
+timestamp: 1784288181817
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-openssl-2.4.2-r45h37c386a_0.conda
+sha256: 0b1010bcebef6d666733f422ede62662c408bd21d35a1a6a415a56469641ff98
+md5: b835aaead878405731f2cd4f92f253ff
+depends:
+- libgcc >=14
+- openssl >=3.5.6,<4.0a0
+- r-askpass
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 683534
+timestamp: 1781024877810
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+sha256: 09df5e8326b04412a26b6c4d896e04adbceba45194457c6d30f370d5ccb4b397
+md5: 0c015ba0c5444777a683c05e4a000f21
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-getopt >=1.20.2
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 119289
+timestamp: 1776419503742
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+sha256: f5de9737f59e1965db2de11c90cf1fdd426db322a7205c935a3e55150287b02f
+md5: 560abd550c097e0d0af2e201b335f53d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 286342
+timestamp: 1761151056217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+sha256: 162742dd773c8a163de6ffdf0e14820b5708b9e1041d4491762c05e00f6be614
+md5: 849a8fcdb5e1d98a3917a7c652c322df
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 679411
+timestamp: 1757649050426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+sha256: a4869bf14ad791c8a5cb48fd0575faa3cdb7b07692cb4b473809c261f584fa45
+md5: 9a48d2e7fdc93937c60481c06d40e6ba
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 234305
+timestamp: 1770387131912
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+sha256: b3f281041ecff2d4a9f40073ad5e7ec6fa7e0c841068ce85c550bcce0ff8938d
+md5: 807ef77a70fc5156f830d6c683d07a29
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 629867
+timestamp: 1758149763203
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+sha256: fda425435a533e86da5f0fc89cf45c9f889a4e6f1e2ed536ca23662a8461602c
+md5: 40a5fdd06c7e7880758a021cf2df6c12
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 27236
+timestamp: 1757447537447
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
+sha256: c27913720e29845540e0f20507cdd43ea2beff02e7a73b1e2f51e4e929c42859
+md5: 51ad52cc7fa715ca7739245162bfab8f
+depends:
+- libgcc >=14
+- openssl >=3.5.3,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 137458
+timestamp: 1758095884906
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
+md5: ced57d920bed79382f382a24a4425ef7
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-crosstalk
+- r-data.table
+- r-digest
+- r-dplyr
+- r-ggplot2 >=3.0.0
+- r-hexbin
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httr
+- r-jsonlite >=1.6
+- r-lazyeval >=0.2.0
+- r-magrittr
+- r-promises
+- r-purrr
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-tibble
+- r-tidyr
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 3587131
+timestamp: 1769337109792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
+sha256: 0150b0ff5b1f10d44d8340697dc75308d000af7173e06a7bd6bbc52662435647
+md5: b5287e844eb29138a9bbac2204c34938
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.0
+license: MIT
+license_family: MIT
+size: 787646
+timestamp: 1757441825154
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
+sha256: 0795c4803d0c96906f1f509db1b444bedbcd49efcf563fa67e34056f155f4944
+md5: 6002b6697d4f3a7aa2112d75938215df
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-ps >=1.2.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 416233
+timestamp: 1776865727437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+sha256: 684dba5d20aae8da37868d603b662014e1944f5568e5f737e42d9d485892a26e
+md5: b2c1b6ef8f12894fd2694b285fe8989a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-fastmap >=1.1.0
+- r-later
+- r-lifecycle
+- r-magrittr >=1.5
+- r-otel >=0.2.0
+- r-r6
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1597704
+timestamp: 1762426228446
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ps-1.9.3-r45h0557e7b_0.conda
+sha256: 9806dc2cd51b90600c0cfaa9414bf037359b48e4409a3e848c714f7fd202e326
+md5: 110a8db7f8f7d81dc6499717e3518901
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 415719
+timestamp: 1777148053343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.2.2-r45h0557e7b_0.conda
+sha256: 132601f0cf01c5472b5808479e92290c4a1764202d8eb370a568c0c8cc42e509
+md5: 9418ed4bd8e6c1f7daa1d86fde8d4bca
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 551426
+timestamp: 1775853641796
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-qap-0.1_2-r45ha85219e_5.conda
+sha256: 130ad15a31352cac447a5d5121df7703a77775be465967816193fadf522ec604
+md5: 0783f6d35f1229fd9476bbd89ebb36e2
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 397185
+timestamp: 1757637123693
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+sha256: bd92e91332eba5f0c689583e80adec85ef272c4e0d0b36ee17cb7c11b5693cf2
+md5: 750802806d7d640c286ed8491bb395dc
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 95073
+timestamp: 1757447661037
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rappdirs-0.3.4-r45h0557e7b_0.conda
+sha256: 86b48f6a5648dab19677da07eb4360ab9f1df1957ab1a5bd7499c14284303fe4
+md5: 37552103a31471f0dd255110017d4397
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 55042
+timestamp: 1768747329339
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+sha256: ddd4e63616ee475bdf9dc63a0b16a89017237121e927d83fbdee07d5a5ccc890
+md5: d8fa238420cb6de47d463b7345a761eb
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68005
+timestamp: 1757452462302
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpp-1.1.2-r45h08b74da_0.conda
+sha256: 4a2c9002ff0360803ab644577bbac5a2277dab69a7cb58c23218d39e84d3371a
+md5: 6cc0478a5eda6092486e4f6fb2de570b
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 2121146
+timestamp: 1783264524840
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpptoml-0.2.3-r45hd601667_1.conda
+sha256: 0481dc92f2c896ce9e25ea69b53c8bfe7ddb76c6e3fc7baaf4cdda8351c385e5
+md5: f68ce5a7d961bf5047a1635c013d5ce2
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.5
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 229676
+timestamp: 1757491689154
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+sha256: 68f01b65843f873b01bff24f61f27298667797aa3ad01d4406a62ae72e7c08c5
+md5: 1a99d6f9dfe5f6e8dc5275d49852cd66
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 208380
+timestamp: 1757507980343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-renv-1.2.3-r45h0557e7b_0.conda
+sha256: 10a562d51e1c0286aeec2a9146e2038b809391bb1aa63700c9ccfb3362e9e372
+md5: 8dfb98a9c08d53deb71fc9f861aedefb
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 2469153
+timestamp: 1778972869359
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-reshape2-1.4.5-r45h08b74da_0.conda
+sha256: 963e97c3784e971a8f6a42efe7734123da1e5de0cea2cef876b0ffc46b303eed
+md5: 1f0843cf4a39b71ae3bb80d11c0d19f1
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-plyr >=1.8.1
+- r-rcpp
+- r-stringr
+license: MIT
+license_family: MIT
+size: 126686
+timestamp: 1762975693066
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.3.0-r45h08b74da_0.conda
+sha256: 074cbdc062065520aa129ac3390dd1dd2ac792a151c0a2441890290f2dc2351f
+md5: c41e2c86ee4633b25d88036ff33b1cdc
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1625093
+timestamp: 1783260250227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+sha256: b3735a4e75eca023b24678251da041854b94a8b96588d81b605928d6ecf74f11
+md5: 25b9dbf0ff990b8b3111774878e3bb07
+depends:
+- pandoc >=1.14
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.2.5.1
+- r-evaluate >=0.13
+- r-fontawesome >=0.5.0
+- r-htmltools >=0.5.1
+- r-jquerylib
+- r-jsonlite
+- r-knitr >=1.43
+- r-tinytex >=0.31
+- r-xfun >=0.36
+- r-yaml >=2.1.19
+license: GPL-3.0-only
+license_family: GPL3
+size: 2085382
+timestamp: 1774555006202
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+sha256: 5f9aa168f5c43f1d3ddbacc701370085fcead3956e2d5879af7fcd9e086a0a0b
+md5: 62f09532f225c86d27e954b36682add5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-digest
+- r-httr2
+- r-jsonlite
+- r-lifecycle
+- r-openssl >=2.0.0
+- r-packrat >=0.6
+- r-pki
+- r-renv >=1.0.0
+- r-rlang >=1.0.0
+- r-rstudioapi >=0.5
+- r-snowflakeauth
+- r-yaml >=2.1.5
+license: GPL-2.0-only
+license_family: GPL2
+size: 830390
+timestamp: 1783503525234
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+sha256: 896aeea3aa679a9dbd0277d10ef8dcfd011e45a1717129180a9877c1fd828f2a
+md5: 5f1b6b899fa3204ab77403e75b9df5fd
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 357140
+timestamp: 1781250782889
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-s7-0.2.2-r45hf488e41_0.conda
+sha256: 1c1be6985179ebd4eefbfc6939f014a4841e3a5b4738a667c0b1575f7bc2d1d1
+md5: 04cc16d1447a6e6cdaebe06e23d46d50
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 312811
+timestamp: 1776861400477
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sass-0.4.10-r45h08b74da_1.conda
+sha256: a318466958e737c4b214299b99974398e769961347cfad85c585e7bc7a959749
+md5: 6a543a95d37cfaa08a3f17dc3e46e8f6
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-fs
+- r-htmltools
+- r-r6
+- r-rappdirs
+- r-rlang
+license: MIT
+license_family: MIT
+size: 2245202
+timestamp: 1757464676590
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+sha256: 260c384e952e5bd4d2c2de77b9e09b24ff1c1f680acd917c4657ab8c9e4e9a2f
+md5: 8bc81cc6fd130cef963bc9e082726a14
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-farver >=2.0.0
+- r-labeling
+- r-lifecycle
+- r-munsell >=0.5
+- r-r6
+- r-rcolorbrewer
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 777793
+timestamp: 1757487539496
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+sha256: bcde368cbf5a2c83b9c1fb8b3ba0722787af759f68d08bac6a82e966adbf999f
+md5: ba820689c02638c807f83e6ab5c53142
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 370745
+timestamp: 1771995271935
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-seriation-1.5.8-r45ha85219e_1.conda
+sha256: e59663a8f5dbd9c6748a353e508f49f85e99622d4adce539cd2b1aef21186624
+md5: 60eaa5984a3efa5d4a7cf167dfe18d75
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-ca
+- r-cluster
+- r-colorspace
+- r-foreach
+- r-gclus
+- r-mass
+- r-qap
+- r-registry
+- r-tsp
+- r-vegan
+license: GPL-3.0-only
+license_family: GPL
+size: 1373552
+timestamp: 1757662510748
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+sha256: ef0042ae1c3926ef9bee6c21cf761d7cf441eae61dceca7df143f3b9dc4c6f04
+md5: 2fb0e1ea59dd281487be303b1b7c6607
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.6.0
+- r-cachem >=1.1.0
+- r-commonmark >=1.7
+- r-crayon
+- r-fastmap >=1.1.1
+- r-fontawesome >=0.4.0
+- r-glue >=1.3.2
+- r-htmltools >=0.5.4
+- r-httpuv >=1.5.2
+- r-jsonlite >=0.9.16
+- r-later >=1.0.0
+- r-lifecycle >=0.2.0
+- r-mime >=0.3
+- r-promises >=1.1.0
+- r-r6 >=2.0
+- r-rlang >=0.4.10
+- r-sourcetools
+- r-withr
+- r-xtable
+license: GPL-3.0-only
+license_family: GPL3
+size: 3789417
+timestamp: 1782070586086
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+sha256: c3ea3d60226ed56e4a40b622b8e4721d257a9fb4ca8502ce89314f48a63a0090
+md5: b5da9b58b4f8137a7f2e14102bc230c9
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-glue
+- r-shiny
+license: MIT
+license_family: MIT
+size: 344724
+timestamp: 1757870156008
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+sha256: 9493d6cbf09850206f5904ccde65643de86bb9bd6add685548331c408e99610a
+md5: 3929f109451367912b4570480f4c572d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest >=0.6.8
+- r-jsonlite
+- r-shiny >=1.0.0
+license: MIT
+license_family: MIT
+size: 1018291
+timestamp: 1768513288077
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
+md5: 7382af8530d082191feb0c8da5f8a41b
+depends:
+- bioconductor-limma
+- bioconductor-summarizedexperiment
+- r-base >=4.5,<4.6.0a0
+- r-biocmanager
+- r-bslib >=0.9.0
+- r-cluster
+- r-dplyr
+- r-dt >=0.2
+- r-ggbeeswarm
+- r-ggdendro
+- r-ggplot2
+- r-heatmaply
+- r-htmltools
+- r-htmlwidgets
+- r-markdown
+- r-matrixstats
+- r-optparse
+- r-plotly >=4.8.0
+- r-rcolorbrewer
+- r-rsconnect
+- r-scatterplot3d
+- r-shiny >=1.7.0
+- r-shinycssloaders
+- r-shinyjs
+- r-viridislite
+- r-yaml
+license: AGPL-3.0
+license_family: AGPL
+size: 3448797
+timestamp: 1784579537432
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
+md5: 1d38994c8bfe421d621d9b3705c37b58
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-jose
+- r-jsonlite
+- r-openssl
+- r-rcpptoml
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76170
+timestamp: 1772133448445
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
+sha256: e0425d3fc2508397001a828f83de7b9057b26bf674f3ad031154c6d3ff737010
+md5: 6df66556d9813139f613a3d5d80aefa3
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 57378
+timestamp: 1774682311091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
+sha256: 72aaa65e6c8aecf46e62493fd569d756ad5f655dfc35e8b65fb32f903e42fac3
+md5: 896cc6b4f51281019f0112a291f2e4b0
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 326784
+timestamp: 1779038275497
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.7-r45h1ddd0e6_2.conda
+sha256: 683aecd70c89afc99c9d1a5358502091d58c5515637839a174170b5270864473
+md5: f70959e59600d520abb4fc5eff09b6b7
+depends:
+- icu >=78.2,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: FOSS
+license_family: OTHER
+size: 948766
+timestamp: 1772037526007
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+sha256: dea2a7676dd03ed93fa0ec961883c5075c361c8522659a1bc1e6b5c16525cb24
+md5: 8db438d8aa370726ee1ce8bf458f2e6d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 319328
+timestamp: 1762269757617
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sys-3.4.3-r45h0557e7b_1.conda
+sha256: 2615aa5617553d22835183a060a13b19a7fd6b006d5570d3dc7d4d0a9a18ffd1
+md5: 902062b1b024b2cf50bcebbdc3f14a33
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 51531
+timestamp: 1757441776397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.1-r45h0557e7b_0.conda
+sha256: 9ef8d3a7e5862ffe7921129d77c0e640eed11233c8c93c03ebbd38c5a7bdfc9b
+md5: 672f703f5dba8c08fe08bd5d6d462b81
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 591468
+timestamp: 1768139158745
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.2-r45h08b74da_0.conda
+sha256: cdceeab30bdc7648b9b037f884d91fafff5e3663b87a72cf9d6c4ee6e68e86d1
+md5: 0757fb6415a03dd46697bcbc836562b0
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127523
+timestamp: 1766142060375
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+sha256: fca09d6b9940f1e1cda0425a0f55716bba202d6f55d6bd25fedec391006c7dc7
+md5: 15aa0f323385403fe182e46a1d095e1b
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 220192
+timestamp: 1757475791328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+sha256: 1fad4d08756ca2d7db04cfaf88e9df797da95a5f7f4b8aabc165eee36faddafc
+md5: 5ee226c1449c66d1cd2399d942faa04d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.48
+license: MIT
+license_family: MIT
+size: 158240
+timestamp: 1782203211628
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tsp-1.2.7-r45hf488e41_0.conda
+sha256: 76b17a4cb143f1441fd91b78d1e05d537dc3fb21ae4c2b0a8247f032f249249d
+md5: d266cd3851cb11b2f619c80ff9adf6f5
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-foreach
+license: GPL-3.0-only
+license_family: GPL3
+size: 737125
+timestamp: 1774391402905
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r45h0557e7b_1.conda
+sha256: c98cdf9a46680cf5e415e37c037cab774b8df2b9b3182f15ece4d740fc0c697b
+md5: a526af0f22a5ac7a3835f1710b63e5b5
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 152455
+timestamp: 1757424718278
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.7.3-r45h08b74da_0.conda
+sha256: 10235170aad63b8412ce99dd1756d250175cf5a3ea987379fea98f0bd9224e82
+md5: f43335c24a9f3fd0920d2a9e721f2845
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1854267
+timestamp: 1775898029394
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vegan-2.7_5-r45ha2e3c6d_0.conda
+sha256: f114cf641e03f2d087d55b37f0826910bdd1e6481c1b18dbcf5d343b84178435
+md5: 5da6b73699a8bb6b0d8f60a9419983e8
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+- r-lattice
+- r-mass
+- r-mgcv
+- r-permute >=0.9_0
+license: GPL-2.0-only
+license_family: GPL2
+size: 3050073
+timestamp: 1779956718513
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+sha256: 859729e8cd04bb92ec144b21a8abfdb2bec9cbac9deaa41ba0cc2add13d088a0
+md5: e605ce527e381c5577d57649e393cb87
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4508304
+timestamp: 1757669044129
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+sha256: 884896b59133b948646b0d1441106120f7b320e9fac827ccb9d44bbe80dda8f2
+md5: e841095941c40142bdad834299b95a30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=1.0.1
+- r-gridextra
+- r-viridislite >=0.4.0
+license: MIT
+license_family: MIT
+size: 2988605
+timestamp: 1757516440048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+sha256: b9ec9606562f0f6bdefc237bbc6163eb1cb022f9d699c80771bc84af0ae37269
+md5: bcadc0a3726e2191e51449f67fa5e0a9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1305542
+timestamp: 1770191459321
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+sha256: e79e366895dfdf79fe92986fe42d0695e3fcacc25411506c48b9db92742eb99c
+md5: e021e3d936f57ea9b35eb099999d6800
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-callr
+- r-jsonlite
+- r-magrittr
+license: GPL-2.0-only
+license_family: GPL2
+size: 206060
+timestamp: 1757520337073
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+sha256: 56f318c90bfc74f01339c83f0e1d0817c1b762ea46cd9e527fec9dcf244c5900
+md5: 388d25e67f93a5fec2aebe56d6a0a1d9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 235287
+timestamp: 1781856624720
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-xfun-0.60-r45hf488e41_0.conda
+sha256: adde9f62c5c7a48edd241547d778f4ff6016970ac4334f34977032394088f12f
+md5: ec03ae90ca44079179679287542be5af
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 651144
+timestamp: 1784103302558
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+sha256: 972923364cfd616ccf38768477c435677cfe1ea18a72016f90344ea920e4fea5
+md5: e18fda0821f0fdc1c34276c5e0acdc92
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL (>= 2)
+license_family: GPL3
+size: 744345
+timestamp: 1771859982217
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-yaml-2.3.12-r45h0557e7b_0.conda
+sha256: 85b3323f76adf8862ad3a52b42270425309a875983da261faa738ed9f7e52586
+md5: 9885e008c928a67e48cd521a98f666d4
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 128431
+timestamp: 1765372892689
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+sha256: fe695f9d215e9a2e3dd0ca7f56435ab4df24f5504b83865e3d295df36e88d216
+md5: 3d49cad61f829f4f0e0611547a9cda12
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 357597
+timestamp: 1765815673644
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+sha256: 7b2d9835a79bd67c0b2966cedf246c85bf650dc961125c8e31f073646d4ac797
+md5: 59f2c90c66b956d9bc3e625df3ad8a0a
+depends:
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 288685
+timestamp: 1776861726084
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+sha256: 1bd2db6b2e451247bab103e4a0128cf6c7595dd72cb26d70f7fadd9edd1d1bc3
+md5: fdf07ab944a222ff28c754914fdb0740
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-aarch64 4.18.0 h05a177a_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 23644746
+timestamp: 1765578629426
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+build_number: 103
+sha256: cd51fbda051a9f3679d10ef4a94cd1ff38c10533b82845dadce8ba87245ba4ce
+md5: 89e78452e06563964e419059ee45584a
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3683040
+timestamp: 1784229053797
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h5f05d98_8.conda
+sha256: 06e25e5026e0058a085be2cbcc55e7ef8cda1263c15bc7e72525c0eb8bb44d5e
+md5: 40266bd074925af4a396250d222d2188
+depends:
+- tk
+- libgcc >=14
+- tk >=8.6.13,<8.7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 106646
+timestamp: 1773733124596
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+sha256: 720691eb59b86f11ceb21b236b9402d59c47d156183375d2b24c53a201dd874b
+md5: 6dc4b55fc391a3d51ff12a6fed979562
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 40249
+timestamp: 1779439555623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+sha256: a2ba1864403c7eb4194dacbfe2777acf3d596feae43aada8d1b478617ce45031
+md5: c8d8ec3e00cd0fd8a231789b91a7c5b7
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 60433
+timestamp: 1734229908988
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+sha256: b86a819cd16f90c01d9d81892155126d01555a20dabd5f3091da59d6309afd0a
+md5: 2d1409c50882819cb1af2de82e2b7208
+depends:
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 28701
+timestamp: 1741897678254
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+sha256: cf886160e2ff580d77f7eb8ec1a77c41c2c5b05343e329bc35f0ddf40b8d92ab
+md5: 22dd10425ef181e80e130db50675d615
+depends:
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 869058
+timestamp: 1770819244991
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+sha256: e9f6e931feeb2f40e1fdbafe41d3b665f1ab6cb39c5880a1fcf9f79a3f3c84a5
+md5: 1c246e1105000c3660558459e2fd6d43
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 16317
+timestamp: 1762977521691
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+sha256: 128d72f36bcc8d2b4cdbec07507542e437c7d67f677b7d77b71ed9eeac7d6df1
+md5: bff06dcde4a707339d66d45d96ceb2e2
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 21039
+timestamp: 1762979038025
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+sha256: db2188bc0d844d4e9747bac7f6c1d067e390bd769c5ad897c93f1df759dc5dba
+md5: fb42b683034619915863d68dd9df03a3
+depends:
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+license: MIT
+license_family: MIT
+size: 52409
+timestamp: 1769446753771
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+sha256: ffd77ee860c9635a28cfda46163dcfe9224dc6248c62404c544ae6b564a0be1f
+md5: ae2c2dd0e2d38d249887727db2af960e
+depends:
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 33649
+timestamp: 1734229123157
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+sha256: 7c109792b60720809a580612aba7f8eb2a0bd425b9fc078748a9d6ffc97cbfa8
+md5: a9e4852c8e0b68ee783e7240030b696f
+depends:
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.9,<2.0a0
+license: MIT
+license_family: MIT
+size: 384752
+timestamp: 1731860572314
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+sha256: 569990cf12e46f9df540275146da567d9c618c1e9c7a0bc9d9cfefadaed20b75
+md5: c3655f82dcea2aa179b291e7099c1fcc
+depends:
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 614429
+timestamp: 1764777145593

--- a/modules/nf-core/shinyngs/staticexploratory/environment.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=2.4.0
+  - bioconda::r-shinyngs=3.1.1

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -3,9 +3,9 @@ process SHINYNGS_STATICEXPLORATORY {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d7/d782b4f11adf8f3cad6af74ea585468decd873a171da1dae0e4a24a82bb29020/data' :
-        'community.wave.seqera.io/library/r-shinyngs:2.4.0--709fc6932be670a5' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d'}"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files), val(variable)

--- a/modules/nf-core/shinyngs/staticexploratory/meta.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/meta.yml
@@ -1,6 +1,5 @@
 name: "shinyngs_staticexploratory"
-description: Make exploratory plots for analysis of matrix data, including PCA, Boxplots
-  and density plots
+description: Make exploratory plots for analysis of matrix data, including PCA, Boxplots and density plots
 keywords:
   - exploratory
   - plot
@@ -9,8 +8,7 @@ keywords:
   - PCA
 tools:
   - "shinyngs":
-      description: "Provides Shiny applications for various array and NGS applications.
-        Currently very RNA-seq centric, with plans for expansion."
+      description: "Provides Shiny applications for various array and NGS applications. Currently very RNA-seq centric, with plans for expansion."
       homepage: "https://github.com/pinin4fjords/shinyngs"
       documentation: "https://rawgit.com/pinin4fjords/shinyngs/master/vignettes/shinyngs.html"
       tool_dev_url: "https://github.com/pinin4fjords/shinyngs"
@@ -213,3 +211,27 @@ authors:
   - "@pinin4fjords"
 maintainers:
   - "@pinin4fjords"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d
+      build_id: bd-b5595b301bfbfd4d_2
+      scan_id: sc-73b4cbdd1930464e_1
+    linux/arm64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--4d71a4d10942e43f
+      build_id: bd-4d71a4d10942e43f_2
+      scan_id: sc-72596f6b93ff3200_1
+  singularity:
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--60831a2d7cd7ae94
+      build_id: bd-60831a2d7cd7ae94_2
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6fff209824ab2042c6f09b68d257d59ae4e0ea7410dad923089db9c5c0dbd683/data
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--791778d7e2758322
+      build_id: bd-791778d7e2758322_2
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data
+  conda:
+    linux/amd64:
+      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+    linux/arm64:
+      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt

--- a/modules/nf-core/shinyngs/staticexploratory/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/staticexploratory/tests/main.nf.test.snap
@@ -12,16 +12,16 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:22:45.037561572",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:52:12.716788"
     },
     "mouse - defaults": {
         "content": [
@@ -36,16 +36,16 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:22:33.22352375",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:51:23.973465"
     },
     "mouse - specify log": {
         "content": [
@@ -60,16 +60,16 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:23:04.288910997",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:54:00.624425"
     },
     "mouse - html": {
         "content": [
@@ -89,15 +89,15 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:23:25.065630217",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:55:52.048115"
     }
 }

--- a/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+++ b/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
@@ -1,0 +1,3302 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-64:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-biobase-2.70.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-delayedarray-0.36.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-genomicranges-1.62.1-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-iranges-2.44.0-r45h01b2380_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-limma-3.66.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4arrays-1.10.1-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4vectors-0.48.0-r45h01b2380_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-sparsearray-1.10.8-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-xvector-0.50.0-r45h01b2380_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.2.0-h281d09f_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-askpass-1.2.1-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.5.3-h502d0c9_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base64enc-0.1_6-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-beeswarm-0.4.0-r45h54b55ab_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cachem-1.1.0-r45h54b55ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.6-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.2-r45heaba542_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-commonmark-2.0.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-curl-7.1.0-r45h10955f1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.18.4-r45h1c8cec4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.39-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.2.1-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.7-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r45h3697838_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fastmap-1.2.0-r45h3697838_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fs-2.1.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.1-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-hexbin-1.28.5-r45heaba542_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-htmltools-0.5.9-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-httpuv-1.6.17-r45h6d565e7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.3.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-jsonlite-2.0.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-later-1.4.8-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_9-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lazyeval-0.2.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.5-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_66-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.7_5-r45h0e4624f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_4-r45h0e4624f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mime-0.13-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_170-r45heaba542_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-openssl-2.4.2-r45h68c19f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ps-1.9.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.2.2-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-qap-0.1_2-r45heaba542_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rappdirs-0.3.4-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.1.2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpptoml-0.2.3-r45h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-renv-1.2.3-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.5-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.3.0-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-s7-0.2.2-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sass-0.4.10-r45h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-seriation-1.5.8-r45heaba542_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.7-r45h3d52c89_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sys-3.4.3-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.1-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.2-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tsp-1.2.7-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r45h54b55ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.7.3-r45h3697838_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vegan-2.7_5-r45h11cdb10_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xfun-0.60-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-yaml-2.3.12-r45h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+md5: a9f577daf3de00bca7c3c76c0ecbd1de
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28948
+timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+depends:
+- ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+- sysroot_linux-64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 3713752
+timestamp: 1784214522814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+sha256: 08d7238663fc408ba2ab60b02fa3d06a7ca9d872962e03e90c7e0fdecb7ed1d0
+md5: 32fd07abe84eb14f17c7f5cc6fa8df82
+depends:
+- binutils_impl_linux-64 2.46.1 default_hfdba357_102
+license: GPL-3.0-only
+license_family: GPL
+size: 36337
+timestamp: 1784214551894
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-biobase-2.70.0-r45h01b2380_0.conda
+sha256: d23fb8b3abab1d8241a9172fc1a4ca586c31d18cb2c4fb5152c53a6cd659777a
+md5: 782edae8ecb3df45c26652d215977957
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2355711
+timestamp: 1770509543214
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+sha256: 97221eda3007381c0a6498608baaebdcec6047f7f26b121c19149fd56aabf032
+md5: 27556377d159490ea87696727ae41808
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-generics
+license: Artistic-2.0
+size: 653523
+timestamp: 1770415244399
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-delayedarray-0.36.0-r45h01b2380_0.conda
+sha256: 1f1fd7027ffffebeaca5c416f05d91bcd3a05cf1d043ee347fffbcdde6978c01
+md5: 8a5b2ea0550afcb925ff5f267ff741ea
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-sparsearray >=1.10.0,<1.11.0
+- bioconductor-sparsearray >=1.10.8,<1.11.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 2204619
+timestamp: 1772123650559
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-genomicranges-1.62.1-r45h01b2380_0.conda
+sha256: 0d5ea1e661e10cfeecf763a7466efebc616ca55a2c9f6ce33cbe41c7eb1a0a4b
+md5: 5dd6ca03e419938e6e4e3bc6b7796b45
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2306994
+timestamp: 1772108656670
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-iranges-2.44.0-r45h01b2380_1.conda
+sha256: 964697eeaeb946ecfe076f3b43eec9bafa018ef21d2dc3555d6c28ca817e4d79
+md5: d6811165f0b3db78b08fdc2c4938bc4e
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2344215
+timestamp: 1770546527540
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-limma-3.66.0-r45h01b2380_0.conda
+sha256: c8dcbf3abfc0c1cf4ff6e68c828e0c59052c2b65dd3dd15aa1d39dbca679991e
+md5: 54dbec67b82ef291760cb0c2927c5002
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-statmod
+license: GPL-2.0-or-later
+size: 3099884
+timestamp: 1770417840293
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+sha256: 169809ca754b2c07f7356f1fc4f365b7d5154fd66229543584f69008fa347c5a
+md5: cdf0406fc3caa814ff7b7876a42973a5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-matrixstats >=1.4.1
+license: Artistic-2.0
+size: 449898
+timestamp: 1770417102301
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4arrays-1.10.1-r45h01b2380_0.conda
+sha256: 0b8729dc75999ab80ff333242f1052de1642f2f5653d344c06a652143b1326bd
+md5: 0b2ad083cc4002a36926c7c31be1c5c8
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-abind
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1027424
+timestamp: 1770628251018
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-s4vectors-0.48.0-r45h01b2380_1.conda
+sha256: d6ffd7388683d03ab6133a3f8efdb69d917718a54c3d08b744c1b4910b876e82
+md5: db7c8f69c137a9a97a11518ce59ca149
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2061150
+timestamp: 1770508921246
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+sha256: 875f5be76bc3b83766ec0cfacf888570d529907412519a537c5f7a318e489976
+md5: cfe7c256532f9a4fc87ec3be955bb9e6
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 598298
+timestamp: 1770628899171
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-sparsearray-1.10.8-r45h01b2380_0.conda
+sha256: 7f1f2c6012e51daa1d5ea291b7928e396763dd073ebef228f2352118d4287096
+md5: 2b73e1653c675b4ba118bb085862771c
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-xvector >=0.50.0,<0.51.0
+- bioconductor-xvector >=0.50.0,<0.51.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-matrixstats
+license: Artistic-2.0
+size: 1636745
+timestamp: 1772107896548
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+sha256: b8ade9f2ab8cc2835357653f5a9bc840323c05f7656659dfb40d20e5623f8ebd
+md5: 74eb95090e807c18f5bc81cb9fb39b3c
+depends:
+- bioconductor-biobase >=2.70.0,<2.71.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-delayedarray >=0.36.0,<0.37.0
+- bioconductor-genomicranges >=1.62.0,<1.63.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1416452
+timestamp: 1772218138703
+- conda: https://conda.anaconda.org/bioconda/linux-64/bioconductor-xvector-0.50.0-r45h01b2380_0.conda
+sha256: c0921f72138df07e69bdae7c16cc1b35deebfaf0fa93e16dfa731838a6c358b7
+md5: ec982ddb97e04a6b40454395fd2dd229
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 641687
+timestamp: 1770628594641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+sha256: c88dd33c89b33409ebcd558d78fdc66a63c18f8b06e04d170668ffb6c8ecfabd
+md5: 983b92277d78c0d0ec498e460caa0e6d
+depends:
+- tk
+license: TCL
+size: 129594
+timestamp: 1750261567920
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+md5: d2ffd7602c02f2b316fd921d39876885
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 260182
+timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+sha256: dee93a82d045f9aa8277829aa465224afa3c7a6ac18388de66099b2be7f705e7
+md5: 6130ad6705adc993b5d8482b7f66e01f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 210929
+timestamp: 1784091008551
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+md5: a9965dd99f683c5f444428f896635716
+depends:
+- __unix
+license: ISC
+size: 128866
+timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
+md5: bb6c4808bfa69d6f7f6b07e5846ced37
+depends:
+- __glibc >=2.17,<3.0.a0
+- fontconfig >=2.15.0,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.1,<79.0a0
+- libexpat >=2.7.3,<3.0a0
+- libfreetype >=2.14.1
+- libfreetype6 >=2.14.1
+- libgcc >=14
+- libglib >=2.86.3,<3.0a0
+- libpng >=1.6.53,<1.7.0a0
+- libstdcxx >=14
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 989514
+timestamp: 1766415934926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
+sha256: ae0b83efb7545ea40845253b76bbfeb12349bd32001728b8f58d726cd532d467
+md5: d09779693563f4a1a0bdb0f715ba2bf0
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 hae6b9f4_2
+- libgcc >=14
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 194776
+timestamp: 1782911792708
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
+md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 281880
+timestamp: 1780450077431
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
+md5: 8462b5322567212beeb025f3519fb3e2
+depends:
+- libfreetype 2.14.3 ha770c72_0
+- libfreetype6 2.14.3 h73754d4_0
+license: GPL-2.0-only OR FTL
+size: 173839
+timestamp: 1774298173462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
+md5: f9f81ea472684d75b9dd8d0b328cf655
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 61244
+timestamp: 1757438574066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he0086c7_19.conda
+sha256: a48400ec4b73369c1c59babe4ad35821b63a88bba0ec40a80cea5f8c53a26b83
+md5: e3be72048d3c4a78b8e27ec48ba06252
+depends:
+- binutils_impl_linux-64 >=2.45
+- libgcc >=15.2.0
+- libgcc-devel_linux-64 15.2.0 hcc6f6b0_119
+- libgomp >=15.2.0
+- libsanitizer 15.2.0 h90f66d4_19
+- libstdcxx >=15.2.0
+- libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 81180457
+timestamp: 1778269124617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+sha256: b24b13d467898a9b9a17a868a2686412a98f8935dc7cc51547dd90645d4e8436
+md5: 28bc49875f9c38e2401696b3e48d0798
+depends:
+- gcc_impl_linux-64 15.2.0.*
+- binutils_linux-64
+- sysroot_linux-64
+license: BSD-3-Clause
+license_family: BSD
+size: 29330
+timestamp: 1781279944230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.2.0-h281d09f_19.conda
+sha256: 2f6a962bfcb74b8262dc0af5cf0716acbd96f769a0443dd231d1041c222b0ca6
+md5: 5d4fdb7935b8aa1cdb2e22ef8958101e
+depends:
+- gcc_impl_linux-64 >=15.2.0
+- libgcc >=15.2.0
+- libgfortran5 >=15.2.0
+- libstdcxx >=15.2.0
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 20041854
+timestamp: 1778269291096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
+md5: cf09e9fc938518e91d0706572cadf17a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 100054
+timestamp: 1780454302233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+sha256: 132a918b676dd1f533d7c6f95e567abf7081a6ea3251c3280de35ef600e0da87
+md5: fec079ba39c9cca093bf4c00001825de
+depends:
+- libblas >=3.8.0,<4.0a0
+- libcblas >=3.8.0,<4.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3376423
+timestamp: 1626369596591
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
+sha256: 3f5288346b9fe233352443b3c2e31f1fde845e39d3e96475fc05ec2e782af158
+md5: 9d41f3899b512199af0a4bb939b83e21
+depends:
+- gcc_impl_linux-64 15.2.0 he0086c7_19
+- libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+- sysroot_linux-64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16356816
+timestamp: 1778269332159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
+sha256: f78da7a8b49943a6ce48372a5bc85ab741ac86666f1040e8876545065ec1096e
+md5: 5e194579a5f72c70102f342aa362f5f9
+depends:
+- gxx_impl_linux-64 15.2.0.*
+- gcc_linux-64 ==15.2.0 h7be306e_27
+- binutils_linux-64
+- sysroot_linux-64
+license: BSD-3-Clause
+license_family: BSD
+size: 27848
+timestamp: 1781279944230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
+md5: 72e956a71241633d8c80aa198fd08784
+depends:
+- libharfbuzz-devel 14.2.1 h17a8019_1
+license: MIT
+license_family: MIT
+size: 11039
+timestamp: 1782800611635
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+md5: c80d8a3b84358cb967fa81e7075fbc8a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 12723451
+timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+md5: 86d9cba083cd041bfbf242a01a7a1999
+constrains:
+- sysroot_linux-64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1278712
+timestamp: 1765578681495
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+md5: b38117a3c920364aff79f870c984b4a3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 134088
+timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+depends:
+- __glibc >=2.17,<3.0.a0
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1388990
+timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+md5: 449500f2c089da11c40f5c21312e3e07
+depends:
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 745303
+timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
+md5: a752488c68f2e7c456bcbd8f16eec275
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 261513
+timestamp: 1773113328888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+build_number: 8
+sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+md5: 00fc660ab1b2f5ca07e92b4900d10c79
+depends:
+- libopenblas >=0.3.33,<0.3.34.0a0
+- libopenblas >=0.3.33,<1.0a0
+constrains:
+- blas 2.308   openblas
+- mkl <2027
+- libcblas   3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18804
+timestamp: 1779859100675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+build_number: 8
+sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+md5: 33a413f1095f8325e5c30fde3b0d2445
+depends:
+- libblas 3.11.0 8_h4a7cf45_openblas
+constrains:
+- blas 2.308   openblas
+- liblapacke 3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18778
+timestamp: 1779859107964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
+md5: f9c59d277a16ec8f272b2d5dd2ec3335
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 480327
+timestamp: 1782911787190
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+md5: 6c77a605a7a689d17d4819c0f8ac9a00
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 73490
+timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+depends:
+- ncurses
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 134676
+timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+md5: 172bf1cd1ff8629f2b1179945ed45055
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 112766
+timestamp: 1702146165126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+md5: b24d3c612f71e7aa74158d92106318b2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77856
+timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+md5: a360c33a5abe61c07959e449fa1453eb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 58592
+timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
+md5: e289f3d17880e44b633ba911d57a321b
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8049
+timestamp: 1774298163029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
+md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 384575
+timestamp: 1774298162622
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+constrains:
+- libgcc-ng ==15.2.0=*_19
+- libgomp 15.2.0 he0feb66_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1041084
+timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+sha256: 38a557eba305468ac1f90ac85e50d8defd76141cb0b8a43b2fc1aca71dd5d5f2
+md5: 683fcb168e1df9a21fa80d5aa2d9330b
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 3095909
+timestamp: 1778268932148
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+md5: 331ee9b72b9dff570d56b1302c5ab37d
+depends:
+- libgcc 15.2.0 he0feb66_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27694
+timestamp: 1778269016987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
+md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
+depends:
+- libgfortran5 15.2.0 h68bc16d_19
+constrains:
+- libgfortran-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27655
+timestamp: 1778269042954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
+md5: 85072b0ad177c966294f129b7c04a2d5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15.2.0
+constrains:
+- libgfortran 15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2483673
+timestamp: 1778269025089
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
+md5: 889febc66cd9e4190f80ef9718fa239b
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libiconv >=1.18,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- libffi >=3.5.2,<3.6.0a0
+- pcre2 >=10.47,<10.48.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4754220
+timestamp: 1782463895250
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+md5: faac990cb7aedc7f3a2224f2c9b0c26c
+depends:
+- __glibc >=2.17,<3.0.a0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 603817
+timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+md5: fb4669c3990b94ea32fbb81f433e9aa6
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1297668
+timestamp: 1782800580119
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+md5: 99cf21100441e51272f1cd6fe0632a20
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libharfbuzz 14.2.1 h17a8019_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1970690
+timestamp: 1782800603897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+md5: 915f5995e94f60e9a4826e0b0920ee88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-only
+size: 790176
+timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+sha256: 716332fd31b3808da7a4235a05212a9e9da05e854864c3def2dea0b5d2bf7610
+md5: 466badda5536d85ddc63ee9404f29735
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 652868
+timestamp: 1783731886811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+build_number: 8
+sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+md5: 809be8ba8712c77bc7d44c2d99390dc4
+depends:
+- libblas 3.11.0 8_h4a7cf45_openblas
+constrains:
+- blas 2.308   openblas
+- libcblas   3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18790
+timestamp: 1779859115086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+md5: b88d90cad08e6bc8ad540cb310a761fb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 113478
+timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+md5: 2a45e7f8af083626f009645a6481f12d
+depends:
+- __glibc >=2.17,<3.0.a0
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 663344
+timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
+md5: 2d3278b721e40468295ca755c3b84070
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.33,<0.3.34.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5931919
+timestamp: 1776993658641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+md5: eba48a68a1a2b9d3c0d9511548db85db
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 317729
+timestamp: 1776315175087
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+sha256: 71118885feab91c61bea4e9532ec46e0653b24f02e563681f822915aee8435bb
+md5: af5ddfb52ad25d833c70c7511478d4eb
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 70092
+timestamp: 1783936855082
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+sha256: 7a58892a52739ce4c0f7109de9e91b4353104748eb04fc6441d88e8af444ba99
+md5: 67eef12ce33f7ff99900c212d7076fc2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15.2.0
+- libstdcxx >=15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7930689
+timestamp: 1778269054623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+md5: eecce068c7e4eddeb169591baac20ac4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 304790
+timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+md5: 5794b3bdc38177caf969dabd3af08549
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc 15.2.0 he0feb66_19
+constrains:
+- libstdcxx-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 5852044
+timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+sha256: a2385f3611d5cd25378f9cf2367183320731709c067ddd08d43330d3170f15b8
+md5: bcfe7eae40158c3e355d2f9d3ed41230
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 20765069
+timestamp: 1778268963689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
+md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
+depends:
+- __glibc >=2.17,<3.0.a0
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 452337
+timestamp: 1783084902636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+md5: 01bb81d12c957de066ea7362007df642
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-3-Clause
+license_family: BSD
+size: 40017
+timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+sha256: e28e4519223f78b3163599ca89c3f2d80bfb53e907e7fc74e806e60d1efa578b
+md5: 4e33d49bf4fc853855a3b00643aa5484
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 419935
+timestamp: 1779396012261
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+md5: aea31d2e5b1091feca96fcfe945c3cf9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 429011
+timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+md5: 92ed62436b625154323d40d5f2f11dd7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- pthread-stubs
+- xorg-libxau >=1.0.11,<2.0a0
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 395888
+timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+md5: d87ff7921124eccd67248aa483c23fec
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- zlib 1.3.2 *_2
+license: Zlib
+license_family: Other
+size: 63629
+timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+sha256: d652c7bd4d3b6f82b0f6d063b0d8df6f54cc47531092d7ff008e780f3261bdda
+md5: 33405d2a66b1411db9f7242c8b97c9e7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 513088
+timestamp: 1727801714848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+md5: fc21868a1a5aacc937e7a18747acb8a5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 918956
+timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+md5: 79dd2074b5cd5c5c6b2930514a11e22d
+depends:
+- __glibc >=2.17,<3.0.a0
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3159683
+timestamp: 1781069855778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+sha256: 2f17a165a04833bd249215336b00df912bad7f03ae445a36765b47593df34057
+md5: a4b80dd6e9e0784ba48e6803bef1e17a
+license: GPL-2.0-or-later
+license_family: GPL
+size: 22516793
+timestamp: 1780595446569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
+md5: d53ffc0edc8eabf4253508008493c5bc
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.17.1,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- harfbuzz >=13.2.1
+- libexpat >=2.7.4,<3.0a0
+- libfreetype >=2.14.2
+- libfreetype6 >=2.14.2
+- libgcc >=14
+- libglib >=2.86.4,<3.0a0
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 458036
+timestamp: 1774281947855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+md5: 7a3bff861a6583f1889021facefc08b1
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1222481
+timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+sha256: 9e5b5be056820ade8b09ef73cf9f4bea037eb9887145d0297ac99e0add88878d
+md5: 7cd77fef4da3e1ca9484394616cb71f1
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 376220
+timestamp: 1784286827180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+sha256: 4ce2e1ee31a6217998f78c31ce7dc0a3e0557d9238b51d49dd20c52d467a126d
+md5: f2c23a77b25efcad57d377b34bd84941
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 593603
+timestamp: 1769710381284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+md5: b3c17d95b5a10c6e64a21fa17573e70e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 8252
+timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+sha256: 5055913d786b82f33a14f493f32945b3b2b5d528ea2f52856ca02b296f6511eb
+md5: dde4691fe168112a90efba6aaa08f13d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: LGPL (>= 2)
+license_family: LGPL
+size: 82526
+timestamp: 1757460261392
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-askpass-1.2.1-r45h54b55ab_1.conda
+sha256: 5c4d2bcc1beba7703acbfe1610a846ce2a4010456714705dfa63989cee722a00
+md5: 1ae3c72e90c6a3871c594448d3e152e4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-sys >=2.1
+license: MIT
+license_family: MIT
+size: 31983
+timestamp: 1758383536121
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+sha256: 90e7ae8aa427274d7d2e510060b68925e60e897ecaa5ea135bb33afa7eb12134
+md5: b5291c60f52b43108a2973ba6f5885d1
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 72543
+timestamp: 1757447376176
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.5.3-h502d0c9_3.conda
+sha256: e6fa14f597334a5178e5ea0ce2290e1bcb5d165d36f6dbcf41a516cba3176dff
+md5: 8e584ef995c58d546ca1b2642fa4deae
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.18.4,<2.0a0
+- curl
+- gcc_linux-64 >=14
+- gfortran_impl_linux-64
+- gsl >=2.7,<2.8.0a0
+- gxx_linux-64 >=14
+- icu >=78.3,<79.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libglib >=2.88.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- make
+- pango >=1.56.4,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- readline >=8.3,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- tzdata >=2024a
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxt >=1.3.1,<2.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 27369225
+timestamp: 1781522577217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base64enc-0.1_6-r45h54b55ab_0.conda
+sha256: 7a3751a340766ee25380a51df70c8356a64cfeb6ac3d982a86e92eb99fec2943
+md5: e573dc135976197e7f819eec202c93f1
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 48616
+timestamp: 1770027796335
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-beeswarm-0.4.0-r45h54b55ab_5.conda
+sha256: 0b1e86ec24e2acc3eae1020cc5b19f9f7e172df8871b4f042fbca11d0fc2e0a6
+md5: 787c18b3e1532606bf796a360cf2ea39
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 89369
+timestamp: 1757583631217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+sha256: 177f262fda25552b8ce3e7685220deefba1625314575a892cd4abca06ddf06a4
+md5: f1b6b9a4e77b21df8a6949102db4f468
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 644936
+timestamp: 1763112090227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+sha256: fafc7a0acb8fc595b8fd89e75ec0b1d7d5af71b2b493570fa05e1f5612d299c2
+md5: dae60c429ab933e549832bc223e95639
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-cachem
+- r-htmltools >=0.5.7
+- r-jquerylib >=0.1.3
+- r-jsonlite
+- r-lifecycle
+- r-memoise >=2.0.1
+- r-mime
+- r-rlang
+- r-sass >=0.4.0
+license: MIT
+license_family: MIT
+size: 5538377
+timestamp: 1778923739710
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+sha256: 20dd6e4aa94d2d5ea97419add6bcac50f81400d297e9933659ff35da41fe2f6d
+md5: c922b0a6584376d3587d8cb3670f5cac
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 256017
+timestamp: 1757560386979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cachem-1.1.0-r45h54b55ab_2.conda
+sha256: 75a21c955abf03fa1804d47c94f5091cd772b614e074b63b02347a23f5649a53
+md5: 42617e710293f0b76ccc08855e0edbc4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fastmap
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76879
+timestamp: 1757441544326
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+sha256: f9f49b2b845f279af84a33c8af19a915b2731c0bd892c608205cbad8a34f423d
+md5: a5cc8a8d0dc08dc769c65a13b3573739
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-processx >=3.4.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 454090
+timestamp: 1757475635573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.6-r45h3697838_0.conda
+sha256: a894e558a680a31444090de217b73f8fc06a3f4c07746d2cde4b6f86acdae0b1
+md5: ed8dcbbe9d66e9093ba58891e3b6065a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1323795
+timestamp: 1775733704549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cluster-2.1.8.2-r45heaba542_0.conda
+sha256: 521cb81e41e3a63717ec7cf317598b8a793969e60c57328b7d382bfea4178b5d
+md5: 421758eee50879a9a7ff122543e38e14
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 592267
+timestamp: 1770285739523
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+sha256: aec327dd836824278a2adf006f426a58d834828de74de7f8348f2f5f068de702
+md5: 8e9e5b14f74a6040c77e0b9c8bfa84ca
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 109200
+timestamp: 1757452164030
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-colorspace-2.1_3-r45h54b55ab_0.conda
+sha256: 16bbbc7347aaee2c73d132584711f42cf612de501197e154385247818018b7a0
+md5: 472eadbb95c9103963bae1631ec23b0f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2542148
+timestamp: 1784283276786
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-commonmark-2.0.0-r45h54b55ab_1.conda
+sha256: 211423381b2e832619cdb964e7fe3833b09871d0140066ca90fd3e91eb86231b
+md5: 769e161acb18575460780ab99acc454e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 139818
+timestamp: 1757422097696
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+sha256: 5993a1b5c08c78a35cdbcf20376773eb7c4def2d28615e49f96008b43a4c05c0
+md5: 71c68a3993a696b6b75f7a6550b3750f
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 246247
+timestamp: 1778089270609
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+sha256: 9126a0408696133893e674549ca7aef317768dba503765a7ed032616aabe5b49
+md5: 4f111ce078b9690abaad6248b831a370
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 168201
+timestamp: 1757452410374
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+sha256: 217e5e210501b7fa611d6c6c46ae1551f443e2359e27164240da5a1219b2551a
+md5: 523a15023a79bd6f0dcb95ba6756ceed
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.3.6
+- r-jsonlite
+- r-lazyeval
+- r-r6
+license: MIT
+license_family: MIT
+size: 382037
+timestamp: 1757479275516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-curl-7.1.0-r45h10955f1_0.conda
+sha256: f2185d7bb29d869cc0d8e65a1913ab715e4f976666f94c18931cfa6b51b12821
+md5: dbfb442102b495d7bfc9f50321410a42
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 473709
+timestamp: 1777147706848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-data.table-1.18.4-r45h1c8cec4_0.conda
+sha256: fc5c6970d5ebbb92ccb61313efab7160869ae2851e48105e5dfff10f939a4bf6
+md5: 141a897d44a6a63b43dc6c1776ba7136
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MPL-2.0
+license_family: OTHER
+size: 2566399
+timestamp: 1783428409426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+sha256: 1edafb4e01397265da1816f3164a451d36f02546f2589c5f45051886ab9f91a8
+md5: f69bda3cb40132707f6efff4c749ce09
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-magrittr >=1.0.1
+- r-viridis
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4839264
+timestamp: 1757633933010
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-digest-0.6.39-r45h3697838_0.conda
+sha256: 33ce40552bc1810252c4445082392638ff2fb883147cf36c3e4017e9b0dc5474
+md5: a0e856537aa7d62a6835e3a528d29517
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 218412
+timestamp: 1763566744987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.2.1-r45h3697838_0.conda
+sha256: 42067805b0742b933de7e1ca4311645797ac687cee6aacd630d9d4c585dfa830
+md5: 7c8e643f764769a184f0d0d06ac0e789
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1445950
+timestamp: 1775207093582
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+sha256: 38eee3a12260e5fff1e2af04250f6b67091b01c694f101ae6448da12c3fcca09
+md5: b78224895a1ad7fb52311ab071c2ec00
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-crosstalk
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httpuv
+- r-jquerylib
+- r-jsonlite >=0.9.16
+- r-magrittr
+- r-promises
+license: GPL-3.0-only
+license_family: GPL3
+size: 1439901
+timestamp: 1757566758266
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+sha256: ec00c0162d803af3c8059e9504d1d0c8b60cabe805c347a4a20300f2cce9e700
+md5: 6ac48e7c4c46b6c0538a779d0a43008a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-gridextra >=2.3
+- r-gtable
+license: GPL-3
+license_family: GPL3
+size: 950098
+timestamp: 1757760318911
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.3-r45h54b55ab_0.conda
+sha256: 19d03273f9d5e1aa41302e1cf080dcb95ced5b955bc978df39eee71a9686a86c
+md5: e43b3e7101a90ac57f58a21da67c99a4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 33411
+timestamp: 1775287239478
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+sha256: d3accfeab1416151515c37e5edc94b18868998db4936183459f8040117d5c83c
+md5: 4e0c71ab78d7292372a89d4daecb49af
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 111914
+timestamp: 1757447684244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.7-r45h54b55ab_0.conda
+sha256: 68dcc5aa6fc4408f9cac5aeaa03a7e6a5d127a949fc72b3fed31fd1af3bbeee5
+md5: 309740f1b6a2d4cb16d395be786c85c5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 329435
+timestamp: 1763566090233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-farver-2.1.2-r45h3697838_2.conda
+sha256: 06c5e73ed5c9c15e7ca944e3a5fabfbcabd9f4aec71804404ecf51c56f78fd8f
+md5: 7896efcfd50f8c1f207acce5d4ab1cc0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1429269
+timestamp: 1757441256046
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fastmap-1.2.0-r45h3697838_2.conda
+sha256: bfec10cec03b434d9010690c61d43a0be79418f67a0713ce31da207a40e1570c
+md5: 245526991ad3b8a1dc97f2dcb5031065
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 73870
+timestamp: 1757421441326
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+sha256: 865df12d8cdd8cf577abc8f785a0aa4ee50b4f8751256dffe4676a350943d591
+md5: e9fccb3617ec9776569c6496fa254e64
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.1.1
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 1335664
+timestamp: 1757461248044
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+sha256: c95d1e61946bf81128be213dea7a07b5196c6e13caf9c6452c38145da8d2dfb1
+md5: 5abe392c8f8c5b954ebdc5fe46fcc709
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-codetools
+- r-iterators
+license: Apache-2.0
+license_family: APACHE
+size: 140909
+timestamp: 1757490449004
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fs-2.1.0-r45h3697838_0.conda
+sha256: 748304679610fe9f5d078f5b9be7c8693858ff5f66db55e43fb98d0e4e07d375
+md5: 67c48aad5ce921ad990b951a1f194f42
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 243286
+timestamp: 1777152733514
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+sha256: 196d29aa2d809d9115dce27236470219e1057d394654b5d73182f0e9d117f2fa
+md5: 4a667a55fc37e12dcbe510262ca61d19
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 424919
+timestamp: 1757627324320
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+sha256: 88a5cf4bac0a553943996bc930b1ea28f2635c262c1b2c5a42b026b69f227f02
+md5: f19c9493b80f63a41fa017ec3b27bc2e
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 88225
+timestamp: 1757455977192
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+sha256: 20c4ea52e72cb2e50907f9e5a446f16b0fce467fec4edab236eeb3b46890f3dd
+md5: b3a121ed6a71f3b674859ccbb15ad56b
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 67477
+timestamp: 1777325952298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+sha256: f8c0982d1579b810fc24cb702f8922794fce7bdfb9d3bf96867a4b038205b045
+md5: 9be31d2adf526d3c38b78a05333ddf30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-beeswarm
+- r-ggplot2 >=3.3.0
+- r-lifecycle
+- r-vipor
+license: GPL-3.0-or-later
+license_family: GPL3
+size: 1761662
+timestamp: 1764399956063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+sha256: 4e0401174fac5b54f124a8e7e418995a74918e8cd52a456a82db3fc5a373f0e0
+md5: bcdfec44c6bf587e65f56de61334a413
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=0.9.2
+- r-mass
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 221547
+timestamp: 1757758420492
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+sha256: 3a91d5334b7d99bc247386eaf0d331e119852e381e769e266f70df20eab22689
+md5: 866fbbf3f356140922d618f26f2b889c
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-gtable >=0.3.6
+- r-isoband
+- r-lifecycle >=1.0.1
+- r-rlang >=1.1.0
+- r-s7
+- r-scales >=1.4.0
+- r-vctrs >=0.6.0
+- r-withr >=2.5.0
+license: MIT
+license_family: MIT
+size: 7812326
+timestamp: 1776860393567
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.1-r45h54b55ab_0.conda
+sha256: c2760270ffabd95e9d0a0caa9cc705c5a0370ad119ace5495acc043b1a35d198
+md5: 65911c2e9cac35ea0235d3d6d4aa9625
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 171639
+timestamp: 1776413601349
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+sha256: e82d7e308a7e6d3eb90d9ea33d1f56d24bd69804995db2dacd5b20b7a20c34e4
+md5: aad2c473bf6f930833d0dc881811cf62
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-gtable
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 529159
+timestamp: 1782547830828
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+sha256: fcd2601af8213f39af6f720e22c8f858b3451f8e3d93cbc9e6aedb2d6f88483e
+md5: f686123cfba49e6299fae7e029a40266
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-lifecycle
+- r-rlang
+license: MIT
+license_family: MIT
+size: 228864
+timestamp: 1757463478042
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+sha256: 2d26e9b5c0e688cc76d33d81f8f62c59de9dc2f0695fd7b110991fa222db5524
+md5: d0bd1b5a09e5d631b8de31949ea19ece
+depends:
+- r-assertthat
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+- r-dendextend >=1.12.0
+- r-egg
+- r-ggplot2 >=2.2.0
+- r-htmlwidgets
+- r-magrittr >=1.0.1
+- r-plotly >=4.7.1
+- r-rcolorbrewer
+- r-reshape2
+- r-scales
+- r-seriation
+- r-viridis
+- r-webshot
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1693764
+timestamp: 1758426737719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-hexbin-1.28.5-r45heaba542_1.conda
+sha256: d3fa5cfc23220d3e279526a36ebcdc375ed2fc6cd45086248bd64a34c6be43d5
+md5: d622c8377663b5d7bdf5da48069f76cb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-only
+license_family: GPL2
+size: 1594722
+timestamp: 1757483295739
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+sha256: e676112aac0dbfe123fcb3108cce376782211a096c898a3af46fdf32a37e12e9
+md5: 0b5902d6af02a23bda1794d46090db42
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.18
+license: GPL-2.0-or-later
+license_family: GPL
+size: 57308
+timestamp: 1772794436225
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-htmltools-0.5.9-r45h3697838_0.conda
+sha256: 1fa1fcdf980d0da17a583e41810da190eb9caf586c3fdf36312d045d9bb812e7
+md5: 2a2297687ae137e7fa90d3c996895e61
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-digest
+- r-ellipsis
+- r-fastmap >=1.1.0
+- r-rlang >=0.4.10
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 367095
+timestamp: 1764860550376
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+sha256: 4c3998ce4b4882429e52eed5c6c53d59056814d8fbc34a41ba79b990fdec1441
+md5: 6f767715f90e7caf17af72959bfcb11e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.7
+- r-jsonlite >=0.9.16
+- r-knitr >=1.8
+- r-rmarkdown
+- r-yaml
+license: MIT
+license_family: MIT
+size: 426023
+timestamp: 1757552859817
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-httpuv-1.6.17-r45h6d565e7_0.conda
+sha256: f0755cf37e28f0e1a142eef051918c90c9e8fece46edb5e40191a7898d8cb217
+md5: 1be1d81542b9c87b4d5197a41dbd0da9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-later >=0.8.0
+- r-promises
+- r-r6
+- r-rcpp >=1.0.7
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 553922
+timestamp: 1773825458255
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+sha256: 4adb565d2b3365108d7efb926c2acdc68c11ef2ad32ed03d1108a3005cf8cdd8
+md5: 259658089c383f2915b167da3e7890aa
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-curl >=0.9.1
+- r-jsonlite
+- r-mime
+- r-openssl >=0.8
+- r-r6
+license: MIT
+license_family: MIT
+size: 474019
+timestamp: 1771005817336
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+sha256: dcc78f60308390c6549e25308fb2437421e8fcaeeb45378b6fbe3a49e3d3cd0b
+md5: b240e3c0e61de35f1f43729f4ea2888e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.0.0
+- r-curl >=5.1.0
+- r-glue
+- r-lifecycle
+- r-magrittr
+- r-openssl
+- r-r6
+- r-rappdirs
+- r-rlang >=1.1.0
+- r-vctrs >=0.6.3
+- r-withr
+license: MIT
+license_family: MIT
+size: 935264
+timestamp: 1784022303810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-isoband-0.3.0-r45h3697838_0.conda
+sha256: a09a6f2f37890560217117463f0722283f8939af945b3e616b9791f2429325b0
+md5: fb538d0b46d6a44aa1ff666b15422ba6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-cpp11
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1657523
+timestamp: 1766530500097
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+sha256: c90d0faa668d2753db9da9458ca085891a3030c6537f5675fe0c1a1b5af2103c
+md5: 7746a41a4cb97cec59db2d5a2cac0701
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 350171
+timestamp: 1757459846270
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+sha256: abb2cd923ed271df8774e696f2e455f8c641532cc984fd770b87852a0017d7ab
+md5: 7113381f500ebcc8a33b61101817d120
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-jsonlite
+- r-openssl >=1.2.1
+license: MIT
+license_family: MIT
+size: 248113
+timestamp: 1776846446837
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+sha256: 3b98f72bb32d4758854805b664b4404602a583da32c9b96026536f5676f41812
+md5: 49a9ed6ed01f4ae6067ead552795bfce
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools
+license: MIT
+license_family: MIT
+size: 307113
+timestamp: 1757459485295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-jsonlite-2.0.0-r45h54b55ab_1.conda
+sha256: bd24c57226192b0decdcddd6fd5fa74db1f29685904e4aff87f2c16eb6493416
+md5: 026c72026f431daf8a5719e09e704faa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 638574
+timestamp: 1757419590757
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+sha256: e2184f1cb58aedacd94d1dbe6e8b5dfa3508151f454e80f6bd49486bdb90625c
+md5: 35b31b96aa7bc052ad6347322a1481f1
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-evaluate >=0.15
+- r-highr >=0.11
+- r-xfun >=0.52
+- r-yaml >=2.1.19
+license: GPL-2.0-or-later
+license_family: GPL
+size: 988526
+timestamp: 1766309267127
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+sha256: 42a06b7c346d6e4550dca1024bbf89e3c22962d568cfe4e8b8be824dea326110
+md5: a41490fdf607381035aa0304c21407c9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 70182
+timestamp: 1757456007088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-later-1.4.8-r45h3697838_0.conda
+sha256: 895f18dfc5a0521c22ad9e38619ea6cf170e38d54aaa4596fb1d0dad7845703b
+md5: a6b2c9882bb1d700f9108bc93c2c12a8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.12.9
+- r-rlang
+license: MIT
+license_family: MIT
+size: 153472
+timestamp: 1772707291964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lattice-0.22_9-r45h54b55ab_0.conda
+sha256: ee233422c029d7b341dd05604d133db6f698ec1cdd4ad8690a312d0f7d958793
+md5: 234365e95fa3cf27bd7946f208d1ed0b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1416943
+timestamp: 1770694116947
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-lazyeval-0.2.3-r45h54b55ab_0.conda
+sha256: 581fec2d1215b6d7b6d35ce9588271ba4bd89c75b0f131c04a718b79cbe2180f
+md5: 5634c3ee3e3c77f7462047a70ed35321
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang
+license: GPL-3.0-only
+license_family: GPL3
+size: 192307
+timestamp: 1775429492578
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+sha256: b7a4d8d98a96d17d18c80fb7e1c8e6cb09b9bd2542e74d91a7f483afccb30ee6
+md5: 5f8369dfbdff08878e58bf15529fca3a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 132636
+timestamp: 1767865665455
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+sha256: 1f594c5be675a53caef3368ea85c048b8bcbc4385e2bd582e977981a1edd5e3e
+md5: b936b3596737a3a1d513e1258d5d0355
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-commonmark >=2.0.0
+- r-xfun >=0.55
+license: MIT
+license_family: MIT
+size: 392980
+timestamp: 1784144498175
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.5-r45h54b55ab_0.conda
+sha256: 5b09fdee8ef5426082844d17d360756922ba74f9e3c428f501373295a5e9228d
+md5: 2e26e018edc1f198aa72a8f2127fab00
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 211086
+timestamp: 1775298609420
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+sha256: 5f27ccd93b39c2435ed6e9b8302ae50d51eb5b6058d7d11edba403e9723f48c6
+md5: 755b46b2896c8526a18074b3b651dfbc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-litedown >=0.6
+- r-xfun
+license: MIT
+license_family: MIT
+size: 72190
+timestamp: 1757496654397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mass-7.3_66-r45h54b55ab_0.conda
+sha256: 89218d4083593e5eae881fe5136befa358333d90a7de1a0ede13e8cd7bb5244e
+md5: 700d7bffd1c317597b574b218b567017
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1141176
+timestamp: 1784201795136
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrix-1.7_5-r45h0e4624f_0.conda
+sha256: de3447368ff93fb293c022d4a1eb8bcffe9044f52baf65c19218d6966815b88d
+md5: ca378a648cfa47523266acd1a0251729
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4301827
+timestamp: 1774809406103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-matrixstats-1.5.0-r45h54b55ab_1.conda
+sha256: 06177df6c2f39df0a90b456557d226c2ffa9eaf55505b35d0ca9a81fe793dc49
+md5: 3deafa947ef32bf21d87b57e74d3711b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 484755
+timestamp: 1757442394466
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+sha256: 91b0eedec5cf5de195b442b97eda508f22fdedbdbc487f74e3868d3e95380fdd
+md5: 2b04206ff6ea5a92e8e36bdaa5feb3cc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cachem
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 57750
+timestamp: 1757456335587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mgcv-1.9_4-r45h0e4624f_0.conda
+sha256: 83a5233b6162c55f5021dea34464bd64d87f18b7815e738c42d06a046780e594
+md5: e33882c93c191f5d9a9b346431f02b43
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-nlme >=3.1_64
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 3644492
+timestamp: 1762539595584
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-mime-0.13-r45h54b55ab_1.conda
+sha256: 03116d6a8db71492d036c6c052d6cfbf5a98c06da071e42aedb5c740920d6b61
+md5: 26aa2fa52d4caed58336f2b4887916d6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 64912
+timestamp: 1757441376534
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+sha256: 97d463c2146c483992a25fe497755e9cf714f95ca611a93d8adbb41c068e9e74
+md5: c78bd534986cde8fc0cb08cc9a1a2cc6
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+license: MIT
+license_family: MIT
+size: 247241
+timestamp: 1757455926748
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-nlme-3.1_170-r45heaba542_0.conda
+sha256: 83964b5b1ea49ed78be1fd7606650cf1ea68b92febe3d0bbdb9fda1be30f2d5b
+md5: 17487ca56832572cb95f9cc1314ddabb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 2356999
+timestamp: 1784288204943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-openssl-2.4.2-r45h68c19f5_0.conda
+sha256: 2796cf7768c939a58344157fcddec88dbdadf9cabd3ab0b24d9bbaf7916b9ebd
+md5: 6568a5797c9d74e89ef94b82724665aa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.6,<4.0a0
+- r-askpass
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 680716
+timestamp: 1781024845749
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+sha256: 09df5e8326b04412a26b6c4d896e04adbceba45194457c6d30f370d5ccb4b397
+md5: 0c015ba0c5444777a683c05e4a000f21
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-getopt >=1.20.2
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 119289
+timestamp: 1776419503742
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+sha256: f5de9737f59e1965db2de11c90cf1fdd426db322a7205c935a3e55150287b02f
+md5: 560abd550c097e0d0af2e201b335f53d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 286342
+timestamp: 1761151056217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+sha256: 162742dd773c8a163de6ffdf0e14820b5708b9e1041d4491762c05e00f6be614
+md5: 849a8fcdb5e1d98a3917a7c652c322df
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 679411
+timestamp: 1757649050426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+sha256: a4869bf14ad791c8a5cb48fd0575faa3cdb7b07692cb4b473809c261f584fa45
+md5: 9a48d2e7fdc93937c60481c06d40e6ba
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 234305
+timestamp: 1770387131912
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+sha256: b3f281041ecff2d4a9f40073ad5e7ec6fa7e0c841068ce85c550bcce0ff8938d
+md5: 807ef77a70fc5156f830d6c683d07a29
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 629867
+timestamp: 1758149763203
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+sha256: fda425435a533e86da5f0fc89cf45c9f889a4e6f1e2ed536ca23662a8461602c
+md5: 40a5fdd06c7e7880758a021cf2df6c12
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 27236
+timestamp: 1757447537447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
+sha256: 691d08f590099bb8cf4042a3af57b742775e02e4272df80dea5388c20e340116
+md5: 2021f458379120ae0d21189bee7e30cc
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.3,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 135276
+timestamp: 1758095801346
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
+md5: ced57d920bed79382f382a24a4425ef7
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-crosstalk
+- r-data.table
+- r-digest
+- r-dplyr
+- r-ggplot2 >=3.0.0
+- r-hexbin
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httr
+- r-jsonlite >=1.6
+- r-lazyeval >=0.2.0
+- r-magrittr
+- r-promises
+- r-purrr
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-tibble
+- r-tidyr
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 3587131
+timestamp: 1769337109792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
+sha256: 353d5945d242b03c47ab0d051cf9058b4459303c96455dba9442100628a0bde1
+md5: 255fec0919919b14789eb30cc448ed20
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.0
+license: MIT
+license_family: MIT
+size: 787537
+timestamp: 1757441721952
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
+sha256: 7f69cd631f28279b4c706fe2341d8ffbd13cc10ed98e648d0c214ceecce4f877
+md5: c38b8f68cbe321dd5b819d397b2b5061
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-ps >=1.2.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 411030
+timestamp: 1776865706038
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+sha256: 684dba5d20aae8da37868d603b662014e1944f5568e5f737e42d9d485892a26e
+md5: b2c1b6ef8f12894fd2694b285fe8989a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-fastmap >=1.1.0
+- r-later
+- r-lifecycle
+- r-magrittr >=1.5
+- r-otel >=0.2.0
+- r-r6
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1597704
+timestamp: 1762426228446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ps-1.9.3-r45h54b55ab_0.conda
+sha256: 598576cd282f2b9c8280696c77b3a9e05d52a8f688174d6c6ed1b3bdad57bcdf
+md5: d4c22257df8cca28d50e604110e68e90
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 414722
+timestamp: 1777148019201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.2.2-r45h54b55ab_0.conda
+sha256: dc5f0ace59844125b92304324000770c7e2e466bab442826cee50a32eef731bf
+md5: dc14c484a0415f43dc1b90b518beb41a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 547035
+timestamp: 1775853612539
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-qap-0.1_2-r45heaba542_5.conda
+sha256: cd5b1706f125067986e083ba343ff6f20f79747c18e801fb6014481ec273964e
+md5: d64850fa9345afe8dbe58b371c32792d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 396309
+timestamp: 1757635813587
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+sha256: bd92e91332eba5f0c689583e80adec85ef272c4e0d0b36ee17cb7c11b5693cf2
+md5: 750802806d7d640c286ed8491bb395dc
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 95073
+timestamp: 1757447661037
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rappdirs-0.3.4-r45h54b55ab_0.conda
+sha256: a9778d5fa6777ce286815eb0abef625ff54693532795ef48a1bc319967e0ecb4
+md5: 9fa763ece102dca3e50892bad36896ff
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 54376
+timestamp: 1768747300036
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+sha256: ddd4e63616ee475bdf9dc63a0b16a89017237121e927d83fbdee07d5a5ccc890
+md5: d8fa238420cb6de47d463b7345a761eb
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68005
+timestamp: 1757452462302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpp-1.1.2-r45h3697838_0.conda
+sha256: dabb73c4d43f352a3154067a20a46cbda1e1027636e72d133010f6f052e8d260
+md5: 1d6e2e4764de896f03fb73e28614022e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 2122066
+timestamp: 1783264478653
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rcpptoml-0.2.3-r45h3697838_1.conda
+sha256: 8e10fa6f550c83cdc99175443ecc92db178369e82a7dcb743e1fe7ce87d39530
+md5: 707ba8dabbbffd03f5907406a0fe8368
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.5
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 227793
+timestamp: 1757490566643
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+sha256: 68f01b65843f873b01bff24f61f27298667797aa3ad01d4406a62ae72e7c08c5
+md5: 1a99d6f9dfe5f6e8dc5275d49852cd66
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 208380
+timestamp: 1757507980343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-renv-1.2.3-r45h54b55ab_0.conda
+sha256: d88af05b70ac871598c7fda5e04c7d024f1011fcc047eeb18d9541ef9b03bea7
+md5: 378f0ed999e77fe5e276ef811d783d96
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 2469798
+timestamp: 1778972824711
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-reshape2-1.4.5-r45h3697838_0.conda
+sha256: ffec1e0396849fab33c12bcc580fe71f90818c83da645146c165449ee9a6e799
+md5: 169cd9281096cd54a29072a2d7eea2a9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-plyr >=1.8.1
+- r-rcpp
+- r-stringr
+license: MIT
+license_family: MIT
+size: 127756
+timestamp: 1762975657971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.3.0-r45h3697838_0.conda
+sha256: 13aed8664cbf46946eed067d1708ee1a8dcbd7cf32d361c7a03a9bf3f83ac425
+md5: afa49304f86d922c157d08e9e9d9ceb8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1593782
+timestamp: 1783260208298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+sha256: b3735a4e75eca023b24678251da041854b94a8b96588d81b605928d6ecf74f11
+md5: 25b9dbf0ff990b8b3111774878e3bb07
+depends:
+- pandoc >=1.14
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.2.5.1
+- r-evaluate >=0.13
+- r-fontawesome >=0.5.0
+- r-htmltools >=0.5.1
+- r-jquerylib
+- r-jsonlite
+- r-knitr >=1.43
+- r-tinytex >=0.31
+- r-xfun >=0.36
+- r-yaml >=2.1.19
+license: GPL-3.0-only
+license_family: GPL3
+size: 2085382
+timestamp: 1774555006202
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+sha256: 5f9aa168f5c43f1d3ddbacc701370085fcead3956e2d5879af7fcd9e086a0a0b
+md5: 62f09532f225c86d27e954b36682add5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-digest
+- r-httr2
+- r-jsonlite
+- r-lifecycle
+- r-openssl >=2.0.0
+- r-packrat >=0.6
+- r-pki
+- r-renv >=1.0.0
+- r-rlang >=1.0.0
+- r-rstudioapi >=0.5
+- r-snowflakeauth
+- r-yaml >=2.1.5
+license: GPL-2.0-only
+license_family: GPL2
+size: 830390
+timestamp: 1783503525234
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+sha256: 896aeea3aa679a9dbd0277d10ef8dcfd011e45a1717129180a9877c1fd828f2a
+md5: 5f1b6b899fa3204ab77403e75b9df5fd
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 357140
+timestamp: 1781250782889
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-s7-0.2.2-r45h54b55ab_0.conda
+sha256: fae29c4af16617a17fea40c5e484e4350a6fe5d9fad40266f95cf3cb13e7019b
+md5: 598ca5290f9be9b22804436295471201
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 311525
+timestamp: 1776861444903
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sass-0.4.10-r45h3697838_1.conda
+sha256: 4d6d7db9d0187a9ede70d6d48278a8ba2b3160e823f5de239b86a6108f23172e
+md5: a3ccf52eefa448628535ee758c5a8a37
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-fs
+- r-htmltools
+- r-r6
+- r-rappdirs
+- r-rlang
+license: MIT
+license_family: MIT
+size: 2319704
+timestamp: 1757464682768
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+sha256: 260c384e952e5bd4d2c2de77b9e09b24ff1c1f680acd917c4657ab8c9e4e9a2f
+md5: 8bc81cc6fd130cef963bc9e082726a14
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-farver >=2.0.0
+- r-labeling
+- r-lifecycle
+- r-munsell >=0.5
+- r-r6
+- r-rcolorbrewer
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 777793
+timestamp: 1757487539496
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+sha256: bcde368cbf5a2c83b9c1fb8b3ba0722787af759f68d08bac6a82e966adbf999f
+md5: ba820689c02638c807f83e6ab5c53142
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 370745
+timestamp: 1771995271935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-seriation-1.5.8-r45heaba542_1.conda
+sha256: ce65e9dfe250a2d142acb7f7c2fec1ebd9e1527c66c5ce1212f0f18a3f2a415a
+md5: 9252542af85ee0c48a0a94ea103181e5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-ca
+- r-cluster
+- r-colorspace
+- r-foreach
+- r-gclus
+- r-mass
+- r-qap
+- r-registry
+- r-tsp
+- r-vegan
+license: GPL-3.0-only
+license_family: GPL
+size: 1372264
+timestamp: 1757660945261
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+sha256: ef0042ae1c3926ef9bee6c21cf761d7cf441eae61dceca7df143f3b9dc4c6f04
+md5: 2fb0e1ea59dd281487be303b1b7c6607
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.6.0
+- r-cachem >=1.1.0
+- r-commonmark >=1.7
+- r-crayon
+- r-fastmap >=1.1.1
+- r-fontawesome >=0.4.0
+- r-glue >=1.3.2
+- r-htmltools >=0.5.4
+- r-httpuv >=1.5.2
+- r-jsonlite >=0.9.16
+- r-later >=1.0.0
+- r-lifecycle >=0.2.0
+- r-mime >=0.3
+- r-promises >=1.1.0
+- r-r6 >=2.0
+- r-rlang >=0.4.10
+- r-sourcetools
+- r-withr
+- r-xtable
+license: GPL-3.0-only
+license_family: GPL3
+size: 3789417
+timestamp: 1782070586086
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+sha256: c3ea3d60226ed56e4a40b622b8e4721d257a9fb4ca8502ce89314f48a63a0090
+md5: b5da9b58b4f8137a7f2e14102bc230c9
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-glue
+- r-shiny
+license: MIT
+license_family: MIT
+size: 344724
+timestamp: 1757870156008
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+sha256: 9493d6cbf09850206f5904ccde65643de86bb9bd6add685548331c408e99610a
+md5: 3929f109451367912b4570480f4c572d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest >=0.6.8
+- r-jsonlite
+- r-shiny >=1.0.0
+license: MIT
+license_family: MIT
+size: 1018291
+timestamp: 1768513288077
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
+md5: 7382af8530d082191feb0c8da5f8a41b
+depends:
+- bioconductor-limma
+- bioconductor-summarizedexperiment
+- r-base >=4.5,<4.6.0a0
+- r-biocmanager
+- r-bslib >=0.9.0
+- r-cluster
+- r-dplyr
+- r-dt >=0.2
+- r-ggbeeswarm
+- r-ggdendro
+- r-ggplot2
+- r-heatmaply
+- r-htmltools
+- r-htmlwidgets
+- r-markdown
+- r-matrixstats
+- r-optparse
+- r-plotly >=4.8.0
+- r-rcolorbrewer
+- r-rsconnect
+- r-scatterplot3d
+- r-shiny >=1.7.0
+- r-shinycssloaders
+- r-shinyjs
+- r-viridislite
+- r-yaml
+license: AGPL-3.0
+license_family: AGPL
+size: 3448797
+timestamp: 1784579537432
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
+md5: 1d38994c8bfe421d621d9b3705c37b58
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-jose
+- r-jsonlite
+- r-openssl
+- r-rcpptoml
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76170
+timestamp: 1772133448445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
+sha256: 885a784f4258b491e48947dbed71bd18b2e2e7da0f0b53ee1dcfed93cfdcd48a
+md5: 1bd0042c176bde3dd1971eac76497219
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 54650
+timestamp: 1774682292388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
+sha256: 3095c4e59616a46480533f2e545136e25b1cb20d7ec6535d4a7f0938c48ff789
+md5: 377126a1601c75ff75c2c8c277e55a81
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 325043
+timestamp: 1779038241839
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.7-r45h3d52c89_2.conda
+sha256: 6d0d8d6f1465b3486996edaef7ccd1020cb2fcca1e69b543fc52dbad5262079b
+md5: c7ce6f26b92398224c78b92c653b94c1
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.2,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: FOSS
+license_family: OTHER
+size: 939928
+timestamp: 1772032511209
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+sha256: dea2a7676dd03ed93fa0ec961883c5075c361c8522659a1bc1e6b5c16525cb24
+md5: 8db438d8aa370726ee1ce8bf458f2e6d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 319328
+timestamp: 1762269757617
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-sys-3.4.3-r45h54b55ab_1.conda
+sha256: 0cf3a7af31b0396d5a2e1c932fffa360472f92a2b373a696f523b0b53ad1d682
+md5: f23bbac61ab0536f59f4caa4c2ebdf88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 50436
+timestamp: 1757441793835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.1-r45h54b55ab_0.conda
+sha256: 256d782fb5773d678f29b88a2c987eb47065e2393a080ca16f400b0256de65bb
+md5: ad28f67cbb0b10a5beaa7bf968761cad
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 589666
+timestamp: 1768139121744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.2-r45h3697838_0.conda
+sha256: 8c4560d92c1adfce9a37da2f963596a369688b0d5f44d1fa2f0fbfecb486d99f
+md5: e571d4d42233dd2aa3bdb0057ffbdc63
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127263
+timestamp: 1766142073696
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+sha256: fca09d6b9940f1e1cda0425a0f55716bba202d6f55d6bd25fedec391006c7dc7
+md5: 15aa0f323385403fe182e46a1d095e1b
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 220192
+timestamp: 1757475791328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+sha256: 1fad4d08756ca2d7db04cfaf88e9df797da95a5f7f4b8aabc165eee36faddafc
+md5: 5ee226c1449c66d1cd2399d942faa04d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.48
+license: MIT
+license_family: MIT
+size: 158240
+timestamp: 1782203211628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tsp-1.2.7-r45h54b55ab_0.conda
+sha256: 54c19b952897b97228f00ff3ae8def7e7af2194c0ed3419737a8fe04a988cd41
+md5: 4518075e6efc2a5c9714751a92bfc73e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-foreach
+license: GPL-3.0-only
+license_family: GPL3
+size: 736826
+timestamp: 1774389996066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r45h54b55ab_1.conda
+sha256: 97186abdf7c29872e012c9fe05ec16c019b58c43ac7b778baa480a8acae9c914
+md5: 75cb2540ac930ea879e92d99e00e97c3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 147244
+timestamp: 1757424673681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.7.3-r45h3697838_0.conda
+sha256: 73b0cdea9f85496b80e75ffa20f94aa4ab746f4b7af566742e22381bffa6772d
+md5: 372cefc1b05a567d1fbe19633766ab0c
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1805012
+timestamp: 1775897999712
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vegan-2.7_5-r45h11cdb10_0.conda
+sha256: b6245a77003ec655ca972e81d25771652991326ed9d7f3514951954565198e94
+md5: 81c256938ff8b33054afde06c7851e4e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+- r-lattice
+- r-mass
+- r-mgcv
+- r-permute >=0.9_0
+license: GPL-2.0-only
+license_family: GPL2
+size: 3049688
+timestamp: 1779956688681
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+sha256: 859729e8cd04bb92ec144b21a8abfdb2bec9cbac9deaa41ba0cc2add13d088a0
+md5: e605ce527e381c5577d57649e393cb87
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4508304
+timestamp: 1757669044129
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+sha256: 884896b59133b948646b0d1441106120f7b320e9fac827ccb9d44bbe80dda8f2
+md5: e841095941c40142bdad834299b95a30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=1.0.1
+- r-gridextra
+- r-viridislite >=0.4.0
+license: MIT
+license_family: MIT
+size: 2988605
+timestamp: 1757516440048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+sha256: b9ec9606562f0f6bdefc237bbc6163eb1cb022f9d699c80771bc84af0ae37269
+md5: bcadc0a3726e2191e51449f67fa5e0a9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1305542
+timestamp: 1770191459321
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+sha256: e79e366895dfdf79fe92986fe42d0695e3fcacc25411506c48b9db92742eb99c
+md5: e021e3d936f57ea9b35eb099999d6800
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-callr
+- r-jsonlite
+- r-magrittr
+license: GPL-2.0-only
+license_family: GPL2
+size: 206060
+timestamp: 1757520337073
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+sha256: 56f318c90bfc74f01339c83f0e1d0817c1b762ea46cd9e527fec9dcf244c5900
+md5: 388d25e67f93a5fec2aebe56d6a0a1d9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 235287
+timestamp: 1781856624720
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-xfun-0.60-r45h54b55ab_0.conda
+sha256: dca6e2c57e1b038682879e793338683f25058362a8f3ca2a88f753e5de085cf0
+md5: 1d3e32dcae994197a303942b6654e577
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 651306
+timestamp: 1784103319293
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+sha256: 972923364cfd616ccf38768477c435677cfe1ea18a72016f90344ea920e4fea5
+md5: e18fda0821f0fdc1c34276c5e0acdc92
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL (>= 2)
+license_family: GPL3
+size: 744345
+timestamp: 1771859982217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-yaml-2.3.12-r45h54b55ab_0.conda
+sha256: f8944d47eccfdb2c04e27fd65797de7468ccc5d9f3fc3d9af296da613d75d79c
+md5: d0d07c6f14b640a98cf6a5e3e4e2e723
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 124461
+timestamp: 1765372968808
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 345073
+timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+sha256: b013d2085ce4ac01daec7b30472e9f3b6c2d69eb3a3a85a6cee3e01a3cb4f61a
+md5: e4a1ff2e59a5d9b38be71d15c93cf1bd
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 268482
+timestamp: 1776859422619
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+md5: 13dc3adbc692664cd3beabd216434749
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-64 4.18.0 he073ed8_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 24008591
+timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+build_number: 103
+sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+md5: 48a1049e710857572fc2a832aa394d9f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3550916
+timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+sha256: 3e20b2f2902a1f402ef2420ce2b9e8c91f9e02748d55530894ac1f640561fdd0
+md5: 72628f56d7a99b86efa435a0b97a4b47
+depends:
+- tk
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- tk >=8.6.13,<8.7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 102544
+timestamp: 1773732786017
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+sha256: 2bf9a40d86d29fd5c30d0febec99d06398143ddeece9ebb175cc5a6d20279943
+md5: f16d4aec5e8135e8e7bba02ef600149e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 38560
+timestamp: 1779439547766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+md5: fb901ff28063514abb6046c9ec2c4a45
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 58628
+timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+md5: 1c74ff8c35dcadf952a16f752ca5aa49
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 27590
+timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 839652
+timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+md5: b2895afaf55bf96a8c8282a2e47a5de0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 15321
+timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+md5: 1dafce8548e38671bea82e3f5c6ce22f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 20591
+timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+md5: 34e54f03dfea3e7a2dcf1453a85f1085
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+license: MIT
+license_family: MIT
+size: 50326
+timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+md5: 96d57aba173e878a2089d5638016dc5e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 33005
+timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+md5: 279b0de5f6ba95457190a1c459a64e31
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 379686
+timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 601375
+timestamp: 1764777111296

--- a/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
+++ b/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
@@ -1,0 +1,3175 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-aarch64:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.46.1-default_hf1166c9_102.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-biobase-2.70.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-delayedarray-0.36.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-genomicranges-1.62.1-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-iranges-2.44.0-r45hbd662d2_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-limma-3.66.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4arrays-1.10.1-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4vectors-0.48.0-r45hbd662d2_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-sparsearray-1.10.8-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-xvector-0.50.0-r45hbd662d2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h3530432_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-15.2.0-h2d9b6d1_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gsl-2.7-h294027d_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h7c59cd8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-14.2.1-h3a99ef3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-devel-14.2.1-h3a99ef3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_19.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandoc-3.10-h8af1aa0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-askpass-1.2.1-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.5.3-h269e6ae_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base64enc-0.1_6-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-beeswarm-0.4.0-r45hf488e41_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cachem-1.1.0-r45h0557e7b_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.6-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cluster-2.1.8.2-r45h6df9e4a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-colorspace-2.1_3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-commonmark-2.0.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-curl-7.1.0-r45hd8a8d9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-data.table-1.18.4-r45hbf3bb9c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-digest-0.6.39-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.2.1-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.7-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-farver-2.1.2-r45h08b74da_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fastmap-1.2.0-r45h08b74da_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fs-2.1.0-r45hd601667_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.1-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-hexbin-1.28.5-r45h6df9e4a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-htmltools-0.5.9-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-httpuv-1.6.17-r45hb62f08c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-isoband-0.3.0-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-jsonlite-2.0.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-later-1.4.8-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lattice-0.22_9-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lazyeval-0.2.3-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.5-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mass-7.3_66-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrix-1.7_5-r45h9301183_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrixstats-1.5.0-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mgcv-1.9_4-r45h8b2cba9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mime-0.13-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-nlme-3.1_170-r45ha85219e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-openssl-2.4.2-r45h37c386a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ps-1.9.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.2.2-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-qap-0.1_2-r45ha85219e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rappdirs-0.3.4-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpp-1.1.2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpptoml-0.2.3-r45hd601667_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-renv-1.2.3-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-reshape2-1.4.5-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.3.0-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-s7-0.2.2-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sass-0.4.10-r45h08b74da_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-seriation-1.5.8-r45ha85219e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.7-r45h1ddd0e6_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sys-3.4.3-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.1-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.2-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tsp-1.2.7-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r45h0557e7b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.7.3-r45h08b74da_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vegan-2.7_5-r45ha2e3c6d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-xfun-0.60-r45hf488e41_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-yaml-2.3.12-r45h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h5f05d98_8.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: a2527b1d81792a0ccd2c05850960df119c2b6d8f5fdec97f2db7d25dc23b1068
+md5: 468fd3bb9e1f671d36c2cbc677e56f1d
+depends:
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28926
+timestamp: 1770939656741
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+sha256: eebe159bf600943552e4319ff4ce27b6a2dadf0dcc5443e76dcee9259a408e11
+md5: 58f37d76b8234c69dbf2939d511bea0b
+depends:
+- ld_impl_linux-aarch64 2.46.1 default_h1979696_102
+- sysroot_linux-aarch64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 4677171
+timestamp: 1784214549910
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.46.1-default_hf1166c9_102.conda
+sha256: d41099a3fe2809a3ab3e4c718ecff4d5f8879e7949f3c8e8efa97fa06a90248c
+md5: 9a340123cb7217eae51c5cae24484631
+depends:
+- binutils_impl_linux-aarch64 2.46.1 default_h5f4c503_102
+license: GPL-3.0-only
+license_family: GPL
+size: 36196
+timestamp: 1784214578949
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-biobase-2.70.0-r45hbd662d2_0.conda
+sha256: 144892eb6a1caeb15ca70a90e9502130ad5d4fb11cb3bfcf23944c540b6fc8c2
+md5: 8256b8838a2ed279aa68d6a74c64f2ae
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2359182
+timestamp: 1770502613668
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-biocgenerics-0.56.0-r45hdfd78af_2.conda
+sha256: 97221eda3007381c0a6498608baaebdcec6047f7f26b121c19149fd56aabf032
+md5: 27556377d159490ea87696727ae41808
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-generics
+license: Artistic-2.0
+size: 653523
+timestamp: 1770415244399
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-delayedarray-0.36.0-r45hbd662d2_0.conda
+sha256: a35e3f96ec640cf7665d74954c96c9dd94acec8c2d3b07773496917465891990
+md5: a539d17dd563adecc5716d832336d257
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-sparsearray >=1.10.0,<1.11.0
+- bioconductor-sparsearray >=1.10.8,<1.11.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 2203445
+timestamp: 1770580775191
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-genomicranges-1.62.1-r45hbd662d2_0.conda
+sha256: 55b5f4217dab83ed83c37669b166d3145eb3d844360f53cbe940b48fad58febd
+md5: 73f836e70629719f303b19c6f88e089e
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2307173
+timestamp: 1770634322279
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-iranges-2.44.0-r45hbd662d2_1.conda
+sha256: 7167ede80515e1b5d88fcfda2c16c01e7e6a39698d1b9824a3a0416b0bed6e1e
+md5: 82dc872dc3591e32ca8e8c051ef0d619
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2354429
+timestamp: 1770538530102
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-limma-3.66.0-r45hbd662d2_0.conda
+sha256: b6c0c4229c65102dbf5135421cdeda72c77bb84a574eb3ad6a017feda47843fe
+md5: 04a2febf68754954062a79fdfc4674df
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-statmod
+license: GPL (>=2)
+size: 3099160
+timestamp: 1770499849646
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-matrixgenerics-1.22.0-r45hdfd78af_1.conda
+sha256: 169809ca754b2c07f7356f1fc4f365b7d5154fd66229543584f69008fa347c5a
+md5: cdf0406fc3caa814ff7b7876a42973a5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-matrixstats >=1.4.1
+license: Artistic-2.0
+size: 449898
+timestamp: 1770417102301
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4arrays-1.10.1-r45hbd662d2_0.conda
+sha256: 3e69df7fbd051d165364424a5b87ad1c902c68b2d4d04e7feffbfe11079bd90b
+md5: b7a8cb11e73c5031c3d6da65845c60b4
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-abind
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1027295
+timestamp: 1770573305521
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-s4vectors-0.48.0-r45hbd662d2_1.conda
+sha256: 714d17a1e87e49a3cb25b42794bb30ffba91921f6d5d7d37c6e80945aa036ef7
+md5: 82884abd1721c6c3fbe6024c7b627174
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 2068293
+timestamp: 1770501459310
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-seqinfo-1.0.0-r45hdfd78af_0.conda
+sha256: 875f5be76bc3b83766ec0cfacf888570d529907412519a537c5f7a318e489976
+md5: cfe7c256532f9a4fc87ec3be955bb9e6
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 598298
+timestamp: 1770628899171
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-sparsearray-1.10.8-r45hbd662d2_0.conda
+sha256: 6d45e717b4a44b4dc5209cc931301be4571db91b0219905d55d110edd3ef145b
+md5: 42802d5b7d809a31cf6e364b4c52a20b
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0a0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4arrays >=1.10.1,<1.11.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- bioconductor-xvector >=0.50.0,<0.51.0
+- bioconductor-xvector >=0.50.0,<0.51.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-matrixstats
+license: Artistic-2.0
+size: 1678434
+timestamp: 1770579674417
+- conda: https://conda.anaconda.org/bioconda/noarch/bioconductor-summarizedexperiment-1.40.0-r45hdfd78af_0.conda
+sha256: b8ade9f2ab8cc2835357653f5a9bc840323c05f7656659dfb40d20e5623f8ebd
+md5: 74eb95090e807c18f5bc81cb9fb39b3c
+depends:
+- bioconductor-biobase >=2.70.0,<2.71.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-delayedarray >=0.36.0,<0.37.0
+- bioconductor-genomicranges >=1.62.0,<1.63.0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-matrixgenerics >=1.22.0,<1.23.0
+- bioconductor-s4arrays >=1.10.0,<1.11.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-seqinfo >=1.0.0,<1.1.0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+license: Artistic-2.0
+size: 1416452
+timestamp: 1772218138703
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/bioconductor-xvector-0.50.0-r45hbd662d2_0.conda
+sha256: 961ac8875597fae63a4efc98917e2be0f58b0299700339ffbf8cdfbdc7cf4beb
+md5: 461fc07891c8587fbe1f870f67f98e91
+depends:
+- bioconductor-biocgenerics >=0.56.0,<0.57.0
+- bioconductor-biocgenerics >=0.56.0,<0.57.0a0
+- bioconductor-iranges >=2.44.0,<2.45.0
+- bioconductor-iranges >=2.44.0,<2.45.0a0
+- bioconductor-s4vectors >=0.48.0,<0.49.0
+- bioconductor-s4vectors >=0.48.0,<0.49.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.2,<6.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+size: 644057
+timestamp: 1770573790622
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+sha256: d9def28d376d13033e0e78d731091a85a49a2297bf5efe15f0ef0d4533a6adeb
+md5: 585e14e544be02d0baceffecd31c7882
+depends:
+- tk
+license: TCL
+size: 129724
+timestamp: 1750262711538
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
+sha256: b3495077889dde6bb370938e7db82be545c73e8589696ad0843a32221520ad4c
+md5: 840d8fc0d7b3209be93080bc20e07f2d
+depends:
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 192412
+timestamp: 1771350241232
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
+sha256: 24f78776eda069a6c1566fd6d65379e45747d0a7cce9f864686690806543c408
+md5: a8a5833ef43f9b31a4d548071ea5ba75
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 220677
+timestamp: 1784091035199
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+md5: a9965dd99f683c5f444428f896635716
+depends:
+- __unix
+license: ISC
+size: 128866
+timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
+sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
+md5: 043c13ed3a18396994be9b4fab6572ad
+depends:
+- fontconfig >=2.15.0,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.1,<79.0a0
+- libexpat >=2.7.3,<3.0a0
+- libfreetype >=2.14.1
+- libfreetype6 >=2.14.1
+- libgcc >=14
+- libglib >=2.86.3,<3.0a0
+- libpng >=1.6.53,<1.7.0a0
+- libstdcxx >=14
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 927045
+timestamp: 1766416003626
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
+sha256: a36ed82bbaebdc59e205d399d6e898bcb20fbcd5aaebb162cdf690ba97173ef5
+md5: a06d829c51a365e8daf0b2a3d4f06d9d
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 h7c59cd8_2
+- libgcc >=14
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 201305
+timestamp: 1782911743345
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
+md5: f4d29a0cd77104a683607319a542ac7e
+depends:
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 290522
+timestamp: 1780450108132
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+sha256: 1112c56bc19cbce233b30d9d31ce8eb6fcc100c9baa5145315aaa1e3a25b5178
+md5: 5e8e88bfb3fbb0df0f9f8bb890721e07
+depends:
+- libfreetype 2.14.3 h8af1aa0_1
+- libfreetype6 2.14.3 hdae7a39_1
+license: GPL-2.0-only OR FTL
+size: 174060
+timestamp: 1780933507786
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_0.conda
+sha256: 1bfcd715bcb49a0b22d5d1899a22c6ff884b06f8e141eb746f3949752469a422
+md5: f3ac54914f7d3e1d68cb8d891765e5f9
+depends:
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 62909
+timestamp: 1757438620177
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h3530432_19.conda
+sha256: cd23829b5fb7f3ff5f44eab2da1a993e06bdf759b681a0a7a73bb5783755b6b3
+md5: 66dfb62e7a47e2b511f9c5ee0ff1abf3
+depends:
+- binutils_impl_linux-aarch64 >=2.45
+- libgcc >=15.2.0
+- libgcc-devel_linux-aarch64 15.2.0 h55c397f_119
+- libgomp >=15.2.0
+- libsanitizer 15.2.0 he19c465_19
+- libstdcxx >=15.2.0
+- libstdcxx-devel_linux-aarch64 15.2.0 ha7b1723_119
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 73237372
+timestamp: 1778268860495
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+sha256: 2450913611189cc3c26062a43a97a93501159335d4d314cca5e2678fb5f4d3b6
+md5: 619b8a05f89220fa8c9536dcfeeddd5b
+depends:
+- gcc_impl_linux-aarch64 15.2.0.*
+- binutils_linux-aarch64
+- sysroot_linux-aarch64
+license: BSD-3-Clause
+license_family: BSD
+size: 29074
+timestamp: 1781279974207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-15.2.0-h2d9b6d1_19.conda
+sha256: eb531f1a37c2efa431fb3104842d98aba271c55ef3de8c2741e9d575bd3cb762
+md5: c8fc81db8eef1e0f76778e8f91ab8ff3
+depends:
+- gcc_impl_linux-aarch64 >=15.2.0
+- libgcc >=15.2.0
+- libgfortran5 >=15.2.0
+- libstdcxx >=15.2.0
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16043253
+timestamp: 1778269041546
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-hfae3067_0.conda
+sha256: 3e529c517a76a1f4497c51eeedeeb927d33f732dcdb48055a020a83eb3e4e95c
+md5: 4db044857ab1d09b2e8f0013c65387c1
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 103119
+timestamp: 1780455096710
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gsl-2.7-h294027d_0.tar.bz2
+sha256: be506a418cc648996bf3376a626826cbe0fa5d9de913598c4d3965a61ddc7a7b
+md5: 8b9533e21be7fa232ab64e85f184e0b3
+depends:
+- libblas >=3.8.0,<4.0a0
+- libcblas >=3.8.0,<4.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3890901
+timestamp: 1626369614424
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
+sha256: afb0fc36b93539a8e43a8063c8d3e1b4bace38a5a0c3c9e1978c72792d633c62
+md5: 7214ae8a8aade7b48a2bfd8bbb4d9e79
+depends:
+- gcc_impl_linux-aarch64 15.2.0 h3530432_19
+- libstdcxx-devel_linux-aarch64 15.2.0 ha7b1723_119
+- sysroot_linux-aarch64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 14640001
+timestamp: 1778269082840
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
+sha256: f4bc63d467e2c48c255bc8d2886fb11f6a8d09c1251a6f5b25628abee1768693
+md5: ea51d6df068bee183ff667f75bfdc2f6
+depends:
+- gxx_impl_linux-aarch64 15.2.0.*
+- gcc_linux-aarch64 ==15.2.0 h0bf4bd8_27
+- binutils_linux-aarch64
+- sysroot_linux-aarch64
+license: BSD-3-Clause
+license_family: BSD
+size: 27620
+timestamp: 1781279974207
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
+sha256: 57b157674ecee4d16e2873a3624095b4ed1859ce8c574b161e0d9c1723788733
+md5: 41198d1dd71d97c1507e6bd17edd10c7
+depends:
+- libharfbuzz-devel 14.2.1 h3a99ef3_1
+license: MIT
+license_family: MIT
+size: 11079
+timestamp: 1782800518091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
+md5: 546da38c2fa9efacf203e2ad3f987c59
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 12837286
+timestamp: 1773822650615
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
+md5: bb3b7cad9005f2cbf9d169fb30263f3e
+constrains:
+- sysroot_linux-aarch64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1248134
+timestamp: 1765578613607
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+sha256: 5ce830ca274b67de11a7075430a72020c1fb7d486161a82839be15c2b84e9988
+md5: e7df0aab10b9cbb73ab2a467ebfaf8c7
+depends:
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 129048
+timestamp: 1754906002667
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+sha256: b644718416a22b5d57c1194ea7207b7f8d33d6a2b42775763782d76cd7457aea
+md5: 5fd2304064ef6199d1f91ec60ee7b820
+depends:
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1518484
+timestamp: 1781859412954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+sha256: 2c4901f4227b0850328ed0c69f958b30ad2cd18982f7a31c7c1f911827004d08
+md5: 489444d0acb2a579d2a002d85a08c059
+depends:
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-aarch64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 905305
+timestamp: 1784214534868
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
+sha256: 8957fd460c1c132c8031f65fd5f56ec3807fd71b7cab2c5e2b0937b13404ab36
+md5: d13423b06447113a90b5b1366d4da171
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 240444
+timestamp: 1773114901155
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
+build_number: 8
+sha256: c897399c943168c646f659952f73a9154f9122d7e9b151649dbe075dfdcd484b
+md5: 8b44dad125760faa2b3925f5a6e3112d
+depends:
+- libopenblas >=0.3.33,<0.3.34.0a0
+- libopenblas >=0.3.33,<1.0a0
+constrains:
+- libcblas   3.11.0   8*_openblas
+- liblapack  3.11.0   8*_openblas
+- mkl <2027
+- blas 2.308   openblas
+- liblapacke 3.11.0   8*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18843
+timestamp: 1779859042591
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-8_hd72aa62_openblas.conda
+build_number: 8
+sha256: 3ba039f0705022939d90e36c1ed2fcbafd7f5bb77563e3702202ae796b32f4d2
+md5: 76242b7ad6e43809afa8671dd609b4ed
+depends:
+- libblas 3.11.0 8_haddc8a3_openblas
+constrains:
+- liblapack  3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+- blas 2.308   openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18817
+timestamp: 1779859049133
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h7c59cd8_2.conda
+sha256: 5846fa724f4b8eb23751e347fc8b31775c0a28a7a34d1e44f081651613470512
+md5: 0a187db240c503afc7eb5bd865c7ff04
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.22.0,<0.23.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 505957
+timestamp: 1782911738398
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-h1af38f5_0.conda
+sha256: 48814b73bd462da6eed2e697e30c060ae16af21e9fbed30d64feaf0aad9da392
+md5: a9138815598fe6b91a1d6782ca657b0c
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 71117
+timestamp: 1761979776756
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+sha256: c0b27546aa3a23d47919226b3a1635fccdb4f24b94e72e206a751b33f46fd8d6
+md5: fb640d776fc92b682a14e001980825b1
+depends:
+- ncurses
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 148125
+timestamp: 1738479808948
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+sha256: 973af77e297f1955dd1f69c2cbdc5ab9dfc88388a5576cd152cda178af0fd006
+md5: a9a13cb143bbaa477b1ebaefbe47a302
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 115123
+timestamp: 1702146237623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+sha256: 20a5726bc8705d91437c9e6ef83b30da64a1719b869656d20a1ee818333ea5ac
+md5: fac3b65a605cd253037fdf3daf2de8d9
+depends:
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77649
+timestamp: 1781203572523
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
+sha256: 3df4c539449aabc3443bbe8c492c01d401eea894603087fca2917aa4e1c2dea9
+md5: 2f364feefb6a7c00423e80dcb12db62a
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 55952
+timestamp: 1769456078358
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+sha256: db75d0fc080992dc67db8e24d7bb2a2f2a0b25bfce8870fa45a82a4b5f6111a2
+md5: a13e600f9d18488b1fd1257344dbfdaa
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8381
+timestamp: 1780933505754
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+sha256: 34fe8276befd6c42956c4acd969caeddbdc7ea8e6ed054b8388709b6c3e94ba4
+md5: 426cc33f8745ce11a73baf73db3954a7
+depends:
+- libgcc >=14
+- libpng >=1.6.58,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 424236
+timestamp: 1780933505195
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
+sha256: 4592b096e553f67799ae70d4b6167eeda3ec74587d68c7aecbf4e7b1df136681
+md5: f35b3f52d0a2ec4ffe3c89ba135cdb9a
+depends:
+- _openmp_mutex >=4.5
+constrains:
+- libgomp 15.2.0 h8acb6b2_19
+- libgcc-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 622462
+timestamp: 1778268755949
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-15.2.0-h55c397f_119.conda
+sha256: fe600a63a39281e6994e27fe79360cd6bd8e576c3ce1af32ce8673b011f46c21
+md5: 18ad0f0b94071d91fa962a1bf3983a78
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2353893
+timestamp: 1778268665954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
+sha256: 1137f93f477f56199ded24117430045a0c02cbe8b10031beac3b9ad2138539d3
+md5: 770cf892e5530f43e63cadc673e85653
+depends:
+- libgcc 15.2.0 h8acb6b2_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27738
+timestamp: 1778268759211
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
+sha256: e5ad94be72634233510b33ba792a3339921bd468f0b8bc6961ea05eded251d9b
+md5: c7a5b5decf969ead5ecada83654164cf
+depends:
+- libgfortran5 15.2.0 h1b7bec0_19
+constrains:
+- libgfortran-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 27728
+timestamp: 1778268784621
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
+sha256: af8e9bdcaa77f133a8ee4c1ef57ef564d9c45aa262abf9f5ef9b50eb99d96407
+md5: 779dbb494de6d3d6477cab52eb34285a
+depends:
+- libgcc >=15.2.0
+constrains:
+- libgfortran 15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1487244
+timestamp: 1778268767295
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.88.2-h96a7f82_0.conda
+sha256: 6a13152a81513117b8d41bf64dea56c731d877bcced5a24fab738e3c0f9ac58c
+md5: 31d404d8c0755d0f9062a4459f5a1084
+depends:
+- libgcc >=14
+- libffi >=3.5.2,<3.6.0a0
+- pcre2 >=10.47,<10.48.0a0
+- libzlib >=1.3.2,<2.0a0
+- libiconv >=1.18,<2.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4943441
+timestamp: 1782464048865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
+sha256: 2370ef0ffcbae5bede3c4bf136add4abc257245eb91f724c99bb4a43116c5a83
+md5: c5e8a379c4a2ec2aea4ba22758c001d9
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 587387
+timestamp: 1778268674393
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-14.2.1-h3a99ef3_1.conda
+sha256: ae1d16dd62f626c4dab1240a49f6b04e14e4f30140e5fb26bb835821dba114b6
+md5: 655cedd9626545089b9e9ead153cf619
+depends:
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1334601
+timestamp: 1782800489368
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libharfbuzz-devel-14.2.1-h3a99ef3_1.conda
+sha256: 866b0132df7d080a7b2e3c44e4c79723f007db6c035b1e751612d29db698859b
+md5: b6762f2c0386ba4606d5b2cba1e41ca8
+depends:
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libglib >=2.88.2,<3.0a0
+- libharfbuzz 14.2.1 h3a99ef3_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 2050496
+timestamp: 1782800511879
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+sha256: 1473451cd282b48d24515795a595801c9b65b567fe399d7e12d50b2d6cdb04d9
+md5: 5a86bf847b9b926f3a4f203339748d78
+depends:
+- libgcc >=14
+license: LGPL-2.1-only
+size: 791226
+timestamp: 1754910975665
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_0.conda
+sha256: da3e45974c1f23c76264d6358463861236862052ca156e34b502ef3c27e36fb8
+md5: de0780a3690bffe75ac3fa70db84596d
+depends:
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 714602
+timestamp: 1783731816001
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-8_h88aeb00_openblas.conda
+build_number: 8
+sha256: d269a684afa0b2fdb44d6b60167f854f30410cdb5ee49a7275c026f6b10c8d05
+md5: 3af3f2aa755abc5e91351114ae214f55
+depends:
+- libblas 3.11.0 8_haddc8a3_openblas
+constrains:
+- libcblas   3.11.0   8*_openblas
+- liblapacke 3.11.0   8*_openblas
+- blas 2.308   openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18828
+timestamp: 1779859055749
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_0.conda
+sha256: d61962b9cd54c3554361550203c64d5b65b71e3058a285b66e4b04b9769f0a5c
+md5: 76298a9e6d71ee6e832a8d0d7373b261
+depends:
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 126102
+timestamp: 1775828008518
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+sha256: 13782715b9eeebc4ad16d36e84ca569d1495e3516aea3fe546a32caa0a597d82
+md5: be5f0f007a4500a226ef001115535a3d
+depends:
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 726928
+timestamp: 1773854039807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
+sha256: b018ecfb05e75a8eea3f21f6b5c5c2a54b5178bdcf19e2e2df2735740214a8c8
+md5: 58a66cd95e9692f08abe89f55a6f3f12
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.33,<0.3.34.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5121336
+timestamp: 1776993423004
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
+md5: f51503ac45a4888bce71af9027a2ecc9
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 341202
+timestamp: 1776315188425
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.22.0-h9aac952_1.conda
+sha256: 15ec553e784f2b8601c3df58e1dbe723309303c5ed405bc671bffae722c81023
+md5: f8f91448e5ba30051ceb17b45b31da9b
+depends:
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 71121
+timestamp: 1783936885865
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-15.2.0-he19c465_19.conda
+sha256: 8115604f113fe2b7be95b2d22183a4dda5779c1cc6db4b826af800581498b4b3
+md5: 95210a1edbd7fc6e12afc9f8276f450a
+depends:
+- libgcc >=15.2.0
+- libstdcxx >=15.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7067965
+timestamp: 1778268796086
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+sha256: 1e289bcce4ee6a5817a19c66e296f3c644dcfa6e562e5c1cba807270798814e7
+md5: eecc495bcfdd9da8058969656f916cc2
+depends:
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 311396
+timestamp: 1745609845915
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.2.0-hef695bb_19.conda
+sha256: 1dadc45e599f510dd5f97141dddcdbb9844d9f1430c1f3a38075cf1c58f87b4e
+md5: 543fbc8d71f2a0baf04cf88ce96cb8bb
+depends:
+- libgcc 15.2.0 h8acb6b2_19
+constrains:
+- libstdcxx-ng ==15.2.0=*_19
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 5546559
+timestamp: 1778268777463
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-15.2.0-ha7b1723_119.conda
+sha256: 6f7ceee16070781b7d642a37a35ffdf09c66796d3df105c919526210ce220443
+md5: 61da34d67f58dd4cf16683f6cdcb06c8
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 17627362
+timestamp: 1778268687968
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+sha256: ef1006578ef7e3f7c420e89d87846213ceb3fdcef2626af2558cbede53d36839
+md5: 20166e2297c1cac346b544d5f6197440
+depends:
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 508982
+timestamp: 1783084925965
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+sha256: 7663489f97c104ae3814db10f384932c74b439f3c1fd4247e4fe3599830c090a
+md5: 58fa42bc4bc71fc329889497ec15effb
+depends:
+- libgcc >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 43248
+timestamp: 1781625528371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.52.1-h80f16a2_0.conda
+sha256: 3e2ead35f47d01364031f323f1be984018c8f19a3a264f952ddcd043685a1c86
+md5: ac7bcbd2c77691cd6d1ede8c029e8c8a
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 456627
+timestamp: 1779396031450
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_0.conda
+sha256: b03700a1f741554e8e5712f9b06dd67e76f5301292958cd3cb1ac8c6fdd9ed25
+md5: 24e92d0942c799db387f5c9d7b81f1af
+depends:
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 359496
+timestamp: 1752160685488
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.17.0-h262b8f6_0.conda
+sha256: 461cab3d5650ac6db73a367de5c8eca50363966e862dcf60181d693236b1ae7b
+md5: cd14ee5cca2464a425b1dbfc24d90db2
+depends:
+- libgcc >=13
+- pthread-stubs
+- xorg-libxau >=1.0.11,<2.0a0
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 397493
+timestamp: 1727280745441
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
+sha256: eb111e32e5a7313a5bf799c7fb2419051fa2fe7eff74769fac8d5a448b309f7f
+md5: 502006882cf5461adced436e410046d1
+constrains:
+- zlib 1.3.2 *_2
+license: Zlib
+license_family: Other
+size: 69833
+timestamp: 1774072605429
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-h2a6d0cb_2.conda
+sha256: d243aea768e6fa360b7eda598340f43d2a41c9fc169d9f97f505410be68815f8
+md5: 5983ffb12d09efc45c4a3b74cd890137
+depends:
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 528318
+timestamp: 1727801707353
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
+sha256: 369db85c5cd8d99dde364ce70725d76511d9c8199e5b820c740414091bf5bcca
+md5: b2a43456aa56fe80c2477a5094899eff
+depends:
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 960036
+timestamp: 1777422174534
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
+sha256: da4a5df42614166b69c2f6d8602fc1425f7aaa699f77c3bafb5c7fe69b3d9fb7
+md5: fa6260b3e6eababf6ca85a7eb3336383
+depends:
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3704664
+timestamp: 1781069675555
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandoc-3.10-h8af1aa0_0.conda
+sha256: 8427cd22ccc4104d1348fe028e130e800328060e3b6f3607ce97f5188c68b835
+md5: 648f4bde42b8c5d708296ca6106c377d
+license: GPL-2.0-or-later
+license_family: GPL
+size: 23565468
+timestamp: 1780595445519
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.56.4-h8547ced_1.conda
+sha256: d209c8b0d53c441ee0bc0d8fce0fcae8e7e05755e51b13b6b9da02c7aa032f98
+md5: 3fc7cc25bba3381e77b753578058e3b0
+depends:
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.17.1,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- harfbuzz >=13.2.0
+- libexpat >=2.7.4,<3.0a0
+- libfreetype >=2.14.2
+- libfreetype6 >=2.14.2
+- libgcc >=14
+- libglib >=2.86.4,<3.0a0
+- libpng >=1.6.55,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 470441
+timestamp: 1774284032397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
+sha256: 04df2cee95feba440387f33f878e9f655521e69f4be33a0cd637f07d3d81f0f9
+md5: 1a30c42e32ca0ea216bd0bfe6f842f0b
+depends:
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1166552
+timestamp: 1763655534263
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_2.conda
+sha256: 414acad3e460cfcf6bf3a764c4b4837359bda9fdc350a85b560e344a9e2306a5
+md5: af8ab93369e53542b135dab29eca49e8
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 304146
+timestamp: 1784286832656
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+sha256: e9cbcbc94e151ada3d6dc365380aaaf591f65012c16d9a2abaea4b9b90adc402
+md5: ab7288cc39545556d1bc5e71ab2df9a9
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 636733
+timestamp: 1769712412683
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
+sha256: 977dfb0cb3935d748521dd80262fe7169ab82920afd38ed14b7fee2ea5ec01ba
+md5: bb5a90c93e3bac3d5690acf76b4a6386
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 8342
+timestamp: 1726803319942
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-abind-1.4_8-r45hc72bb7e_1.conda
+sha256: 5055913d786b82f33a14f493f32945b3b2b5d528ea2f52856ca02b296f6511eb
+md5: dde4691fe168112a90efba6aaa08f13d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: LGPL (>= 2)
+license_family: LGPL
+size: 82526
+timestamp: 1757460261392
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-askpass-1.2.1-r45h0557e7b_1.conda
+sha256: e6d37a7c16ca9693a1dee6ab71778c78f6539508ca59934f38c97ff2a5129565
+md5: 6dd9985ca467090a3ce338ea95da715c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-sys >=2.1
+license: MIT
+license_family: MIT
+size: 33005
+timestamp: 1758383588821
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r45hc72bb7e_6.conda
+sha256: 90e7ae8aa427274d7d2e510060b68925e60e897ecaa5ea135bb33afa7eb12134
+md5: b5291c60f52b43108a2973ba6f5885d1
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 72543
+timestamp: 1757447376176
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.5.3-h269e6ae_3.conda
+sha256: 27649f8b9717afec0d32b3ddd2537f08948321a5b311d8ed49bedfd4dde6b718
+md5: bd35d2e5e6972908b398aaf340861ff1
+depends:
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.18.4,<2.0a0
+- curl
+- gcc_linux-aarch64 >=14
+- gfortran_impl_linux-aarch64
+- gsl >=2.7,<2.8.0a0
+- gxx_linux-aarch64 >=14
+- icu >=78.3,<79.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libglib >=2.88.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libuuid >=2.42.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- make
+- pango >=1.56.4,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- readline >=8.3,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- tzdata >=2024a
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxt >=1.3.1,<2.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 27596006
+timestamp: 1781523590403
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base64enc-0.1_6-r45h0557e7b_0.conda
+sha256: 2172b3db2c71520fd5018cac6e7db1659a43054b71f331573e30e0c30acbec20
+md5: 8b5fb4c68b8c612747adcf9ef27e397c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 50459
+timestamp: 1770027826952
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-beeswarm-0.4.0-r45hf488e41_5.conda
+sha256: 5284e4fd8982aa2e63d73f1b8bd760462311b5e9a853a341f5b872cd0c22d463
+md5: a0429d68e95c279c95760fa4da3ea648
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 89962
+timestamp: 1757584938658
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-biocmanager-1.30.27-r45hc72bb7e_0.conda
+sha256: 177f262fda25552b8ce3e7685220deefba1625314575a892cd4abca06ddf06a4
+md5: f1b6b9a4e77b21df8a6949102db4f468
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 644936
+timestamp: 1763112090227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-bslib-0.11.0-r45hc72bb7e_0.conda
+sha256: fafc7a0acb8fc595b8fd89e75ec0b1d7d5af71b2b493570fa05e1f5612d299c2
+md5: dae60c429ab933e549832bc223e95639
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-cachem
+- r-htmltools >=0.5.7
+- r-jquerylib >=0.1.3
+- r-jsonlite
+- r-lifecycle
+- r-memoise >=2.0.1
+- r-mime
+- r-rlang
+- r-sass >=0.4.0
+license: MIT
+license_family: MIT
+size: 5538377
+timestamp: 1778923739710
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ca-0.71.1-r45hc72bb7e_5.conda
+sha256: 20dd6e4aa94d2d5ea97419add6bcac50f81400d297e9933659ff35da41fe2f6d
+md5: c922b0a6584376d3587d8cb3670f5cac
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 256017
+timestamp: 1757560386979
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cachem-1.1.0-r45h0557e7b_2.conda
+sha256: c8fd2712d1a19d32feabf471fd4f5e01d8d9a622a08f76b1c3cf638f4ab1dccb
+md5: 7ac09a862af4168c7e6ca6f018464c55
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fastmap
+- r-rlang
+license: MIT
+license_family: MIT
+size: 77756
+timestamp: 1757441578494
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-callr-3.7.6-r45hc72bb7e_2.conda
+sha256: f9f49b2b845f279af84a33c8af19a915b2731c0bd892c608205cbad8a34f423d
+md5: a5cc8a8d0dc08dc769c65a13b3573739
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-processx >=3.4.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 454090
+timestamp: 1757475635573
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.6-r45h08b74da_0.conda
+sha256: 5416a041dbc61d4d3b74c0c888295aaf7cb71262236a4fc09242c18711ed00ff
+md5: 196fedd5e490165a94ee856d727aa247
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1346019
+timestamp: 1775733744341
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cluster-2.1.8.2-r45h6df9e4a_0.conda
+sha256: bf4a9118958688ef6a7b06267fb0aa7006fa97ec37d400f194c48175ff5df3f7
+md5: 5b08c25df4a50c12c8bfdfe65d191ce8
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 595768
+timestamp: 1770285735470
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-codetools-0.2_20-r45hc72bb7e_2.conda
+sha256: aec327dd836824278a2adf006f426a58d834828de74de7f8348f2f5f068de702
+md5: 8e9e5b14f74a6040c77e0b9c8bfa84ca
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 109200
+timestamp: 1757452164030
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-colorspace-2.1_3-r45h0557e7b_0.conda
+sha256: d78a45f9c58a3182ba17a3851017b7adaa6d0ecebcee872998bb41e6cc312782
+md5: 01eaba8437d8c23d0dea562c29e406a8
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2546382
+timestamp: 1784283306550
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-commonmark-2.0.0-r45h0557e7b_1.conda
+sha256: 1382bc1e64063f49fdc406d0ce92a815c43b9be9cb098d8e65f7059f97117535
+md5: 4f0d0c8eeeaad3aab64c7bee16426a28
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 144114
+timestamp: 1757422195437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.5-r45h785f33e_0.conda
+sha256: 5993a1b5c08c78a35cdbcf20376773eb7c4def2d28615e49f96008b43a4c05c0
+md5: 71c68a3993a696b6b75f7a6550b3750f
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 246247
+timestamp: 1778089270609
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r45hc72bb7e_2.conda
+sha256: 9126a0408696133893e674549ca7aef317768dba503765a7ed032616aabe5b49
+md5: 4f111ce078b9690abaad6248b831a370
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 168201
+timestamp: 1757452410374
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crosstalk-1.2.2-r45hc72bb7e_1.conda
+sha256: 217e5e210501b7fa611d6c6c46ae1551f443e2359e27164240da5a1219b2551a
+md5: 523a15023a79bd6f0dcb95ba6756ceed
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.3.6
+- r-jsonlite
+- r-lazyeval
+- r-r6
+license: MIT
+license_family: MIT
+size: 382037
+timestamp: 1757479275516
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-curl-7.1.0-r45hd8a8d9c_0.conda
+sha256: 91fce711e5bacf578c37e9c5012563d60d1dbe5a05dcf0f2a8080d3be2a938bf
+md5: 328d250136cafc6b644b5174767dbea4
+depends:
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 477493
+timestamp: 1777147747989
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-data.table-1.18.4-r45hbf3bb9c_0.conda
+sha256: d4a19f503b0705d9662ce3e9d81753aa720202c5c87e0f64869599dcfa9e84d7
+md5: 8f3b2a953fcbc5eb2dadb5dab1f0d5b6
+depends:
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MPL-2.0
+license_family: OTHER
+size: 2644344
+timestamp: 1783428401576
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dendextend-1.19.1-r45hc72bb7e_1.conda
+sha256: 1edafb4e01397265da1816f3164a451d36f02546f2589c5f45051886ab9f91a8
+md5: f69bda3cb40132707f6efff4c749ce09
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-magrittr >=1.0.1
+- r-viridis
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4839264
+timestamp: 1757633933010
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-digest-0.6.39-r45h08b74da_0.conda
+sha256: 2cf79b6af8cdd8215ffed899d016c1554935cab5cc419a9390cc6931cdf49513
+md5: c5109e71b8b0a7dcdddcc4f6fa21605d
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 225830
+timestamp: 1763566824454
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.2.1-r45h08b74da_0.conda
+sha256: c7a33bc92936537648e29cb70b0912deaa4a79cc4d8f30f4e4dd213723eb00a0
+md5: 93bb33f64dce6cdcd5251d8d2234bac7
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1449577
+timestamp: 1775207129641
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-dt-0.34.0-r45hc72bb7e_1.conda
+sha256: 38eee3a12260e5fff1e2af04250f6b67091b01c694f101ae6448da12c3fcca09
+md5: b78224895a1ad7fb52311ab071c2ec00
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-crosstalk
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httpuv
+- r-jquerylib
+- r-jsonlite >=0.9.16
+- r-magrittr
+- r-promises
+license: GPL-3.0-only
+license_family: GPL3
+size: 1439901
+timestamp: 1757566758266
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-egg-0.4.5-r45hc72bb7e_6.conda
+sha256: ec00c0162d803af3c8059e9504d1d0c8b60cabe805c347a4a20300f2cce9e700
+md5: 6ac48e7c4c46b6c0538a779d0a43008a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2
+- r-gridextra >=2.3
+- r-gtable
+license: GPL-3
+license_family: GPL3
+size: 950098
+timestamp: 1757760318911
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.3-r45h0557e7b_0.conda
+sha256: cdd63168ef461c582d26b5a8bcd7e5378575a20068e61ab119cdbb544329f5a4
+md5: a52d33523179da32a3c9d11ff27b730d
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 34061
+timestamp: 1775287261756
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-evaluate-1.0.5-r45hc72bb7e_1.conda
+sha256: d3accfeab1416151515c37e5edc94b18868998db4936183459f8040117d5c83c
+md5: 4e0c71ab78d7292372a89d4daecb49af
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 111914
+timestamp: 1757447684244
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.7-r45h0557e7b_0.conda
+sha256: 9a8c13e87085007face8d9576ca4675ac2187e4b2082f195199b6b6af67c45c6
+md5: a0702b7eb11d1a382527a02baf1fd0bc
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 339732
+timestamp: 1763566140258
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-farver-2.1.2-r45h08b74da_2.conda
+sha256: bad9c13ce006e7e972cd3b240efc2ab457557acfec2a5566c85b91f6f354cd8f
+md5: e3468d0fb1e32edf11badd5dcdb847e4
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1401937
+timestamp: 1757441349828
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fastmap-1.2.0-r45h08b74da_2.conda
+sha256: 3bff61e00966863ab1febada7f64a9618db330aa97dd527b0d2719990993e1a3
+md5: 679225ca2785ed02ffd33b5cd998e514
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 74243
+timestamp: 1757421537458
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-fontawesome-0.5.3-r45hc72bb7e_1.conda
+sha256: 865df12d8cdd8cf577abc8f785a0aa4ee50b4f8751256dffe4676a350943d591
+md5: e9fccb3617ec9776569c6496fa254e64
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.1.1
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 1335664
+timestamp: 1757461248044
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-foreach-1.5.2-r45hc72bb7e_4.conda
+sha256: c95d1e61946bf81128be213dea7a07b5196c6e13caf9c6452c38145da8d2dfb1
+md5: 5abe392c8f8c5b954ebdc5fe46fcc709
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-codetools
+- r-iterators
+license: Apache-2.0
+license_family: APACHE
+size: 140909
+timestamp: 1757490449004
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fs-2.1.0-r45hd601667_0.conda
+sha256: 305a53e9e768366f5a143376ad618c5c08f67ac96242d747ec7bd6a0db71d1c2
+md5: 87df8bfe7e48c5b0537cc534f8a5b3a3
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 244508
+timestamp: 1777152716131
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gclus-1.3.3-r45hc72bb7e_1.conda
+sha256: 196d29aa2d809d9115dce27236470219e1057d394654b5d73182f0e9d117f2fa
+md5: 4a667a55fc37e12dcbe510262ca61d19
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 424919
+timestamp: 1757627324320
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r45hc72bb7e_1.conda
+sha256: 88a5cf4bac0a553943996bc930b1ea28f2635c262c1b2c5a42b026b69f227f02
+md5: f19c9493b80f63a41fa017ec3b27bc2e
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 88225
+timestamp: 1757455977192
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-getopt-1.21.1-r45ha770c72_0.conda
+sha256: 20c4ea52e72cb2e50907f9e5a446f16b0fce467fec4edab236eeb3b46890f3dd
+md5: b3a121ed6a71f3b674859ccbb15ad56b
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 67477
+timestamp: 1777325952298
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggbeeswarm-0.7.3-r45hc72bb7e_0.conda
+sha256: f8c0982d1579b810fc24cb702f8922794fce7bdfb9d3bf96867a4b038205b045
+md5: 9be31d2adf526d3c38b78a05333ddf30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-beeswarm
+- r-ggplot2 >=3.3.0
+- r-lifecycle
+- r-vipor
+license: GPL-3.0-or-later
+license_family: GPL3
+size: 1761662
+timestamp: 1764399956063
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggdendro-0.2.0-r45hc72bb7e_2.conda
+sha256: 4e0401174fac5b54f124a8e7e418995a74918e8cd52a456a82db3fc5a373f0e0
+md5: bcdfec44c6bf587e65f56de61334a413
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=0.9.2
+- r-mass
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 221547
+timestamp: 1757758420492
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-ggplot2-4.0.3-r45h785f33e_0.conda
+sha256: 3a91d5334b7d99bc247386eaf0d331e119852e381e769e266f70df20eab22689
+md5: 866fbbf3f356140922d618f26f2b889c
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-gtable >=0.3.6
+- r-isoband
+- r-lifecycle >=1.0.1
+- r-rlang >=1.1.0
+- r-s7
+- r-scales >=1.4.0
+- r-vctrs >=0.6.0
+- r-withr >=2.5.0
+license: MIT
+license_family: MIT
+size: 7812326
+timestamp: 1776860393567
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.1-r45h0557e7b_0.conda
+sha256: 02f33f91373217832525d722f7e3be2ac47a1b8f9e1e65a33a03622180ff2360
+md5: a410160f41fb5192efccd33986aced38
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 172828
+timestamp: 1776413622694
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gridextra-2.3.1-r45hc72bb7e_0.conda
+sha256: e82d7e308a7e6d3eb90d9ea33d1f56d24bd69804995db2dacd5b20b7a20c34e4
+md5: aad2c473bf6f930833d0dc881811cf62
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-gtable
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 529159
+timestamp: 1782547830828
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-gtable-0.3.6-r45hc72bb7e_1.conda
+sha256: fcd2601af8213f39af6f720e22c8f858b3451f8e3d93cbc9e6aedb2d6f88483e
+md5: f686123cfba49e6299fae7e029a40266
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue
+- r-lifecycle
+- r-rlang
+license: MIT
+license_family: MIT
+size: 228864
+timestamp: 1757463478042
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-heatmaply-1.6.0-r45hc72bb7e_1.conda
+sha256: 2d26e9b5c0e688cc76d33d81f8f62c59de9dc2f0695fd7b110991fa222db5524
+md5: d0bd1b5a09e5d631b8de31949ea19ece
+depends:
+- r-assertthat
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+- r-dendextend >=1.12.0
+- r-egg
+- r-ggplot2 >=2.2.0
+- r-htmlwidgets
+- r-magrittr >=1.0.1
+- r-plotly >=4.7.1
+- r-rcolorbrewer
+- r-reshape2
+- r-scales
+- r-seriation
+- r-viridis
+- r-webshot
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1693764
+timestamp: 1758426737719
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-hexbin-1.28.5-r45h6df9e4a_1.conda
+sha256: 1b589435aaf7c11bb23d6877f077a61f387a696fdeb7fd4d8307b5e4e5fcbebe
+md5: a7e475f65cbe95ff5193d520cdd5196c
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-only
+license_family: GPL2
+size: 1594883
+timestamp: 1757483340587
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-highr-0.12-r45hc72bb7e_0.conda
+sha256: e676112aac0dbfe123fcb3108cce376782211a096c898a3af46fdf32a37e12e9
+md5: 0b5902d6af02a23bda1794d46090db42
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.18
+license: GPL-2.0-or-later
+license_family: GPL
+size: 57308
+timestamp: 1772794436225
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-htmltools-0.5.9-r45h08b74da_0.conda
+sha256: 71fb50fb947fc5209e6abc3ea4a7e388e32f564f306a4771c46b26dcf7474369
+md5: bd128ae05e4cb14baa66ff86ad9b3126
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-digest
+- r-ellipsis
+- r-fastmap >=1.1.0
+- r-rlang >=0.4.10
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 368214
+timestamp: 1764860572792
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-htmlwidgets-1.6.4-r45h785f33e_4.conda
+sha256: 4c3998ce4b4882429e52eed5c6c53d59056814d8fbc34a41ba79b990fdec1441
+md5: 6f767715f90e7caf17af72959bfcb11e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools >=0.5.7
+- r-jsonlite >=0.9.16
+- r-knitr >=1.8
+- r-rmarkdown
+- r-yaml
+license: MIT
+license_family: MIT
+size: 426023
+timestamp: 1757552859817
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-httpuv-1.6.17-r45hb62f08c_0.conda
+sha256: f80c025e58243755b5a66d125fff21aff8f081fee0428a9254c62ee9cde6dc65
+md5: d1e3db0a93a2074799a0659080178b8e
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libuv >=1.51.0,<2.0a0
+- libzlib >=1.3.1,<2.0a0
+- r-base >=4.5,<4.6.0a0
+- r-later >=0.8.0
+- r-promises
+- r-r6
+- r-rcpp >=1.0.7
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 553429
+timestamp: 1773825488822
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr-1.4.8-r45hc72bb7e_0.conda
+sha256: 4adb565d2b3365108d7efb926c2acdc68c11ef2ad32ed03d1108a3005cf8cdd8
+md5: 259658089c383f2915b167da3e7890aa
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-curl >=0.9.1
+- r-jsonlite
+- r-mime
+- r-openssl >=0.8
+- r-r6
+license: MIT
+license_family: MIT
+size: 474019
+timestamp: 1771005817336
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-httr2-1.3.0-r45hc72bb7e_0.conda
+sha256: dcc78f60308390c6549e25308fb2437421e8fcaeeb45378b6fbe3a49e3d3cd0b
+md5: b240e3c0e61de35f1f43729f4ea2888e
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.0.0
+- r-curl >=5.1.0
+- r-glue
+- r-lifecycle
+- r-magrittr
+- r-openssl
+- r-r6
+- r-rappdirs
+- r-rlang >=1.1.0
+- r-vctrs >=0.6.3
+- r-withr
+license: MIT
+license_family: MIT
+size: 935264
+timestamp: 1784022303810
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-isoband-0.3.0-r45h08b74da_0.conda
+sha256: e70c9f8bb4b0100ac45e9aeed982c2a72357c4b8ca529fa2927cbc917e283c4c
+md5: 04efe7d434cd3e6f5a69e4799eb6cbbd
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-cpp11
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1660497
+timestamp: 1766530417757
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-iterators-1.0.14-r45hc72bb7e_4.conda
+sha256: c90d0faa668d2753db9da9458ca085891a3030c6537f5675fe0c1a1b5af2103c
+md5: 7746a41a4cb97cec59db2d5a2cac0701
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 350171
+timestamp: 1757459846270
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jose-2.0.0-r45hc72bb7e_0.conda
+sha256: abb2cd923ed271df8774e696f2e455f8c641532cc984fd770b87852a0017d7ab
+md5: 7113381f500ebcc8a33b61101817d120
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-jsonlite
+- r-openssl >=1.2.1
+license: MIT
+license_family: MIT
+size: 248113
+timestamp: 1776846446837
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-jquerylib-0.1.4-r45hc72bb7e_4.conda
+sha256: 3b98f72bb32d4758854805b664b4404602a583da32c9b96026536f5676f41812
+md5: 49a9ed6ed01f4ae6067ead552795bfce
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-htmltools
+license: MIT
+license_family: MIT
+size: 307113
+timestamp: 1757459485295
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-jsonlite-2.0.0-r45h0557e7b_1.conda
+sha256: cd484854182eca0e62cacf6f5dfdc3d11106d4ab0307d41361c772247e9ae283
+md5: 0c7d7b8541f5619f09dd9334deb7dbf7
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 645626
+timestamp: 1757419590460
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-knitr-1.51-r45hc72bb7e_0.conda
+sha256: e2184f1cb58aedacd94d1dbe6e8b5dfa3508151f454e80f6bd49486bdb90625c
+md5: 35b31b96aa7bc052ad6347322a1481f1
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-evaluate >=0.15
+- r-highr >=0.11
+- r-xfun >=0.52
+- r-yaml >=2.1.19
+license: GPL-2.0-or-later
+license_family: GPL
+size: 988526
+timestamp: 1766309267127
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-labeling-0.4.3-r45hc72bb7e_2.conda
+sha256: 42a06b7c346d6e4550dca1024bbf89e3c22962d568cfe4e8b8be824dea326110
+md5: a41490fdf607381035aa0304c21407c9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 70182
+timestamp: 1757456007088
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-later-1.4.8-r45h08b74da_0.conda
+sha256: b7c530de9a38fcf30ae63c92cd60fb0d23567e6567f70694d350ff2adeec88e0
+md5: 3601ce2112d41114cdb6ed340ee44442
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.12.9
+- r-rlang
+license: MIT
+license_family: MIT
+size: 155668
+timestamp: 1772707321535
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lattice-0.22_9-r45h0557e7b_0.conda
+sha256: a6f30211a8b3511e27c2aac99b499cdb4751a950fe5595a48672a38de8ecc28d
+md5: 2049f7981874aefa34b2b5b53af007eb
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1418137
+timestamp: 1770694138040
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-lazyeval-0.2.3-r45hf488e41_0.conda
+sha256: c9f7bb66c064e813d5aa82e60b70ab4fb1f0b6acda05a43cbbb3615bd2c71899
+md5: 2a54efbd48368966f65e6500198574e7
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-rlang
+license: GPL-3.0-only
+license_family: GPL3
+size: 195208
+timestamp: 1775429446648
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.5-r45hc72bb7e_0.conda
+sha256: b7a4d8d98a96d17d18c80fb7e1c8e6cb09b9bd2542e74d91a7f483afccb30ee6
+md5: 5f8369dfbdff08878e58bf15529fca3a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 132636
+timestamp: 1767865665455
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-litedown-0.10-r45hc72bb7e_0.conda
+sha256: 1f594c5be675a53caef3368ea85c048b8bcbc4385e2bd582e977981a1edd5e3e
+md5: b936b3596737a3a1d513e1258d5d0355
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-commonmark >=2.0.0
+- r-xfun >=0.55
+license: MIT
+license_family: MIT
+size: 392980
+timestamp: 1784144498175
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.5-r45h0557e7b_0.conda
+sha256: 0a4dbbb3acc77222d0119e1d9c47c94359e5a05290a514b5ac345512e6d5d125
+md5: e61a28ac3cbd3f76f96f9aef579ae6ef
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 212064
+timestamp: 1775298634467
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-markdown-2.0-r45hc72bb7e_1.conda
+sha256: 5f27ccd93b39c2435ed6e9b8302ae50d51eb5b6058d7d11edba403e9723f48c6
+md5: 755b46b2896c8526a18074b3b651dfbc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-litedown >=0.6
+- r-xfun
+license: MIT
+license_family: MIT
+size: 72190
+timestamp: 1757496654397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mass-7.3_66-r45hf488e41_0.conda
+sha256: cadc1e7cb74ec9999a2393b5225bca8f39da162f5ea1719783c4186dffd5d223
+md5: 615cb3f4dc69d374da874553f58cc61c
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 1143006
+timestamp: 1784201763856
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrix-1.7_5-r45h9301183_0.conda
+sha256: 0671e1595f283ed8f5a67f6006821b90b58a954c095d230cf0c3543d45aa6e1f
+md5: dbc4de669537f1b65a8f63e92d01c0de
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4492870
+timestamp: 1774809348312
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-matrixstats-1.5.0-r45h0557e7b_1.conda
+sha256: cc732696567fd2e79cf48cb9ae19cfed65d2a547ef7657b847ea6e52ab29cef0
+md5: 28f5371af404b055c4e8fda252343eff
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Artistic-2.0
+license_family: OTHER
+size: 508907
+timestamp: 1757442506110
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-memoise-2.0.1-r45hc72bb7e_4.conda
+sha256: 91b0eedec5cf5de195b442b97eda508f22fdedbdbc487f74e3868d3e95380fdd
+md5: 2b04206ff6ea5a92e8e36bdaa5feb3cc
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cachem
+- r-rlang >=0.4.10
+license: MIT
+license_family: MIT
+size: 57750
+timestamp: 1757456335587
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mgcv-1.9_4-r45h8b2cba9_0.conda
+sha256: deb54e1594e6cff5fa5c1851b6ba9b8e9ddb663fc2a5bd0a770bd7348fca0740
+md5: 3f3684540a7cf2f8aba9bd7419b86182
+depends:
+- _openmp_mutex >=4.5
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-matrix
+- r-nlme >=3.1_64
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 3663168
+timestamp: 1762539639167
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-mime-0.13-r45h0557e7b_1.conda
+sha256: 7ebc8c9727a9841e9c0ac408d67dda73618105a6741e6ee2764d3b5838006adc
+md5: a18f44c7e30f17a25dae01a2ebdd64ac
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 65881
+timestamp: 1757441504988
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-munsell-0.5.1-r45hc72bb7e_2.conda
+sha256: 97d463c2146c483992a25fe497755e9cf714f95ca611a93d8adbb41c068e9e74
+md5: c78bd534986cde8fc0cb08cc9a1a2cc6
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-colorspace
+license: MIT
+license_family: MIT
+size: 247241
+timestamp: 1757455926748
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-nlme-3.1_170-r45ha85219e_0.conda
+sha256: 5a665d1c57741a6ad27b09c26a5c70c1e8b2600b99c1ca70850b01e67981aba1
+md5: 9d56b3fd30b35e8511816cd727b71c75
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-lattice
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 2364152
+timestamp: 1784288181817
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-openssl-2.4.2-r45h37c386a_0.conda
+sha256: 0b1010bcebef6d666733f422ede62662c408bd21d35a1a6a415a56469641ff98
+md5: b835aaead878405731f2cd4f92f253ff
+depends:
+- libgcc >=14
+- openssl >=3.5.6,<4.0a0
+- r-askpass
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 683534
+timestamp: 1781024877810
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-optparse-1.8.2-r45hc72bb7e_0.conda
+sha256: 09df5e8326b04412a26b6c4d896e04adbceba45194457c6d30f370d5ccb4b397
+md5: 0c015ba0c5444777a683c05e4a000f21
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-getopt >=1.20.2
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 119289
+timestamp: 1776419503742
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-otel-0.2.0-r45hc72bb7e_1.conda
+sha256: f5de9737f59e1965db2de11c90cf1fdd426db322a7205c935a3e55150287b02f
+md5: 560abd550c097e0d0af2e201b335f53d
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 286342
+timestamp: 1761151056217
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-packrat-0.9.3-r45hc72bb7e_1.conda
+sha256: 162742dd773c8a163de6ffdf0e14820b5708b9e1041d4491762c05e00f6be614
+md5: 849a8fcdb5e1d98a3917a7c652c322df
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 679411
+timestamp: 1757649050426
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-permute-0.9_10-r45hc72bb7e_0.conda
+sha256: a4869bf14ad791c8a5cb48fd0575faa3cdb7b07692cb4b473809c261f584fa45
+md5: 9a48d2e7fdc93937c60481c06d40e6ba
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 234305
+timestamp: 1770387131912
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
+sha256: b3f281041ecff2d4a9f40073ad5e7ec6fa7e0c841068ce85c550bcce0ff8938d
+md5: 807ef77a70fc5156f830d6c683d07a29
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 629867
+timestamp: 1758149763203
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
+sha256: fda425435a533e86da5f0fc89cf45c9f889a4e6f1e2ed536ca23662a8461602c
+md5: 40a5fdd06c7e7880758a021cf2df6c12
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 27236
+timestamp: 1757447537447
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
+sha256: c27913720e29845540e0f20507cdd43ea2beff02e7a73b1e2f51e4e929c42859
+md5: 51ad52cc7fa715ca7739245162bfab8f
+depends:
+- libgcc >=14
+- openssl >=3.5.3,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 137458
+timestamp: 1758095884906
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
+md5: ced57d920bed79382f382a24a4425ef7
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-base64enc
+- r-crosstalk
+- r-data.table
+- r-digest
+- r-dplyr
+- r-ggplot2 >=3.0.0
+- r-hexbin
+- r-htmltools >=0.3.6
+- r-htmlwidgets >=1.3
+- r-httr
+- r-jsonlite >=1.6
+- r-lazyeval >=0.2.0
+- r-magrittr
+- r-promises
+- r-purrr
+- r-rcolorbrewer
+- r-rlang
+- r-scales
+- r-tibble
+- r-tidyr
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 3587131
+timestamp: 1769337109792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
+sha256: 0150b0ff5b1f10d44d8340697dc75308d000af7173e06a7bd6bbc52662435647
+md5: b5287e844eb29138a9bbac2204c34938
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.0
+license: MIT
+license_family: MIT
+size: 787646
+timestamp: 1757441825154
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
+sha256: 0795c4803d0c96906f1f509db1b444bedbcd49efcf563fa67e34056f155f4944
+md5: 6002b6697d4f3a7aa2112d75938215df
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-ps >=1.2.0
+- r-r6
+license: MIT
+license_family: MIT
+size: 416233
+timestamp: 1776865727437
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
+sha256: 684dba5d20aae8da37868d603b662014e1944f5568e5f737e42d9d485892a26e
+md5: b2c1b6ef8f12894fd2694b285fe8989a
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-fastmap >=1.1.0
+- r-later
+- r-lifecycle
+- r-magrittr >=1.5
+- r-otel >=0.2.0
+- r-r6
+- r-rlang
+license: MIT
+license_family: MIT
+size: 1597704
+timestamp: 1762426228446
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ps-1.9.3-r45h0557e7b_0.conda
+sha256: 9806dc2cd51b90600c0cfaa9414bf037359b48e4409a3e848c714f7fd202e326
+md5: 110a8db7f8f7d81dc6499717e3518901
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 415719
+timestamp: 1777148053343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.2.2-r45h0557e7b_0.conda
+sha256: 132601f0cf01c5472b5808479e92290c4a1764202d8eb370a568c0c8cc42e509
+md5: 9418ed4bd8e6c1f7daa1d86fde8d4bca
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 551426
+timestamp: 1775853641796
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-qap-0.1_2-r45ha85219e_5.conda
+sha256: 130ad15a31352cac447a5d5121df7703a77775be465967816193fadf522ec604
+md5: 0783f6d35f1229fd9476bbd89ebb36e2
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 397185
+timestamp: 1757637123693
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r45hc72bb7e_1.conda
+sha256: bd92e91332eba5f0c689583e80adec85ef272c4e0d0b36ee17cb7c11b5693cf2
+md5: 750802806d7d640c286ed8491bb395dc
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 95073
+timestamp: 1757447661037
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rappdirs-0.3.4-r45h0557e7b_0.conda
+sha256: 86b48f6a5648dab19677da07eb4360ab9f1df1957ab1a5bd7499c14284303fe4
+md5: 37552103a31471f0dd255110017d4397
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 55042
+timestamp: 1768747329339
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rcolorbrewer-1.1_3-r45h785f33e_4.conda
+sha256: ddd4e63616ee475bdf9dc63a0b16a89017237121e927d83fbdee07d5a5ccc890
+md5: d8fa238420cb6de47d463b7345a761eb
+depends:
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68005
+timestamp: 1757452462302
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpp-1.1.2-r45h08b74da_0.conda
+sha256: 4a2c9002ff0360803ab644577bbac5a2277dab69a7cb58c23218d39e84d3371a
+md5: 6cc0478a5eda6092486e4f6fb2de570b
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 2121146
+timestamp: 1783264524840
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rcpptoml-0.2.3-r45hd601667_1.conda
+sha256: 0481dc92f2c896ce9e25ea69b53c8bfe7ddb76c6e3fc7baaf4cdda8351c385e5
+md5: f68ce5a7d961bf5047a1635c013d5ce2
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-rcpp >=0.11.5
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 229676
+timestamp: 1757491689154
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-registry-0.5_1-r45hc72bb7e_6.conda
+sha256: 68f01b65843f873b01bff24f61f27298667797aa3ad01d4406a62ae72e7c08c5
+md5: 1a99d6f9dfe5f6e8dc5275d49852cd66
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 208380
+timestamp: 1757507980343
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-renv-1.2.3-r45h0557e7b_0.conda
+sha256: 10a562d51e1c0286aeec2a9146e2038b809391bb1aa63700c9ccfb3362e9e372
+md5: 8dfb98a9c08d53deb71fc9f861aedefb
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 2469153
+timestamp: 1778972869359
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-reshape2-1.4.5-r45h08b74da_0.conda
+sha256: 963e97c3784e971a8f6a42efe7734123da1e5de0cea2cef876b0ffc46b303eed
+md5: 1f0843cf4a39b71ae3bb80d11c0d19f1
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-plyr >=1.8.1
+- r-rcpp
+- r-stringr
+license: MIT
+license_family: MIT
+size: 126686
+timestamp: 1762975693066
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.3.0-r45h08b74da_0.conda
+sha256: 074cbdc062065520aa129ac3390dd1dd2ac792a151c0a2441890290f2dc2351f
+md5: c41e2c86ee4633b25d88036ff33b1cdc
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1625093
+timestamp: 1783260250227
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rmarkdown-2.31-r45hc72bb7e_0.conda
+sha256: b3735a4e75eca023b24678251da041854b94a8b96588d81b605928d6ecf74f11
+md5: 25b9dbf0ff990b8b3111774878e3bb07
+depends:
+- pandoc >=1.14
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.2.5.1
+- r-evaluate >=0.13
+- r-fontawesome >=0.5.0
+- r-htmltools >=0.5.1
+- r-jquerylib
+- r-jsonlite
+- r-knitr >=1.43
+- r-tinytex >=0.31
+- r-xfun >=0.36
+- r-yaml >=2.1.19
+license: GPL-3.0-only
+license_family: GPL3
+size: 2085382
+timestamp: 1774555006202
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rsconnect-1.10.1-r45hc72bb7e_0.conda
+sha256: 5f9aa168f5c43f1d3ddbacc701370085fcead3956e2d5879af7fcd9e086a0a0b
+md5: 62f09532f225c86d27e954b36682add5
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-digest
+- r-httr2
+- r-jsonlite
+- r-lifecycle
+- r-openssl >=2.0.0
+- r-packrat >=0.6
+- r-pki
+- r-renv >=1.0.0
+- r-rlang >=1.0.0
+- r-rstudioapi >=0.5
+- r-snowflakeauth
+- r-yaml >=2.1.5
+license: GPL-2.0-only
+license_family: GPL2
+size: 830390
+timestamp: 1783503525234
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-rstudioapi-0.19.0-r45hc72bb7e_0.conda
+sha256: 896aeea3aa679a9dbd0277d10ef8dcfd011e45a1717129180a9877c1fd828f2a
+md5: 5f1b6b899fa3204ab77403e75b9df5fd
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 357140
+timestamp: 1781250782889
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-s7-0.2.2-r45hf488e41_0.conda
+sha256: 1c1be6985179ebd4eefbfc6939f014a4841e3a5b4738a667c0b1575f7bc2d1d1
+md5: 04cc16d1447a6e6cdaebe06e23d46d50
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 312811
+timestamp: 1776861400477
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sass-0.4.10-r45h08b74da_1.conda
+sha256: a318466958e737c4b214299b99974398e769961347cfad85c585e7bc7a959749
+md5: 6a543a95d37cfaa08a3f17dc3e46e8f6
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-fs
+- r-htmltools
+- r-r6
+- r-rappdirs
+- r-rlang
+license: MIT
+license_family: MIT
+size: 2245202
+timestamp: 1757464676590
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scales-1.4.0-r45hc72bb7e_1.conda
+sha256: 260c384e952e5bd4d2c2de77b9e09b24ff1c1f680acd917c4657ab8c9e4e9a2f
+md5: 8bc81cc6fd130cef963bc9e082726a14
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-farver >=2.0.0
+- r-labeling
+- r-lifecycle
+- r-munsell >=0.5
+- r-r6
+- r-rcolorbrewer
+- r-viridislite
+license: MIT
+license_family: MIT
+size: 777793
+timestamp: 1757487539496
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-scatterplot3d-0.3_45-r45h785f33e_0.conda
+sha256: bcde368cbf5a2c83b9c1fb8b3ba0722787af759f68d08bac6a82e966adbf999f
+md5: ba820689c02638c807f83e6ab5c53142
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-only
+license_family: GPL2
+size: 370745
+timestamp: 1771995271935
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-seriation-1.5.8-r45ha85219e_1.conda
+sha256: e59663a8f5dbd9c6748a353e508f49f85e99622d4adce539cd2b1aef21186624
+md5: 60eaa5984a3efa5d4a7cf167dfe18d75
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+- r-ca
+- r-cluster
+- r-colorspace
+- r-foreach
+- r-gclus
+- r-mass
+- r-qap
+- r-registry
+- r-tsp
+- r-vegan
+license: GPL-3.0-only
+license_family: GPL
+size: 1373552
+timestamp: 1757662510748
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
+sha256: ef0042ae1c3926ef9bee6c21cf761d7cf441eae61dceca7df143f3b9dc4c6f04
+md5: 2fb0e1ea59dd281487be303b1b7c6607
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-bslib >=0.6.0
+- r-cachem >=1.1.0
+- r-commonmark >=1.7
+- r-crayon
+- r-fastmap >=1.1.1
+- r-fontawesome >=0.4.0
+- r-glue >=1.3.2
+- r-htmltools >=0.5.4
+- r-httpuv >=1.5.2
+- r-jsonlite >=0.9.16
+- r-later >=1.0.0
+- r-lifecycle >=0.2.0
+- r-mime >=0.3
+- r-promises >=1.1.0
+- r-r6 >=2.0
+- r-rlang >=0.4.10
+- r-sourcetools
+- r-withr
+- r-xtable
+license: GPL-3.0-only
+license_family: GPL3
+size: 3789417
+timestamp: 1782070586086
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
+sha256: c3ea3d60226ed56e4a40b622b8e4721d257a9fb4ca8502ce89314f48a63a0090
+md5: b5da9b58b4f8137a7f2e14102bc230c9
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest
+- r-glue
+- r-shiny
+license: MIT
+license_family: MIT
+size: 344724
+timestamp: 1757870156008
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
+sha256: 9493d6cbf09850206f5904ccde65643de86bb9bd6add685548331c408e99610a
+md5: 3929f109451367912b4570480f4c572d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-digest >=0.6.8
+- r-jsonlite
+- r-shiny >=1.0.0
+license: MIT
+license_family: MIT
+size: 1018291
+timestamp: 1768513288077
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
+md5: 7382af8530d082191feb0c8da5f8a41b
+depends:
+- bioconductor-limma
+- bioconductor-summarizedexperiment
+- r-base >=4.5,<4.6.0a0
+- r-biocmanager
+- r-bslib >=0.9.0
+- r-cluster
+- r-dplyr
+- r-dt >=0.2
+- r-ggbeeswarm
+- r-ggdendro
+- r-ggplot2
+- r-heatmaply
+- r-htmltools
+- r-htmlwidgets
+- r-markdown
+- r-matrixstats
+- r-optparse
+- r-plotly >=4.8.0
+- r-rcolorbrewer
+- r-rsconnect
+- r-scatterplot3d
+- r-shiny >=1.7.0
+- r-shinycssloaders
+- r-shinyjs
+- r-viridislite
+- r-yaml
+license: AGPL-3.0
+license_family: AGPL
+size: 3448797
+timestamp: 1784579537432
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
+sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
+md5: 1d38994c8bfe421d621d9b3705c37b58
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-curl
+- r-jose
+- r-jsonlite
+- r-openssl
+- r-rcpptoml
+- r-rlang
+license: MIT
+license_family: MIT
+size: 76170
+timestamp: 1772133448445
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
+sha256: e0425d3fc2508397001a828f83de7b9057b26bf674f3ad031154c6d3ff737010
+md5: 6df66556d9813139f613a3d5d80aefa3
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 57378
+timestamp: 1774682311091
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
+sha256: 72aaa65e6c8aecf46e62493fd569d756ad5f655dfc35e8b65fb32f903e42fac3
+md5: 896cc6b4f51281019f0112a291f2e4b0
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 326784
+timestamp: 1779038275497
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.7-r45h1ddd0e6_2.conda
+sha256: 683aecd70c89afc99c9d1a5358502091d58c5515637839a174170b5270864473
+md5: f70959e59600d520abb4fc5eff09b6b7
+depends:
+- icu >=78.2,<79.0a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+license: FOSS
+license_family: OTHER
+size: 948766
+timestamp: 1772037526007
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.6.0-r45h785f33e_0.conda
+sha256: dea2a7676dd03ed93fa0ec961883c5075c361c8522659a1bc1e6b5c16525cb24
+md5: 8db438d8aa370726ee1ce8bf458f2e6d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 319328
+timestamp: 1762269757617
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sys-3.4.3-r45h0557e7b_1.conda
+sha256: 2615aa5617553d22835183a060a13b19a7fd6b006d5570d3dc7d4d0a9a18ffd1
+md5: 902062b1b024b2cf50bcebbdc3f14a33
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 51531
+timestamp: 1757441776397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.1-r45h0557e7b_0.conda
+sha256: 9ef8d3a7e5862ffe7921129d77c0e640eed11233c8c93c03ebbd38c5a7bdfc9b
+md5: 672f703f5dba8c08fe08bd5d6d462b81
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 591468
+timestamp: 1768139158745
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.2-r45h08b74da_0.conda
+sha256: cdceeab30bdc7648b9b037f884d91fafff5e3663b87a72cf9d6c4ee6e68e86d1
+md5: 0757fb6415a03dd46697bcbc836562b0
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127523
+timestamp: 1766142060375
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r45hc72bb7e_2.conda
+sha256: fca09d6b9940f1e1cda0425a0f55716bba202d6f55d6bd25fedec391006c7dc7
+md5: 15aa0f323385403fe182e46a1d095e1b
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 220192
+timestamp: 1757475791328
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tinytex-0.60-r45hc72bb7e_0.conda
+sha256: 1fad4d08756ca2d7db04cfaf88e9df797da95a5f7f4b8aabc165eee36faddafc
+md5: 5ee226c1449c66d1cd2399d942faa04d
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-xfun >=0.48
+license: MIT
+license_family: MIT
+size: 158240
+timestamp: 1782203211628
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tsp-1.2.7-r45hf488e41_0.conda
+sha256: 76b17a4cb143f1441fd91b78d1e05d537dc3fb21ae4c2b0a8247f032f249249d
+md5: d266cd3851cb11b2f619c80ff9adf6f5
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+- r-foreach
+license: GPL-3.0-only
+license_family: GPL3
+size: 737125
+timestamp: 1774391402905
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r45h0557e7b_1.conda
+sha256: c98cdf9a46680cf5e415e37c037cab774b8df2b9b3182f15ece4d740fc0c697b
+md5: a526af0f22a5ac7a3835f1710b63e5b5
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 152455
+timestamp: 1757424718278
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.7.3-r45h08b74da_0.conda
+sha256: 10235170aad63b8412ce99dd1756d250175cf5a3ea987379fea98f0bd9224e82
+md5: f43335c24a9f3fd0920d2a9e721f2845
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.5,<4.6.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1854267
+timestamp: 1775898029394
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vegan-2.7_5-r45ha2e3c6d_0.conda
+sha256: f114cf641e03f2d087d55b37f0826910bdd1e6481c1b18dbcf5d343b84178435
+md5: 5da6b73699a8bb6b0d8f60a9419983e8
+depends:
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- r-base >=4.5,<4.6.0a0
+- r-cluster
+- r-lattice
+- r-mass
+- r-mgcv
+- r-permute >=0.9_0
+license: GPL-2.0-only
+license_family: GPL2
+size: 3050073
+timestamp: 1779956718513
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-vipor-0.4.7-r45hc72bb7e_2.conda
+sha256: 859729e8cd04bb92ec144b21a8abfdb2bec9cbac9deaa41ba0cc2add13d088a0
+md5: e605ce527e381c5577d57649e393cb87
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 4508304
+timestamp: 1757669044129
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridis-0.6.5-r45hc72bb7e_2.conda
+sha256: 884896b59133b948646b0d1441106120f7b320e9fac827ccb9d44bbe80dda8f2
+md5: e841095941c40142bdad834299b95a30
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-ggplot2 >=1.0.1
+- r-gridextra
+- r-viridislite >=0.4.0
+license: MIT
+license_family: MIT
+size: 2988605
+timestamp: 1757516440048
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-viridislite-0.4.3-r45hc72bb7e_0.conda
+sha256: b9ec9606562f0f6bdefc237bbc6163eb1cb022f9d699c80771bc84af0ae37269
+md5: bcadc0a3726e2191e51449f67fa5e0a9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 1305542
+timestamp: 1770191459321
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-webshot-0.5.5-r45hc72bb7e_2.conda
+sha256: e79e366895dfdf79fe92986fe42d0695e3fcacc25411506c48b9db92742eb99c
+md5: e021e3d936f57ea9b35eb099999d6800
+depends:
+- r-base >=4.5,<4.6.0a0
+- r-callr
+- r-jsonlite
+- r-magrittr
+license: GPL-2.0-only
+license_family: GPL2
+size: 206060
+timestamp: 1757520337073
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.3-r45hc72bb7e_0.conda
+sha256: 56f318c90bfc74f01339c83f0e1d0817c1b762ea46cd9e527fec9dcf244c5900
+md5: 388d25e67f93a5fec2aebe56d6a0a1d9
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 235287
+timestamp: 1781856624720
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-xfun-0.60-r45hf488e41_0.conda
+sha256: adde9f62c5c7a48edd241547d778f4ff6016970ac4334f34977032394088f12f
+md5: ec03ae90ca44079179679287542be5af
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: MIT
+license_family: MIT
+size: 651144
+timestamp: 1784103302558
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-xtable-1.8_8-r45hc72bb7e_0.conda
+sha256: 972923364cfd616ccf38768477c435677cfe1ea18a72016f90344ea920e4fea5
+md5: e18fda0821f0fdc1c34276c5e0acdc92
+depends:
+- r-base >=4.5,<4.6.0a0
+license: GPL (>= 2)
+license_family: GPL3
+size: 744345
+timestamp: 1771859982217
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-yaml-2.3.12-r45h0557e7b_0.conda
+sha256: 85b3323f76adf8862ad3a52b42270425309a875983da261faa738ed9f7e52586
+md5: 9885e008c928a67e48cd521a98f666d4
+depends:
+- libgcc >=14
+- r-base >=4.5,<4.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 128431
+timestamp: 1765372892689
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+sha256: fe695f9d215e9a2e3dd0ca7f56435ab4df24f5504b83865e3d295df36e88d216
+md5: 3d49cad61f829f4f0e0611547a9cda12
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 357597
+timestamp: 1765815673644
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+sha256: 7b2d9835a79bd67c0b2966cedf246c85bf650dc961125c8e31f073646d4ac797
+md5: 59f2c90c66b956d9bc3e625df3ad8a0a
+depends:
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 288685
+timestamp: 1776861726084
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+sha256: 1bd2db6b2e451247bab103e4a0128cf6c7595dd72cb26d70f7fadd9edd1d1bc3
+md5: fdf07ab944a222ff28c754914fdb0740
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-aarch64 4.18.0 h05a177a_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 23644746
+timestamp: 1765578629426
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5cf4473_3.conda
+build_number: 103
+sha256: cd51fbda051a9f3679d10ef4a94cd1ff38c10533b82845dadce8ba87245ba4ce
+md5: 89e78452e06563964e419059ee45584a
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3683040
+timestamp: 1784229053797
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h5f05d98_8.conda
+sha256: 06e25e5026e0058a085be2cbcc55e7ef8cda1263c15bc7e72525c0eb8bb44d5e
+md5: 40266bd074925af4a396250d222d2188
+depends:
+- tk
+- libgcc >=14
+- tk >=8.6.13,<8.7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 106646
+timestamp: 1773733124596
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+sha256: 720691eb59b86f11ceb21b236b9402d59c47d156183375d2b24c53a201dd874b
+md5: 6dc4b55fc391a3d51ff12a6fed979562
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 40249
+timestamp: 1779439555623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+sha256: a2ba1864403c7eb4194dacbfe2777acf3d596feae43aada8d1b478617ce45031
+md5: c8d8ec3e00cd0fd8a231789b91a7c5b7
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 60433
+timestamp: 1734229908988
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+sha256: b86a819cd16f90c01d9d81892155126d01555a20dabd5f3091da59d6309afd0a
+md5: 2d1409c50882819cb1af2de82e2b7208
+depends:
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 28701
+timestamp: 1741897678254
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
+sha256: cf886160e2ff580d77f7eb8ec1a77c41c2c5b05343e329bc35f0ddf40b8d92ab
+md5: 22dd10425ef181e80e130db50675d615
+depends:
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 869058
+timestamp: 1770819244991
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_1.conda
+sha256: e9f6e931feeb2f40e1fdbafe41d3b665f1ab6cb39c5880a1fcf9f79a3f3c84a5
+md5: 1c246e1105000c3660558459e2fd6d43
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 16317
+timestamp: 1762977521691
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_1.conda
+sha256: 128d72f36bcc8d2b4cdbec07507542e437c7d67f677b7d77b71ed9eeac7d6df1
+md5: bff06dcde4a707339d66d45d96ceb2e2
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 21039
+timestamp: 1762979038025
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.7-he30d5cf_0.conda
+sha256: db2188bc0d844d4e9747bac7f6c1d067e390bd769c5ad897c93f1df759dc5dba
+md5: fb42b683034619915863d68dd9df03a3
+depends:
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+license: MIT
+license_family: MIT
+size: 52409
+timestamp: 1769446753771
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.12-h86ecc28_0.conda
+sha256: ffd77ee860c9635a28cfda46163dcfe9224dc6248c62404c544ae6b564a0be1f
+md5: ae2c2dd0e2d38d249887727db2af960e
+depends:
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+license: MIT
+license_family: MIT
+size: 33649
+timestamp: 1734229123157
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+sha256: 7c109792b60720809a580612aba7f8eb2a0bd425b9fc078748a9d6ffc97cbfa8
+md5: a9e4852c8e0b68ee783e7240030b696f
+depends:
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.9,<2.0a0
+license: MIT
+license_family: MIT
+size: 384752
+timestamp: 1731860572314
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+sha256: 569990cf12e46f9df540275146da567d9c618c1e9c7a0bc9d9cfefadaed20b75
+md5: c3655f82dcea2aa179b291e7099c1fcc
+depends:
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 614429
+timestamp: 1764777145593

--- a/modules/nf-core/shinyngs/validatefomcomponents/environment.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=2.4.0
+  - bioconda::r-shinyngs=3.1.1

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -3,9 +3,9 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d7/d782b4f11adf8f3cad6af74ea585468decd873a171da1dae0e4a24a82bb29020/data' :
-        'community.wave.seqera.io/library/r-shinyngs:2.4.0--709fc6932be670a5' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d'}"
 
     input:
     tuple val(meta),  path(sample), path(assay_files)

--- a/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
@@ -1,6 +1,5 @@
 name: "shinyngs_validatefomcomponents"
-description: validate consistency of feature and sample annotations with matrices
-  and contrasts
+description: validate consistency of feature and sample annotations with matrices and contrasts
 keywords:
   - expression
   - features
@@ -8,8 +7,7 @@ keywords:
   - validation
 tools:
   - "shinyngs":
-      description: "Provides Shiny applications for various array and NGS applications.
-        Currently very RNA-seq centric, with plans for expansion."
+      description: "Provides Shiny applications for various array and NGS applications. Currently very RNA-seq centric, with plans for expansion."
       homepage: "https://github.com/pinin4fjords/shinyngs"
       documentation: "https://rawgit.com/pinin4fjords/shinyngs/master/vignettes/shinyngs.html"
       tool_dev_url: "https://github.com/pinin4fjords/shinyngs"
@@ -127,3 +125,27 @@ authors:
   - "@pinin4fjords"
 maintainers:
   - "@pinin4fjords"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d
+      build_id: bd-b5595b301bfbfd4d_2
+      scan_id: sc-73b4cbdd1930464e_1
+    linux/arm64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--4d71a4d10942e43f
+      build_id: bd-4d71a4d10942e43f_2
+      scan_id: sc-72596f6b93ff3200_1
+  singularity:
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--60831a2d7cd7ae94
+      build_id: bd-60831a2d7cd7ae94_2
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6fff209824ab2042c6f09b68d257d59ae4e0ea7410dad923089db9c5c0dbd683/data
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--791778d7e2758322
+      build_id: bd-791778d7e2758322_2
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data
+  conda:
+    linux/amd64:
+      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+    linux/arm64:
+      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt

--- a/modules/nf-core/shinyngs/validatefomcomponents/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/validatefomcomponents/tests/main.nf.test.snap
@@ -38,7 +38,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ],
                 "assays": [
@@ -77,16 +77,16 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:23:44.917738684",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:51:30.322038"
     },
     "stub": {
         "content": [
@@ -127,7 +127,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ],
                 "assays": [
@@ -166,16 +166,16 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-12T17:51:50.819361",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:54:06.396638"
     },
     "test_yaml": {
         "content": [
@@ -216,7 +216,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ],
                 "assays": [
@@ -255,15 +255,15 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "2.4.0"
+                        "3.1.1"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-04-16T19:24:04.83911964",
         "meta": {
-            "nf-test": "0.9.4",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-07-20T23:53:15.603678"
     }
 }


### PR DESCRIPTION
## Summary

- Bumps all 4 `shinyngs` modules (`app`, `staticdifferential`, `staticexploratory`, `validatefomcomponents`) from `r-shinyngs` 2.4.0 to 3.1.1.
- Built multi-arch (linux/amd64, linux/arm64) Wave containers for the new environment using the new `nf-core/tools` dev `modules containers create` command, and added the resulting `containers:` metadata block plus `.conda-lock/` files to each module's `meta.yml`, following the existing `fastqc`/`multiqc` precedent.
- Fixed the `staticdifferential` test's `--unlog_foldchanges` invocation: it's a boolean `store_true` flag and doesn't take a value, so it's now only passed as a bare flag when the corresponding param is true.
- Updated snapshots: every diff is the `2.4.0` -> `3.1.1` version string (plus the `app.R` content hash for `shinyngs/app`, since `make_app_from_files.R`'s generated app bundle differs slightly between versions).

## Test plan

- [x] `nf-core modules lint` on all 4 modules: 0 failed (the 2 pre-existing warnings, `container_links` 404 and `main_nf_container` version mismatch, are stable-linter limitations with Wave containers - also present on the already-merged `multiqc` module)
- [x] `nf-test --profile docker` for all 4 modules: all pass
- [x] Verified the actual regression this bump depended on - a crash in the MAD/outlier plot whenever `--write_html` is used - is fixed upstream in [pinin4fjords/shinyngs#268](https://github.com/pinin4fjords/shinyngs/pull/268) (released as 3.1.1)