### PR TITLE
Migrate ngmerge to topic channels

### DIFF
--- a/modules/nf-core/ngmerge/main.nf
+++ b/modules/nf-core/ngmerge/main.nf
@@ -14,7 +14,7 @@ process NGMERGE {
     tuple val(meta), path("*.merged.fq.gz"), emit: merged_reads
     tuple val(meta), path("*_1.fastq.gz")  , emit: unstitched_read1
     tuple val(meta), path("*_2.fastq.gz")  , emit: unstitched_read2
-    path "versions.yml"                    , emit: versions
+    tuple val("${task.process}"), val('ngmerge'), eval("NGmerge --version 2>&1 | sed -n '1s/^NGmerge, version //p'"), emit: versions_ngmerge, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,12 +32,6 @@ process NGMERGE {
         -z \\
         -n $task.cpus \\
         $args
-
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        NGmerge: \$(echo \$(NGmerge --version 2>&1) | sed 's/^.*NGmerge, version //; s/ Copyright.*// ; s/: //g' ))
-    END_VERSIONS
     """
 
     stub:
@@ -45,10 +39,5 @@ process NGMERGE {
 
     """
     echo "" | gzip > ${prefix}.merged.fq.gz
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        NGmerge: \$(echo \$(NGmerge --version 2>&1) | sed 's/^.*NGmerge, version //; s/ Copyright.*// ; s/: //g' ))
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/ngmerge/meta.yml
+++ b/modules/nf-core/ngmerge/meta.yml
@@ -63,13 +63,27 @@ output:
           pattern: "*.{fa,fasta,fastq,fq,fa.gz,fasta.gz,fastq.gz,fq.gz}"
           ontologies:
             - edam: http://edamontology.org/format_1930 # FASTQ
+  versions_ngmerge:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ngmerge:
+          type: string
+          description: The name of the tool
+      - NGmerge --version 2>&1 | sed -n '1s/^NGmerge, version //p':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ngmerge:
+          type: string
+          description: The name of the tool
+      - NGmerge --version 2>&1 | sed -n '1s/^NGmerge, version //p':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@charlotteanne"
   - "@jsh58"

--- a/modules/nf-core/ngmerge/tests/main.nf.test
+++ b/modules/nf-core/ngmerge/tests/main.nf.test
@@ -33,7 +33,7 @@ nextflow_process {
 					file(process.out.merged_reads[0][1]).name,
 					file(process.out.unstitched_read1[0][1]).name,
 					file(process.out.unstitched_read2[0][1]).name,
-					process.out.versions
+					process.out.findAll { key, val -> key.startsWith('versions') }
 					).match()
 				}
             )

--- a/modules/nf-core/ngmerge/tests/main.nf.test.snap
+++ b/modules/nf-core/ngmerge/tests/main.nf.test.snap
@@ -4,14 +4,20 @@
             "test.merged.fq.gz",
             "test_unstitched_1.fastq.gz",
             "test_unstitched_2.fastq.gz",
-            [
-                "versions.yml:md5,fbe3b4187e1c70c016f738aeff8ab5f1"
-            ]
+            {
+                "versions_ngmerge": [
+                    [
+                        "NGMERGE",
+                        "ngmerge",
+                        "0.2"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-07-26T22:27:41.689762297",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-23T12:02:38.100015"
+            "nf-test": "0.9.5",
+            "nextflow": "26.07.0"
+        }
     }
 }


### PR DESCRIPTION
## Description

Migrate `ngmerge` from the legacy `versions.yml` output to the `versions` topic channel.

- Add the structured `versions_ngmerge` output
- Remove `versions.yml` generation from the script and stub
- Update the output and topic definitions in `meta.yml`
- Update the nf-test assertion and generated snapshot

Closes #12323

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Tests have been updated.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions`.
- [x] Follow the naming conventions.
- [x] Follow the input/output options guidelines.
- [x] Use BioConda and BioContainers where possible.

### Tests

- [x] `nf-core modules test ngmerge --profile docker`
- [x] `nf-core modules test ngmerge --profile singularity`
- [x] `nf-core modules test ngmerge --profile conda`