### PR TITLE
Update Parabricks modules to version 4.7.1

### DIFF
--- a/modules/nf-core/parabricks/README.md
+++ b/modules/nf-core/parabricks/README.md
@@ -4,7 +4,7 @@ These nf-core modules implement functionality of the NVIDIA Parabricks software 
 
 ## General considerations
 
-Parabricks is available only through a docker container: `nvcr.io/nvidia/clara/clara-parabricks:4.6.0-1`. The main entrypoint to the Parabricks is the command line program `pbrun`, which calls several sub-programs within the container. The Parabricks authors combined several common patterns into a single tool, such as `fq2bam` performing alignment, sorting, mark duplicates, and base quality score recalibration, all within a single command. Generally, the tools can be used for only a subset of the entire functionality as well.
+Parabricks is available only through a docker container: `nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1`. The main entrypoint to the Parabricks is the command line program `pbrun`, which calls several sub-programs within the container. The Parabricks authors combined several common patterns into a single tool, such as `fq2bam` performing alignment, sorting, mark duplicates, and base quality score recalibration, all within a single command. Generally, the tools can be used for only a subset of the entire functionality as well.
 
 ## Hardware Requirements
 

--- a/modules/nf-core/parabricks/applybqsr/main.nf
+++ b/modules/nf-core/parabricks/applybqsr/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_APPLYBQSR {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta),  path(bam)

