### PR TITLE
fix(custom/orfnormalise): resolve PRICE gene ids from the annotation

### DIFF
--- a/modules/nf-core/custom/orfnormalise/meta.yml
+++ b/modules/nf-core/custom/orfnormalise/meta.yml
@@ -46,6 +46,10 @@ description: |
 
   Per-caller mapping notes (lossy collapses):
 
+    - PRICE's `Gene` column concatenates every gene overlapping an ORF's
+      genomic span, so `gene_id` is resolved from the GTF via the ORF's
+      transcript id; the `Gene` column is used only for transcripts absent
+      from the annotation, and can then carry a multi-gene value.
     - PRICE `iORF` (internal ORF), `intronic`, and `orphan` map to `other`.
       Cross-caller catalogue tracking still flags these via
       `called_by_price`, but the specific PRICE sub-type is not preserved.

--- a/modules/nf-core/custom/orfnormalise/templates/orfnormalise.py
+++ b/modules/nf-core/custom/orfnormalise/templates/orfnormalise.py
@@ -766,6 +766,24 @@ def _price_score_from_p(p):
     return clamp1000(min(-math.log10(p) * 100, 1000))
 
 
+def _price_transcript_id(orf_id_raw, orf_type):
+    """Recover the transcript id from PRICE's `Id` column.
+
+    PRICE builds `Id` as `<transcript_id>_<orf_type>_<n>` (an increasing
+    counter within the transcript). The split anchors on the row's own
+    `orf_type` value so transcript ids that themselves contain underscores
+    (true for some non-Ensembl annotations) survive intact.
+    """
+    if orf_type:
+        m = re.match(r"^(.+)_" + re.escape(orf_type) + r"_\\d+\$", orf_id_raw)
+        if m:
+            return m.group(1)
+    parts = orf_id_raw.rsplit("_", 2)
+    if len(parts) == 3 and parts[2].isdigit():
+        return parts[0]
+    return orf_id_raw.split("_", 1)[0]
+
+
 def parse_price(path, transcripts, fields):
     resolved = {"score": "", "orf_type": ""}
     rows = []
@@ -785,12 +803,16 @@ def parse_price(path, transcripts, fields):
 
             orf_type = (pick(row, fields, resolved, "orf_type") or "").strip()
 
-            tid = orf_id_raw.split("_", 1)[0]
-            gid = (row.get("Gene") or "").strip()
-            if not gid:
-                t = transcripts.get(tid)
-                if t is not None:
-                    gid = t.gene_id
+            tid = _price_transcript_id(orf_id_raw, orf_type)
+            t = transcripts.get(tid)
+            if t is not None:
+                gid = t.gene_id
+            else:
+                # PRICE's `Gene` column concatenates every gene overlapping the
+                # ORF's genomic span with an underscore, so this fallback value
+                # may itself be a multi-gene string; passed through as-is,
+                # downstream joins against a single-gene matrix won't match it.
+                gid = (row.get("Gene") or "").strip()
 
             length_nt = sum(b[1] - b[0] for b in blocks)
             aa_len = max(0, (length_nt - 3) // 3) if length_nt > 0 else 0

--- a/modules/nf-core/custom/orfnormalise/tests/main.nf.test
+++ b/modules/nf-core/custom/orfnormalise/tests/main.nf.test
@@ -224,6 +224,44 @@ nextflow_process {
         }
     }
 
+    test("price - gene_id resolved from transcript, not the concatenated Gene column") {
+
+        when {
+            process {
+                """
+                input[0] = channel
+                    .of(
+                        'Gene\tId\tLocation\tType\tp value',
+                        'ENSG_A_ENSG_B\tENST_FAKE_TX_CDS_1\tchr1+:100-130\tCDS\t0.001'
+                    )
+                    .collectFile(name: 'price_gene_precedence.orfs.tsv', newLine: true, sort: false)
+                    .map { orfs -> [[id: 'sample1'], orfs, 'price'] }
+                input[1] = channel
+                    .of('chr1\ttest\texon\t100\t130\t.\t+\t.\tgene_id "ENSG_PLAIN"; transcript_id "ENST_FAKE_TX";')
+                    .collectFile(name: 'price_gene_precedence.gtf', newLine: true)
+                    .map { gtf -> [[id: 'reference'], gtf] }
+                """
+            }
+        }
+
+        then {
+            def lines = path(process.out.tsv[0][1]).text.readLines().findAll { !it.startsWith('#') }
+            def cols  = lines[0].split('\t') as List
+            def row   = lines[1].split('\t')
+            def gid   = cols.indexOf('gene_id')
+            def tid   = cols.indexOf('transcript_id')
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                // The Gene column holds PRICE's concatenated multi-gene form
+                // 'ENSG_A_ENSG_B'; the annotation resolves ENST_FAKE_TX to a
+                // single gene, which must win.
+                { assert row[gid] == 'ENSG_PLAIN' },
+                { assert row[tid] == 'ENST_FAKE_TX' }
+            )
+        }
+    }
+
     test("homo_sapiens [chr20] - ribotish - score-field override") {
         config "./score_override.config"
 

--- a/modules/nf-core/custom/orfnormalise/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/orfnormalise/tests/main.nf.test.snap
@@ -243,5 +243,54 @@
             "nextflow": "25.10.4"
         },
         "timestamp": "2026-06-12T13:07:59.997149"
