### PR TITLE
Update shinyngs modules to r-shinyngs 3.2.0

### DIFF
--- a/modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
+++ b/modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
@@ -30,14 +30,14 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
@@ -50,7 +50,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
@@ -183,7 +183,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
@@ -210,7 +210,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
@@ -539,14 +539,14 @@ license: MIT
 license_family: MIT
 size: 210929
 timestamp: 1784091008551
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-md5: a9965dd99f683c5f444428f896635716
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
 depends:
 - __unix
 license: ISC
-size: 128866
-timestamp: 1781708962055
+size: 131780
+timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
 sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
 md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -618,21 +618,20 @@ license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
 license_family: Other
 size: 1620504
 timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
-sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
-md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
+sha256: d77a47bc2b340b997c680241751e581672d1d0377a680eaf0b19026f013f56b7
+md5: 3c702747058a5d0af93fe71e559327f3
 depends:
 - __glibc >=2.17,<3.0.a0
 - libexpat >=2.8.1,<3.0a0
 - libfreetype >=2.14.3
 - libfreetype6 >=2.14.3
 - libgcc >=14
-- libuuid >=2.42.1,<3.0a0
+- libuuid >=2.42.2,<3.0a0
 - libzlib >=1.3.2,<2.0a0
 license: MIT
-license_family: MIT
-size: 281880
-timestamp: 1780450077431
+size: 292684
+timestamp: 1784754430789
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
 md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -767,17 +766,17 @@ license: MIT
 license_family: MIT
 size: 11039
 timestamp: 1782800611635
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
-md5: c80d8a3b84358cb967fa81e7075fbc8a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
+sha256: c054e32ac4c14426006edf9d01981dc564559b4065af7c13c26be904e1babf04
+md5: 3c7763347873f07adfd87e8001b5b1d1
 depends:
 - __glibc >=2.17,<3.0.a0
 - libgcc >=14
 - libstdcxx >=14
 license: MIT
 license_family: MIT
-size: 12723451
-timestamp: 1773822285671
+size: 12709032
+timestamp: 1784588496729
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
 sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
 md5: 86d9cba083cd041bfbf242a01a7a1999
@@ -2412,9 +2411,9 @@ license: GPL-2.0-or-later
 license_family: GPL3
 size: 135276
 timestamp: 1758095801346
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
-sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
-md5: ced57d920bed79382f382a24a4425ef7
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
+sha256: 63c9c3607e1ffb749aa9aa5ae6f26c3cf1bba9d4c6c9eab6c5748d869b5d843b
+md5: f49a3dafb01430e8e722d6d83be5e52e
 depends:
 - r-base >=4.5,<4.6.0a0
 - r-base64enc
@@ -2440,8 +2439,8 @@ depends:
 - r-viridislite
 license: MIT
 license_family: MIT
-size: 3587131
-timestamp: 1769337109792
+size: 3696584
+timestamp: 1784741096909
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
 sha256: 353d5945d242b03c47ab0d051cf9058b4459303c96455dba9442100628a0bde1
 md5: 255fec0919919b14789eb30cc448ed20
@@ -2806,9 +2805,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
-sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
-md5: 7382af8530d082191feb0c8da5f8a41b
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
+md5: 3cbf92ab81953cc169f46813c8fdb9e3
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2838,8 +2837,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3448797
-timestamp: 1784579537432
+size: 3465016
+timestamp: 1784742023776
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
+++ b/modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
@@ -30,14 +30,14 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.2-hba86a56_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
@@ -50,7 +50,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
@@ -183,7 +183,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
@@ -210,7 +210,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
@@ -536,14 +536,14 @@ license: MIT
 license_family: MIT
 size: 220677
 timestamp: 1784091035199
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-md5: a9965dd99f683c5f444428f896635716
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
 depends:
 - __unix
 license: ISC
-size: 128866
-timestamp: 1781708962055
+size: 131780
+timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
 sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
 md5: 043c13ed3a18396994be9b4fab6572ad
@@ -613,20 +613,19 @@ license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
 license_family: Other
 size: 1620504
 timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
-sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
-md5: f4d29a0cd77104a683607319a542ac7e
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.2-hba86a56_0.conda
+sha256: 12e49d4bcc7b57ebcb51e199921604ec6218c6a09d345449b2bc7772fe5061b7
+md5: 4c3b60329dd9fbd20940b28d6f45f4a1
 depends:
 - libexpat >=2.8.1,<3.0a0
 - libfreetype >=2.14.3
 - libfreetype6 >=2.14.3
 - libgcc >=14
-- libuuid >=2.42.1,<3.0a0
+- libuuid >=2.42.2,<3.0a0
 - libzlib >=1.3.2,<2.0a0
 license: MIT
