### PR TITLE
Missed prettier for meta.yml for importsegementation

### DIFF
--- a/modules/nf-core/xeniumranger/importsegmentation/meta.yml
+++ b/modules/nf-core/xeniumranger/importsegmentation/meta.yml
@@ -108,7 +108,7 @@ input:
         description: |
           Distance (in microns) to expand nuclei outward into cell boundaries. Only valid for
           nuclei-based imports (`nuclei` must be set); xeniumranger rejects it for
-          transcript-assignment imports and cells-only imports. Default: 5. Range: 0-100. 
+          transcript-assignment imports and cells-only imports. Default: 5. Range: 0-100.
 output:
   outs:
     - - meta:


### PR DESCRIPTION
The title says it all. It was discovered just during implmentation into the spatialaxe pipeline.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Follow the naming conventions.
- [X] Follow the parameters requirements.
- [X] Follow the input/output options guidelines.
- [X] Add a resource `label`
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
