### PR TITLE
Bump shinyngs modules to r-shinyngs 3.2.1

### DIFF
--- a/modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
+++ b/modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
@@ -210,7 +210,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
@@ -2805,9 +2805,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
-sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
-md5: 3cbf92ab81953cc169f46813c8fdb9e3
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
+sha256: 976441f2fbbe37fb2813f1a3656d55972d762f2ed65fd8f1c0cf9b42362bcb73
+md5: ba2d6a8d4285703dd5ac796026fe4d98
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2837,8 +2837,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3465016
-timestamp: 1784742023776
+size: 3469058
+timestamp: 1784889280771
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt
+++ b/modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt
@@ -210,7 +210,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
@@ -2704,9 +2704,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
-sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
-md5: 3cbf92ab81953cc169f46813c8fdb9e3
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
+sha256: 976441f2fbbe37fb2813f1a3656d55972d762f2ed65fd8f1c0cf9b42362bcb73
+md5: ba2d6a8d4285703dd5ac796026fe4d98
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2736,8 +2736,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3465016
-timestamp: 1784742023776
+size: 3469058
+timestamp: 1784889280771
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/app/environment.yml
+++ b/modules/nf-core/shinyngs/app/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=3.2.0
+  - bioconda::r-shinyngs=3.2.1

--- a/modules/nf-core/shinyngs/app/main.nf
+++ b/modules/nf-core/shinyngs/app/main.nf
@@ -14,8 +14,8 @@ process SHINYNGS_APP {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data'
-        : 'community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5f79ef0afe3e3831496c61c81aeda56312f49ac324dc378d3312af7acae2ec6/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.2.1--d43071e62bc500d3'}"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files)    // Experiment-level info

--- a/modules/nf-core/shinyngs/app/meta.yml
+++ b/modules/nf-core/shinyngs/app/meta.yml
@@ -116,24 +116,24 @@ maintainers:
 containers:
   docker:
     linux/amd64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7
-      build_id: bd-19cca4636e20b0f7_1
-      scan_id: sc-501add0467d2f061_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.1--d43071e62bc500d3
+      build_id: bd-d43071e62bc500d3_1
+      scan_id: sc-5ac2dcb847246bad_1
     linux/arm64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--71dbb9a6ee95bc28
-      build_id: bd-71dbb9a6ee95bc28_1
-      scan_id: sc-0b57ec15282cc0fe_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.1--d168a374ce5dc1af
+      build_id: bd-d168a374ce5dc1af_1
+      scan_id: sc-0f3dfab20873614f_1
   singularity:
     linux/amd64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--c8c7c602b7ecaf69
-      build_id: bd-c8c7c602b7ecaf69_1
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.1--b810af5b9efbb4b2
+      build_id: bd-b810af5b9efbb4b2_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5f79ef0afe3e3831496c61c81aeda56312f49ac324dc378d3312af7acae2ec6/data
     linux/arm64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--537d87067431146d
-      build_id: bd-537d87067431146d_1
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a0bd003b3b7ca7b4081291d4b2cf34b41afb8cf1dd18ffb6f3c7134aaa00c7df/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.1--ed7d3904b821c0a8
+      build_id: bd-ed7d3904b821c0a8_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/74/74ebb0b4cfa12e1174262987ffa0559ab388198ba94196a4fd295ce5a9051a22/data
   conda:
     linux/amd64:
-      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
+      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
     linux/arm64:
-      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
+      lock_file: modules/nf-core/shinyngs/app/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt

--- a/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/app/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -28,7 +28,7 @@
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -48,7 +48,7 @@
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -68,7 +68,7 @@
                     [
                         "SHINYNGS_APP",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }

--- a/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
+++ b/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
@@ -210,7 +210,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
@@ -2805,9 +2805,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
-sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
-md5: 3cbf92ab81953cc169f46813c8fdb9e3
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
+sha256: 976441f2fbbe37fb2813f1a3656d55972d762f2ed65fd8f1c0cf9b42362bcb73
+md5: ba2d6a8d4285703dd5ac796026fe4d98
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2837,8 +2837,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3465016
-timestamp: 1784742023776
+size: 3469058
+timestamp: 1784889280771
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt
+++ b/modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt
@@ -210,7 +210,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
@@ -2704,9 +2704,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
-sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
-md5: 3cbf92ab81953cc169f46813c8fdb9e3
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
+sha256: 976441f2fbbe37fb2813f1a3656d55972d762f2ed65fd8f1c0cf9b42362bcb73
+md5: ba2d6a8d4285703dd5ac796026fe4d98
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2736,8 +2736,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3465016
-timestamp: 1784742023776
+size: 3469058
+timestamp: 1784889280771
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/staticdifferential/environment.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=3.2.0
+  - bioconda::r-shinyngs=3.2.1