-license_family: MIT
-size: 290522
-timestamp: 1780450108132
+size: 305564
+timestamp: 1784754428554
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
 md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -759,16 +758,16 @@ license: MIT
 license_family: MIT
 size: 11079
 timestamp: 1782800518091
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
-md5: 546da38c2fa9efacf203e2ad3f987c59
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
+sha256: ba4e1acdaf6c66961d6a1863c10851dde2378fa18af48de0156b9874556ca438
+md5: da55da4ed68dcac1ce28faa0a3450b65
 depends:
 - libgcc >=14
 - libstdcxx >=14
 license: MIT
 license_family: MIT
-size: 12837286
-timestamp: 1773822650615
+size: 12870753
+timestamp: 1784588696185
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
 sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
 md5: bb3b7cad9005f2cbf9d169fb30263f3e
@@ -2325,9 +2324,9 @@ license: GPL-2.0-or-later
 license_family: GPL3
 size: 137458
 timestamp: 1758095884906
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
-sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
-md5: ced57d920bed79382f382a24a4425ef7
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
+sha256: 63c9c3607e1ffb749aa9aa5ae6f26c3cf1bba9d4c6c9eab6c5748d869b5d843b
+md5: f49a3dafb01430e8e722d6d83be5e52e
 depends:
 - r-base >=4.5,<4.6.0a0
 - r-base64enc
@@ -2353,8 +2352,8 @@ depends:
 - r-viridislite
 license: MIT
 license_family: MIT
-size: 3587131
-timestamp: 1769337109792
+size: 3696584
+timestamp: 1784741096909
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
 sha256: 0150b0ff5b1f10d44d8340697dc75308d000af7173e06a7bd6bbc52662435647
 md5: b5287e844eb29138a9bbac2204c34938
@@ -2705,9 +2704,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
-sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
-md5: 7382af8530d082191feb0c8da5f8a41b
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
+md5: 3cbf92ab81953cc169f46813c8fdb9e3
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2737,8 +2736,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3448797
-timestamp: 1784579537432
+size: 3465016
+timestamp: 1784742023776
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/app/environment.yml
+++ b/modules/nf-core/shinyngs/app/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=3.1.1
+  - bioconda::r-shinyngs=3.2.0

--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -14,8 +14,8 @@ process SHINYNGS_APP {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data'
-        : 'community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7'}"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)    // Experiment-level info

--- a/modules/nf-core/shinyngs/app/meta.yml
+++ b/modules/nf-core/shinyngs/app/meta.yml
@@ -103,24 +103,24 @@ maintainers:
 containers:
   docker:
     linux/amd64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d
-      build_id: bd-b5595b301bfbfd4d_2
-      scan_id: sc-73b4cbdd1930464e_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7
+      build_id: bd-19cca4636e20b0f7_1
+      scan_id: sc-501add0467d2f061_1
     linux/arm64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--4d71a4d10942e43f
-      build_id: bd-4d71a4d10942e43f_2
-      scan_id: sc-72596f6b93ff3200_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--71dbb9a6ee95bc28
+      build_id: bd-71dbb9a6ee95bc28_1
+      scan_id: sc-0b57ec15282cc0fe_1
   singularity:
     linux/amd64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--791778d7e2758322
-      build_id: bd-791778d7e2758322_2
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--c8c7c602b7ecaf69
+      build_id: bd-c8c7c602b7ecaf69_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data
     linux/arm64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--60831a2d7cd7ae94
-      build_id: bd-60831a2d7cd7ae94_2
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6fff209824ab2042c6f09b68d257d59ae4e0ea7410dad923089db9c5c0dbd683/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--537d87067431146d
+      build_id: bd-537d87067431146d_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a0bd003b3b7ca7b4081291d4b2cf34b41afb8cf1dd18ffb6f3c7134aaa00c7df/data
   conda:
     linux/amd64:
-      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
     linux/arm64:
-      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
+      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt

