### PR TITLE
fix(ribotish/predict): pin python=3.13.9 to avoid Python 3.14 forkserver default

### DIFF
--- a/modules/nf-core/ribotish/predict/environment.yml
+++ b/modules/nf-core/ribotish/predict/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - conda-forge::python<3.14
   - bioconda::ribotish=0.2.8

--- a/modules/nf-core/ribotish/predict/environment.yml
+++ b/modules/nf-core/ribotish/predict/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::python<3.14
   - bioconda::ribotish=0.2.8
+  - conda-forge::python=3.13.9

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test
@@ -54,7 +54,7 @@ nextflow_process {
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert snapshot(
-                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name ] },
+                    process.out.transprofile.collect { meta, prof -> [ meta, "${file(prof).name}:md5,${path(prof).readLines().sort().join('\n').md5()}" ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -93,7 +93,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.predictions,
                     process.out.all,
-                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name ] },
+                    process.out.transprofile.collect { meta, prof -> [ meta, "${file(prof).name}:md5,${path(prof).readLines().sort().join('\n').md5()}" ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -136,7 +136,7 @@ nextflow_process {
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert snapshot(
-                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name ] },
+                    process.out.transprofile.collect { meta, prof -> [ meta, "${file(prof).name}:md5,${path(prof).readLines().sort().join('\n').md5()}" ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -181,7 +181,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.predictions,
                     process.out.all,
-                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name ] },
+                    process.out.transprofile.collect { meta, prof -> [ meta, "${file(prof).name}:md5,${path(prof).readLines().sort().join('\n').md5()}" ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test
@@ -54,7 +54,7 @@ nextflow_process {
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert snapshot(
-                    process.out.transprofile,
+                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name, file(prof).readLines().sort().join('\n').digest('MD5') ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -93,7 +93,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.predictions,
                     process.out.all,
-                    process.out.transprofile,
+                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name, file(prof).readLines().sort().join('\n').digest('MD5') ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -136,7 +136,7 @@ nextflow_process {
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert snapshot(
-                    process.out.transprofile,
+                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name, file(prof).readLines().sort().join('\n').digest('MD5') ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -181,7 +181,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.predictions,
                     process.out.all,
-                    process.out.transprofile,
+                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name, file(prof).readLines().sort().join('\n').digest('MD5') ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test
@@ -54,7 +54,7 @@ nextflow_process {
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000132640\tENST00000254977\tBTBD3\tprotein_coding\t20:11890767-11923666:+\tATG\t45\t1743\tExtended\t0\t0\tNone\t0.013377070461772932\tT\tNone\tNone\t0.02118962148347") },
                 { assert snapshot(
-                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name, file(prof).readLines().sort().join('\n').digest('MD5') ] },
+                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -93,7 +93,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.predictions,
                     process.out.all,
-                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name, file(prof).readLines().sort().join('\n').digest('MD5') ] },
+                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -136,7 +136,7 @@ nextflow_process {
                 { assert path(process.out.predictions[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert path(process.out.all[0][1]).getText().contains("ENSG00000284776\tENST00000618693\t\tprotein_coding\t20:18567478-18744216:+\tATG\t26\t695\tAnnotated\t0\t0\tNone\t0.0006123183014212") },
                 { assert snapshot(
-                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name, file(prof).readLines().sort().join('\n').digest('MD5') ] },
+                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
@@ -181,7 +181,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.predictions,
                     process.out.all,
-                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name, file(prof).readLines().sort().join('\n').digest('MD5') ] },
+                    process.out.transprofile.collect { meta, prof -> [ meta, file(prof).name ] },
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
@@ -28,7 +28,8 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test_transprofile.py",
+                    "d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
             {
@@ -41,10 +42,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-19T10:03:51.7008198",
+        "timestamp": "2026-07-27T12:46:49.440056573",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.6"
         }
     },
     "sarscov2 [bam] - single_end - multi ribo bam - stub": {
@@ -76,7 +77,8 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "test_transprofile.py",
+                    "d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
             {
@@ -89,10 +91,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-19T10:04:37.952263709",
+        "timestamp": "2026-07-27T12:47:17.848478252",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.6"
         }
     },
     "sarscov2 [bam] - single_end - multi ribo bam": {
@@ -104,7 +106,8 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py:md5,202a5b5983806e8d9f242c6157736357"
+                    "test_transprofile.py",
+                    "41e478f5d77211752652e1beeb5ce2ed"
                 ]
             ],
             {
@@ -117,10 +120,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-19T10:04:30.097163994",
+        "timestamp": "2026-07-27T12:47:10.15958091",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.6"
         }
     },
     "sarscov2 [bam] - single_end - single ribo bam": {
@@ -132,7 +135,8 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py:md5,3e6aaa9ec9f3346ae8c838da2d415924"
+                    "test_transprofile.py",
+                    "a7d46de56c1c039bfde279c703c321c9"
                 ]
             ],
             {
@@ -145,10 +149,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-19T10:03:43.377664597",
+        "timestamp": "2026-07-27T12:46:41.549198689",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
@@ -28,8 +28,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py",
-                    "d41d8cd98f00b204e9800998ecf8427e"
+                    "test_transprofile.py"
                 ]
             ],
             {
@@ -42,7 +41,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T12:46:49.440056573",
+        "timestamp": "2026-07-27T15:51:21.523789868",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -77,8 +76,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py",
-                    "d41d8cd98f00b204e9800998ecf8427e"
+                    "test_transprofile.py"
                 ]
             ],
             {
@@ -91,7 +89,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T12:47:17.848478252",
+        "timestamp": "2026-07-27T15:51:50.07836503",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -106,8 +104,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py",
-                    "41e478f5d77211752652e1beeb5ce2ed"
+                    "test_transprofile.py"
                 ]
             ],
             {
@@ -120,7 +117,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T12:47:10.15958091",
+        "timestamp": "2026-07-27T15:51:42.351195058",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -135,8 +132,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py",
-                    "a7d46de56c1c039bfde279c703c321c9"
+                    "test_transprofile.py"
                 ]
             ],
             {
@@ -149,7 +145,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T12:46:41.549198689",
+        "timestamp": "2026-07-27T15:51:13.649626993",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/ribotish/predict/tests/main.nf.test.snap
@@ -28,7 +28,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py"
+                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
             {
@@ -41,10 +41,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T15:51:21.523789868",
+        "timestamp": "2026-05-19T10:03:51.7008198",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.6"
+            "nextflow": "26.04.1"
         }
     },
     "sarscov2 [bam] - single_end - multi ribo bam - stub": {
@@ -76,7 +76,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py"
+                    "test_transprofile.py:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
             ],
             {
@@ -89,10 +89,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T15:51:50.07836503",
+        "timestamp": "2026-05-19T10:04:37.952263709",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.6"
+            "nextflow": "26.04.1"
         }
     },
     "sarscov2 [bam] - single_end - multi ribo bam": {
@@ -104,7 +104,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py"
+                    "test_transprofile.py:md5,41e478f5d77211752652e1beeb5ce2ed"
                 ]
             ],
             {
@@ -117,7 +117,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T15:51:42.351195058",
+        "timestamp": "2026-07-27T16:37:29.048696238",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -132,7 +132,7 @@
                         "single_end": true,
                         "strandedness": "forward"
                     },
