### PR TITLE
bump default CPU and memory to use the full runner resources

### DIFF
--- a/modules/nf-core/gapseq/doall/tests/nextflow.config
+++ b/modules/nf-core/gapseq/doall/tests/nextflow.config
@@ -4,7 +4,6 @@ singularity {
 
 process {
     withName: GAPSEQ_DOALL {
-        cpus = 4
         ext.args = '-A diamond -O'
     }
 }

--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -11,8 +11,8 @@ aws.client.anonymous = true
 nextflow.enable.strict = true
 
 process {
-    cpus   = 2
-    memory = '4.GB'
+    cpus   = 4
+    memory = '15.GB'
     time   = '2.h'
 }
 


### PR DESCRIPTION
This was set back when GitHub runners only had 2 CPUs, I guess.

Discovered in #12385