### PR TITLE
Change arity for tumor-only mode: `nanomonsv/get` module

### DIFF
--- a/modules/nf-core/nanomonsv/get/main.nf
+++ b/modules/nf-core/nanomonsv/get/main.nf
@@ -32,14 +32,13 @@ process NANOMONSV_GET {
     prefix2 = task.ext.prefix2 ?: "${meta2.id}"
 
     def simple_repeat_arg = simple_repeat_bed ? "--simple_repeat_bed ${simple_repeat_bed[0]}" : ""
-    def control_bam_arg = control_bam ? "--control_bam ${control_bam[0]}" : ""
+    def control_args = control_bam ? "--control_bam ${control_bam[0]} --control_prefix ${prefix2}" : ""
 
     """
     nanomonsv get \\
         ${args} \\
         --processes ${task.cpus} \\
-        ${control_bam_arg} \\
-        --control_prefix ${prefix2} \\
+        ${control_args} \\
         ${simple_repeat_arg} \\
         ${prefix} \\
         ${tumor_bam} \\

--- a/modules/nf-core/nanomonsv/get/main.nf
+++ b/modules/nf-core/nanomonsv/get/main.nf
@@ -9,7 +9,7 @@ process NANOMONSV_GET {
 
     input:
     tuple val(meta), path(tumor_bam), path(tumor_bai), path(tumor_parse_files, arity: '8')
-    tuple val(meta2), path(control_bam), path(control_bai), path(control_parse_files, arity: '8')
+    tuple val(meta2), path(control_bam), path(control_bai), path(control_parse_files, arity: '0..8')
     tuple val(meta3), path(ref), path(ref_index)
     path simple_repeat_bed
     path simple_repeat_bed_index

--- a/modules/nf-core/nanomonsv/get/meta.yml
+++ b/modules/nf-core/nanomonsv/get/meta.yml
@@ -67,7 +67,7 @@ input:
     - control_parse_files:
         type: file
         description: |
-          Control nanomonsv parse outputs in order:
+          Optional control sample nanomonsv parse outputs in order:
           insertion, insertion index, deletion, deletion index,
           rearrangement, rearrangement index, bp_info, bp_info index.
           The parse prefix defaults to `meta2.id` and can be overridden with


### PR DESCRIPTION
This PR makes a small change to the `main.nf` of `nanomonsv/get` to allow it to run in tumor-only mode without matched control files from `nanomonsv/parse`.