### PR TITLE
Add new component: gridss/call

### DIFF
--- a/modules/nf-core/gridss/call/environment.yml
+++ b/modules/nf-core/gridss/call/environment.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::gridss=2.13.2

--- a/modules/nf-core/gridss/call/main.nf
+++ b/modules/nf-core/gridss/call/main.nf
@@ -1,0 +1,56 @@
+process GRIDSS_CALL {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gridss:2.13.2--h50ea8bc_3':
+        'quay.io/biocontainers/gridss:2.13.2--h50ea8bc_3' }"
+
+    input:
+    tuple val(meta), path(bams), path(bais), path(preprocess_dir), path(assemble_dir), path(assemble_bam)
+    tuple val(meta2), path(fasta), path(fasta_fai), path(bwa_index)
+    tuple val(meta3), path(gridss_config)
+
+    output:
+    tuple val(meta), path("*.sv.gridss.vcf.gz"),  emit: vcf
+    tuple val("${task.process}"), val('gridss'), eval("CallVariants --version 2>&1 | sed 's/-gridss\$//'")  , topic: versions, emit: versions_gridss
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def arg_config = gridss_config ? "-c ${gridss_config}" : ""
+    def bams_list = bams instanceof List ? bams : [bams]
+
+    """
+    # GRIDSS requires all BWA index files to have the exact
+    # same basename as the reference fasta. This is a hard
+    # requirement of the tool - it will fail to find indices otherwise.
+    index_files=(\$(find -L "${bwa_index}" -regex '.*\\.\\(amb\\|ann\\|pac\\|gridsscache\\|sa\\|bwt\\|img\\|alt\\)\$'))
+
+    for index_file in "\${index_files[@]}"; do
+        ln -sf "\$index_file" "./${fasta}.\${index_file##*.}"
+    done
+
+    gridss ${args} \\
+        --jvmheap ${Math.round(task.memory.bytes * 0.95)} \\
+        --steps call \\
+        --reference ${fasta} \\
+        --workingdir  "." \\
+        --assembly ${assemble_bam} \\
+        --output ${prefix}.sv.gridss.vcf.gz \\
+        --threads ${task.cpus} ${arg_config} ${bams_list.join(' ')}
+
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    touch ${prefix}.sv.gridss.vcf.gz
+    """
+}

--- a/modules/nf-core/gridss/call/main.nf
+++ b/modules/nf-core/gridss/call/main.nf
@@ -8,7 +8,7 @@ process GRIDSS_CALL {
         'quay.io/biocontainers/gridss:2.13.2--h50ea8bc_3' }"
 
     input:
-    tuple val(meta), path(bams), path(bais), path(preprocess_dir), path(assemble_dir), path(assemble_bam)
+    tuple val(meta), path(bam), path(bai), path(preprocess_dir), path(assemble_dir), path(assemble_bam)
     tuple val(meta2), path(fasta), path(fasta_fai), path(bwa_index)
     tuple val(meta3), path(gridss_config)
 
