### PR TITLE
feat: Add sentieon label to qualcal process

### DIFF
--- a/modules/nf-core/sentieon/qualcal/main.nf
+++ b/modules/nf-core/sentieon/qualcal/main.nf
@@ -1,6 +1,7 @@
 process SENTIEON_QUALCAL {
     tag "${meta.id}"
     label 'process_medium'
+    label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container


### PR DESCRIPTION
Sentieon QualCal was missing it's label, probably a mistake.

This pull request makes a minor update to the `SENTIEON_QUALCAL` process by adding the `sentieon` label. This helps with resource labeling and scheduling in Nextflow pipelines.

* Added the `sentieon` label to the `SENTIEON_QUALCAL` process in `main.nf` for improved process categorization and resource management.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [x] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
