### PR TITLE
Migrate nanolyse to topic channels

### DIFF
--- a/modules/nf-core/nanolyse/main.nf
+++ b/modules/nf-core/nanolyse/main.nf
@@ -14,7 +14,7 @@ process NANOLYSE {
     output:
     tuple val(meta), path("*.fastq.gz"), emit: fastq
     path "*.log"                       , emit: log
-    path "versions.yml"                , emit: versions
+    tuple val("${task.process}"), val('nanolyse'), eval('NanoLyse --version 2>&1 | sed -e "s/NanoLyse //g"'), emit: versions_nanolyse, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,22 +24,12 @@ process NANOLYSE {
     """
     gunzip -c $fastq | NanoLyse -r $fasta | gzip > ${prefix}.fastq.gz
     mv NanoLyse.log ${prefix}.nanolyse.log
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nanolyse: \$(NanoLyse --version 2>&1 | sed -e "s/NanoLyse //g")
-    END_VERSIONS
     """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo | gzip > ${prefix}.fastq.gz
+    echo "" | gzip > ${prefix}.fastq.gz
     touch ${prefix}.nanolyse.log
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nanolyse: \$(NanoLyse --version 2>&1 | sed -e "s/NanoLyse //g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/nanolyse/meta.yml
+++ b/modules/nf-core/nanolyse/meta.yml
@@ -50,13 +50,27 @@ output:
         description: Log of the Nanolyse run.
         pattern: "*.log"
         ontologies: []
+  versions_nanolyse:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - nanolyse:
+          type: string
+          description: The name of the tool
+      - NanoLyse --version 2>&1 | sed -e "s/NanoLyse //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - nanolyse:
+          type: string
+          description: The name of the tool
+      - NanoLyse --version 2>&1 | sed -e "s/NanoLyse //g":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@yuukiiwa"
 maintainers:

--- a/modules/nf-core/nanolyse/tests/main.nf.test
+++ b/modules/nf-core/nanolyse/tests/main.nf.test
@@ -28,12 +28,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-					process.out.fastq,
-					file(process.out.log[0]).name,
-					process.out.findAll { key, val -> key.startsWith('versions') }
-					).match()
-				}
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
             )
         }
     }

--- a/modules/nf-core/nanolyse/tests/main.nf.test
+++ b/modules/nf-core/nanolyse/tests/main.nf.test
@@ -31,7 +31,7 @@ nextflow_process {
                 { assert snapshot(
 					process.out.fastq,
 					file(process.out.log[0]).name,
-					process.out.versions
+					process.out.findAll { key, val -> key.startsWith('versions') }
 					).match()
 				}
             )

--- a/modules/nf-core/nanolyse/tests/main.nf.test.snap
+++ b/modules/nf-core/nanolyse/tests/main.nf.test.snap
@@ -14,7 +14,11 @@
                     "test.clean.nanolyse.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "2": [
-                    "versions.yml:md5,21c1b87b05965e1d414140994af338ef"
+                    [
+                        "NANOLYSE",
+                        "nanolyse",
+                        "1.2.0"
+                    ]
                 ],
                 "fastq": [
                     [
@@ -27,16 +31,20 @@
                 "log": [
                     "test.clean.nanolyse.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
-                "versions": [
-                    "versions.yml:md5,21c1b87b05965e1d414140994af338ef"
+                "versions_nanolyse": [
+                    [
+                        "NANOLYSE",
+                        "nanolyse",
+                        "1.2.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-07-27T16:20:04.131999082",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-30T12:46:33.908168"
+            "nf-test": "0.9.5",
+            "nextflow": "26.07.0"
+        }
     },
     "test-nanolyse": {
         "content": [
@@ -49,14 +57,20 @@
                 ]
             ],
             "test.clean.nanolyse.log",
-            [
-                "versions.yml:md5,21c1b87b05965e1d414140994af338ef"
-            ]
+            {
+                "versions_nanolyse": [
+                    [
+                        "NANOLYSE",
+                        "nanolyse",
+                        "1.2.0"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-07-27T16:19:52.11256459",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-30T15:23:25.853435"
+            "nf-test": "0.9.5",
+            "nextflow": "26.07.0"
+        }
     }
 }

--- a/modules/nf-core/nanolyse/tests/main.nf.test.snap
+++ b/modules/nf-core/nanolyse/tests/main.nf.test.snap
@@ -48,16 +48,18 @@
     },
     "test-nanolyse": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.clean.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
-                ]
-            ],
-            "test.clean.nanolyse.log",
             {
+                "fastq": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.clean.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                    ]
+                ],
+                "log": [
+                    "test.clean.nanolyse.log"
+                ],
                 "versions_nanolyse": [
                     [
                         "NANOLYSE",
@@ -67,7 +69,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-27T16:19:52.11256459",
+        "timestamp": "2026-07-27T17:49:53.720356286",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.07.0"


### PR DESCRIPTION
## Description

- migrate NanoLyse version reporting from the legacy `versions.yml` file to a structured `versions` topic output
- update the module metadata, nf-test assertions, and snapshots
- fix the stub gzip command to satisfy current module linting requirements

## PR checklist

Closes #12317

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`.
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] `nf-core modules test nanolyse --profile docker`
- [x] `nf-core modules test nanolyse --profile singularity`
- [x] `nf-core modules test nanolyse --profile conda`