### PR TITLE
Updated iqtree to v3 and model output

### DIFF
--- a/modules/nf-core/iqtree/environment.yml
+++ b/modules/nf-core/iqtree/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::iqtree=2.4.0
+  - bioconda::iqtree=3.1.3

--- a/modules/nf-core/iqtree/main.nf
+++ b/modules/nf-core/iqtree/main.nf
@@ -4,8 +4,8 @@ process IQTREE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/iqtree:2.4.0--h503566f_0' :
-        'quay.io/biocontainers/iqtree:2.4.0--h503566f_0' }"
+        'https://depot.galaxyproject.org/singularity/iqtree:3.1.3--h8471819_0' :
+        'quay.io/biocontainers/iqtree:3.1.3--h8471819_0' }"
 
     input:
     tuple val(meta), path(alignment), path(tree)
@@ -34,6 +34,7 @@ process IQTREE {
     tuple val(meta), path("*.state")         , emit: state         , optional: true
     tuple val(meta), path("*.contree")       , emit: contree       , optional: true
     tuple val(meta), path("*.nex")           , emit: nex           , optional: true
+    tuple val(meta), path("*.best_scheme")   , emit: best_scheme   , optional: true
     tuple val(meta), path("*.splits")        , emit: splits        , optional: true
     tuple val(meta), path("*.suptree")       , emit: suptree       , optional: true
     tuple val(meta), path("*.alninfo")       , emit: alninfo       , optional: true
@@ -41,11 +42,11 @@ process IQTREE {
     tuple val(meta), path("*.siteprob")      , emit: siteprob      , optional: true
     tuple val(meta), path("*.sitelh")        , emit: sitelh        , optional: true
     tuple val(meta), path("*.treels")        , emit: treels        , optional: true
-    tuple val(meta), path("*.rate  ")        , emit: rate          , optional: true
+    tuple val(meta), path("*.rate")          , emit: rate          , optional: true
     tuple val(meta), path("*.mlrate")        , emit: mlrate        , optional: true
     tuple val(meta), path("GTRPMIX.nex")     , emit: exch_matrix   , optional: true
     tuple val(meta), path("*.log")           , emit: log
-    tuple val("${task.process}"), val('iqtree'), eval("iqtree -version 2>&1 | head -n1 | sed 's/^IQ-TREE multicore version //;s/ .*//'"), emit: versions_iqtree, topic: versions
+    tuple val("${task.process}"), val('iqtree'), eval("iqtree -version 2>&1 | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -n1"), emit: versions_iqtree, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -68,6 +69,10 @@ process IQTREE {
     def trees_rf_arg                = trees_rf                ? "-rf $trees_rf"                 : ''
     def prefix                      = task.ext.prefix         ?: meta.id
     def memory                      = task.memory.toString().replaceAll(' ', '')
+    // IQ-TREE rejects -mem when a partition model is in use:
+    // "-mem option does not work with partition models yet".
+    def partitioned                 = partitions_equal || partitions_proportional || partitions_unlinked
+    def memory_arg                  = partitioned             ? ''                              : "-mem $memory"
     """
     iqtree \\
         $args \\
@@ -88,7 +93,7 @@ process IQTREE {
         -pre $prefix \\
         -nt AUTO \\
         -ntmax $task.cpus \\
-        -mem $memory
+        $memory_arg
     """
 
     stub:
@@ -105,6 +110,7 @@ process IQTREE {
     touch "${prefix}.state"
     touch "${prefix}.contree"
     touch "${prefix}.nex"
+    touch "${prefix}.best_scheme"
     touch "${prefix}.splits"
     touch "${prefix}.suptree"
     touch "${prefix}.alninfo"

--- a/modules/nf-core/iqtree/meta.yml
+++ b/modules/nf-core/iqtree/meta.yml
@@ -219,6 +219,17 @@ output:
             File containing consensus network (-net/-bb)
           pattern: "*.{nex}"
           ontologies: []
+  best_scheme:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.best_scheme":
+          type: file
+          description: |
+            File containing the best-fit partitioning scheme selected by
+            ModelFinder partition merging (-m MFP+MERGE/TESTMERGE)
+          pattern: "*.{best_scheme}"
+          ontologies: []
   splits:
     - - meta:
           type: map
@@ -294,7 +305,7 @@ output:
     - - meta:
           type: map
           description: Groovy Map containing sample information
-      - "*.rate  ":
+      - "*.rate":
           type: file
           description: |
             File containing inferred site-specific
@@ -338,7 +349,7 @@ output:
       - iqtree:
           type: string
           description: The name of the tool
-      - iqtree -version 2>&1 | head -n1 | sed 's/^IQ-TREE multicore version //;s/ .*//':
+      - iqtree -version 2>&1 | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -n1:
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -349,7 +360,7 @@ topics:
       - iqtree:
           type: string
           description: The name of the tool
-      - iqtree -version 2>&1 | head -n1 | sed 's/^IQ-TREE multicore version //;s/ .*//':
+      - iqtree -version 2>&1 | grep -oE '[0-9]+[.][0-9]+[.][0-9]+' | head -n1:
           type: eval
           description: The expression to obtain the version of the tool
 authors:
@@ -358,3 +369,4 @@ authors:
 maintainers:
   - "@avantonder"
   - "@aunderwo"
+  - "@chriswyatt1"

--- a/modules/nf-core/iqtree/tests/main.nf.test.snap
+++ b/modules/nf-core/iqtree/tests/main.nf.test.snap
@@ -17,27 +17,27 @@
                 ""
             ],
             "5",
-            "IQ-TREE 2.4.0 built Feb 12 2025",
-            "IQ-TREE multicore version 2.4.0 for Linux x86 64-bit built Feb 12 2025",
+            "IQ-TREE 3.1.3 built Jul 26 2026",
+            "IQ-TREE version 3.1.3 for Linux x86 64-bit built Jul 26 2026",
             {
                 "versions_iqtree": [
                     [
                         "IQTREE",
                         "iqtree",
-                        "2.4.0"
+                        "3.1.3"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-03T12:27:52.22755478",
+        "timestamp": "2026-07-26T19:46:14.63709",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.6"
         }
     },
     "hydrogenase - sup": {
         "content": [
-            "IQ-TREE multicore version 2.4.0 for Linux x86 64-bit built Feb 12 2025",
+            "IQ-TREE version 3.1.3 for Linux x86 64-bit built Jul 26 2026",
             [
                 [
                     {
@@ -51,57 +51,57 @@
                     [
                         "IQTREE",
                         "iqtree",
-                        "2.4.0"
+                        "3.1.3"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-03T12:27:55.709012076",
+        "timestamp": "2026-07-26T19:46:18.21335",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.6"
         }
     },
     "setoxin - treels": {
         "content": [
             "5",
-            "IQ-TREE 2.4.0 built Feb 12 2025",
-            "IQ-TREE multicore version 2.4.0 for Linux x86 64-bit built Feb 12 2025",
+            "IQ-TREE 3.1.3 built Jul 26 2026",
+            "IQ-TREE version 3.1.3 for Linux x86 64-bit built Jul 26 2026",
             {
                 "versions_iqtree": [
                     [
                         "IQTREE",
                         "iqtree",
-                        "2.4.0"
+                        "3.1.3"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-03T12:27:45.349027097",
+        "timestamp": "2026-07-26T19:46:00.23881",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.6"
         }
     },
     "setoxin - basic": {
         "content": [
             "5",
-            "IQ-TREE 2.4.0 built Feb 12 2025",
-            "IQ-TREE multicore version 2.4.0 for Linux x86 64-bit built Feb 12 2025",
+            "IQ-TREE 3.1.3 built Jul 26 2026",
+            "IQ-TREE version 3.1.3 for Linux x86 64-bit built Jul 26 2026",
             {
                 "versions_iqtree": [
                     [
                         "IQTREE",
                         "iqtree",
-                        "2.4.0"
+                        "3.1.3"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-03T12:27:38.363757239",
+        "timestamp": "2026-07-26T19:45:45.706524",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.6"
         }
     },
     "hydrogenase - optional": {
@@ -130,8 +130,8 @@
                 "#   Site:   Alignment site ID",
                 "#   Rate:   Site rate estimated by maximum likelihood"
             ],
-            "IQ-TREE 2.4.0 built Feb 12 2025",
-            "IQ-TREE multicore version 2.4.0 for Linux x86 64-bit built Feb 12 2025",
+            "IQ-TREE 3.1.3 built Jul 26 2026",
+            "IQ-TREE version 3.1.3 for Linux x86 64-bit built Jul 26 2026",
             [
                 
             ],
@@ -160,7 +160,12 @@
                 ]
             ],
             [
-                
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.rate:md5,a142257cce95dffde8dec4e68995e553"
+                ]
             ],
             [
                 [
@@ -178,15 +183,15 @@
                     [
                         "IQTREE",
                         "iqtree",
-                        "2.4.0"
+                        "3.1.3"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-03T12:28:14.6874385",
+        "timestamp": "2026-07-26T19:46:42.031271",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.6"
         }
     },
     "stub": {
@@ -224,7 +229,7 @@
                         {
                             "id": "test"
                         },
-                        "test.splits:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.best_scheme:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "12": [
@@ -232,7 +237,7 @@
                         {
                             "id": "test"
                         },
-                        "test.suptree:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.splits:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "13": [
@@ -240,7 +245,7 @@
                         {
                             "id": "test"
                         },
-                        "test.alninfo:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.suptree:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "14": [
@@ -248,7 +253,7 @@
                         {
                             "id": "test"
                         },
-                        "test.partlh:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.alninfo:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "15": [
@@ -256,7 +261,7 @@
                         {
                             "id": "test"
                         },
-                        "test.siteprob:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.partlh:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "16": [
@@ -264,7 +269,7 @@
                         {
                             "id": "test"
                         },
-                        "test.sitelh:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.siteprob:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "17": [
@@ -272,18 +277,23 @@
                         {
                             "id": "test"
                         },
-                        "test.treels:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.sitelh:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "18": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.treels:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "19": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.mlrate:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.rate:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "2": [
@@ -299,7 +309,7 @@
                         {
                             "id": "test"
                         },
-                        "GTRPMIX.nex:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.mlrate:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "21": [
@@ -307,14 +317,22 @@
                         {
                             "id": "test"
                         },
-                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "GTRPMIX.nex:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "22": [
                     [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "23": [
+                    [
                         "IQTREE",
                         "iqtree",
-                        "2.4.0"
+                        "3.1.3"
                     ]
                 ],
                 "3": [
@@ -379,6 +397,14 @@
                             "id": "test"
                         },
                         "test.alninfo:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "best_scheme": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.best_scheme:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "bootstrap": [
@@ -481,7 +507,12 @@
                     ]
                 ],
                 "rate": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.rate:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "report": [
                     [
@@ -551,15 +582,15 @@
                     [
                         "IQTREE",
                         "iqtree",
-                        "2.4.0"
+                        "3.1.3"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-03T12:28:17.584753988",
+        "timestamp": "2026-07-26T19:46:45.677464",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.6"
         }
     }
 }


### PR DESCRIPTION

Added the v3.1.3 container and conda env.
Removed a stray space in tuple val(meta), path("*.rate   ")   , which I checked out, must have been a typo.
Updated the snapshots, and had to update the way to extract the version to get the 3.1.3 as expected.
New output scheme, which is useful to me. 
Linted the module.

Finallty, I added a suppress `-mem` when a partition model is used. 
IQ-TREE aborts with
  `ERROR: -mem option does not work with partition models yet` whenever a
  partition file (`-q`/`-spp`/`-sp`) is combined with `-mem`
  (`utils/tools.cpp:5733`). Since this module injected `-mem` unconditionally,
  **every** run using `partitions_equal`, `partitions_proportional` or
  `partitions_unlinked` failed outright. Support for `-mem` with partitioned
  models remains an open upstream request: iqtree/iqtree2#346

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
