### PR TITLE
fix(gtf_hybridmerge_gffcompare): anchor withName selectors

### DIFF
--- a/subworkflows/nf-core/gtf_hybridmerge_gffcompare/nextflow.config
+++ b/subworkflows/nf-core/gtf_hybridmerge_gffcompare/nextflow.config
@@ -10,6 +10,10 @@
  * `process_single`. Fine for annotation-scale GTFs; for >~500 MB inputs
  * override `memory` / `cpus` directly via `withName`.
  *
+ * Selector form: Nextflow matches `withName` as a full-string regex against
+ * the fully qualified process name, so the leading `.*` is required for these
+ * blocks to apply inside a consumer pipeline as well as standalone.
+ *
  * Annotation format: the bundled awks assume standard GTF2 with `gene_id`
  * and `transcript_id` attributes in column 9 and `gene` / `transcript` in
  * column 3. GFF3 inputs (Parent= / ID= attributes), prokaryotic GTFs
@@ -20,7 +24,7 @@ process {
     // GAWK_FILTER (awk/filter.awk): keeps the records belonging to
     // transcripts whose gffcompare class_code is in the caller-supplied set
     // passed through `meta.class_codes`.
-    withName: 'GTF_HYBRIDMERGE_GFFCOMPARE:GAWK_FILTER' {
+    withName: '.*GTF_HYBRIDMERGE_GFFCOMPARE:GAWK_FILTER' {
         ext.args   = { "-v codes_csv='${meta.class_codes}'" }
         ext.prefix = { "${meta.id}_filtered" }
         ext.suffix = 'gtf'
@@ -28,7 +32,7 @@ process {
 
     // BEDTOOLS_INTERSECT: `-v` makes "blacklist" mean subtraction. Consumers
     // can override (`-v -s`, positive overlap, etc.) in their modules.config.
-    withName: 'GTF_HYBRIDMERGE_GFFCOMPARE:BEDTOOLS_INTERSECT' {
+    withName: '.*GTF_HYBRIDMERGE_GFFCOMPARE:BEDTOOLS_INTERSECT' {
         ext.args   = '-v'
         ext.prefix = { "${meta.id}_blacklisted" }
         ext.suffix = 'gtf'
@@ -37,7 +41,7 @@ process {
     // GAWK_CONCAT (awk/concat.awk): merges the filtered survivors into the
     // backbone, synthesising a `gene` row (with union span) for any novel
     // gene_id absent from the backbone.
-    withName: 'GTF_HYBRIDMERGE_GFFCOMPARE:GAWK_CONCAT' {
+    withName: '.*GTF_HYBRIDMERGE_GFFCOMPARE:GAWK_CONCAT' {
         ext.prefix = { "${meta.id}_hybrid" }
         ext.suffix = 'gtf'
     }

--- a/subworkflows/nf-core/gtf_hybridmerge_gffcompare/nextflow.config
+++ b/subworkflows/nf-core/gtf_hybridmerge_gffcompare/nextflow.config
@@ -10,10 +10,6 @@
  * `process_single`. Fine for annotation-scale GTFs; for >~500 MB inputs
  * override `memory` / `cpus` directly via `withName`.
  *
- * Selector form: Nextflow matches `withName` as a full-string regex against
- * the fully qualified process name, so the leading `.*` is required for these
- * blocks to apply inside a consumer pipeline as well as standalone.
- *
  * Annotation format: the bundled awks assume standard GTF2 with `gene_id`
  * and `transcript_id` attributes in column 9 and `gene` / `transcript` in
  * column 3. GFF3 inputs (Parent= / ID= attributes), prokaryotic GTFs


### PR DESCRIPTION
## Problem

`gtf_hybridmerge_gffcompare/nextflow.config` uses unanchored `withName` selectors of the form `GTF_HYBRIDMERGE_GFFCOMPARE:GAWK_FILTER`. Nextflow full-string matches `withName` against the fully qualified process name, so these match when the subworkflow is invoked directly, as in its own nf-test, but never inside a consumer pipeline where the name is prefixed by the calling chain. The config block then silently never applies, with no warning or error.

Because the bundled tests invoke the subworkflow at the top level, this class of bug is invisible to nf-core/modules CI: lint and nf-test both pass with or without the fix.

## Impact

In nf-core/riboseq, which nests this several levels deep, `GAWK_FILTER` never received `-v codes_csv=...`, so the awk filter ran with an empty keep-set and emitted nothing. The hybrid GTF silently contained zero novel transcripts while the pipeline completed cleanly.

Confirmed with a three-level probe pipeline on Nextflow 26.04.6. Before the fix the merged GTF had an identical md5 across three runs seeded with three different novel-transcript inputs; after, all three differ.

## Fix

Anchor all three selectors (`GAWK_FILTER`, `BEDTOOLS_INTERSECT`, `GAWK_CONCAT`) with a leading `.*` so they match standalone and nested.

`nf-core subworkflows lint`: 28/28 passed. `nf-test`: both tests still pass, confirming standalone invocation is unaffected.

## Scale of the pattern

A sweep of every `subworkflows/nf-core/*/nextflow.config` found one other component with the identical defect, `orftable_fasta_gtf_buildorfcatalogue`, addressed separately in #12434. Everything else is either already anchored or selects on unqualified simple names, which match at any nesting depth.

nf-core/riboseq carries this as a local patch pending this landing.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `nf-core subworkflows test gtf_hybridmerge_gffcompare --profile docker`
- [ ] `nf-core subworkflows test gtf_hybridmerge_gffcompare --profile singularity`
- [ ] `nf-core subworkflows test gtf_hybridmerge_gffcompare --profile conda`