-                    "test_transprofile.py"
+                    "test_transprofile.py:md5,a7d46de56c1c039bfde279c703c321c9"
                 ]
             ],
             {
@@ -145,7 +145,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T15:51:13.649626993",
+        "timestamp": "2026-07-27T16:37:00.615810516",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"


### PR DESCRIPTION
Two changes to `ribotish/predict`.

**Pin `conda-forge::python=3.13.9`**, matching the biocontainers image. `predict.py` sets per-run state in module-level globals inside `run()` and reads them back in `_pred_gene`, mapped across a `multiprocessing.Pool` when `-p` is above 1. That relies on `fork` inheriting the parent's globals. Python 3.14 switched the default start method on non-macOS POSIX to `forkserver`, whose workers re-import the module and never see them, so predict fails with `NameError: name 'genomefapath' is not defined`. Only conda is exposed: `ribotish=0.2.8` requires just `python >=3`, while the container is fixed at 3.13.9. Exact pin rather than `<3.14` because `environment-schema.json` rejects `<` and `>`. The underlying bug is Ribo-TISH's own use of globals across a process pool, which nothing on their tracker covers; the pin only avoids triggering it.

**Hash `transprofile` over sorted lines.** ribotish emits rows through `imap_unordered`, so the raw file md5 differs between runs while the content does not. The snapshot value is a hash of the sorted lines rather than of the file as written. Not caused by the pin: it fails on docker and singularity too.

`ribotish/quality` has no `multiprocessing.Pool` usage and is untouched.

Verified: `nf-core modules lint` clean, all four tests pass on repeated runs, container confirmed at Python 3.13.9.

Consumed by nf-core/riboseq.
