### PR TITLE
Migrate nextgenmap to topic channels

### DIFF
--- a/modules/nf-core/nextgenmap/main.nf
+++ b/modules/nf-core/nextgenmap/main.nf
@@ -13,7 +13,7 @@ process NEXTGENMAP {
 
     output:
     tuple val(meta), path("*.bam"), emit: bam
-    path  "versions.yml"          , emit: versions
+    tuple val("${task.process}"), val('nextgenmap'), eval("ngm --version 2>&1 | sed -n '1s/^.*NextGenMap //p'"), emit: versions_nextgenmap, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,11 +32,6 @@ process NEXTGENMAP {
             --bam \\
             -o ${prefix}.bam \\
             $args
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            NextGenMap: \$(ngm 2>&1 | head -1 | grep -o -E '[[:digit:]]+.[[:digit:]]+.[[:digit:]]+')
-        END_VERSIONS
         """
     } else{
         """
@@ -48,11 +43,6 @@ process NEXTGENMAP {
             --bam \\
             -o ${prefix}.bam \\
             $args
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            NextGenMap: \$(ngm 2>&1 | head -1 | grep -o -E '[[:digit:]]+.[[:digit:]]+.[[:digit:]]+')
-        END_VERSIONS
         """
     }
 
@@ -60,10 +50,5 @@ process NEXTGENMAP {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.bam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        NextGenMap: \$(ngm 2>&1 | head -1 | grep -o -E '[[:digit:]]+.[[:digit:]]+.[[:digit:]]+')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/nextgenmap/meta.yml
+++ b/modules/nf-core/nextgenmap/meta.yml
@@ -52,13 +52,27 @@ output:
             meta, above
           pattern: "*.{bam}"
           ontologies: []
+  versions_nextgenmap:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - nextgenmap:
+          type: string
+          description: The name of the tool
+      - "ngm --version 2>&1 | sed -n '1s/^.*NextGenMap //p'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - nextgenmap:
+          type: string
+          description: The name of the tool
+      - "ngm --version 2>&1 | sed -n '1s/^.*NextGenMap //p'":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@cmatkhan"
 maintainers:

--- a/modules/nf-core/nextgenmap/tests/main.nf.test
+++ b/modules/nf-core/nextgenmap/tests/main.nf.test
@@ -31,7 +31,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
 					bam(process.out.bam[0][1]).getReadsMD5(),
-					process.out.versions
+					process.out.versions_nextgenmap
 					).match()
 				}
             )
@@ -61,7 +61,7 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
 					bam(process.out.bam[0][1]).getReadsMD5(),
-					process.out.versions
+					process.out.versions_nextgenmap
 					).match()
 				}
             )

--- a/modules/nf-core/nextgenmap/tests/main.nf.test.snap
+++ b/modules/nf-core/nextgenmap/tests/main.nf.test.snap
@@ -3,27 +3,35 @@
         "content": [
             "798439cbd7fd81cbcc5078022dc5479d",
             [
-                "versions.yml:md5,ed7a2cfe2387b964c06b6c6847f46996"
+                [
+                    "NEXTGENMAP",
+                    "nextgenmap",
+                    "0.5.5"
+                ]
             ]
         ],
+        "timestamp": "2026-07-27T18:08:39.448471424",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-30T12:42:15.405989"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "test-bwamem2-mem-paired-end": {
         "content": [
             "4caba28aeaa490d0b4759fe1ac324790",
             [
-                "versions.yml:md5,ed7a2cfe2387b964c06b6c6847f46996"
+                [
+                    "NEXTGENMAP",
+                    "nextgenmap",
+                    "0.5.5"
+                ]
             ]
         ],
+        "timestamp": "2026-07-27T18:08:56.454416253",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-30T12:42:24.214845"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     },
     "test-bwamem2-mem-paired-end-stub": {
         "content": [
@@ -38,7 +46,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,ed7a2cfe2387b964c06b6c6847f46996"
+                    [
+                        "NEXTGENMAP",
+                        "nextgenmap",
+                        "0.5.5"
+                    ]
                 ],
                 "bam": [
                     [
@@ -49,15 +61,19 @@
                         "test.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,ed7a2cfe2387b964c06b6c6847f46996"
+                "versions_nextgenmap": [
+                    [
+                        "NEXTGENMAP",
+                        "nextgenmap",
+                        "0.5.5"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-07-27T18:09:14.423895356",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-30T12:42:29.971965"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
     }
 }


### PR DESCRIPTION
## Description

- replace the legacy `versions.yml` output with a `versions_nextgenmap` tuple broadcast to `topic: versions`
- use a verified NextGenMap version expression that returns `0.5.5`
- update the module metadata, nf-tests, and snapshots for the new version output

Generated by Codex

## PR checklist

Closes #12321

- [x] This comment contains a description of changes (with reason).
- [x] Tests cover the changed version output.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions`.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`.
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] Docker test
- [x] Singularity test
- [x] Conda test