--- a/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -17,18 +17,18 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:46:04.599962"
+        "timestamp": "2026-07-23T10:14:46.417429"
     },
     "mouse - multi matrix": {
         "content": [
             "data.rds",
-            "app.R:md5,2706f3949cd8e1ab20ef8021a58f8e84",
+            "app.R:md5,1e02e7b6d263199c3f45891b3126a3ca",
             {
                 "versions_shinyngs": [
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -37,18 +37,18 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:43:56.866763"
+        "timestamp": "2026-07-23T10:10:38.049064"
     },
     "mouse - single matrix": {
         "content": [
             "data.rds",
-            "app.R:md5,2706f3949cd8e1ab20ef8021a58f8e84",
+            "app.R:md5,1e02e7b6d263199c3f45891b3126a3ca",
             {
                 "versions_shinyngs": [
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -57,6 +57,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:45:19.325048"
+        "timestamp": "2026-07-23T10:13:18.083428"
     }
 }

--- a/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
+++ b/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
@@ -30,14 +30,14 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
@@ -50,7 +50,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
@@ -183,7 +183,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
@@ -210,7 +210,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
@@ -539,14 +539,14 @@ license: MIT
 license_family: MIT
 size: 210929
 timestamp: 1784091008551
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-md5: a9965dd99f683c5f444428f896635716
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
 depends:
 - __unix
 license: ISC
-size: 128866
-timestamp: 1781708962055
+size: 131780
+timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
 sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
 md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -618,21 +618,20 @@ license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
 license_family: Other
 size: 1620504
 timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
-sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
-md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
+sha256: d77a47bc2b340b997c680241751e581672d1d0377a680eaf0b19026f013f56b7
+md5: 3c702747058a5d0af93fe71e559327f3
 depends:
 - __glibc >=2.17,<3.0.a0
 - libexpat >=2.8.1,<3.0a0
 - libfreetype >=2.14.3
 - libfreetype6 >=2.14.3
 - libgcc >=14
-- libuuid >=2.42.1,<3.0a0
+- libuuid >=2.42.2,<3.0a0
 - libzlib >=1.3.2,<2.0a0
 license: MIT
-license_family: MIT
-size: 281880
-timestamp: 1780450077431
+size: 292684
+timestamp: 1784754430789
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
 md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -767,17 +766,17 @@ license: MIT
 license_family: MIT
 size: 11039
 timestamp: 1782800611635
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
-md5: c80d8a3b84358cb967fa81e7075fbc8a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
+sha256: c054e32ac4c14426006edf9d01981dc564559b4065af7c13c26be904e1babf04
+md5: 3c7763347873f07adfd87e8001b5b1d1
 depends:
 - __glibc >=2.17,<3.0.a0
 - libgcc >=14
 - libstdcxx >=14
 license: MIT
 license_family: MIT
-size: 12723451
-timestamp: 1773822285671
+size: 12709032
+timestamp: 1784588496729
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
 sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
 md5: 86d9cba083cd041bfbf242a01a7a1999
@@ -2412,9 +2411,9 @@ license: GPL-2.0-or-later
 license_family: GPL3
 size: 135276
 timestamp: 1758095801346
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
-sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
-md5: ced57d920bed79382f382a24a4425ef7
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
+sha256: 63c9c3607e1ffb749aa9aa5ae6f26c3cf1bba9d4c6c9eab6c5748d869b5d843b
+md5: f49a3dafb01430e8e722d6d83be5e52e
 depends:
 - r-base >=4.5,<4.6.0a0
 - r-base64enc
@@ -2440,8 +2439,8 @@ depends:
 - r-viridislite
 license: MIT
 license_family: MIT
-size: 3587131
-timestamp: 1769337109792
+size: 3696584
+timestamp: 1784741096909
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
 sha256: 353d5945d242b03c47ab0d051cf9058b4459303c96455dba9442100628a0bde1
 md5: 255fec0919919b14789eb30cc448ed20
@@ -2806,9 +2805,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
-sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
-md5: 7382af8530d082191feb0c8da5f8a41b
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
+md5: 3cbf92ab81953cc169f46813c8fdb9e3
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2838,8 +2837,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3448797
-timestamp: 1784579537432
+size: 3465016
+timestamp: 1784742023776
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
+++ b/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
@@ -30,14 +30,14 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.2-hba86a56_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
@@ -50,7 +50,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
@@ -183,7 +183,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
@@ -210,7 +210,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
@@ -536,14 +536,14 @@ license: MIT
 license_family: MIT
 size: 220677
 timestamp: 1784091035199
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-md5: a9965dd99f683c5f444428f896635716
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
 depends:
 - __unix
 license: ISC
-size: 128866
-timestamp: 1781708962055
+size: 131780
+timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
 sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
 md5: 043c13ed3a18396994be9b4fab6572ad
@@ -613,20 +613,19 @@ license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
 license_family: Other
 size: 1620504
 timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
-sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
-md5: f4d29a0cd77104a683607319a542ac7e
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.2-hba86a56_0.conda
+sha256: 12e49d4bcc7b57ebcb51e199921604ec6218c6a09d345449b2bc7772fe5061b7
+md5: 4c3b60329dd9fbd20940b28d6f45f4a1
 depends:
 - libexpat >=2.8.1,<3.0a0
 - libfreetype >=2.14.3
 - libfreetype6 >=2.14.3
 - libgcc >=14
-- libuuid >=2.42.1,<3.0a0
+- libuuid >=2.42.2,<3.0a0
 - libzlib >=1.3.2,<2.0a0
 license: MIT
-license_family: MIT
-size: 290522
-timestamp: 1780450108132
+size: 305564
+timestamp: 1784754428554
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
 md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -759,16 +758,16 @@ license: MIT
 license_family: MIT
 size: 11079
 timestamp: 1782800518091
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
-md5: 546da38c2fa9efacf203e2ad3f987c59
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
+sha256: ba4e1acdaf6c66961d6a1863c10851dde2378fa18af48de0156b9874556ca438
+md5: da55da4ed68dcac1ce28faa0a3450b65
 depends:
 - libgcc >=14
 - libstdcxx >=14
 license: MIT
 license_family: MIT
-size: 12837286
-timestamp: 1773822650615
+size: 12870753
+timestamp: 1784588696185
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
 sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
 md5: bb3b7cad9005f2cbf9d169fb30263f3e
@@ -2325,9 +2324,9 @@ license: GPL-2.0-or-later
 license_family: GPL3
 size: 137458
 timestamp: 1758095884906
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
-sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
-md5: ced57d920bed79382f382a24a4425ef7
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
+sha256: 63c9c3607e1ffb749aa9aa5ae6f26c3cf1bba9d4c6c9eab6c5748d869b5d843b
+md5: f49a3dafb01430e8e722d6d83be5e52e
 depends:
 - r-base >=4.5,<4.6.0a0
 - r-base64enc
@@ -2353,8 +2352,8 @@ depends:
 - r-viridislite
 license: MIT
 license_family: MIT
-size: 3587131
-timestamp: 1769337109792
+size: 3696584
+timestamp: 1784741096909
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
 sha256: 0150b0ff5b1f10d44d8340697dc75308d000af7173e06a7bd6bbc52662435647
 md5: b5287e844eb29138a9bbac2204c34938
@@ -2705,9 +2704,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
-sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
-md5: 7382af8530d082191feb0c8da5f8a41b
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
+md5: 3cbf92ab81953cc169f46813c8fdb9e3
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2737,8 +2736,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3448797
-timestamp: 1784579537432
+size: 3465016
+timestamp: 1784742023776
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/staticdifferential/environment.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=3.1.1
+  - bioconda::r-shinyngs=3.2.0

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_STATICDIFFERENTIAL {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data'
-        : 'community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7'}"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticdifferential/meta.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/meta.yml
@@ -101,24 +101,24 @@ maintainers:
 containers:
   docker:
     linux/arm64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--4d71a4d10942e43f
-      build_id: bd-4d71a4d10942e43f_2
-      scan_id: sc-72596f6b93ff3200_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--71dbb9a6ee95bc28
+      build_id: bd-71dbb9a6ee95bc28_1
+      scan_id: sc-0b57ec15282cc0fe_1
     linux/amd64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d
-      build_id: bd-b5595b301bfbfd4d_2
-      scan_id: sc-73b4cbdd1930464e_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7
+      build_id: bd-19cca4636e20b0f7_1
+      scan_id: sc-501add0467d2f061_1
   singularity:
-    linux/arm64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--60831a2d7cd7ae94
-      build_id: bd-60831a2d7cd7ae94_2
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6fff209824ab2042c6f09b68d257d59ae4e0ea7410dad923089db9c5c0dbd683/data
     linux/amd64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--791778d7e2758322
-      build_id: bd-791778d7e2758322_2
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--c8c7c602b7ecaf69
+      build_id: bd-c8c7c602b7ecaf69_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--537d87067431146d
+      build_id: bd-537d87067431146d_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a0bd003b3b7ca7b4081291d4b2cf34b41afb8cf1dd18ffb6f3c7134aaa00c7df/data
   conda:
     linux/amd64:
-      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
     linux/arm64:
-      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
+      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt

--- a/modules/nf-core/shinyngs/staticdifferential/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/staticdifferential/tests/main.nf.test.snap
@@ -10,7 +10,7 @@
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -19,7 +19,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:47:46.296759"
+        "timestamp": "2026-07-23T10:19:58.64156"
     },
     "stub": {
         "content": [
@@ -52,14 +52,14 @@
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ],
                 "versions_shinyngs": [
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ],
                 "volcanos_html": [
@@ -92,6 +92,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:48:32.900666"
+        "timestamp": "2026-07-23T10:22:21.174397"
     }
 }

--- a/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
+++ b/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
@@ -30,14 +30,14 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
@@ -50,7 +50,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
@@ -183,7 +183,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
@@ -210,7 +210,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
@@ -539,14 +539,14 @@ license: MIT
 license_family: MIT
 size: 210929
 timestamp: 1784091008551
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-md5: a9965dd99f683c5f444428f896635716
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
 depends:
 - __unix
 license: ISC
-size: 128866
-timestamp: 1781708962055
+size: 131780
+timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
 sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
 md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -618,21 +618,20 @@ license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
 license_family: Other
 size: 1620504
 timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
-sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
-md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
+sha256: d77a47bc2b340b997c680241751e581672d1d0377a680eaf0b19026f013f56b7
+md5: 3c702747058a5d0af93fe71e559327f3
 depends:
 - __glibc >=2.17,<3.0.a0
 - libexpat >=2.8.1,<3.0a0
 - libfreetype >=2.14.3
 - libfreetype6 >=2.14.3
 - libgcc >=14
-- libuuid >=2.42.1,<3.0a0
+- libuuid >=2.42.2,<3.0a0
 - libzlib >=1.3.2,<2.0a0
 license: MIT
-license_family: MIT
-size: 281880
-timestamp: 1780450077431
+size: 292684
+timestamp: 1784754430789
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
 md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -767,17 +766,17 @@ license: MIT
 license_family: MIT
 size: 11039
 timestamp: 1782800611635
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
-md5: c80d8a3b84358cb967fa81e7075fbc8a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
+sha256: c054e32ac4c14426006edf9d01981dc564559b4065af7c13c26be904e1babf04
+md5: 3c7763347873f07adfd87e8001b5b1d1
 depends:
 - __glibc >=2.17,<3.0.a0
 - libgcc >=14
 - libstdcxx >=14
 license: MIT
 license_family: MIT
-size: 12723451
-timestamp: 1773822285671
+size: 12709032
+timestamp: 1784588496729
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
 sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
 md5: 86d9cba083cd041bfbf242a01a7a1999
@@ -2412,9 +2411,9 @@ license: GPL-2.0-or-later
 license_family: GPL3
 size: 135276
 timestamp: 1758095801346
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
-sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
-md5: ced57d920bed79382f382a24a4425ef7
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
+sha256: 63c9c3607e1ffb749aa9aa5ae6f26c3cf1bba9d4c6c9eab6c5748d869b5d843b
+md5: f49a3dafb01430e8e722d6d83be5e52e
 depends:
 - r-base >=4.5,<4.6.0a0
 - r-base64enc
@@ -2440,8 +2439,8 @@ depends:
 - r-viridislite
 license: MIT
 license_family: MIT
-size: 3587131
-timestamp: 1769337109792
+size: 3696584
+timestamp: 1784741096909
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
 sha256: 353d5945d242b03c47ab0d051cf9058b4459303c96455dba9442100628a0bde1
 md5: 255fec0919919b14789eb30cc448ed20
@@ -2806,9 +2805,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
-sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
-md5: 7382af8530d082191feb0c8da5f8a41b
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
+md5: 3cbf92ab81953cc169f46813c8fdb9e3
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2838,8 +2837,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3448797
-timestamp: 1784579537432
+size: 3465016
+timestamp: 1784742023776
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
+++ b/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
@@ -30,14 +30,14 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.2-hba86a56_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
@@ -50,7 +50,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
@@ -183,7 +183,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
@@ -210,7 +210,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
@@ -536,14 +536,14 @@ license: MIT
 license_family: MIT
 size: 220677
 timestamp: 1784091035199
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-md5: a9965dd99f683c5f444428f896635716
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
 depends:
 - __unix
 license: ISC
-size: 128866
-timestamp: 1781708962055
+size: 131780
+timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
 sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
 md5: 043c13ed3a18396994be9b4fab6572ad
@@ -613,20 +613,19 @@ license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
 license_family: Other
 size: 1620504
 timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
-sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
-md5: f4d29a0cd77104a683607319a542ac7e
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.2-hba86a56_0.conda
+sha256: 12e49d4bcc7b57ebcb51e199921604ec6218c6a09d345449b2bc7772fe5061b7
+md5: 4c3b60329dd9fbd20940b28d6f45f4a1
 depends:
 - libexpat >=2.8.1,<3.0a0
 - libfreetype >=2.14.3
 - libfreetype6 >=2.14.3
 - libgcc >=14
-- libuuid >=2.42.1,<3.0a0
+- libuuid >=2.42.2,<3.0a0
 - libzlib >=1.3.2,<2.0a0
 license: MIT
-license_family: MIT
-size: 290522
-timestamp: 1780450108132
+size: 305564
+timestamp: 1784754428554
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
 md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -759,16 +758,16 @@ license: MIT
 license_family: MIT
 size: 11079
 timestamp: 1782800518091
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
-md5: 546da38c2fa9efacf203e2ad3f987c59
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
+sha256: ba4e1acdaf6c66961d6a1863c10851dde2378fa18af48de0156b9874556ca438
+md5: da55da4ed68dcac1ce28faa0a3450b65
 depends:
 - libgcc >=14
 - libstdcxx >=14
 license: MIT
 license_family: MIT
-size: 12837286
-timestamp: 1773822650615
+size: 12870753
+timestamp: 1784588696185
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
 sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
 md5: bb3b7cad9005f2cbf9d169fb30263f3e
@@ -2325,9 +2324,9 @@ license: GPL-2.0-or-later
 license_family: GPL3
 size: 137458
 timestamp: 1758095884906
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
-sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
-md5: ced57d920bed79382f382a24a4425ef7
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
+sha256: 63c9c3607e1ffb749aa9aa5ae6f26c3cf1bba9d4c6c9eab6c5748d869b5d843b
+md5: f49a3dafb01430e8e722d6d83be5e52e
 depends:
 - r-base >=4.5,<4.6.0a0
 - r-base64enc
@@ -2353,8 +2352,8 @@ depends:
 - r-viridislite
 license: MIT
 license_family: MIT
-size: 3587131
-timestamp: 1769337109792
+size: 3696584
+timestamp: 1784741096909
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
 sha256: 0150b0ff5b1f10d44d8340697dc75308d000af7173e06a7bd6bbc52662435647
 md5: b5287e844eb29138a9bbac2204c34938
@@ -2705,9 +2704,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
-sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
-md5: 7382af8530d082191feb0c8da5f8a41b
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
+md5: 3cbf92ab81953cc169f46813c8fdb9e3
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2737,8 +2736,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3448797
-timestamp: 1784579537432
+size: 3465016
+timestamp: 1784742023776
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/staticexploratory/environment.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=3.1.1
+  - bioconda::r-shinyngs=3.2.0

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_STATICEXPLORATORY {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data'
-        : 'community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7'}"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files), val(variable)

--- a/modules/nf-core/shinyngs/staticexploratory/meta.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/meta.yml
@@ -214,24 +214,24 @@ maintainers:
 containers:
   docker:
     linux/amd64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d
-      build_id: bd-b5595b301bfbfd4d_2
-      scan_id: sc-73b4cbdd1930464e_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7
+      build_id: bd-19cca4636e20b0f7_1
+      scan_id: sc-501add0467d2f061_1
     linux/arm64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--4d71a4d10942e43f
-      build_id: bd-4d71a4d10942e43f_2
-      scan_id: sc-72596f6b93ff3200_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--71dbb9a6ee95bc28
+      build_id: bd-71dbb9a6ee95bc28_1
+      scan_id: sc-0b57ec15282cc0fe_1
   singularity:
-    linux/arm64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--60831a2d7cd7ae94
-      build_id: bd-60831a2d7cd7ae94_2
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6fff209824ab2042c6f09b68d257d59ae4e0ea7410dad923089db9c5c0dbd683/data
     linux/amd64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--791778d7e2758322
-      build_id: bd-791778d7e2758322_2
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--c8c7c602b7ecaf69
+      build_id: bd-c8c7c602b7ecaf69_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--537d87067431146d
+      build_id: bd-537d87067431146d_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a0bd003b3b7ca7b4081291d4b2cf34b41afb8cf1dd18ffb6f3c7134aaa00c7df/data
   conda:
     linux/amd64:
-      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
     linux/arm64:
-      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
+      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt

--- a/modules/nf-core/shinyngs/staticexploratory/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/staticexploratory/tests/main.nf.test.snap
@@ -12,7 +12,7 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -21,7 +21,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:52:12.716788"
+        "timestamp": "2026-07-23T10:19:07.565362"
     },
     "mouse - defaults": {
         "content": [
@@ -36,7 +36,7 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -45,7 +45,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:51:23.973465"
+        "timestamp": "2026-07-23T10:18:05.608568"
     },
     "mouse - specify log": {
         "content": [
@@ -60,7 +60,7 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -69,7 +69,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:54:00.624425"
+        "timestamp": "2026-07-23T10:22:42.348431"
     },
     "mouse - html": {
         "content": [
@@ -89,7 +89,7 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -98,6 +98,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:55:52.048115"
+        "timestamp": "2026-07-23T10:24:49.241938"
     }
 }

--- a/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
+++ b/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
@@ -30,14 +30,14 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hae6b9f4_2.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
@@ -50,7 +50,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.2.0-hda75c37_19.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.2.0-hcb00b6d_27.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
@@ -183,7 +183,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-pki-0.1_14-r45h50f7d53_3.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-processx-3.9.0-r45h54b55ab_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
@@ -210,7 +210,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
@@ -539,14 +539,14 @@ license: MIT
 license_family: MIT
 size: 210929
 timestamp: 1784091008551
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-md5: a9965dd99f683c5f444428f896635716
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
 depends:
 - __unix
 license: ISC
-size: 128866
-timestamp: 1781708962055
+size: 131780
+timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
 sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
 md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -618,21 +618,20 @@ license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
 license_family: Other
 size: 1620504
 timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
-sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
-md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
+sha256: d77a47bc2b340b997c680241751e581672d1d0377a680eaf0b19026f013f56b7
+md5: 3c702747058a5d0af93fe71e559327f3
 depends:
 - __glibc >=2.17,<3.0.a0
 - libexpat >=2.8.1,<3.0a0
 - libfreetype >=2.14.3
 - libfreetype6 >=2.14.3
 - libgcc >=14
-- libuuid >=2.42.1,<3.0a0
+- libuuid >=2.42.2,<3.0a0
 - libzlib >=1.3.2,<2.0a0
 license: MIT
-license_family: MIT
-size: 281880
-timestamp: 1780450077431
+size: 292684
+timestamp: 1784754430789
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
 md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -767,17 +766,17 @@ license: MIT
 license_family: MIT
 size: 11039
 timestamp: 1782800611635
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
-md5: c80d8a3b84358cb967fa81e7075fbc8a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
+sha256: c054e32ac4c14426006edf9d01981dc564559b4065af7c13c26be904e1babf04
+md5: 3c7763347873f07adfd87e8001b5b1d1
 depends:
 - __glibc >=2.17,<3.0.a0
 - libgcc >=14
 - libstdcxx >=14
 license: MIT
 license_family: MIT
-size: 12723451
-timestamp: 1773822285671
+size: 12709032
+timestamp: 1784588496729
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
 sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
 md5: 86d9cba083cd041bfbf242a01a7a1999
@@ -2412,9 +2411,9 @@ license: GPL-2.0-or-later
 license_family: GPL3
 size: 135276
 timestamp: 1758095801346
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
-sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
-md5: ced57d920bed79382f382a24a4425ef7
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
+sha256: 63c9c3607e1ffb749aa9aa5ae6f26c3cf1bba9d4c6c9eab6c5748d869b5d843b
+md5: f49a3dafb01430e8e722d6d83be5e52e
 depends:
 - r-base >=4.5,<4.6.0a0
 - r-base64enc
@@ -2440,8 +2439,8 @@ depends:
 - r-viridislite
 license: MIT
 license_family: MIT
-size: 3587131
-timestamp: 1769337109792
+size: 3696584
+timestamp: 1784741096909
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-plyr-1.8.9-r45h3697838_3.conda
 sha256: 353d5945d242b03c47ab0d051cf9058b4459303c96455dba9442100628a0bde1
 md5: 255fec0919919b14789eb30cc448ed20
@@ -2806,9 +2805,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
-sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
-md5: 7382af8530d082191feb0c8da5f8a41b
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
+md5: 3cbf92ab81953cc169f46813c8fdb9e3
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2838,8 +2837,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3448797
-timestamp: 1784579537432
+size: 3465016
+timestamp: 1784742023776
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
+++ b/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
@@ -30,14 +30,14 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-he30d5cf_0.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-h7c59cd8_2.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.2-hba86a56_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
@@ -50,7 +50,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-15.2.0-h03e2352_19.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-15.2.0-h7e4acf5_27.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-14.2.1-h8af1aa0_1.conda
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
@@ -183,7 +183,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r45hc72bb7e_5.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-pki-0.1_14-r45h254ea06_3.conda
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-processx-3.9.0-r45h0557e7b_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-promises-1.5.0-r45hc72bb7e_1.conda
@@ -210,7 +210,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
@@ -536,14 +536,14 @@ license: MIT
 license_family: MIT
 size: 220677
 timestamp: 1784091035199
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-md5: a9965dd99f683c5f444428f896635716
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
 depends:
 - __unix
 license: ISC
-size: 128866
-timestamp: 1781708962055
+size: 131780
+timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
 sha256: 675db823f3d6fb6bf747fab3b0170ba99b269a07cf6df1e49fff2f9972be9cd1
 md5: 043c13ed3a18396994be9b4fab6572ad
@@ -613,20 +613,19 @@ license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
 license_family: Other
 size: 1620504
 timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
-sha256: 2ccfd118269d363a5506161c4a0d96da46d2f01beecc74e0540a54b4737d0e45
-md5: f4d29a0cd77104a683607319a542ac7e
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.2-hba86a56_0.conda
+sha256: 12e49d4bcc7b57ebcb51e199921604ec6218c6a09d345449b2bc7772fe5061b7
+md5: 4c3b60329dd9fbd20940b28d6f45f4a1
 depends:
 - libexpat >=2.8.1,<3.0a0
 - libfreetype >=2.14.3
 - libfreetype6 >=2.14.3
 - libgcc >=14
-- libuuid >=2.42.1,<3.0a0
+- libuuid >=2.42.2,<3.0a0
 - libzlib >=1.3.2,<2.0a0
 license: MIT
-license_family: MIT
-size: 290522
-timestamp: 1780450108132
+size: 305564
+timestamp: 1784754428554
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
 sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
 md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -759,16 +758,16 @@ license: MIT
 license_family: MIT
 size: 11079
 timestamp: 1782800518091
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-sha256: 49ba6aed2c6b482bb0ba41078057555d29764299bc947b990708617712ef6406
-md5: 546da38c2fa9efacf203e2ad3f987c59
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
+sha256: ba4e1acdaf6c66961d6a1863c10851dde2378fa18af48de0156b9874556ca438
+md5: da55da4ed68dcac1ce28faa0a3450b65
 depends:
 - libgcc >=14
 - libstdcxx >=14
 license: MIT
 license_family: MIT
-size: 12837286
-timestamp: 1773822650615
+size: 12870753
+timestamp: 1784588696185
 - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
 sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
 md5: bb3b7cad9005f2cbf9d169fb30263f3e
@@ -2325,9 +2324,9 @@ license: GPL-2.0-or-later
 license_family: GPL3
 size: 137458
 timestamp: 1758095884906
-- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.0-r45hc72bb7e_0.conda
-sha256: 8447c2d7e0f6fc0486e812432e0ee01bb898fc13c84ec4a996126739c031ddbe
-md5: ced57d920bed79382f382a24a4425ef7
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-plotly-4.12.1-r45hc72bb7e_0.conda
+sha256: 63c9c3607e1ffb749aa9aa5ae6f26c3cf1bba9d4c6c9eab6c5748d869b5d843b
+md5: f49a3dafb01430e8e722d6d83be5e52e
 depends:
 - r-base >=4.5,<4.6.0a0
 - r-base64enc
@@ -2353,8 +2352,8 @@ depends:
 - r-viridislite
 license: MIT
 license_family: MIT
-size: 3587131
-timestamp: 1769337109792
+size: 3696584
+timestamp: 1784741096909
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-plyr-1.8.9-r45h08b74da_3.conda
 sha256: 0150b0ff5b1f10d44d8340697dc75308d000af7173e06a7bd6bbc52662435647
 md5: b5287e844eb29138a9bbac2204c34938
@@ -2705,9 +2704,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.1.1-r45hdfd78af_0.conda
-sha256: 59bc25b354edacba90648c5a6ba55c9a164fa914d92de4323ef7abedce4ba470
-md5: 7382af8530d082191feb0c8da5f8a41b
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
+md5: 3cbf92ab81953cc169f46813c8fdb9e3
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2737,8 +2736,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3448797
-timestamp: 1784579537432
+size: 3465016
+timestamp: 1784742023776
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/validatefomcomponents/environment.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=3.1.1
+  - bioconda::r-shinyngs=3.2.0

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data'
-        : 'community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7'}"
 
     input:
     tuple val(meta),  path(sample), path(assay_files)

--- a/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
@@ -128,24 +128,24 @@ maintainers:
 containers:
   docker:
     linux/amd64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--b5595b301bfbfd4d
-      build_id: bd-b5595b301bfbfd4d_2
-      scan_id: sc-73b4cbdd1930464e_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7
+      build_id: bd-19cca4636e20b0f7_1
+      scan_id: sc-501add0467d2f061_1
     linux/arm64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.1.1--4d71a4d10942e43f
-      build_id: bd-4d71a4d10942e43f_2
-      scan_id: sc-72596f6b93ff3200_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--71dbb9a6ee95bc28
+      build_id: bd-71dbb9a6ee95bc28_1
+      scan_id: sc-0b57ec15282cc0fe_1
   singularity:
-    linux/arm64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--60831a2d7cd7ae94
-      build_id: bd-60831a2d7cd7ae94_2
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/6f/6fff209824ab2042c6f09b68d257d59ae4e0ea7410dad923089db9c5c0dbd683/data
     linux/amd64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.1.1--791778d7e2758322
-      build_id: bd-791778d7e2758322_2
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/8a/8acde9b0bc0374d51ca50f3e49fb0f26a6fb394d277b3af5e276de8bf1786610/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--c8c7c602b7ecaf69
+      build_id: bd-c8c7c602b7ecaf69_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--537d87067431146d
+      build_id: bd-537d87067431146d_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a0bd003b3b7ca7b4081291d4b2cf34b41afb8cf1dd18ffb6f3c7134aaa00c7df/data
   conda:
     linux/amd64:
-      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-b5595b301bfbfd4d_2.txt
+      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
     linux/arm64:
-      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-4d71a4d10942e43f_2.txt
+      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt

--- a/modules/nf-core/shinyngs/validatefomcomponents/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/validatefomcomponents/tests/main.nf.test.snap
@@ -38,7 +38,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ],
                 "assays": [
@@ -77,7 +77,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -86,7 +86,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:51:30.322038"
+        "timestamp": "2026-07-23T10:18:02.183916"
     },
     "stub": {
         "content": [
@@ -127,7 +127,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ],
                 "assays": [
@@ -166,7 +166,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -175,7 +175,7 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:54:06.396638"
+        "timestamp": "2026-07-23T10:22:38.926193"
     },
     "test_yaml": {
         "content": [
@@ -216,7 +216,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ],
                 "assays": [
@@ -255,7 +255,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.1.1"
+                        "3.2.0"
                     ]
                 ]
             }
@@ -264,6 +264,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-07-20T23:53:15.603678"
+        "timestamp": "2026-07-23T10:21:00.752449"
     }
 }


### PR DESCRIPTION
## Summary

- Bumps all 4 `shinyngs` modules (`app`, `staticdifferential`, `staticexploratory`, `validatefomcomponents`) from `r-shinyngs` 3.1.1 to 3.2.0.
- Rebuilt multi-arch (linux/amd64, linux/arm64) Wave containers and refreshed each module's `containers:`/`.conda-lock` metadata via `nf-core modules containers create`.
- No module or test changes needed beyond the version bump: 3.2.0's CLI additions (`--pca_scale` in `exploratory_plots.R`, several `--heatmap_*` layout options in `make_app_from_files.R`) are purely additive with defaults matching prior behaviour.
- Updated snapshots: every diff is the `3.1.1` -> `3.2.0` version string, plus the `app.R` content hash for `shinyngs/app` (the generated app bundle now wires through the new heatmap layout options).

## Test plan

- [x] `nf-core modules lint` on all 4 modules: 0 failed (2 pre-existing warnings, `container_links` 404 and `main_nf_container` version mismatch, are stable-linter limitations with Wave containers - also present on the already-merged `multiqc` module)
- [x] `nf-test --profile docker` for all 4 modules: all pass