+    },
+    "price - gene_id resolved from transcript, not the concatenated Gene column": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "sample1"
+                        },
+                        "sample1.normalised.bed12:md5,a41a522d29f027394cbc1bd9766b68eb"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "sample1"
+                        },
+                        "sample1.normalised.tsv:md5,aec9d0eec2ae9f5f9a13945e850bc241"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,e7fc396424c69f0969daec4a45c3de70"
+                ],
+                "bed12": [
+                    [
+                        {
+                            "id": "sample1"
+                        },
+                        "sample1.normalised.bed12:md5,a41a522d29f027394cbc1bd9766b68eb"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "sample1"
+                        },
+                        "sample1.normalised.tsv:md5,aec9d0eec2ae9f5f9a13945e850bc241"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e7fc396424c69f0969daec4a45c3de70"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        },
+        "timestamp": "2026-07-27T12:09:36.088453606"
     }
 }


### PR DESCRIPTION
`parse_price` took `gene_id` from PRICE's `Gene` column first and only consulted the annotation when that column was empty. PRICE concatenates every gene overlapping an ORF's genomic span with an underscore, so multi-gene ORFs came out with ids like `GENEA_GENEB`, which are meaningless downstream and will not join against a single-gene count matrix. This flips the precedence: resolve from the GTF transcript-to-gene mapping first, fall back to the `Gene` column only when the transcript is absent from the annotation.

It also fixes the `Id` parse. PRICE builds `Id` as `<transcript_id>_<orf_type>_<n>`, and `split("_", 1)[0]` assumed the transcript id has no underscore, which holds for Ensembl but not for every annotation. A new `_price_transcript_id` helper anchors the split on the row's own `orf_type` value.

### Verified

- The existing `homo_sapiens [chr19+chr22] - price` case runs against the real `cohort.price.orfs.tsv` in nf-core/test-datasets and passes an empty annotation, so every row takes the `Gene`-column fallback and its snapshot entry is byte identical after the change. That path is worth keeping: PRICE without a GTF is a supported mode, and 9 of that fixture's 15 rows carry a concatenated `Gene` value, so it pins the fallback behaviour precisely.
- Because that case supplies no annotation, it cannot reach the transcript-first resolution this PR adds. The new case is the one that exercises it: a row whose `Gene` column holds a concatenated id and whose transcript, itself underscore-containing, is present in a small GTF, asserting the plain gene id from the GTF wins. Its inputs are built with `collectFile` rather than shipped fixture files, matching how other modules handle small synthetic inputs; no module in this repo keeps data fixtures in its `tests/` directory.
- Full module suite passes on x86_64 with nf-test 0.9.5 and Docker, 7 tests. The snap diff is 49 insertions and no deletions.
- `nf-core modules lint custom/orfnormalise`: 59 passed, 0 failed. The two warnings (container registry 404, container version mismatch) are pre-existing and untouched.
- `ruff check`, `ruff format`, prettier and the meta.yml schema check are clean.

### Other parsers

I checked the other four parsers in the same template for the same precedence mistake. `parse_ribotish` has the same shape (tool column first, annotation fallback), but Ribo-TISH's `Gid` is a single gene id, so there is nothing to fix. `parse_ribocode` and `parse_ribotricer` read a single-gene `gene_id` column with no annotation fallback, and `parse_rpbp` resolves from the annotation only. PRICE is the only caller that emits a concatenated multi-gene value.

Consumed by nf-core/riboseq, which currently carries this as a local patch.

