### PR TITLE
Fix contract comments in orftable_fasta_gtf_buildorfcatalogue and bam_dedup_umi

### DIFF
--- a/subworkflows/nf-core/bam_dedup_umi/main.nf
+++ b/subworkflows/nf-core/bam_dedup_umi/main.nf
@@ -143,7 +143,7 @@ workflow BAM_DEDUP_UMI {
     tsv_edit_distance              = ch_tsv_edit_distance // channel: [ val(meta), path(tsv) ]
     tsv_per_umi                    = ch_tsv_per_umi // channel: [ val(meta), path(tsv) ]
     tsv_umi_per_position           = ch_tsv_umi_per_position // channel: [ val(meta), path(tsv) ]
-    multiqc_files                  = ch_multiqc_files // channel: file
+    multiqc_files                  = ch_multiqc_files // channel: [ val(meta), path(file) ]
     transcriptome_bam              = ch_dedup_transcriptome_bam // channel: [ val(meta), path(bam) ] - final output
     transcriptome_dedup_bam        = UMI_DEDUP_TRANSCRIPTOME.out.bam // channel: [ val(meta), path(bam) ] - after dedup, before name sort
     transcriptome_sorted_bam       = SAMTOOLS_SORT.out.bam // channel: [ val(meta), path(bam) ] - name-sorted

--- a/subworkflows/nf-core/bam_dedup_umi/meta.yml
+++ b/subworkflows/nf-core/bam_dedup_umi/meta.yml
@@ -213,6 +213,9 @@ output:
   - multiqc_files:
       description: Channel containing files for MultiQC
       structure:
+        - meta:
+            type: map
+            description: Metadata map
         - file:
             type: file
             description: File for MultiQC

--- a/subworkflows/nf-core/bam_dedup_umi/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_dedup_umi/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                     {
                         "id": "test"
                     },
-                    "test.umi_dedup.genome.sorted.bam.stats:md5,5268f5f25556d02765bdf5ffaf27a44b"
+                    "test.umi_dedup.genome.sorted.bam.stats:md5,1dd820a35cddeb92c12619d2cf3f699b"
                 ]
             ],
             [
@@ -42,13 +42,13 @@
                     {
                         "id": "test"
                     },
-                    "test.umi_dedup.genome.sorted.bam.stats:md5,5268f5f25556d02765bdf5ffaf27a44b"
+                    "test.umi_dedup.genome.sorted.bam.stats:md5,1dd820a35cddeb92c12619d2cf3f699b"
                 ],
                 [
                     {
                         "id": "test"
                     },
-                    "test.umi_dedup.transcriptome.sorted.bam.stats:md5,13518c3e657b9a67b3792a2e82336494"
+                    "test.umi_dedup.transcriptome.sorted.bam.stats:md5,9f51c672c343bdb63f66a272c3a7a0f0"
                 ]
             ],
             [

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/main.nf
@@ -21,8 +21,8 @@ workflow ORFTABLE_FASTA_GTF_BUILDORFCATALOGUE {
                    //          all caller outputs flow through one channel with the
                    //          caller id carried as a per-record val (not in meta).
     ch_fasta       // channel: [ val(meta), path(fasta) ]   - reference genome FASTA
-    ch_gtf         // channel: [ val(meta), path(gtf)   ]   - reference GTF (used by
-                   //          ribocode/ribotish normalisers; ignored by rpbp/price)
+    ch_gtf         // channel: [ val(meta), path(gtf)   ]   - reference GTF (read by
+                   //          every normaliser except ribotricer)
     val_collapse   // boolean: cluster catalogue peptides by amino-acid identity
                    //          and fold duplicate small ORFs to one representative
                    //          each. When false the merged catalogue is emitted

--- a/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
+++ b/subworkflows/nf-core/orftable_fasta_gtf_buildorfcatalogue/meta.yml
@@ -58,11 +58,11 @@ input:
         Structure: [ val(meta), path(fasta) ]
   - ch_gtf:
       description: |
-        Reference annotation GTF. Used by the ribocode and ribotish
-        normalisers to lift transcript coordinates to genomic blocks;
-        ignored by callers that already emit genomic coordinates
-        (ribotricer, rpbp, price). Pass `[ [:], [] ]` if no GTF is
-        available (caller subset must then exclude ribocode and ribotish).
+        Reference annotation GTF. The ribocode and ribotish normalisers use
+        it to lift transcript coordinates to genomic blocks; rpbp and price
+        resolve gene ids from it, and rpbp has no fallback, so its ORFs get
+        an empty gene_id without it. Only ribotricer ignores it. Pass
+        `[ [:], [] ]` only when the caller subset is limited to ribotricer.
         Structure: [ val(meta), path(gtf) ]
   - val_collapse:
       description: |


### PR DESCRIPTION
Two subworkflow contract comments say the opposite of what the code does, and both have already caused bugs downstream in nf-core/riboseq. `orftable_fasta_gtf_buildorfcatalogue` documents the GTF as ignored by rpbp and price, but both resolve gene ids from it and rpbp has no fallback. `bam_dedup_umi` documents `multiqc_files` as bare files, but it emits `[ meta, file ]`. Comments and `meta.yml` only, no functional change.

<details>
<summary>Detail (AI-assisted analysis)</summary>

## `orftable_fasta_gtf_buildorfcatalogue`

Which parsers in `custom/orfnormalise` read the GTF to resolve `gene_id`:

| parser | reads the GTF? | line |
| --- | --- | --- |
| `parse_ribocode` | yes | 473 |
| `parse_ribotish` | yes, after the `Gid` column | 533 |
| `parse_ribotricer` | no — takes `transcripts`, never reads it | 618 |
| `parse_rpbp` | yes, and it is the only source | 715 |
| `parse_price` | yes, `Gene` column as fallback | 807-809 |

`parse_rpbp` is `gid = transcripts[tid].gene_id if tid in transcripts else ""`, so without a GTF every rpbp ORF gets an empty `gene_id`. `parse_price` started preferring the annotation in #12436.

That also made the old `[ [:], [] ]` advice unsafe: with rpbp enabled it gives empty gene ids, and with price enabled it gives PRICE's `Gene` column, which concatenates every gene an ORF's genomic span overlaps.

Downstream: nf-core/riboseq fed the catalogue its one-transcript-per-gene backbone on the strength of the old wording, dropping PRICE ORFs on non-representative isoforms out of the ORF-level DTE join (nf-core/riboseq#203, fixed in nf-core/riboseq#207).

## `bam_dedup_umi`

`ch_multiqc_files` mixes `[ meta, path ]` module outputs and ends with `.transpose()` (L117-121), so every emission is a two-element tuple. Mixing it straight into a MultiQC input channel passes the meta map where a path is expected:

```
Not a valid path value type: java.util.LinkedHashMap
```

That broke every `--with_umi` run in nf-core/riboseq#220, fixed there with `.map { _meta, file -> file }` at the call site. `genomic_dedup_log` from the same source channel is annotated correctly two lines up, so this looks like an oversight rather than an intended contract. Fixing the comment rather than the emission avoids breaking existing consumers.

</details>