--- a/modules/nf-core/parabricks/applybqsr/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/applybqsr/tests/main.nf.test.snap
@@ -22,7 +22,7 @@
                     [
                         "PARABRICKS_APPLYBQSR",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -45,7 +45,7 @@
                     [
                         "PARABRICKS_APPLYBQSR",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -65,7 +65,7 @@
                     [
                         "PARABRICKS_APPLYBQSR",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -99,7 +99,7 @@
                     [
                         "PARABRICKS_APPLYBQSR",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -122,7 +122,7 @@
                     [
                         "PARABRICKS_APPLYBQSR",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -142,7 +142,7 @@
                     [
                         "PARABRICKS_APPLYBQSR",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -162,7 +162,7 @@
                     [
                         "PARABRICKS_APPLYBQSR",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }

--- a/modules/nf-core/parabricks/dbsnp/main.nf
+++ b/modules/nf-core/parabricks/dbsnp/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_DBSNP {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta), path(vcf_file), path(dbsnp_file), path(tabix_file)

--- a/modules/nf-core/parabricks/dbsnp/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/dbsnp/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                     [
                         "PARABRICKS_DBSNP",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -31,17 +31,17 @@
                     ]
                 ],
                 "1": [
-                    "compatible_versions.yml:md5,a1244a714c4fcc3ce041e8672bbf2c27"
+                    "compatible_versions.yml:md5,ebf34ae33fe5f95a0797339c7b7af4e1"
                 ],
                 "2": [
                     [
                         "PARABRICKS_DBSNP",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,a1244a714c4fcc3ce041e8672bbf2c27"
+                    "compatible_versions.yml:md5,ebf34ae33fe5f95a0797339c7b7af4e1"
                 ],
                 "vcf": [
                     [
@@ -56,13 +56,13 @@
                     [
                         "PARABRICKS_DBSNP",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
             {
                 "PARABRICKS_DBSNP": {
-                    "pbrun_version": "4.7.0-1",
+                    "pbrun_version": "4.7.1-1",
                     "compatible_with": {
                         "GATK:": "4.3.0.0"
                     }
@@ -73,6 +73,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T07:55:49.545889511"
+        "timestamp": "2026-07-22T13:54:04.606322563"
     }
 }

--- a/modules/nf-core/parabricks/deepvariant/main.nf
+++ b/modules/nf-core/parabricks/deepvariant/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_DEEPVARIANT {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)

--- a/modules/nf-core/parabricks/deepvariant/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/deepvariant/tests/main.nf.test.snap
@@ -109,7 +109,7 @@
                     [
                         "PARABRICKS_DEEPVARIANT",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -135,17 +135,17 @@
                     
                 ],
                 "2": [
-                    "compatible_versions.yml:md5,dbd6540b88f488accb37d270fa4b6bd1"
+                    "compatible_versions.yml:md5,68b2cf8e6a93e78f1abb7487b94c60b8"
                 ],
                 "3": [
                     [
                         "PARABRICKS_DEEPVARIANT",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,dbd6540b88f488accb37d270fa4b6bd1"
+                    "compatible_versions.yml:md5,68b2cf8e6a93e78f1abb7487b94c60b8"
                 ],
                 "gvcf": [
                     
@@ -162,13 +162,13 @@
                     [
                         "PARABRICKS_DEEPVARIANT",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
             {
                 "PARABRICKS_DEEPVARIANT": {
-                    "pbrun_version": "4.7.0-1",
+                    "pbrun_version": "4.7.1-1",
                     "compatible_with": {
                         "DeepVariant:": "1.9.0"
                     }
@@ -179,110 +179,110 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T07:57:11.632600274"
+        "timestamp": "2026-07-22T13:55:20.9987153"
     },
     "human - bam - intervals": {
         "content": [
             [
                 "chr21\t6118303\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:12:10,2:0.166667:0,15,22",
                 "chr21\t6118347\t.\tG\tT\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:12:11:9,2:0.181818:0,12,19",
-                "chr21\t6118556\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:8:6,2:0.25:0,17,21",
-                "chr21\t6118720\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:7:5,2:0.285714:0,17,22",
+                "chr21\t6118556\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:8:6,2:0.25:small_model:0,25,25",
+                "chr21\t6118720\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:7:5,2:0.285714:small_model:0,25,23",
                 "chr21\t6120003\t.\tT\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:14:12,2:0.142857:0,17,23",
                 "chr21\t6120024\t.\tT\tA\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:12:13:11,2:0.153846:0,12,20",
                 "chr21\t6120030\t.\tC\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:13:11,2:0.153846:0,21,24",
                 "chr21\t6120072\t.\tA\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:8:6,2:0.25:0,21,22",
-                "chr21\t6120881\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:12:10,2:0.166667:0,24,24",
+                "chr21\t6120881\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:57:12:10,2:0.166667:small_model:0,57,64",
                 "chr21\t6120947\t.\tC\tA\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:11:7:5,2:0.285714:0,11,21",
-                "chr21\t6120949\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:7:5,2:0.285714:0,21,23",
-                "chr21\t6121084\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:18:15,3:0.166667:0,16,21",
+                "chr21\t6120949\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:20:7:5,2:0.285714:small_model:0,21,26",
+                "chr21\t6121084\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:29:18:15,3:0.166667:small_model:0,31,31",
                 "chr21\t6121094\t.\tC\tA\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:13:10:8,2:0.2:0,14,17",
-                "chr21\t6121559\t.\tG\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:16:14,2:0.125:0,16,23",
-                "chr21\t6121578\t.\tT\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:15:13,2:0.133333:0,20,24",
+                "chr21\t6121559\t.\tG\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:16:14,2:0.125:small_model:0,23,27",
+                "chr21\t6121578\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:15:13,2:0.133333:small_model:0,24,25",
                 "chr21\t6121586\t.\tT\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:13:11,2:0.153846:0,20,23",
                 "chr21\t6121604\t.\tA\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:9:7,2:0.222222:0,22,24",
-                "chr21\t6121869\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:14:12,2:0.142857:0,23,23",
-                "chr21\t6121881\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:16:14,2:0.125:0,17,21",
-                "chr21\t6121908\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:22:19,3:0.136364:0,16,21",
+                "chr21\t6121869\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:32:14:12,2:0.142857:small_model:0,33,37",
+                "chr21\t6121881\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:31:16:14,2:0.125:small_model:0,36,32",
+                "chr21\t6121908\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:22:19,3:0.136364:small_model:0,28,23",
                 "chr21\t6448617\t.\tC\tG\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:9:7,2:0.222222:0,15,19",
-                "chr21\t6448984\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:8:6,2:0.25:0,19,19",
-                "chr21\t6448991\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:10:8,2:0.2:0,21,22",
-                "chr21\t6449024\t.\tG\tC\t0.5\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:9:10:8,2:0.2:0,9,17",
+                "chr21\t6448984\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:60:8:6,2:0.25:small_model:0,66,60",
+                "chr21\t6448991\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:99:10:8,2:0.2:small_model:0,99,99",
+                "chr21\t6449024\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:10:8,2:0.2:small_model:0,32,21",
                 "chr21\t6449032\t.\tG\tC\t1.4\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:6:10:8,2:0.2:0,5,10",
                 "chr21\t6456868\t.\tC\tG\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:26:22,4:0.153846:0,15,18",
-                "chr21\t6457020\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:16:14,2:0.125:0,20,23",
-                "chr21\t6457037\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:15:13,2:0.133333:0,19,23",
-                "chr21\t6457123\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:13:11,2:0.153846:0,17,22",
-                "chr21\t6457130\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:15:13,2:0.133333:0,23,24",
+                "chr21\t6457020\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:33:16:14,2:0.125:small_model:0,34,36",
+                "chr21\t6457037\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:29:15:13,2:0.133333:small_model:0,31,31",
+                "chr21\t6457123\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:46:13:11,2:0.153846:small_model:0,50,48",
+                "chr21\t6457130\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:69:15:13,2:0.133333:small_model:0,67,74",
                 "chr21\t6457281\t.\tC\tA\t0.5\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:10:10:7,3:0.3:0,10,17",
                 "chr21\t6457305\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:16:14,2:0.125:0,17,21",
                 "chr21\t6457779\t.\tC\tA\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:12:8:6,2:0.25:0,13,16",
-                "chr21\t6457856\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:15:13,2:0.133333:0,18,23",
+                "chr21\t6457856\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:37:15:13,2:0.133333:small_model:0,37,48",
                 "chr21\t6457945\t.\tT\tA\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:13:16:13,2:0.125:0,13,17",
                 "chr21\t6457975\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:15:13,2:0.133333:0,21,19",
-                "chr21\t6458092\t.\tG\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:12:10,2:0.166667:0,21,23",
+                "chr21\t6458092\t.\tG\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:12:10,2:0.166667:small_model:0,22,33",
                 "chr21\t6458154\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:15:12,2:0.133333:0,19,23",
-                "chr21\t6458590\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:9:7,2:0.222222:0,17,23",
+                "chr21\t6458590\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:25:9:7,2:0.222222:small_model:0,26,33",
                 "chr21\t6458638\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:4:2,2:0.5:0,20,20",
-                "chr21\t6460434\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,23,24",
-                "chr21\t6460458\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:16:14,2:0.125:0,18,24",
-                "chr21\t6460463\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,23,24",
-                "chr21\t6460509\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:13:11,2:0.153846:0,21,24",
+                "chr21\t6460434\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:42:16:14,2:0.125:small_model:0,42,52",
+                "chr21\t6460458\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:29:16:14,2:0.125:small_model:0,29,37",
+                "chr21\t6460463\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:37:16:14,2:0.125:small_model:0,38,44",
+                "chr21\t6460509\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:30:13:11,2:0.153846:small_model:0,30,40",
                 "chr21\t6460819\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:4:2,2:0.5:0,18,18",
                 "chr21\t6486155\t.\tA\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:8:6,2:0.25:0,20,23",
                 "chr21\t6486158\t.\tC\tG\t0.6\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:9:8:6,2:0.25:0,9,13",
                 "chr21\t6486188\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:15:12,3:0.2:0,18,24",
                 "chr21\t6486215\t.\tG\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,24,24",
                 "chr21\t6486239\t.\tG\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:15:12,3:0.2:0,17,23",
-                "chr21\t6486290\t.\tC\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:16:14,2:0.125:0,21,24",
-                "chr21\t6486418\t.\tT\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:13:11,2:0.153846:0,20,23",
-                "chr21\t6486657\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:11:9,2:0.181818:0,24,24",
+                "chr21\t6486290\t.\tC\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:16:14,2:0.125:small_model:0,25,28",
+                "chr21\t6486418\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:13:11,2:0.153846:small_model:0,23,36",
+                "chr21\t6486657\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:33:11:9,2:0.181818:small_model:0,33,45",
                 "chr21\t6486707\t.\tA\tT\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:4:2,2:0.5:0,17,16",
-                "chr21\t6486906\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,22,24",
+                "chr21\t6486906\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:99:16:14,2:0.125:small_model:0,89,99",
                 "chr21\t6486948\t.\tG\tC\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:11:9,2:0.181818:0,15,22",
-                "chr21\t6486950\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:11:9,2:0.181818:0,21,24",
-                "chr21\t6487007\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:9:7,2:0.222222:0,17,24",
-                "chr21\t6487510\t.\tA\tT\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:11:8:6,2:0.25:0,11,18",
-                "chr21\t6487521\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:8:6,2:0.25:0,21,23",
-                "chr21\t6487625\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:10:8,2:0.2:0,17,21",
-                "chr21\t6487657\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:15:13,2:0.133333:0,17,21",
-                "chr21\t6487658\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:15:13,2:0.133333:0,21,21",
-                "chr21\t6487686\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:16:14,2:0.125:0,22,23",
+                "chr21\t6486950\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:21:11:9,2:0.181818:small_model:0,22,26",
+                "chr21\t6487007\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:37:9:7,2:0.222222:small_model:0,37,47",
+                "chr21\t6487510\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:8:6,2:0.25:small_model:0,26,27",
+                "chr21\t6487521\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:44:8:6,2:0.25:small_model:0,49,45",
+                "chr21\t6487625\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:31:10:8,2:0.2:small_model:0,32,34",
+                "chr21\t6487657\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:15:13,2:0.133333:small_model:0,27,26",
+                "chr21\t6487658\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:30:15:13,2:0.133333:small_model:0,31,34",
+                "chr21\t6487686\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:38:16:14,2:0.125:small_model:0,39,43",
                 "chr21\t6496004\t.\tT\tA\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:8:6,2:0.25:0,15,17",
                 "chr21\t6496138\t.\tA\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:7:5,2:0.285714:0,17,22",
                 "chr21\t6496183\t.\tA\tC\t0.4\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:11:5:3,2:0.4:0,11,16",
                 "chr21\t6499400\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:5:3,2:0.4:0,19,20",
-                "chr21\t6499446\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:8:6,2:0.25:0,17,21",
-                "chr21\t6499463\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:8:6,2:0.25:0,17,20",
-                "chr21\t6499670\t.\tC\tA\t0.9\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:7:7:5,2:0.285714:0,7,10",
+                "chr21\t6499446\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:30:8:6,2:0.25:small_model:0,33,32",
+                "chr21\t6499463\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:26:8:6,2:0.25:small_model:0,32,26",
+                "chr21\t6499670\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:29:7:5,2:0.285714:small_model:0,31,33",
                 "chr21\t6560761\t.\tC\tG\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:16:13,2:0.125:0,16,18",
-                "chr21\t6560926\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:15:13,2:0.133333:0,20,22",
-                "chr21\t6560993\t.\tT\tA\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:13:23:18,3:0.130435:0,13,20",
-                "chr21\t6561014\t.\tA\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:25:21,4:0.16:0,21,24",
-                "chr21\t6561195\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:14:12,2:0.142857:0,19,22",
-                "chr21\t6561526\t.\tT\tG\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:13:6:4,2:0.333333:0,13,18",
+                "chr21\t6560926\t.\tC\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:21:15:13,2:0.133333:small_model:0,23,23",
+                "chr21\t6560993\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:23:18,3:0.130435:small_model:0,24,33",
+                "chr21\t6561014\t.\tA\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:20:25:21,4:0.16:small_model:0,21,28",
+                "chr21\t6561195\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:37:14:12,2:0.142857:small_model:0,38,42",
+                "chr21\t6561526\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:6:4,2:0.333333:small_model:0,25,25",
                 "chr21\t6561527\t.\tC\tA\t1.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:7:6:4,2:0.333333:0,6,15",
-                "chr21\t7819842\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:24:21,3:0.125:0,23,24",
-                "chr21\t7819981\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:17:14,3:0.176471:0,23,24",
-                "chr21\t7820004\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:15:13,2:0.133333:0,22,23",
-                "chr21\t7820006\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:16:14,2:0.125:0,16,22",
+                "chr21\t7819842\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:35:24:21,3:0.125:small_model:0,37,38",
+                "chr21\t7819981\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:32:17:14,3:0.176471:small_model:0,36,34",
+                "chr21\t7820004\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:21:15:13,2:0.133333:small_model:0,21,27",
+                "chr21\t7820006\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:16:14,2:0.125:small_model:0,25,26",
                 "chr21\t7820008\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:16:13,2:0.125:0,16,21",
-                "chr21\t7820041\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:15:12,2:0.133333:0,16,21",
-                "chr21\t10538700\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:17:14,3:0.176471:0,22,23",
-                "chr21\t10538961\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,24,24",
-                "chr21\t10539145\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:12:9,3:0.25:0,19,24",
-                "chr21\t10539156\t.\tG\tC\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:11:12:10,2:0.166667:0,11,24",
-                "chr21\t10539199\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:11:9,2:0.181818:0,21,24",
-                "chr21\t10539215\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:9:7,2:0.222222:0,23,24",
-                "chr21\t10541372\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:22:16:14,2:0.125:0,24,24",
-                "chr21\t10541384\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:22:16:14,2:0.125:0,24,24",
-                "chr21\t10541585\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:25:22,3:0.12:0,23,24",
-                "chr21\t10541615\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:20:17,3:0.15:0,15,23",
-                "chr21\t10541650\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:11:9,2:0.181818:0,18,24",
-                "chr21\t10541704\t.\tA\tT\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:12:6:4,2:0.333333:0,11,22",
-                "chr21\t10542594\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:15:13,2:0.133333:0,22,24",
-                "chr21\t10542621\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:22:16:14,2:0.125:0,24,24",
-                "chr21\t10542681\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:22:15:13,2:0.133333:0,24,24",
+                "chr21\t7820041\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:32:15:12,2:0.133333:small_model:0,33,36",
+                "chr21\t10538700\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:47:17:14,3:0.176471:small_model:0,46,99",
+                "chr21\t10538961\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:51:16:14,2:0.125:small_model:0,51,71",
+                "chr21\t10539145\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:40:12:9,3:0.25:small_model:0,40,54",
+                "chr21\t10539156\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:39:12:10,2:0.166667:small_model:0,39,52",
+                "chr21\t10539199\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:27:11:9,2:0.181818:small_model:0,27,40",
+                "chr21\t10539215\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:9:7,2:0.222222:small_model:0,24,38",
+                "chr21\t10541372\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:53:16:14,2:0.125:small_model:0,53,65",
+                "chr21\t10541384\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:55:16:14,2:0.125:small_model:0,55,70",
+                "chr21\t10541585\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:60:25:22,3:0.12:small_model:0,60,77",
+                "chr21\t10541615\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:51:20:17,3:0.15:small_model:0,51,64",
+                "chr21\t10541650\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:36:11:9,2:0.181818:small_model:0,36,55",
+                "chr21\t10541704\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:6:4,2:0.333333:small_model:0,23,36",
+                "chr21\t10542594\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:38:15:13,2:0.133333:small_model:0,37,54",
+                "chr21\t10542621\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:43:16:14,2:0.125:small_model:0,42,61",
+                "chr21\t10542681\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:57:15:13,2:0.133333:small_model:0,56,75",
                 "chr21\t10542821\t.\tG\tC\t0.7\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:8:8:6,2:0.25:0,7,22"
             ],
             {
@@ -290,7 +290,7 @@
                     [
                         "PARABRICKS_DEEPVARIANT",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -299,110 +299,110 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T07:56:31.704139318"
+        "timestamp": "2026-07-22T13:54:43.339144689"
     },
     "human - bam": {
         "content": [
             [
                 "chr21\t6118303\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:12:10,2:0.166667:0,15,22",
                 "chr21\t6118347\t.\tG\tT\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:12:11:9,2:0.181818:0,12,19",
-                "chr21\t6118556\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:8:6,2:0.25:0,17,21",
-                "chr21\t6118720\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:7:5,2:0.285714:0,17,22",
+                "chr21\t6118556\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:8:6,2:0.25:small_model:0,25,25",
+                "chr21\t6118720\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:7:5,2:0.285714:small_model:0,25,23",
                 "chr21\t6120003\t.\tT\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:14:12,2:0.142857:0,17,23",
                 "chr21\t6120024\t.\tT\tA\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:12:13:11,2:0.153846:0,12,20",
                 "chr21\t6120030\t.\tC\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:13:11,2:0.153846:0,21,24",
                 "chr21\t6120072\t.\tA\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:8:6,2:0.25:0,21,22",
-                "chr21\t6120881\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:12:10,2:0.166667:0,24,24",
+                "chr21\t6120881\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:57:12:10,2:0.166667:small_model:0,57,64",
                 "chr21\t6120947\t.\tC\tA\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:11:7:5,2:0.285714:0,11,21",
-                "chr21\t6120949\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:7:5,2:0.285714:0,21,23",
-                "chr21\t6121084\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:18:15,3:0.166667:0,16,21",
+                "chr21\t6120949\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:20:7:5,2:0.285714:small_model:0,21,26",
+                "chr21\t6121084\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:29:18:15,3:0.166667:small_model:0,31,31",
                 "chr21\t6121094\t.\tC\tA\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:13:10:8,2:0.2:0,14,17",
-                "chr21\t6121559\t.\tG\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:16:14,2:0.125:0,16,23",
-                "chr21\t6121578\t.\tT\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:15:13,2:0.133333:0,20,24",
+                "chr21\t6121559\t.\tG\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:16:14,2:0.125:small_model:0,23,27",
+                "chr21\t6121578\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:15:13,2:0.133333:small_model:0,24,25",
                 "chr21\t6121586\t.\tT\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:13:11,2:0.153846:0,20,23",
                 "chr21\t6121604\t.\tA\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:9:7,2:0.222222:0,22,24",
-                "chr21\t6121869\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:14:12,2:0.142857:0,23,23",
-                "chr21\t6121881\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:16:14,2:0.125:0,17,21",
-                "chr21\t6121908\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:22:19,3:0.136364:0,16,21",
+                "chr21\t6121869\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:32:14:12,2:0.142857:small_model:0,33,37",
+                "chr21\t6121881\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:31:16:14,2:0.125:small_model:0,36,32",
+                "chr21\t6121908\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:22:19,3:0.136364:small_model:0,28,23",
                 "chr21\t6448617\t.\tC\tG\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:9:7,2:0.222222:0,15,19",
-                "chr21\t6448984\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:8:6,2:0.25:0,19,19",
-                "chr21\t6448991\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:10:8,2:0.2:0,21,22",
-                "chr21\t6449024\t.\tG\tC\t0.5\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:9:10:8,2:0.2:0,9,17",
+                "chr21\t6448984\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:61:8:6,2:0.25:small_model:0,67,62",
+                "chr21\t6448991\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:99:10:8,2:0.2:small_model:0,99,99",
+                "chr21\t6449024\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:21:10:8,2:0.2:small_model:0,31,21",
                 "chr21\t6449032\t.\tG\tC\t1.4\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:6:10:8,2:0.2:0,5,10",
                 "chr21\t6456868\t.\tC\tG\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:26:22,4:0.153846:0,15,18",
-                "chr21\t6457020\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:16:14,2:0.125:0,20,23",
-                "chr21\t6457037\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:15:13,2:0.133333:0,19,23",
-                "chr21\t6457123\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:13:11,2:0.153846:0,17,22",
-                "chr21\t6457130\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:15:13,2:0.133333:0,23,24",
+                "chr21\t6457020\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:33:16:14,2:0.125:small_model:0,34,36",
+                "chr21\t6457037\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:29:15:13,2:0.133333:small_model:0,31,31",
+                "chr21\t6457123\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:46:13:11,2:0.153846:small_model:0,50,48",
+                "chr21\t6457130\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:69:15:13,2:0.133333:small_model:0,67,74",
                 "chr21\t6457281\t.\tC\tA\t0.5\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:10:10:7,3:0.3:0,10,17",
                 "chr21\t6457305\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:16:14,2:0.125:0,17,21",
                 "chr21\t6457779\t.\tC\tA\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:12:8:6,2:0.25:0,13,16",
-                "chr21\t6457856\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:15:13,2:0.133333:0,18,23",
+                "chr21\t6457856\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:37:15:13,2:0.133333:small_model:0,37,48",
                 "chr21\t6457945\t.\tT\tA\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:13:16:13,2:0.125:0,13,17",
                 "chr21\t6457975\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:15:13,2:0.133333:0,21,19",
-                "chr21\t6458092\t.\tG\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:12:10,2:0.166667:0,21,23",
+                "chr21\t6458092\t.\tG\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:22:12:10,2:0.166667:small_model:0,22,33",
                 "chr21\t6458154\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:15:12,2:0.133333:0,19,23",
-                "chr21\t6458590\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:9:7,2:0.222222:0,17,23",
+                "chr21\t6458590\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:25:9:7,2:0.222222:small_model:0,26,33",
                 "chr21\t6458638\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:4:2,2:0.5:0,20,20",
-                "chr21\t6460434\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,23,24",
-                "chr21\t6460458\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:16:14,2:0.125:0,18,24",
-                "chr21\t6460463\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,23,24",
-                "chr21\t6460509\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:13:11,2:0.153846:0,21,24",
+                "chr21\t6460434\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:42:16:14,2:0.125:small_model:0,42,52",
+                "chr21\t6460458\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:29:16:14,2:0.125:small_model:0,29,37",
+                "chr21\t6460463\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:37:16:14,2:0.125:small_model:0,38,44",
+                "chr21\t6460509\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:30:13:11,2:0.153846:small_model:0,30,40",
                 "chr21\t6460819\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:4:2,2:0.5:0,18,18",
                 "chr21\t6486155\t.\tA\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:8:6,2:0.25:0,20,23",
                 "chr21\t6486158\t.\tC\tG\t0.6\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:9:8:6,2:0.25:0,9,13",
                 "chr21\t6486188\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:15:12,3:0.2:0,18,24",
                 "chr21\t6486215\t.\tG\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,24,24",
                 "chr21\t6486239\t.\tG\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:15:12,3:0.2:0,17,23",
-                "chr21\t6486290\t.\tC\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:16:14,2:0.125:0,21,24",
-                "chr21\t6486418\t.\tT\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:13:11,2:0.153846:0,20,23",
-                "chr21\t6486657\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:11:9,2:0.181818:0,24,24",
+                "chr21\t6486290\t.\tC\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:16:14,2:0.125:small_model:0,25,28",
+                "chr21\t6486418\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:13:11,2:0.153846:small_model:0,23,36",
+                "chr21\t6486657\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:33:11:9,2:0.181818:small_model:0,33,45",
                 "chr21\t6486707\t.\tA\tT\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:4:2,2:0.5:0,17,16",
-                "chr21\t6486906\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,22,24",
+                "chr21\t6486906\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:99:16:14,2:0.125:small_model:0,89,99",
                 "chr21\t6486948\t.\tG\tC\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:11:9,2:0.181818:0,15,22",
-                "chr21\t6486950\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:11:9,2:0.181818:0,21,24",
-                "chr21\t6487007\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:9:7,2:0.222222:0,17,24",
-                "chr21\t6487510\t.\tA\tT\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:11:8:6,2:0.25:0,11,18",
-                "chr21\t6487521\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:8:6,2:0.25:0,21,23",
-                "chr21\t6487625\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:10:8,2:0.2:0,17,21",
-                "chr21\t6487657\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:15:13,2:0.133333:0,17,21",
-                "chr21\t6487658\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:15:13,2:0.133333:0,21,21",
-                "chr21\t6487686\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:16:14,2:0.125:0,22,23",
+                "chr21\t6486950\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:21:11:9,2:0.181818:small_model:0,22,26",
+                "chr21\t6487007\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:37:9:7,2:0.222222:small_model:0,37,47",
+                "chr21\t6487510\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:8:6,2:0.25:small_model:0,26,27",
+                "chr21\t6487521\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:44:8:6,2:0.25:small_model:0,49,45",
+                "chr21\t6487625\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:31:10:8,2:0.2:small_model:0,32,34",
+                "chr21\t6487657\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:15:13,2:0.133333:small_model:0,27,26",
+                "chr21\t6487658\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:30:15:13,2:0.133333:small_model:0,31,34",
+                "chr21\t6487686\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:38:16:14,2:0.125:small_model:0,39,43",
                 "chr21\t6496004\t.\tT\tA\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:8:6,2:0.25:0,15,17",
                 "chr21\t6496138\t.\tA\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:7:5,2:0.285714:0,17,22",
                 "chr21\t6496183\t.\tA\tC\t0.4\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:11:5:3,2:0.4:0,11,16",
                 "chr21\t6499400\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:17:5:3,2:0.4:0,19,20",
-                "chr21\t6499446\t.\tG\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:8:6,2:0.25:0,17,21",
-                "chr21\t6499463\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:8:6,2:0.25:0,17,20",
-                "chr21\t6499670\t.\tC\tA\t0.9\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:7:7:5,2:0.285714:0,7,10",
+                "chr21\t6499446\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:30:8:6,2:0.25:small_model:0,33,32",
+                "chr21\t6499463\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:26:8:6,2:0.25:small_model:0,32,26",
+                "chr21\t6499670\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:29:7:5,2:0.285714:small_model:0,31,33",
                 "chr21\t6560761\t.\tC\tG\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:14:16:13,2:0.125:0,16,18",
-                "chr21\t6560926\t.\tC\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:15:13,2:0.133333:0,20,22",
-                "chr21\t6560993\t.\tT\tA\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:13:23:18,3:0.130435:0,13,20",
-                "chr21\t6561014\t.\tA\tC\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:25:21,4:0.16:0,21,24",
-                "chr21\t6561195\t.\tA\tT\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:14:12,2:0.142857:0,19,22",
-                "chr21\t6561526\t.\tT\tG\t0.2\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:13:6:4,2:0.333333:0,13,18",
+                "chr21\t6560926\t.\tC\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:21:15:13,2:0.133333:small_model:0,23,23",
+                "chr21\t6560993\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:23:18,3:0.130435:small_model:0,24,33",
+                "chr21\t6561014\t.\tA\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:20:25:21,4:0.16:small_model:0,20,27",
+                "chr21\t6561195\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:37:14:12,2:0.142857:small_model:0,38,42",
+                "chr21\t6561526\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:6:4,2:0.333333:small_model:0,25,25",
                 "chr21\t6561527\t.\tC\tA\t1.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:7:6:4,2:0.333333:0,6,15",
-                "chr21\t7819842\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:24:21,3:0.125:0,23,24",
-                "chr21\t7819981\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:17:14,3:0.176471:0,23,24",
-                "chr21\t7820004\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:15:13,2:0.133333:0,22,23",
-                "chr21\t7820006\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:16:14,2:0.125:0,16,22",
+                "chr21\t7819842\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:35:24:21,3:0.125:small_model:0,37,38",
+                "chr21\t7819981\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:32:17:14,3:0.176471:small_model:0,36,34",
+                "chr21\t7820004\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:21:15:13,2:0.133333:small_model:0,21,27",
+                "chr21\t7820006\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:16:14,2:0.125:small_model:0,25,26",
                 "chr21\t7820008\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:16:13,2:0.125:0,16,21",
-                "chr21\t7820041\t.\tC\tA\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:16:15:12,2:0.133333:0,16,21",
-                "chr21\t10538700\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:17:14,3:0.176471:0,22,23",
-                "chr21\t10538961\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:16:14,2:0.125:0,24,24",
-                "chr21\t10539145\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:19:12:9,3:0.25:0,19,24",
-                "chr21\t10539156\t.\tG\tC\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:11:12:10,2:0.166667:0,11,24",
-                "chr21\t10539199\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:11:9,2:0.181818:0,21,24",
-                "chr21\t10539215\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:9:7,2:0.222222:0,23,24",
-                "chr21\t10541372\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:22:16:14,2:0.125:0,24,24",
-                "chr21\t10541384\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:22:16:14,2:0.125:0,24,24",
-                "chr21\t10541585\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:21:25:22,3:0.12:0,23,24",
-                "chr21\t10541615\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:15:20:17,3:0.15:0,15,23",
-                "chr21\t10541650\t.\tT\tG\t0.1\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:18:11:9,2:0.181818:0,18,24",
-                "chr21\t10541704\t.\tA\tT\t0.3\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:12:6:4,2:0.333333:0,11,22",
-                "chr21\t10542594\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:20:15:13,2:0.133333:0,22,24",
-                "chr21\t10542621\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:22:16:14,2:0.125:0,24,24",
-                "chr21\t10542681\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t0/0:22:15:13,2:0.133333:0,24,24",
+                "chr21\t7820041\t.\tC\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:32:15:12,2:0.133333:small_model:0,33,36",
+                "chr21\t10538700\t.\tT\tA\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:47:17:14,3:0.176471:small_model:0,46,99",
+                "chr21\t10538961\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:51:16:14,2:0.125:small_model:0,51,71",
+                "chr21\t10539145\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:40:12:9,3:0.25:small_model:0,40,54",
+                "chr21\t10539156\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:39:12:10,2:0.166667:small_model:0,39,52",
+                "chr21\t10539199\t.\tG\tC\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:27:11:9,2:0.181818:small_model:0,27,40",
+                "chr21\t10539215\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:24:9:7,2:0.222222:small_model:0,24,38",
+                "chr21\t10541372\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:53:16:14,2:0.125:small_model:0,53,65",
+                "chr21\t10541384\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:55:16:14,2:0.125:small_model:0,55,70",
+                "chr21\t10541585\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:60:25:22,3:0.12:small_model:0,60,77",
+                "chr21\t10541615\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:51:20:17,3:0.15:small_model:0,51,64",
+                "chr21\t10541650\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:36:11:9,2:0.181818:small_model:0,36,55",
+                "chr21\t10541704\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:23:6:4,2:0.333333:small_model:0,23,36",
+                "chr21\t10542594\t.\tT\tG\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:38:15:13,2:0.133333:small_model:0,37,54",
+                "chr21\t10542621\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:43:16:14,2:0.125:small_model:0,42,61",
+                "chr21\t10542681\t.\tA\tT\t0\tRefCall\t.\tGT:GQ:DP:AD:VAF:MID:PL\t0/0:57:15:13,2:0.133333:small_model:0,56,75",
                 "chr21\t10542821\t.\tG\tC\t0.7\tRefCall\t.\tGT:GQ:DP:AD:VAF:PL\t./.:8:8:6,2:0.25:0,7,22"
             ],
             {
@@ -410,7 +410,7 @@
                     [
                         "PARABRICKS_DEEPVARIANT",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -419,7 +419,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T07:56:15.037289899"
+        "timestamp": "2026-07-22T13:54:27.267963808"
     },
     "human - bam - intervals - gvcf - stub": {
         "content": [
@@ -441,17 +441,17 @@
                     ]
                 ],
                 "2": [
-                    "compatible_versions.yml:md5,dbd6540b88f488accb37d270fa4b6bd1"
+                    "compatible_versions.yml:md5,68b2cf8e6a93e78f1abb7487b94c60b8"
                 ],
                 "3": [
                     [
                         "PARABRICKS_DEEPVARIANT",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,dbd6540b88f488accb37d270fa4b6bd1"
+                    "compatible_versions.yml:md5,68b2cf8e6a93e78f1abb7487b94c60b8"
                 ],
                 "gvcf": [
                     [
@@ -473,7 +473,7 @@
                     [
                         "PARABRICKS_DEEPVARIANT",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -482,7 +482,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T07:57:21.609551822"
+        "timestamp": "2026-07-22T13:55:28.742123322"
     },
     "human - bam - gvcf": {
         "content": [
@@ -594,7 +594,7 @@
                     [
                         "PARABRICKS_DEEPVARIANT",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }

--- a/modules/nf-core/parabricks/fq2bam/main.nf
+++ b/modules/nf-core/parabricks/fq2bam/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_FQ2BAM {
     // needed by the module to run on a cluster because we need to copy the fasta reference, see https://github.com/nf-core/modules/issues/9230
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/parabricks/fq2bam/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/fq2bam/tests/main.nf.test.snap
@@ -36,13 +36,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,daf8cc0f6110c611f9f71e2a5c50e96c"
+                    "compatible_versions.yml:md5,c48631d6ae7f0acd46e4c08881c0cde4"
                 ],
                 "8": [
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -67,7 +67,7 @@
                     
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,daf8cc0f6110c611f9f71e2a5c50e96c"
+                    "compatible_versions.yml:md5,c48631d6ae7f0acd46e4c08881c0cde4"
                 ],
                 "crai": [
                     
@@ -85,13 +85,13 @@
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
             {
                 "PARABRICKS_FQ2BAM": null,
-                "pbrun_version": "4.7.0-1",
+                "pbrun_version": "4.7.1-1",
                 "compatible_with": "BWA mem: 0.7.15, Picard: 2.18.25"
             }
         ],
@@ -99,7 +99,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T07:57:54.537127867"
+        "timestamp": "2026-07-22T13:56:25.919782719"
     },
     "sarscov2 - fastq - pe - stub": {
         "content": [
@@ -138,13 +138,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,daf8cc0f6110c611f9f71e2a5c50e96c"
+                    "compatible_versions.yml:md5,c48631d6ae7f0acd46e4c08881c0cde4"
                 ],
                 "8": [
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -169,7 +169,7 @@
                     
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,daf8cc0f6110c611f9f71e2a5c50e96c"
+                    "compatible_versions.yml:md5,c48631d6ae7f0acd46e4c08881c0cde4"
                 ],
                 "crai": [
                     
@@ -187,13 +187,13 @@
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
             {
                 "PARABRICKS_FQ2BAM": null,
-                "pbrun_version": "4.7.0-1",
+                "pbrun_version": "4.7.1-1",
                 "compatible_with": "BWA mem: 0.7.15, Picard: 2.18.25"
             }
         ],
@@ -201,7 +201,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T07:58:20.084300726"
+        "timestamp": "2026-07-22T13:57:20.850459502"
     },
     "sarscov2 - fastq - pe": {
         "content": [
@@ -212,7 +212,7 @@
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -232,7 +232,7 @@
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -280,13 +280,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,daf8cc0f6110c611f9f71e2a5c50e96c"
+                    "compatible_versions.yml:md5,c48631d6ae7f0acd46e4c08881c0cde4"
                 ],
                 "8": [
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -299,7 +299,7 @@
                     
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,daf8cc0f6110c611f9f71e2a5c50e96c"
+                    "compatible_versions.yml:md5,c48631d6ae7f0acd46e4c08881c0cde4"
                 ],
                 "crai": [
                     [
@@ -329,7 +329,7 @@
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -338,7 +338,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T07:58:45.441327996"
+        "timestamp": "2026-07-22T13:58:14.974718817"
     },
     "SRR389222 - fastq - se": {
         "content": [
@@ -349,7 +349,7 @@
                     [
                         "PARABRICKS_FQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }

--- a/modules/nf-core/parabricks/fq2bammeth/main.nf
+++ b/modules/nf-core/parabricks/fq2bammeth/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_FQ2BAMMETH {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta),  path(reads)

--- a/modules/nf-core/parabricks/fq2bammeth/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/fq2bammeth/tests/main.nf.test.snap
@@ -33,7 +33,7 @@
                     [
                         "PARABRICKS_FQ2BAMMETH",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -67,7 +67,7 @@
                     [
                         "PARABRICKS_FQ2BAMMETH",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -112,7 +112,7 @@
                     [
                         "PARABRICKS_FQ2BAMMETH",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -146,7 +146,7 @@
                     [
                         "PARABRICKS_FQ2BAMMETH",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -174,7 +174,7 @@
                     [
                         "PARABRICKS_FQ2BAMMETH",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }

--- a/modules/nf-core/parabricks/genotypegvcf/main.nf
+++ b/modules/nf-core/parabricks/genotypegvcf/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_GENOTYPEGVCF {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta),  path(input)

--- a/modules/nf-core/parabricks/genotypegvcf/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/genotypegvcf/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                     [
                         "PARABRICKS_GENOTYPEGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -34,7 +34,7 @@
                     [
                         "PARABRICKS_GENOTYPEGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "vcf": [
@@ -50,7 +50,7 @@
                     [
                         "PARABRICKS_GENOTYPEGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }

--- a/modules/nf-core/parabricks/haplotypecaller/main.nf
+++ b/modules/nf-core/parabricks/haplotypecaller/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_HAPLOTYPECALLER {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta), path(input), path(input_index), path(intervals)

--- a/modules/nf-core/parabricks/haplotypecaller/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/haplotypecaller/tests/main.nf.test.snap
@@ -24,17 +24,17 @@
                     
                 ],
                 "2": [
-                    "compatible_versions.yml:md5,bccbd04b9cc3fe86310c65de87f68bce"
+                    "compatible_versions.yml:md5,f33bcfc78fef1f8b1314c038eca05930"
                 ],
                 "3": [
                     [
                         "PARABRICKS_HAPLOTYPECALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,bccbd04b9cc3fe86310c65de87f68bce"
+                    "compatible_versions.yml:md5,f33bcfc78fef1f8b1314c038eca05930"
                 ],
                 "gvcf": [
                     
@@ -51,13 +51,13 @@
                     [
                         "PARABRICKS_HAPLOTYPECALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
             {
                 "PARABRICKS_HAPLOTYPECALLER": {
-                    "pbrun_version": "4.7.0-1",
+                    "pbrun_version": "4.7.1-1",
                     "compatible_with": {
                         "GATK:": "4.3.0.0"
                     }
@@ -68,7 +68,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:01:45.579712219"
+        "timestamp": "2026-07-22T14:00:59.770132188"
     },
     "human - bam - intervals": {
         "content": [
@@ -78,7 +78,7 @@
                     [
                         "PARABRICKS_HAPLOTYPECALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -97,7 +97,7 @@
                     [
                         "PARABRICKS_HAPLOTYPECALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -123,17 +123,17 @@
                     ]
                 ],
                 "2": [
-                    "compatible_versions.yml:md5,bccbd04b9cc3fe86310c65de87f68bce"
+                    "compatible_versions.yml:md5,f33bcfc78fef1f8b1314c038eca05930"
                 ],
                 "3": [
                     [
                         "PARABRICKS_HAPLOTYPECALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,bccbd04b9cc3fe86310c65de87f68bce"
+                    "compatible_versions.yml:md5,f33bcfc78fef1f8b1314c038eca05930"
                 ],
                 "gvcf": [
                     [
@@ -150,7 +150,7 @@
                     [
                         "PARABRICKS_HAPLOTYPECALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -159,7 +159,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:01:54.686762276"
+        "timestamp": "2026-07-22T14:01:07.652784055"
     },
     "human - bam - gvcf": {
         "content": [
@@ -169,7 +169,7 @@
                     [
                         "PARABRICKS_HAPLOTYPECALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }

--- a/modules/nf-core/parabricks/indexgvcf/main.nf
+++ b/modules/nf-core/parabricks/indexgvcf/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_INDEXGVCF {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta), path(gvcf)

--- a/modules/nf-core/parabricks/indexgvcf/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/indexgvcf/tests/main.nf.test.snap
@@ -17,7 +17,7 @@
                     [
                         "PARABRICKS_INDEXGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
@@ -35,7 +35,7 @@
                     [
                         "PARABRICKS_INDEXGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -54,7 +54,7 @@
                     [
                         "PARABRICKS_INDEXGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -77,17 +77,17 @@
                     ]
                 ],
                 "1": [
-                    "compatible_versions.yml:md5,c238cde6963f7e9178a58f9603d7a6ba"
+                    "compatible_versions.yml:md5,ac481933e4706f81716845306ca16eb8"
                 ],
                 "2": [
                     [
                         "PARABRICKS_INDEXGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,c238cde6963f7e9178a58f9603d7a6ba"
+                    "compatible_versions.yml:md5,ac481933e4706f81716845306ca16eb8"
                 ],
                 "gvcf_index": [
                     [
@@ -101,13 +101,13 @@
                     [
                         "PARABRICKS_INDEXGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
             {
                 "PARABRICKS_INDEXGVCF": {
-                    "pbrun_version": "4.7.0-1",
+                    "pbrun_version": "4.7.1-1",
                     "compatible_with": {
                         "GATK:": "4.3.0.0"
                     }
@@ -118,7 +118,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:02:25.137037794"
+        "timestamp": "2026-07-22T14:01:29.013709643"
     },
     "human - gvcf.gz - stub": {
         "content": [
@@ -132,17 +132,17 @@
                     ]
                 ],
                 "1": [
-                    "compatible_versions.yml:md5,c238cde6963f7e9178a58f9603d7a6ba"
+                    "compatible_versions.yml:md5,ac481933e4706f81716845306ca16eb8"
                 ],
                 "2": [
                     [
                         "PARABRICKS_INDEXGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,c238cde6963f7e9178a58f9603d7a6ba"
+                    "compatible_versions.yml:md5,ac481933e4706f81716845306ca16eb8"
                 ],
                 "gvcf_index": [
                     [
@@ -156,7 +156,7 @@
                     [
                         "PARABRICKS_INDEXGVCF",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -165,6 +165,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:02:33.08091659"
+        "timestamp": "2026-07-22T14:01:35.805472948"
     }
 }

--- a/modules/nf-core/parabricks/minimap2/main.nf
+++ b/modules/nf-core/parabricks/minimap2/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_MINIMAP2 {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta),  path(reads)

--- a/modules/nf-core/parabricks/minimap2/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/minimap2/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -28,7 +28,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -76,13 +76,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "8": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -95,7 +95,7 @@
                     
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "crai": [
                     [
@@ -125,7 +125,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -134,7 +134,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:06:09.119305778"
+        "timestamp": "2026-07-22T14:04:51.3729922"
     },
     "homo_sapiens - bam - cram": {
         "content": [
@@ -145,7 +145,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -199,13 +199,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "8": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -236,7 +236,7 @@
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "crai": [
                     
@@ -254,7 +254,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -263,7 +263,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:05:00.08925079"
+        "timestamp": "2026-07-22T14:03:47.379018246"
     },
     "homo_sapiens - bam - bam": {
         "content": [
@@ -274,7 +274,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -328,13 +328,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "8": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -365,7 +365,7 @@
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "crai": [
                     
@@ -383,7 +383,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -392,7 +392,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:04:24.280784153"
+        "timestamp": "2026-07-22T14:03:14.717094186"
     },
     "homo_sapiens - fastq - bam - interval_file": {
         "content": [
@@ -414,7 +414,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -434,7 +434,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -482,13 +482,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "8": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -513,7 +513,7 @@
                     
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "crai": [
                     
@@ -531,7 +531,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -540,7 +540,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:05:34.932153656"
+        "timestamp": "2026-07-22T14:04:20.415416049"
     },
     "homo_sapiens - fastq - bam - stub": {
         "content": [
@@ -579,13 +579,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "8": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -610,7 +610,7 @@
                     
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "crai": [
                     
@@ -628,15 +628,15 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
             {
                 "PARABRICKS_MINIMAP2": {
-                    "pbrun_version": "4.7.0-1",
+                    "pbrun_version": "4.7.1-1",
                     "compatible_with": {
-                        "minimap2": 2.3
+                        "minimap2": 2.31
                     }
                 }
             }
@@ -645,7 +645,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:03:14.72008813"
+        "timestamp": "2026-07-22T14:02:08.253405214"
     },
     "homo_sapiens - bam - cram - stub": {
         "content": [
@@ -684,13 +684,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "8": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -703,7 +703,7 @@
                     
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "crai": [
                     [
@@ -733,7 +733,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -742,7 +742,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:06:42.685049957"
+        "timestamp": "2026-07-22T14:05:22.701764204"
     },
     "homo_sapiens - fastq - bam - interval_file - stub": {
         "content": [
@@ -781,13 +781,13 @@
                     
                 ],
                 "7": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "8": [
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "bai": [
@@ -812,7 +812,7 @@
                     
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,493cd4518173daa74759a0e8ec95c05b"
+                    "compatible_versions.yml:md5,3848622dd0e65ae30c1f11beaab3d0f1"
                 ],
                 "crai": [
                     
@@ -830,7 +830,7 @@
                     [
                         "PARABRICKS_MINIMAP2",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -839,6 +839,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-17T08:03:48.704360504"
+        "timestamp": "2026-07-22T14:02:40.732861506"
     }
 }

--- a/modules/nf-core/parabricks/mutectcaller/main.nf
+++ b/modules/nf-core/parabricks/mutectcaller/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_MUTECTCALLER {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta), val(tumor_name), val(normal_name), path(tumor_bam), path(tumor_bam_index), path(normal_bam), path(normal_bam_index), path(intervals)

--- a/modules/nf-core/parabricks/mutectcaller/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/mutectcaller/tests/main.nf.test.snap
@@ -22,17 +22,17 @@
                     ]
                 ],
                 "2": [
-                    "compatible_versions.yml:md5,2d6eedcfb8cfa31f923ac0fa830d4479"
+                    "compatible_versions.yml:md5,c0e51da32ba7664cc88938bf54d4f806"
                 ],
                 "3": [
                     [
                         "PARABRICKS_MUTECTCALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,2d6eedcfb8cfa31f923ac0fa830d4479"
+                    "compatible_versions.yml:md5,c0e51da32ba7664cc88938bf54d4f806"
                 ],
                 "stats": [
                     [
@@ -57,16 +57,16 @@
                     [
                         "PARABRICKS_MUTECTCALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.1"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T08:05:46.467440276"
+        "timestamp": "2026-07-22T14:05:59.071527475"
     },
     "human - bam - stub": {
         "content": [
@@ -88,17 +88,17 @@
                     ]
                 ],
                 "2": [
-                    "compatible_versions.yml:md5,2d6eedcfb8cfa31f923ac0fa830d4479"
+                    "compatible_versions.yml:md5,c0e51da32ba7664cc88938bf54d4f806"
                 ],
                 "3": [
                     [
                         "PARABRICKS_MUTECTCALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "compatible_versions": [
-                    "compatible_versions.yml:md5,2d6eedcfb8cfa31f923ac0fa830d4479"
+                    "compatible_versions.yml:md5,c0e51da32ba7664cc88938bf54d4f806"
                 ],
                 "stats": [
                     [
@@ -120,13 +120,13 @@
                     [
                         "PARABRICKS_MUTECTCALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
             {
                 "PARABRICKS_MUTECTCALLER": {
-                    "pbrun_version": "4.7.0-1",
+                    "pbrun_version": "4.7.1-1",
                     "compatible_with": {
                         "GATK:": "4.3.0.0"
                     }
@@ -135,9 +135,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.1"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-29T08:05:36.745386073"
+        "timestamp": "2026-07-22T14:05:50.72227014"
     },
     "human - bam": {
         "content": [
@@ -155,7 +155,7 @@
                     [
                         "PARABRICKS_MUTECTCALLER",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }

--- a/modules/nf-core/parabricks/rnafq2bam/main.nf
+++ b/modules/nf-core/parabricks/rnafq2bam/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_RNAFQ2BAM {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta),  path(reads)

--- a/modules/nf-core/parabricks/rnafq2bam/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/rnafq2bam/tests/main.nf.test.snap
@@ -97,7 +97,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "2": [
@@ -342,7 +342,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "wig": [
@@ -460,7 +460,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "2": [
@@ -705,7 +705,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "wig": [
@@ -733,7 +733,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
@@ -755,7 +755,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }

--- a/modules/nf-core/parabricks/starfusion/main.nf
+++ b/modules/nf-core/parabricks/starfusion/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_STARFUSION {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta), path(chimeric_junction)

--- a/modules/nf-core/parabricks/starfusion/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/starfusion/tests/main.nf.test.snap
@@ -24,7 +24,7 @@
                     [
                         "PARABRICKS_STARFUSION",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "abridged": [
@@ -49,7 +49,7 @@
                     [
                         "PARABRICKS_STARFUSION",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
@@ -85,7 +85,7 @@
                     [
                         "PARABRICKS_STARFUSION",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "abridged": [
@@ -110,7 +110,7 @@
                     [
                         "PARABRICKS_STARFUSION",
                         "parabricks",
-                        "4.7.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }


### PR DESCRIPTION
This PR bumps the version of the Parabricks modules from 4.7 to 4.7.1. The full [release notes](https://docs.nvidia.com/clara/parabricks/about-parabricks/release-notes/4-7-1-1-release-notes) show all the changes in this version, but pasted below are the highlights: 

- Performance improvements in [deepvariant](https://docs.nvidia.com/clara/parabricks/tool-reference/tools/deepvariant) with small model enabled. The small model is now enabled by default, similar to Google DeepVariant.
- Added Roche SBX mode to [pangenome_aware_deepvariant](https://docs.nvidia.com/clara/parabricks/tool-reference/tools/pangenome_aware_deepvariant) with the new --sbx flag for GPU-accelerated variant calling on Roche SBX-D and SBX-Fast sequencing data.
- Performance improvements for [fq2bam](https://docs.nvidia.com/clara/parabricks/tool-reference/tools/fq2bam) and [fq2bam_meth](https://docs.nvidia.com/clara/parabricks/tool-reference/tools/fq2bam_meth). Added optional support for processing reads up to 1024 bp on GPU.
- Performance improvements for single-end alignment with [giraffe](https://docs.nvidia.com/clara/parabricks/tool-reference/tools/giraffe).
- Added support for reading CRAM v3.1 files.
- Updated version of [minimap2](https://docs.nvidia.com/clara/parabricks/tool-reference/tools/minimap2) to v2.31.
- GPU-accelerated chaining in [minimap2](https://docs.nvidia.com/clara/parabricks/tool-reference/tools/minimap2) with the new --chaining-on-gpu flag.