--- a/modules/nf-core/shinyngs/staticdifferential/main.nf
+++ b/modules/nf-core/shinyngs/staticdifferential/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_STATICDIFFERENTIAL {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data'
-        : 'community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5f79ef0afe3e3831496c61c81aeda56312f49ac324dc378d3312af7acae2ec6/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.2.1--d43071e62bc500d3'}"
 
     input:
     tuple val(meta), path(differential_result)                              // Differential info: contrast and differential stats

--- a/modules/nf-core/shinyngs/staticdifferential/meta.yml
+++ b/modules/nf-core/shinyngs/staticdifferential/meta.yml
@@ -100,25 +100,25 @@ maintainers:
   - "@pinin4fjords"
 containers:
   docker:
-    linux/arm64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--71dbb9a6ee95bc28
-      build_id: bd-71dbb9a6ee95bc28_1
-      scan_id: sc-0b57ec15282cc0fe_1
     linux/amd64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7
-      build_id: bd-19cca4636e20b0f7_1
-      scan_id: sc-501add0467d2f061_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.1--d43071e62bc500d3
+      build_id: bd-d43071e62bc500d3_1
+      scan_id: sc-5ac2dcb847246bad_1
+    linux/arm64:
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.1--d168a374ce5dc1af
+      build_id: bd-d168a374ce5dc1af_1
+      scan_id: sc-0f3dfab20873614f_1
   singularity:
     linux/amd64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--c8c7c602b7ecaf69
-      build_id: bd-c8c7c602b7ecaf69_1
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.1--b810af5b9efbb4b2
+      build_id: bd-b810af5b9efbb4b2_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5f79ef0afe3e3831496c61c81aeda56312f49ac324dc378d3312af7acae2ec6/data
     linux/arm64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--537d87067431146d
-      build_id: bd-537d87067431146d_1
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a0bd003b3b7ca7b4081291d4b2cf34b41afb8cf1dd18ffb6f3c7134aaa00c7df/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.1--ed7d3904b821c0a8
+      build_id: bd-ed7d3904b821c0a8_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/74/74ebb0b4cfa12e1174262987ffa0559ab388198ba94196a4fd295ce5a9051a22/data
   conda:
     linux/amd64:
-      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
+      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
     linux/arm64:
-      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
+      lock_file: modules/nf-core/shinyngs/staticdifferential/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt

