### PR TITLE
feat(shinyngs/app): add optional gene_sets and enrichment_results inputs

### DIFF
--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -21,6 +21,8 @@ process SHINYNGS_APP {
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)    // Experiment-level info
     tuple val(meta2), path(contrasts), path(differential_results)           // Differential info: contrasts and differential stats
     val(contrast_stats_assay)
+    path(gene_sets)                                                         // Optional: GMT gene set files for enrichment (referenced via --enrichment_gene_sets)
+    path(enrichment_results)                                               // Optional: per-contrast enrichment result tables (matched via --enrichment_filename_template)
 
     output:
     tuple val(meta), path("*/data.rds"), path("*/app.R")    , emit: app

--- a/modules/nf-core/shinyngs/app/meta.yml
+++ b/modules/nf-core/shinyngs/app/meta.yml
@@ -53,6 +53,19 @@ input:
       type: file
       description: contrast statistics
       ontologies: []
+  - gene_sets:
+      type: file
+      description: |
+        Optional: GMT-format gene set files used for enrichment, referenced in the
+        app via the shinyngs `--enrichment_gene_sets` argument.
+      pattern: "*.{gmt}"
+      ontologies: []
+  - enrichment_results:
+      type: file
+      description: |
+        Optional: per-contrast enrichment result tables (e.g. GSEA output), matched
+        to contrasts in the app via the shinyngs `--enrichment_filename_template` argument.
+      ontologies: []
 output:
   app:
     - - meta:

--- a/modules/nf-core/shinyngs/app/tests/main.nf.test
+++ b/modules/nf-core/shinyngs/app/tests/main.nf.test
@@ -56,6 +56,62 @@ nextflow_process {
         }
     }
 
+    test("mouse - with enrichment") {
+
+        when {
+            params {
+                module_args = "--assay_names raw,normalised --enrichment_gene_sets mh.all.v2022.1.Mm.symbols.gmt --enrichment_filename_template '{contrast_name}.{geneset_type}.gsea_report_for_{target|reference}.tsv' --enrichment_gene_type_id gene_name"
+            }
+            process {
+                """
+                expression_test_data_dir = params.modules_testdata_base_path + 'genomics/mus_musculus/rnaseq_expression/'
+                gene_set_data_dir = params.modules_testdata_base_path + 'genomics/mus_musculus/gene_set_analysis/'
+
+                expression_sample_sheet = file(expression_test_data_dir + 'SRP254919.samplesheet.csv', checkIfExists: true)
+                expression_feature_meta = file(expression_test_data_dir + 'SRP254919.gene_meta.tsv', checkIfExists: true)
+                raw_expression_matrix_file = file(expression_test_data_dir + 'SRP254919.salmon.merged.gene_counts.top1000cov.tsv', checkIfExists: true)
+                expression_contrasts = file(expression_test_data_dir + 'SRP254919.contrasts.csv', checkIfExists: true)
+                expression_differential = file(expression_test_data_dir + 'SRP254919.salmon.merged.deseq2.results.tsv', checkIfExists: true)
+
+                // Copy some inputs for testing the multi-matrix functionality
+                raw_expression_matrix_file.copyTo('normalised.tsv')
+                normalised_expression_matrix_file = file('normalised.tsv')
+                expression_differential.copyTo('second_contrast_stats.tsv')
+                second_contrast_stats = file('second_contrast_stats.tsv')
+
+                contrast_stats_assay = Channel.value(2)
+
+                // GMT gene sets and per-contrast GSEA report tables matched via the
+                // --enrichment_filename_template, one up/down pair per contrast
+                gene_sets = file(gene_set_data_dir + 'mh.all.v2022.1.Mm.symbols.gmt', checkIfExists: true)
+                enrichment_results = [
+                    file(gene_set_data_dir + 'shinyngs/treatment_mCherry_hND6_.mh.all.v2022.1.Mm.symbols.gsea_report_for_hND6.tsv', checkIfExists: true),
+                    file(gene_set_data_dir + 'shinyngs/treatment_mCherry_hND6_.mh.all.v2022.1.Mm.symbols.gsea_report_for_mCherry.tsv', checkIfExists: true),
+                    file(gene_set_data_dir + 'shinyngs/treatment_mCherry_hND6_sample_number.mh.all.v2022.1.Mm.symbols.gsea_report_for_hND6.tsv', checkIfExists: true),
+                    file(gene_set_data_dir + 'shinyngs/treatment_mCherry_hND6_sample_number.mh.all.v2022.1.Mm.symbols.gsea_report_for_mCherry.tsv', checkIfExists: true)
+                ]
+
+                input[0] = [ [ "id":"SRP254919" ], expression_sample_sheet,  expression_feature_meta, [ raw_expression_matrix_file, normalised_expression_matrix_file ] ]
+                input[1] = [ [ "id":"SRP254919" ], expression_contrasts, [ expression_differential, second_contrast_stats  ] ]
+                input[2] = contrast_stats_assay
+                input[3] = gene_sets
+                input[4] = enrichment_results
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.app[0][1]).name,
+                    process.out.app[0][2],
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
     test("mouse - single matrix") {
 
         when {

--- a/modules/nf-core/shinyngs/app/tests/main.nf.test
+++ b/modules/nf-core/shinyngs/app/tests/main.nf.test
@@ -38,6 +38,8 @@ nextflow_process {
                 input[0] = [ [ "id":"SRP254919" ], expression_sample_sheet,  expression_feature_meta, [ raw_expression_matrix_file, normalised_expression_matrix_file ] ]
                 input[1] = [ [ "id":"SRP254919" ], expression_contrasts, [ expression_differential, second_contrast_stats  ] ]
                 input[2] = contrast_stats_assay
+                input[3] = []
+                input[4] = []
                 """
             }
         }
@@ -79,6 +81,8 @@ nextflow_process {
                 input[0] = [ [ "id":"SRP254919" ], expression_sample_sheet,  expression_feature_meta, [ raw_expression_matrix_file ] ]
                 input[1] = [ [ "id":"SRP254919" ], expression_contrasts, [ expression_differential, second_contrast_stats  ] ]
                 input[2] = contrast_stats_assay
+                input[3] = []
+                input[4] = []
                 """
             }
         }
@@ -122,6 +126,8 @@ nextflow_process {
                 input[0] = [ [ "id":"SRP254919" ], expression_sample_sheet,  expression_feature_meta, [ raw_expression_matrix_file ] ]
                 input[1] = [ [ "id":"SRP254919" ], expression_contrasts, [ expression_differential, second_contrast_stats  ] ]
                 input[2] = contrast_stats_assay
+                input[3] = []
+                input[4] = []
                 """
             }
         }

