### PR TITLE
feat: Add sentieon label to qualcal process

### DIFF
--- a/modules/nf-core/sentieon/qualcal/main.nf
+++ b/modules/nf-core/sentieon/qualcal/main.nf
@@ -1,6 +1,7 @@
 process SENTIEON_QUALCAL {
     tag "${meta.id}"
     label 'process_medium'
+    label 'sentieon'
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container


### PR DESCRIPTION
Adds the `sentieon` process label to `SENTIEON_QUALCAL`, matching other Sentieon modules.

Replaces #12411. That PR was opened from a fork, so the `SENTIEON_LICENSE` / `SENTIEON_AUTH_DATA` GitHub Actions org secrets are not exposed to its CI runs (secrets are unavailable to fork PRs), producing:

```
WARN: Environment variable SENTIEON_LICENSE evaluates to an empty value
WARN: Environment variable SENTIEON_AUTH_DATA evaluates to an empty value
```

Opening from a branch on `nf-core/modules` directly so the secrets are available and the Sentieon tests run with a valid license.

Generated by Claude Code