--- a/modules/nf-core/shinyngs/staticdifferential/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/staticdifferential/tests/main.nf.test.snap
@@ -10,7 +10,7 @@
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -52,14 +52,14 @@
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ],
                 "versions_shinyngs": [
                     [
                         "SHINYNGS_STATICDIFFERENTIAL",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ],
                 "volcanos_html": [

--- a/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
+++ b/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
@@ -210,7 +210,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
@@ -2805,9 +2805,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
-sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
-md5: 3cbf92ab81953cc169f46813c8fdb9e3
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
+sha256: 976441f2fbbe37fb2813f1a3656d55972d762f2ed65fd8f1c0cf9b42362bcb73
+md5: ba2d6a8d4285703dd5ac796026fe4d98
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2837,8 +2837,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3465016
-timestamp: 1784742023776
+size: 3469058
+timestamp: 1784889280771
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt
+++ b/modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt
@@ -210,7 +210,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
@@ -2704,9 +2704,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
-sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
-md5: 3cbf92ab81953cc169f46813c8fdb9e3
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
+sha256: 976441f2fbbe37fb2813f1a3656d55972d762f2ed65fd8f1c0cf9b42362bcb73
+md5: ba2d6a8d4285703dd5ac796026fe4d98
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2736,8 +2736,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3465016
-timestamp: 1784742023776
+size: 3469058
+timestamp: 1784889280771
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/staticexploratory/environment.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=3.2.0
+  - bioconda::r-shinyngs=3.2.1

--- a/modules/nf-core/shinyngs/staticexploratory/main.nf
+++ b/modules/nf-core/shinyngs/staticexploratory/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_STATICEXPLORATORY {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data'
-        : 'community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5f79ef0afe3e3831496c61c81aeda56312f49ac324dc378d3312af7acae2ec6/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.2.1--d43071e62bc500d3'}"
 
     input:
     tuple val(meta), path(sample), path(feature_meta), path(assay_files), val(variable)

--- a/modules/nf-core/shinyngs/staticexploratory/meta.yml
+++ b/modules/nf-core/shinyngs/staticexploratory/meta.yml
@@ -214,24 +214,24 @@ maintainers:
 containers:
   docker:
     linux/amd64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7
-      build_id: bd-19cca4636e20b0f7_1
-      scan_id: sc-501add0467d2f061_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.1--d43071e62bc500d3
+      build_id: bd-d43071e62bc500d3_1
+      scan_id: sc-5ac2dcb847246bad_1
     linux/arm64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--71dbb9a6ee95bc28
-      build_id: bd-71dbb9a6ee95bc28_1
-      scan_id: sc-0b57ec15282cc0fe_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.1--d168a374ce5dc1af
+      build_id: bd-d168a374ce5dc1af_1
+      scan_id: sc-0f3dfab20873614f_1
   singularity:
     linux/amd64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--c8c7c602b7ecaf69
-      build_id: bd-c8c7c602b7ecaf69_1
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.1--b810af5b9efbb4b2
+      build_id: bd-b810af5b9efbb4b2_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5f79ef0afe3e3831496c61c81aeda56312f49ac324dc378d3312af7acae2ec6/data
     linux/arm64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--537d87067431146d
-      build_id: bd-537d87067431146d_1
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a0bd003b3b7ca7b4081291d4b2cf34b41afb8cf1dd18ffb6f3c7134aaa00c7df/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.1--ed7d3904b821c0a8
+      build_id: bd-ed7d3904b821c0a8_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/74/74ebb0b4cfa12e1174262987ffa0559ab388198ba94196a4fd295ce5a9051a22/data
   conda:
     linux/amd64:
-      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
+      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
     linux/arm64:
-      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
+      lock_file: modules/nf-core/shinyngs/staticexploratory/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt

--- a/modules/nf-core/shinyngs/staticexploratory/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/staticexploratory/tests/main.nf.test.snap
@@ -12,7 +12,7 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -36,7 +36,7 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -60,7 +60,7 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -89,7 +89,7 @@
                     [
                         "SHINYNGS_STATICEXPLORATORY",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }

--- a/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
+++ b/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
@@ -210,7 +210,7 @@ linux-64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-sourcetools-0.1.7_2-r45h3697838_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-64/r-statmod-1.5.2-r45hb1d0f04_0.conda
@@ -2805,9 +2805,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
-sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
-md5: 3cbf92ab81953cc169f46813c8fdb9e3
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
+sha256: 976441f2fbbe37fb2813f1a3656d55972d762f2ed65fd8f1c0cf9b42362bcb73
+md5: ba2d6a8d4285703dd5ac796026fe4d98
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2837,8 +2837,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3465016
-timestamp: 1784742023776
+size: 3469058
+timestamp: 1784889280771
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt
+++ b/modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt
@@ -210,7 +210,7 @@ linux-aarch64:
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shiny-1.14.0-r45h785f33e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinycssloaders-1.1.0-r45hc72bb7e_1.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-shinyjs-2.1.1-r45hc72bb7e_0.conda
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-sourcetools-0.1.7_2-r45h08b74da_0.conda
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-statmod-1.5.2-r45h4ebe5a5_0.conda
@@ -2704,9 +2704,9 @@ license: MIT
 license_family: MIT
 size: 1018291
 timestamp: 1768513288077
-- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.0-r45hdfd78af_0.conda
-sha256: ff3681edf5388153a939563dd57fc6ddd32c53ab1118e9834d60842a302b86b7
-md5: 3cbf92ab81953cc169f46813c8fdb9e3
+- conda: https://conda.anaconda.org/bioconda/noarch/r-shinyngs-3.2.1-r45hdfd78af_0.conda
+sha256: 976441f2fbbe37fb2813f1a3656d55972d762f2ed65fd8f1c0cf9b42362bcb73
+md5: ba2d6a8d4285703dd5ac796026fe4d98
 depends:
 - bioconductor-limma
 - bioconductor-summarizedexperiment
@@ -2736,8 +2736,8 @@ depends:
 - r-yaml
 license: AGPL-3.0
 license_family: AGPL
-size: 3465016
-timestamp: 1784742023776
+size: 3469058
+timestamp: 1784889280771
 - conda: https://conda.anaconda.org/conda-forge/noarch/r-snowflakeauth-0.2.2-r45hc72bb7e_0.conda
 sha256: c2beeab7a52ee1f6c55b96df5caca3b36afce1887025b1d5d94b1aae34a819a3
 md5: 1d38994c8bfe421d621d9b3705c37b58

--- a/modules/nf-core/shinyngs/validatefomcomponents/environment.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::r-shinyngs=3.2.0
+  - bioconda::r-shinyngs=3.2.1

--- a/modules/nf-core/shinyngs/validatefomcomponents/main.nf
+++ b/modules/nf-core/shinyngs/validatefomcomponents/main.nf
@@ -4,8 +4,8 @@ process SHINYNGS_VALIDATEFOMCOMPONENTS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data'
-        : 'community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5f79ef0afe3e3831496c61c81aeda56312f49ac324dc378d3312af7acae2ec6/data'
+        : 'community.wave.seqera.io/library/r-shinyngs:3.2.1--d43071e62bc500d3'}"
 
     input:
     tuple val(meta),  path(sample), path(assay_files)

--- a/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
+++ b/modules/nf-core/shinyngs/validatefomcomponents/meta.yml
@@ -128,24 +128,24 @@ maintainers:
 containers:
   docker:
     linux/amd64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--19cca4636e20b0f7
-      build_id: bd-19cca4636e20b0f7_1
-      scan_id: sc-501add0467d2f061_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.1--d43071e62bc500d3
+      build_id: bd-d43071e62bc500d3_1
+      scan_id: sc-5ac2dcb847246bad_1
     linux/arm64:
-      name: community.wave.seqera.io/library/r-shinyngs:3.2.0--71dbb9a6ee95bc28
-      build_id: bd-71dbb9a6ee95bc28_1
-      scan_id: sc-0b57ec15282cc0fe_1
+      name: community.wave.seqera.io/library/r-shinyngs:3.2.1--d168a374ce5dc1af
+      build_id: bd-d168a374ce5dc1af_1
+      scan_id: sc-0f3dfab20873614f_1
   singularity:
     linux/amd64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--c8c7c602b7ecaf69
-      build_id: bd-c8c7c602b7ecaf69_1
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/41/41759558393509662940440e609bd5e89e4ec0d4b02c09421923fa0270926666/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.1--b810af5b9efbb4b2
+      build_id: bd-b810af5b9efbb4b2_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d5/d5f79ef0afe3e3831496c61c81aeda56312f49ac324dc378d3312af7acae2ec6/data
     linux/arm64:
-      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.0--537d87067431146d
-      build_id: bd-537d87067431146d_1
-      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a0/a0bd003b3b7ca7b4081291d4b2cf34b41afb8cf1dd18ffb6f3c7134aaa00c7df/data
+      name: oras://community.wave.seqera.io/library/r-shinyngs:3.2.1--ed7d3904b821c0a8
+      build_id: bd-ed7d3904b821c0a8_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/74/74ebb0b4cfa12e1174262987ffa0559ab388198ba94196a4fd295ce5a9051a22/data
   conda:
     linux/amd64:
-      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-19cca4636e20b0f7_1.txt
+      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_amd64-bd-d43071e62bc500d3_1.txt
     linux/arm64:
-      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-71dbb9a6ee95bc28_1.txt
+      lock_file: modules/nf-core/shinyngs/validatefomcomponents/.conda-lock/linux_arm64-bd-d168a374ce5dc1af_1.txt

--- a/modules/nf-core/shinyngs/validatefomcomponents/tests/main.nf.test.snap
+++ b/modules/nf-core/shinyngs/validatefomcomponents/tests/main.nf.test.snap
@@ -38,7 +38,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ],
                 "assays": [
@@ -77,7 +77,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -127,7 +127,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ],
                 "assays": [
@@ -166,7 +166,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }
@@ -216,7 +216,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ],
                 "assays": [
@@ -255,7 +255,7 @@
                     [
                         "SHINYNGS_VALIDATEFOMCOMPONENTS",
                         "shinyngs",
-                        "3.2.0"
+                        "3.2.1"
                     ]
                 ]
             }


### PR DESCRIPTION
## Summary
- Bumps all 4 shinyngs modules (app, staticdifferential, staticexploratory, validatefomcomponents) from r-shinyngs 3.2.0 to 3.2.1
- Rebuilds the multi-arch (linux/amd64, linux/arm64) Wave Docker + Singularity containers and refreshes the `containers:`/conda-lock metadata in each module's `meta.yml`
- r-shinyngs 3.2.1 is a patch release with no dependency changes, so no module or test changes were needed beyond the version bump

## Test plan
- [x] `nf-test` run locally against Docker for all 4 modules (13 test cases total), all passing against the updated snapshots