--- a/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
@@ -39,6 +39,26 @@
         },
         "timestamp": "2026-07-23T10:10:38.049064"
     },
+    "mouse - with enrichment": {
+        "content": [
+            "data.rds",
+            "app.R:md5,1e02e7b6d263199c3f45891b3126a3ca",
+            {
+                "versions_shinyngs": [
+                    [
+                        "SHINYNGS_APP",
+                        "shinyngs",
+                        "3.2.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        },
+        "timestamp": "2026-07-23T12:47:20.019006501"
+    },
     "mouse - single matrix": {
         "content": [
             "data.rds",

--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -2,7 +2,7 @@ params {
     publish_dir_mode                  = "copy"
     singularity_pull_docker_container = false
     test_data_base                    = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules'
-    modules_testdata_base_path        = 'https://raw.githubusercontent.com/pinin4fjords/test-datasets/shinyngs-app-enrichment/data/'
+    modules_testdata_base_path        = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
 }
 
 // Resolves issue with accessing s3 from self-hosted runners

--- a/tests/config/nf-test.config
+++ b/tests/config/nf-test.config
@@ -2,7 +2,7 @@ params {
     publish_dir_mode                  = "copy"
     singularity_pull_docker_container = false
     test_data_base                    = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules'
-    modules_testdata_base_path        = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
+    modules_testdata_base_path        = 'https://raw.githubusercontent.com/pinin4fjords/test-datasets/shinyngs-app-enrichment/data/'
 }
 
 // Resolves issue with accessing s3 from self-hosted runners


### PR DESCRIPTION
## Summary

Adds two optional `path` inputs to the `shinyngs/app` module:

- `gene_sets` - GMT-format gene set files, referenced in the app via shinyngs' `--enrichment_gene_sets` argument.
- `enrichment_results` - per-contrast enrichment result tables (e.g. GSEA output), matched to contrasts via shinyngs' `--enrichment_filename_template` argument.

These let GSEA enrichment tables and gene-set GMTs be baked into the shinyngs app object using the existing shinyngs `--enrichment_*` CLI (shinyngs >= 3.1). The new inputs are staged files consumed only via `task.ext.args`, so the `script:` block, container, tool version, and outputs are all unchanged.

## Tests

A new `mouse - with enrichment` nf-test case stages the mouse `mh.all.v2022.1.Mm.symbols.gmt` gene sets and per-contrast GSEA report tables, and passes them via `--enrichment_gene_sets` / `--enrichment_filename_template` (with `--enrichment_gene_type_id`). No `--enrichment_skip_missing` is set, so the test fails if any referenced file is not staged. This exercises shinyngs' `read_enrichment_file()` at app-build time: the resulting `data.rds` carries the enrichment tables keyed by assay / gene-set type / contrast (verified: 50 rows per contrast, up+down combined).

The three pre-existing test cases pass the two new positional inputs as empty (`[]`), so their behaviour and snapshots are unchanged.

## Dependency

The enrichment test consumes new fixtures added in **nf-core/test-datasets#2171**; that PR must merge before CI here can go green (the last push carries a skip-CI marker to avoid a guaranteed-red run against the not-yet-merged data).

## Downstream consumer

Unblocks nf-core/differentialabundance#748, which bakes GSEA enrichment into the shinyngs app object.