### PR TITLE
fix(fastq_remove_rrna): drop redundant .first() on internally built SortMeRNA index

### DIFF
--- a/subworkflows/nf-core/fastq_remove_rrna/main.nf
+++ b/subworkflows/nf-core/fastq_remove_rrna/main.nf
@@ -37,8 +37,8 @@ workflow FASTQ_REMOVE_RRNA {
     take:
     ch_reads // channel: [ val(meta), [ reads ] ]
     ch_rrna_fastas // channel: one or more fasta files containing rrna sequences
-    ch_sortmerna_index // channel: /path/to/sortmerna/index/ (optional)
-    ch_bowtie2_index // channel: /path/to/bowtie2/index/ (optional)
+    ch_sortmerna_index // channel: /path/to/sortmerna/index/ (optional, must be a value channel: reused across every sample)
+    ch_bowtie2_index // channel: /path/to/bowtie2/index/ (optional, must be a value channel: reused across every sample)
     ribo_removal_tool // string (enum): 'sortmerna', 'ribodetector', or 'bowtie2'
     make_sortmerna_index // boolean: Whether to create a sortmerna index before running sortmerna
     make_bowtie2_index // boolean: Whether to create a bowtie2 index before running bowtie2
@@ -68,7 +68,7 @@ workflow FASTQ_REMOVE_RRNA {
                 ch_sortmerna_fastas,
                 [[], []],
             )
-            ch_sortmerna_index = SORTMERNA_INDEX.out.index.first()
+            ch_sortmerna_index = SORTMERNA_INDEX.out.index
         }
 
         SORTMERNA(

--- a/subworkflows/nf-core/fastq_remove_rrna/main.nf
+++ b/subworkflows/nf-core/fastq_remove_rrna/main.nf
@@ -37,8 +37,8 @@ workflow FASTQ_REMOVE_RRNA {
     take:
     ch_reads // channel: [ val(meta), [ reads ] ]
     ch_rrna_fastas // channel: one or more fasta files containing rrna sequences
-    ch_sortmerna_index // channel: /path/to/sortmerna/index/ (optional, must be a value channel: reused across every sample)
-    ch_bowtie2_index // channel: /path/to/bowtie2/index/ (optional, must be a value channel: reused across every sample)
+    ch_sortmerna_index // channel: /path/to/sortmerna/index/ (optional)
+    ch_bowtie2_index // channel: /path/to/bowtie2/index/ (optional)
     ribo_removal_tool // string (enum): 'sortmerna', 'ribodetector', or 'bowtie2'
     make_sortmerna_index // boolean: Whether to create a sortmerna index before running sortmerna
     make_bowtie2_index // boolean: Whether to create a bowtie2 index before running bowtie2

--- a/subworkflows/nf-core/fastq_remove_rrna/meta.yml
+++ b/subworkflows/nf-core/fastq_remove_rrna/meta.yml
@@ -45,7 +45,6 @@ input:
       type: directory
       description: |
         Pre-built SortMeRNA index directory. Optional - can be built on-the-fly if make_sortmerna_index is true.
-        Must be a value channel: it is paired with the per-sample reads channel across every SORTMERNA call.
       structure:
         - meta:
             type: map
@@ -57,7 +56,6 @@ input:
       type: directory
       description: |
         Pre-built Bowtie2 index directory. Optional - can be built on-the-fly if make_bowtie2_index is true.
-        Must be a value channel: it is paired with the per-sample reads channel across every BOWTIE2_ALIGN call.
       structure:
         - meta:
             type: map

--- a/subworkflows/nf-core/fastq_remove_rrna/meta.yml
+++ b/subworkflows/nf-core/fastq_remove_rrna/meta.yml
@@ -45,6 +45,7 @@ input:
       type: directory
       description: |
         Pre-built SortMeRNA index directory. Optional - can be built on-the-fly if make_sortmerna_index is true.
+        Must be a value channel: it is paired with the per-sample reads channel across every SORTMERNA call.
       structure:
         - meta:
             type: map
@@ -56,6 +57,7 @@ input:
       type: directory
       description: |
         Pre-built Bowtie2 index directory. Optional - can be built on-the-fly if make_bowtie2_index is true.
+        Must be a value channel: it is paired with the per-sample reads channel across every BOWTIE2_ALIGN call.
       structure:
         - meta:
             type: map


### PR DESCRIPTION
`SORTMERNA_INDEX.out.index` is built inside the subworkflow from `.collect()`-derived inputs, so it is already a value channel. The `.first()` applied to it was a no-op that only produced a `useless when applied to a value channel` warning.

The caller-supplied `ch_sortmerna_index` and `ch_bowtie2_index` are untouched, so nothing changes for a consumer passing a queue channel.

`nf-core subworkflows lint`: 46/46 passed. `nf-test --profile docker`: 6/6 passed, no snapshot changes.