@@ -23,17 +23,13 @@ process GRIDSS_CALL {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def arg_config = gridss_config ? "-c ${gridss_config}" : ""
-    def bams_list = bams instanceof List ? bams : [bams]
+    def bam_list = bam instanceof List ? bam : [bam]
 
+    def index_files = bwa_index instanceof List ? bwa_index : [bwa_index]
+	// GRIDSS requires all BWA index files to have the exact same basename as the reference fasta
+	def link_cmds = index_files.collect { idx -> "ln -sf ${idx} ./${fasta}.${idx.extension}" }.join('\n')
     """
-    # GRIDSS requires all BWA index files to have the exact
-    # same basename as the reference fasta. This is a hard
-    # requirement of the tool - it will fail to find indices otherwise.
-    index_files=(\$(find -L "${bwa_index}" -regex '.*\\.\\(amb\\|ann\\|pac\\|gridsscache\\|sa\\|bwt\\|img\\|alt\\)\$'))
-
-    for index_file in "\${index_files[@]}"; do
-        ln -sf "\$index_file" "./${fasta}.\${index_file##*.}"
-    done
+    ${link_cmds}
 
     gridss ${args} \\
         --jvmheap ${Math.round(task.memory.bytes * 0.95)} \\
@@ -42,7 +38,7 @@ process GRIDSS_CALL {
         --workingdir  "." \\
         --assembly ${assemble_bam} \\
         --output ${prefix}.sv.gridss.vcf.gz \\
-        --threads ${task.cpus} ${arg_config} ${bams_list.join(' ')}
+        --threads ${task.cpus} ${arg_config} ${bam_list.join(' ')}
 
     """
 
@@ -51,6 +47,6 @@ process GRIDSS_CALL {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    touch ${prefix}.sv.gridss.vcf.gz
+    echo "" | gzip > ${prefix}.sv.gridss.vcf.gz
     """
 }

--- a/modules/nf-core/gridss/call/meta.yml
+++ b/modules/nf-core/gridss/call/meta.yml
@@ -1,0 +1,116 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "gridss_call"
+description: Run the GRIDSS variant calling step to identify structural variants
+  from pre-processed and assembled alignments.
+keywords:
+  - gridss
+  - structural variants
+  - variant calling
+  - bam
+  - vcf
+tools:
+  - "gridss":
+      description: "GRIDSS: the Genomic Rearrangement IDentification Software Suite"
+      homepage: "https://github.com/PapenfussLab/gridss/wiki/GRIDSS-Documentation"
+      documentation: "https://github.com/PapenfussLab/gridss/wiki/GRIDSS-Documentation"
+      tool_dev_url: "https://github.com/PapenfussLab/gridss"
+      doi: "10.1186/s13059-021-02423-x"
+      licence: ["GPL v3"]
+      identifier: biotools:gridss
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test' ]`
+    - bams:
+        type: file
+        description: One or more input BAM file(s)
+        pattern: "*.{bam}"
+        ontologies:
+          - edam: http://edamontology.org/data_1383 # Sequence alignment (nucleic acid)
+          - edam: http://edamontology.org/format_2572 # BAM
+    - bais:
+        type: file
+        description: Index file(s) for the input BAM file(s)
+        pattern: "*.{bai}"
+        ontologies: []
+    - preprocess_dir:
+        type: directory
+        description: Working directory containing the output of the GRIDSS preprocess step
+    - assemble_dir:
+        type: directory
+        description: Working directory containing the output of the GRIDSS assemble step
+    - assemble_bam:
+        type: file
+        description: The assembly BAM file created by the GRIDSS assemble step
+        pattern: "*.{bam}"
+        ontologies:
+          - edam: http://edamontology.org/data_1383 # Sequence alignment (nucleic acid)
+          - edam: http://edamontology.org/format_2572 # BAM
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. `[ id:'genome' ]`
+    - fasta:
+        type: file
+        description: The reference fasta
+        pattern: "*.{fa,fna,fasta}"
+        ontologies: []
+    - fasta_fai:
+        type: file
+        description: The index of the reference fasta
+        pattern: "*.fai"
+        ontologies: []
+    - bwa_index:
+        type: directory
+        description: The BWA index created from the reference fasta
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test' ]`
+    - gridss_config:
+        type: file
+        description: OPTIONAL - A GRIDSS configuration file
+
+output:
+  vcf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test' ]`
+      - "*.sv.gridss.vcf.gz":
+          type: file
+          description: The called VCF file created by the GRIDSS call step
+          pattern: "*.sv.gridss.vcf.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  versions_gridss:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gridss:
+          type: string
+          description: The name of the tool
+      - CallVariants --version 2>&1 | sed 's/-gridss$//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gridss:
+          type: string
+          description: The name of the tool
+      - CallVariants --version 2>&1 | sed 's/-gridss$//':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@imsarath"
+maintainers:
+  - "@imsarath"

--- a/modules/nf-core/gridss/call/meta.yml
+++ b/modules/nf-core/gridss/call/meta.yml
@@ -36,11 +36,11 @@ input:
         ontologies: []
     - preprocess_dir:
         type: directory
-        description: Working directory containing the output of the GRIDSS
+        description: Working directory containing the output of the GRIDSS preprocess step
           preprocess step
     - assemble_dir:
         type: directory
-        description: Working directory containing the output of the GRIDSS
+        description: Working directory containing the output of the GRIDSS assemble step
           assemble step
     - assemble_bam:
         type: file
@@ -74,7 +74,9 @@ input:
           e.g. `[ id:'test' ]`
     - gridss_config:
         type: file
-        description: OPTIONAL - A GRIDSS configuration file
+        description: OPTIONAL - A GRIDSS configuration file (Java .properties format).
+          See the default config for available settings,
+          https://github.com/PapenfussLab/gridss/blob/825bc8e1bb092e9bb2ccb0c1c51dc6e7e1a922dd/src/main/resources/gridss.properties
         ontologies: []
 output:
   vcf:

--- a/modules/nf-core/gridss/call/meta.yml
+++ b/modules/nf-core/gridss/call/meta.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "gridss_call"
 description: Run the GRIDSS variant calling step to identify structural variants
   from pre-processed and assembled alignments.
@@ -15,40 +14,41 @@ tools:
       documentation: "https://github.com/PapenfussLab/gridss/wiki/GRIDSS-Documentation"
       tool_dev_url: "https://github.com/PapenfussLab/gridss"
       doi: "10.1186/s13059-021-02423-x"
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: biotools:gridss
-
 input:
   - - meta:
         type: map
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'test' ]`
-    - bams:
+    - bam:
         type: file
-        description: One or more input BAM file(s)
-        pattern: "*.{bam}"
+        description: Input BAM file(s)
+        pattern: "*.bam"
         ontologies:
-          - edam: http://edamontology.org/data_1383 # Sequence alignment (nucleic acid)
-          - edam: http://edamontology.org/format_2572 # BAM
-    - bais:
+          - edam: http://edamontology.org/format_2572
+    - bai:
         type: file
-        description: Index file(s) for the input BAM file(s)
-        pattern: "*.{bai}"
+        description: BAM index file(s)
+        pattern: "*.bam.bai"
         ontologies: []
     - preprocess_dir:
         type: directory
-        description: Working directory containing the output of the GRIDSS preprocess step
+        description: Working directory containing the output of the GRIDSS
+          preprocess step
     - assemble_dir:
         type: directory
-        description: Working directory containing the output of the GRIDSS assemble step
+        description: Working directory containing the output of the GRIDSS
+          assemble step
     - assemble_bam:
         type: file
         description: The assembly BAM file created by the GRIDSS assemble step
         pattern: "*.{bam}"
         ontologies:
-          - edam: http://edamontology.org/data_1383 # Sequence alignment (nucleic acid)
-          - edam: http://edamontology.org/format_2572 # BAM
+          - edam: http://edamontology.org/data_1383
+          - edam: http://edamontology.org/format_2572
   - - meta2:
         type: map
         description: |
@@ -75,7 +75,7 @@ input:
     - gridss_config:
         type: file
         description: OPTIONAL - A GRIDSS configuration file
-
+        ontologies: []
 output:
   vcf:
     - - meta:
@@ -88,7 +88,7 @@ output:
           description: The called VCF file created by the GRIDSS call step
           pattern: "*.sv.gridss.vcf.gz"
           ontologies:
-            - edam: http://edamontology.org/format_3989 # GZIP format
+            - edam: http://edamontology.org/format_3989
   versions_gridss:
     - - ${task.process}:
           type: string
@@ -96,7 +96,7 @@ output:
       - gridss:
           type: string
           description: The name of the tool
-      - CallVariants --version 2>&1 | sed 's/-gridss$//':
+      - CallVariants --version 2>&1 | sed 's/-gridss\$//':
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -107,7 +107,7 @@ topics:
       - gridss:
           type: string
           description: The name of the tool
-      - CallVariants --version 2>&1 | sed 's/-gridss$//':
+      - CallVariants --version 2>&1 | sed 's/-gridss\$//':
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/gridss/call/tests/main.nf.test
+++ b/modules/nf-core/gridss/call/tests/main.nf.test
@@ -1,0 +1,135 @@
+nextflow_process {
+
+    name "Test Process GRIDSS_CALL"
+    script "../main.nf"
+    process "GRIDSS_CALL"
+
+    tag "modules"
+    tag "modules_local"
+    tag "gridss"
+    tag "gridss/call"
+
+    setup {
+        run("BWA_INDEX") {
+            script "../../../bwa/index/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id: 'fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        run("GRIDSS_PREPROCESS") {
+            script "../../preprocess/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ]
+                input[1] = channel.of([
+                    [id:'fasta'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]).join(BWA_INDEX.out.index)
+                """
+            }
+        }
+
+        // run("GRIDSS_ASSEMBLE") {
+        //     script "../../assemble/main.nf"
+        //     process {
+        //         """
+        //         input[0] = channel.of([
+        //             [ id:'test' ],
+        //             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+        //             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+        //         ]).join(GRIDSS_PREPROCESS.out.preprocess_dir)
+        //         input[1] = channel.of([
+        //             [id:'fasta'],
+        //             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+        //             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+        //         ]).join(BWA_INDEX.out.index)
+        //         input[2] = channel.of([
+        //             [ id: 'gridss_config' ],
+        //             file(params.modules_testdata_base_path + 'test-data/reference/GRCh37/gridss/gridss.properties', checkIfExists: true)
+        //         ])
+        //         """
+        //     }
+        // }
+    }
+
+    // test("human - bam") {
+
+    //     when {
+    //         process {
+    //             """
+    //             input[0] = channel.of([
+    //                 [ id:'test' ],
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+    //             ]).join(GRIDSS_PREPROCESS.out.preprocess_dir)
+    //             input[1] = channel.of([
+    //                 [id:'fasta'],
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+    //             ]).join(BWA_INDEX.out.index)
+    //             input[2] = channel.of([
+    //                 [ id: 'gridss_config' ],
+    //                 file(params.modules_testdata_base_path + 'test-data/reference/GRCh37/gridss/gridss.properties', checkIfExists: true)
+    //             ])
+    //             """
+    //         }
+    //     }
+
+    //     then {
+    //         assertAll(
+    //             { assert process.success },
+    //             { assert snapshot(
+    //                 process.out.assemble_dir.collect { meta, working, assembly ->
+    //                     [meta, file(working).list().sort(), file(assembly).name]
+    //                 },
+    //                 process.out.findAll { key, val -> key.startsWith("versions") }
+    //             ).match() }
+    //         )
+    //     }
+    // }
+
+    test("human - bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ]).join(GRIDSS_PREPROCESS.out.preprocess_dir).join(GRIDSS_ASSEMBLE.out.assembly)
+                input[1] = channel.of([
+                    [id:'fasta'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]).join(BWA_INDEX.out.index)
+                input[2] = channel.of([
+                    [ id: 'gridss_config' ],
+                    file(params.modules_testdata_base_path + 'test-data/reference/GRCh37/gridss/gridss.properties', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/gridss/call/tests/main.nf.test
+++ b/modules/nf-core/gridss/call/tests/main.nf.test
@@ -5,8 +5,11 @@ nextflow_process {
     process "GRIDSS_CALL"
 
     tag "modules"
-    tag "modules_local"
+    tag "modules_nfcore"
+    tag "bwa/index"
     tag "gridss"
+    tag "gridss/preprocess"
+    tag "gridss/assemble"
     tag "gridss/call"
 
     setup {
@@ -40,64 +43,62 @@ nextflow_process {
             }
         }
 
-        // run("GRIDSS_ASSEMBLE") {
-        //     script "../../assemble/main.nf"
-        //     process {
-        //         """
-        //         input[0] = channel.of([
-        //             [ id:'test' ],
-        //             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
-        //             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
-        //         ]).join(GRIDSS_PREPROCESS.out.preprocess_dir)
-        //         input[1] = channel.of([
-        //             [id:'fasta'],
-        //             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-        //             file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
-        //         ]).join(BWA_INDEX.out.index)
-        //         input[2] = channel.of([
-        //             [ id: 'gridss_config' ],
-        //             file(params.modules_testdata_base_path + 'test-data/reference/GRCh37/gridss/gridss.properties', checkIfExists: true)
-        //         ])
-        //         """
-        //     }
-        // }
+        run("GRIDSS_ASSEMBLE") {
+            script "../../assemble/main.nf"
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ]).join(GRIDSS_PREPROCESS.out.preprocess_dir)
+                input[1] = channel.of([
+                    [id:'fasta'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]).join(BWA_INDEX.out.index)
+                input[2] = channel.of([
+                    [ id: 'gridss_config' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gridss/gridss.properties', checkIfExists: true)
+                ])
+                """
+            }
+        }
     }
 
-    // test("human - bam") {
+    test("human - bam") {
 
-    //     when {
-    //         process {
-    //             """
-    //             input[0] = channel.of([
-    //                 [ id:'test' ],
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
-    //             ]).join(GRIDSS_PREPROCESS.out.preprocess_dir)
-    //             input[1] = channel.of([
-    //                 [id:'fasta'],
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
-    //                 file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
-    //             ]).join(BWA_INDEX.out.index)
-    //             input[2] = channel.of([
-    //                 [ id: 'gridss_config' ],
-    //                 file(params.modules_testdata_base_path + 'test-data/reference/GRCh37/gridss/gridss.properties', checkIfExists: true)
-    //             ])
-    //             """
-    //         }
-    //     }
+        when {
+            process {
+                """
+                input[0] = channel.of([
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ]).join(GRIDSS_PREPROCESS.out.preprocess_dir).join(GRIDSS_ASSEMBLE.out.assemble_dir)
+                input[1] = channel.of([
+                    [id:'fasta'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]).join(BWA_INDEX.out.index)
+                input[2] = channel.of([
+                    [ id: 'gridss_config' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gridss/gridss.properties', checkIfExists: true)
+                ])
+                """
+            }
+        }
 
-    //     then {
-    //         assertAll(
-    //             { assert process.success },
-    //             { assert snapshot(
-    //                 process.out.assemble_dir.collect { meta, working, assembly ->
-    //                     [meta, file(working).list().sort(), file(assembly).name]
-    //                 },
-    //                 process.out.findAll { key, val -> key.startsWith("versions") }
-    //             ).match() }
-    //         )
-    //     }
-    // }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    path(process.out.vcf[0][1]).vcf.summary,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
 
     test("human - bam - stub") {
 
@@ -110,7 +111,7 @@ nextflow_process {
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
-                ]).join(GRIDSS_PREPROCESS.out.preprocess_dir).join(GRIDSS_ASSEMBLE.out.assembly)
+                ]).join(GRIDSS_PREPROCESS.out.preprocess_dir).join(GRIDSS_ASSEMBLE.out.assemble_dir)
                 input[1] = channel.of([
                     [id:'fasta'],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
@@ -118,7 +119,7 @@ nextflow_process {
                 ]).join(BWA_INDEX.out.index)
                 input[2] = channel.of([
                     [ id: 'gridss_config' ],
-                    file(params.modules_testdata_base_path + 'test-data/reference/GRCh37/gridss/gridss.properties', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/gridss/gridss.properties', checkIfExists: true)
                 ])
                 """
             }

--- a/modules/nf-core/gridss/call/tests/main.nf.test.snap
+++ b/modules/nf-core/gridss/call/tests/main.nf.test.snap
@@ -1,0 +1,47 @@
+{
+    "human - bam - stub": {
+        "content": [
+            {
+                "vcf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sv.gridss.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_gridss": [
+                    [
+                        "GRIDSS_CALL",
+                        "gridss",
+                        "2.13.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-27T11:40:58.652323404",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.3"
+        }
+    },
+    "human - bam": {
+        "content": [
+            "VcfFile [chromosomes=[], sampleCount=1, variantCount=0, phased=true, phasedAutodetect=true]",
+            {
+                "versions_gridss": [
+                    [
+                        "GRIDSS_CALL",
+                        "gridss",
+                        "2.13.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-27T11:40:40.343197386",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "26.04.3"
+        }
+    }
+}


### PR DESCRIPTION
As part of the distributed computing GRIDSS subworkflow #4498, I added this gridss/call module. This module wraps the variant-calling step: it takes the per-sample preprocessed data and the assembly BAM (along with the input BAM/BAI files and reference genome), calls structural variants across the genome, and produces the final *.sv.gridss.vcf.gz.

## PR checklist

Closes #4503

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
