### PR TITLE
New module: ANGSD/SOAPSNPCALIBRATION

### DIFF
--- a/modules/nf-core/angsd/soapsnpcalibration/environment.yml
+++ b/modules/nf-core/angsd/soapsnpcalibration/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::angsd=0.940
+  - bioconda::htslib=1.17

--- a/modules/nf-core/angsd/soapsnpcalibration/main.nf
+++ b/modules/nf-core/angsd/soapsnpcalibration/main.nf
@@ -12,7 +12,7 @@ process ANGSD_SOAPSNPCALIBRATION {
     tuple path(reference_fasta), path(reference_fai)
 
     output:
-    tuple val(meta), path("*_calibration_matrix"), emit: gl_calibration
+    tuple val(meta), path("*_calibration_matrix"), emit: soapsnp_calibration
     tuple val("${task.process}"), val('angsd'), eval("angsd 2>&1 | sed '1!d;s/.*version: //;s/ .*//'"), emit: versions_angsd, topic: versions
 
     when:

--- a/modules/nf-core/angsd/soapsnpcalibration/main.nf
+++ b/modules/nf-core/angsd/soapsnpcalibration/main.nf
@@ -25,6 +25,7 @@ process ANGSD_SOAPSNPCALIBRATION {
     // Touch fai index to ensure it is newer than the fasta (ANGSD requirement)
     def touch_ref = reference_fai  ? "sleep 1 && touch ${reference_fai}"  : ''
     
+    // Note: -GL 3 and -minQ 0 hardcoded as required to perform SOAPsnp calibration
     """
     ${touch_ref}
     printf '%s\\n' ${bams} > bamlist.txt

--- a/modules/nf-core/angsd/soapsnpcalibration/main.nf
+++ b/modules/nf-core/angsd/soapsnpcalibration/main.nf
@@ -19,7 +19,7 @@ process ANGSD_SOAPSNPCALIBRATION {
     task.ext.when == null || task.ext.when
 
     script:
-    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def prefix = task.ext.prefix ?: "${meta.id}"
     def args   = task.ext.args ?: ''
 
     // Touch fai index to ensure it is newer than the fasta (ANGSD requirement)

--- a/modules/nf-core/angsd/soapsnpcalibration/main.nf
+++ b/modules/nf-core/angsd/soapsnpcalibration/main.nf
@@ -1,0 +1,56 @@
+process ANGSD_SOAPSNPCALIBRATION {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/angsd:0.940--h13024bc_4':
+        'quay.io/biocontainers/angsd:0.940--h13024bc_4' }"
+
+    input:
+    tuple val(meta), path(bams), path(bam_indices)
+    tuple path(reference_fasta), path(reference_fai)
+
+    output:
+    tuple val(meta), path("*_calibration_matrix"), emit: gl_calibration
+    tuple val("${task.process}"), val('angsd'), eval("angsd 2>&1 | sed '1!d;s/.*version: //;s/ .*//'"), emit: versions_angsd, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix    = task.ext.prefix ?: "${meta.id}"
+    def args   = task.ext.args ?: ''
+
+    // Touch fai index to ensure it is newer than the fasta (ANGSD requirement)
+    def touch_ref = reference_fai  ? "sleep 1 && touch ${reference_fai}"  : ''
+    
+    """
+    ${touch_ref}
+    printf '%s\\n' ${bams} > bamlist.txt
+
+    angsd \\
+        -nThreads ${task.cpus} \\
+        -bam bamlist.txt \\
+        -minQ 0 \\
+        -GL 3 \\
+        -ref ${reference_fasta} \\
+        -out ${prefix} \\
+        ${args} \\
+        -tmpdir ${prefix}_calibration_matrix
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir ${prefix}_calibration_matrix
+    touch ${prefix}_calibration_matrix/0.counts0
+    touch ${prefix}_calibration_matrix/0.qual0
+    touch ${prefix}_calibration_matrix/1.counts1
+    touch ${prefix}_calibration_matrix/1.qual1
+    touch ${prefix}_calibration_matrix/2.counts2
+    touch ${prefix}_calibration_matrix/2.qual2
+    touch ${prefix}_calibration_matrix/3.counts3
+    touch ${prefix}_calibration_matrix/3.qual3
+    """
+}

--- a/modules/nf-core/angsd/soapsnpcalibration/meta.yml
+++ b/modules/nf-core/angsd/soapsnpcalibration/meta.yml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "angsd_soapsnpcalibration"
+description: Generate ANGSD SOAPsnp genotype likelihood calibration files (counts/quality matrices) from BAM alignments.
+keywords:
+  - angsd
+  - genotype likelihood
+  - soapsnp calibration
+  - genomics
+tools:
+  - "angsd":
+      description: "ANGSD: Analysis of next generation Sequencing Data"
+      homepage: "http://www.popgen.dk/angsd/"
+      documentation: "http://www.popgen.dk/angsd/"
+      tool_dev_url: "https://github.com/ANGSD/angsd"
+      doi: "10.1186/s12859-014-0356-4"
+      licence:
+        - "GPL v3"
+        - "MIT"
+      identifier: biotools:angsd
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing population information
+          e.g. [ id:'test', population:'population id', samples:'sample IDs' ]
+    - bams:
+        type: file
+        description: A list of BAM or CRAM files.
+        pattern: "*.{bam,cram}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572"
+          - edam: "http://edamontology.org/format_3462"
+    - bam_indices:
+        type: file
+        description: A list of BAM or CRAM indices.
+        pattern: "*.{bam.bai,cram.crai}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3327"
+          - edam: "http://edamontology.org/format_3462"
+  - - reference_fasta:
+        type: file
+        description: A reference genome in FASTA format.
+        pattern: "*.{fasta,fa,fasta.gz,fa.gz}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929"
+    - reference_fai:
+        type: file
+        description: Index of the reference genome FASTA file.
+        pattern: "*.{fasta,fa,fasta.gz,fa.gz}.fai"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929"
+output:
+  soapsnp_calibration:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing population information
+            e.g. [ id:'test', population:'population id', samples:'sample IDs' ]
+      - "*_calibration_matrix":
+          type: directory
+          description: Directory containing per-individual ANGSD SOAPsnp calibration files (counts and quality matrices)
+          pattern: "*_calibration_matrix"
+          ontologies: []
+  versions_angsd:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - angsd:
+          type: string
+          description: The name of the tool
+      - "angsd 2>&1 | sed '1!d;s/.*version: //;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - angsd:
+          type: string
+          description: The name of the tool
+      - "angsd 2>&1 | sed '1!d;s/.*version: //;s/ .*//'":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@ASendellPrice"
+maintainers:
+  - "@ASendellPrice"

--- a/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test
+++ b/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test
@@ -49,7 +49,6 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert process.out.soapsnp_calibration },
                 { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }

--- a/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test
+++ b/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test
@@ -95,7 +95,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test
+++ b/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test
@@ -1,0 +1,104 @@
+// nf-core modules test angsd/soapsnpcalibration
+nextflow_process {
+
+    name "Test Process ANGSD_SOAPSNPCALIBRATION"
+    script "../main.nf"
+    process "ANGSD_SOAPSNPCALIBRATION"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "angsd"
+    tag "angsd/soapsnpcalibration"
+
+    test("angsd - soapSNP - calibration") {
+        config "./nextflow.config"
+
+        when {
+            params {
+                angsd_args   = '-r chr20:1400000-1500000 -checkBamHeaders 0'
+            }
+            process {
+                """
+                input[0] = [
+                    [
+                        id: "FIN",
+                        population: "FIN",
+                        samples: ["HG00349", "HG00358", "HG00350", "HG00351"]
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00349.chr20_1400000-1500000.bam"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00350.chr20_1400000-1500000.bam"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00351.chr20_1400000-1500000.bam"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00358.chr20_1400000-1500000.bam")
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00349.chr20_1400000-1500000.bam.bai"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00350.chr20_1400000-1500000.bam.bai"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00351.chr20_1400000-1500000.bam.bai"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00358.chr20_1400000-1500000.bam.bai")
+                    ]
+                ]
+                input[1] = [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr20/sequence/GRCh38_chr20_1_2000000.fasta.gz'),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr20/sequence/GRCh38_chr20_1_2000000.fasta.gz.fai')
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.soapsnp_calibration },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+
+    test("angsd - soapSNP - calibration - stub") {
+        options "-stub"
+        config "./nextflow.config"
+
+        when {
+            params {
+                angsd_args   = '-r chr20:1400000-1500000 -checkBamHeaders 0'
+            }
+            process {
+                """
+                input[0] = [
+                    [
+                        id: "FIN",
+                        population: "FIN",
+                        samples: ["HG00349", "HG00358", "HG00350", "HG00351"]
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00349.chr20_1400000-1500000.bam"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00350.chr20_1400000-1500000.bam"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00351.chr20_1400000-1500000.bam"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00358.chr20_1400000-1500000.bam")
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00349.chr20_1400000-1500000.bam.bai"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00350.chr20_1400000-1500000.bam.bai"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00351.chr20_1400000-1500000.bam.bai"),
+                        file(params.modules_testdata_base_path + "genomics/homo_sapiens/illumina/bam/HG00358.chr20_1400000-1500000.bam.bai")
+                    ]
+                ]
+                input[1] = [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr20/sequence/GRCh38_chr20_1_2000000.fasta.gz'),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/chr20/sequence/GRCh38_chr20_1_2000000.fasta.gz.fai')
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test.snap
+++ b/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test.snap
@@ -159,37 +159,6 @@
     "angsd - soapSNP - calibration - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "FIN",
-                            "population": "FIN",
-                            "samples": [
-                                "HG00349",
-                                "HG00358",
-                                "HG00350",
-                                "HG00351"
-                            ]
-                        },
-                        [
-                            "0.counts0:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "0.qual0:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "1.counts1:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "1.qual1:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "2.counts2:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "2.qual2:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "3.counts3:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "3.qual3:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "1": [
-                    [
-                        "ANGSD_SOAPSNPCALIBRATION",
-                        "angsd",
-                        "0.940-dirty"
-                    ]
-                ],
                 "soapsnp_calibration": [
                     [
                         {
@@ -223,7 +192,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-22T21:48:44.461452",
+        "timestamp": "2026-07-23T11:08:27.92489",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.1"

--- a/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test.snap
+++ b/modules/nf-core/angsd/soapsnpcalibration/tests/main.nf.test.snap
@@ -1,0 +1,232 @@
+{
+    "angsd - soapSNP - calibration": {
+        "content": [
+            {
+                "soapsnp_calibration": [
+                    [
+                        {
+                            "id": "FIN",
+                            "population": "FIN",
+                            "samples": [
+                                "HG00349",
+                                "HG00358",
+                                "HG00350",
+                                "HG00351"
+                            ]
+                        },
+                        [
+                            "0.counts0:md5,673bb1d2954009bec6d02777034b357c",
+                            "0.qual0:md5,54c31d636922064c41e3bbded537c3f6",
+                            "1.counts1:md5,48b08aa5c030ad25f6466fb07cd8b463",
+                            "1.qual1:md5,df650aacbb5daaa8c70f9a6384efd808",
+                            "2.counts2:md5,f9fdb910c40411a8ecd6cd8c21cc2bcd",
+                            "2.qual2:md5,71a1c093b142caf1ade628f442b5443b",
+                            "3.counts3:md5,52334ddff2b9216d0ba758973bbad70a",
+                            "3.qual3:md5,7b83bfe82176b40ec1a0cbf458b28a71"
+                        ]
+                    ]
+                ],
+                "versions_angsd": [
+                    [
+                        "ANGSD_SOAPSNPCALIBRATION",
+                        "angsd",
+                        "0.940-dirty"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-22T21:48:39.98077",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "angsd - GL 3 - calibration - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "FIN",
+                            "population": "FIN",
+                            "samples": [
+                                "HG00349",
+                                "HG00358",
+                                "HG00350",
+                                "HG00351"
+                            ]
+                        },
+                        [
+                            "0.counts0:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "0.qual0:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "1.counts1:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "1.qual1:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "2.counts2:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "2.qual2:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "3.counts3:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "3.qual3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        "ANGSD_SOAPSNPCALIBRATION",
+                        "angsd",
+                        "0.940-dirty"
+                    ]
+                ],
+                "gl_calibration": [
+                    [
+                        {
+                            "id": "FIN",
+                            "population": "FIN",
+                            "samples": [
+                                "HG00349",
+                                "HG00358",
+                                "HG00350",
+                                "HG00351"
+                            ]
+                        },
+                        [
+                            "0.counts0:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "0.qual0:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "1.counts1:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "1.qual1:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "2.counts2:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "2.qual2:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "3.counts3:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "3.qual3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions_angsd": [
+                    [
+                        "ANGSD_SOAPSNPCALIBRATION",
+                        "angsd",
+                        "0.940-dirty"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-22T21:38:57.552184",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "angsd - GL 3 - calibration": {
+        "content": [
+            {
+                "gl_calibration": [
+                    [
+                        {
+                            "id": "FIN",
+                            "population": "FIN",
+                            "samples": [
+                                "HG00349",
+                                "HG00358",
+                                "HG00350",
+                                "HG00351"
+                            ]
+                        },
+                        [
+                            "0.counts0:md5,673bb1d2954009bec6d02777034b357c",
+                            "0.qual0:md5,54c31d636922064c41e3bbded537c3f6",
+                            "1.counts1:md5,48b08aa5c030ad25f6466fb07cd8b463",
+                            "1.qual1:md5,df650aacbb5daaa8c70f9a6384efd808",
+                            "2.counts2:md5,f9fdb910c40411a8ecd6cd8c21cc2bcd",
+                            "2.qual2:md5,71a1c093b142caf1ade628f442b5443b",
+                            "3.counts3:md5,52334ddff2b9216d0ba758973bbad70a",
+                            "3.qual3:md5,7b83bfe82176b40ec1a0cbf458b28a71"
+                        ]
+                    ]
+                ],
+                "versions_angsd": [
+                    [
+                        "ANGSD_SOAPSNPCALIBRATION",
+                        "angsd",
+                        "0.940-dirty"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-22T21:38:52.647358",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    },
+    "angsd - soapSNP - calibration - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "FIN",
+                            "population": "FIN",
+                            "samples": [
+                                "HG00349",
+                                "HG00358",
+                                "HG00350",
+                                "HG00351"
+                            ]
+                        },
+                        [
+                            "0.counts0:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "0.qual0:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "1.counts1:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "1.qual1:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "2.counts2:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "2.qual2:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "3.counts3:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "3.qual3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        "ANGSD_SOAPSNPCALIBRATION",
+                        "angsd",
+                        "0.940-dirty"
+                    ]
+                ],
+                "soapsnp_calibration": [
+                    [
+                        {
+                            "id": "FIN",
+                            "population": "FIN",
+                            "samples": [
+                                "HG00349",
+                                "HG00358",
+                                "HG00350",
+                                "HG00351"
+                            ]
+                        },
+                        [
+                            "0.counts0:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "0.qual0:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "1.counts1:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "1.qual1:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "2.counts2:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "2.qual2:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "3.counts3:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "3.qual3:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions_angsd": [
+                    [
+                        "ANGSD_SOAPSNPCALIBRATION",
+                        "angsd",
+                        "0.940-dirty"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-22T21:48:44.461452",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.1"
+        }
+    }
+}

--- a/modules/nf-core/angsd/soapsnpcalibration/tests/nextflow.config
+++ b/modules/nf-core/angsd/soapsnpcalibration/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: ANGSD_SOAPSNPCALIBRATION {
+        ext.args  = { params.angsd_args }
+    }
+}


### PR DESCRIPTION
This PR adds a new module, `angsd/soapsnpcalibration`, which runs SOAPsnp calibration via angsd. The module generates calibration files (counts/qual matrices) needed when performing genotype likelihood estimation using -GL 3 (soapSNP model).

This module was requested during review of module `angsd/dosaf' (PR https://github.com/nf-core/modules/pull/12359), as a prerequisite/companion step for SOAPsnp-based GL estimation.


## PR checklist

Closes #12405

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [X] If necessary, include test data in your PR. - uses existing test data
- [X] Remove all TODO statements.
- [X] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [X] Add a resource `label`
- [X] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [X] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`

