### PR TITLE
Fix broken stub test

### DIFF
--- a/modules/nf-core/duckdb/table2parquet/tests/main.nf.test.snap
+++ b/modules/nf-core/duckdb/table2parquet/tests/main.nf.test.snap
@@ -2,21 +2,6 @@
     "csv - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.parquet:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        "DUCKDB_TABLE2PARQUET",
-                        "duckdb",
-                        "1.5.5"
-                    ]
-                ],
                 "parquet": [
                     [
                         {
@@ -34,7 +19,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-29T15:06:24.674447722",
+        "timestamp": "2026-07-31T08:15:34.157728597",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"


### PR DESCRIPTION
#12461 merged with a failing stub test (due to sanitizeOutput being added without regenerating the snapshot).