### PR TITLE
Bump trgt/merge

### DIFF
--- a/modules/nf-core/trgt/merge/environment.yml
+++ b/modules/nf-core/trgt/merge/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::trgt=5.0.0
+  - bioconda::trgt=5.1.0
+  - conda-forge::gzip=1.14

--- a/modules/nf-core/trgt/merge/main.nf
+++ b/modules/nf-core/trgt/merge/main.nf
@@ -4,8 +4,8 @@ process TRGT_MERGE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/trgt:5.0.0--h9ee0642_0':
-        'quay.io/biocontainers/trgt:5.0.0--h9ee0642_0' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/b9/b94772fdcba7aa8027797b0d092a77b272cebc8d566fec3c960a1470e20223cf/data':
+        'community.wave.seqera.io/library/trgt:5.1.0--66e3b26326e566e7' }"
 
     input:
     tuple val(meta) , path(vcfs), path(tbis)

--- a/modules/nf-core/trgt/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/trgt/merge/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                     {
                         "id": "test"
                     },
-                    "test.bcf.gz.csi:md5,25edb1e7fca90690371848b7c01b9631"
+                    "test.bcf.gz.csi:md5,b0655bed37ce5fa72c57e0a2a34ca077"
                 ]
             ],
             {
@@ -15,15 +15,15 @@
                     [
                         "TRGT_MERGE",
                         "trgt",
-                        "5.0.0-e9acee0"
+                        "5.1.0-ec66463"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-12-10T15:42:21.803640957",
+        "timestamp": "2026-08-01T13:54:39.089059801",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     },
     "homo sapiens - 2 VCFs - reference": {
@@ -39,15 +39,15 @@
                     [
                         "TRGT_MERGE",
                         "trgt",
-                        "5.0.0-e9acee0"
+                        "5.1.0-ec66463"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-12-10T15:36:01.2063008",
+        "timestamp": "2026-08-01T13:54:09.926067752",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     },
     "homo sapiens - 2 VCFs": {
@@ -63,15 +63,15 @@
                     [
                         "TRGT_MERGE",
                         "trgt",
-                        "5.0.0-e9acee0"
+                        "5.1.0-ec66463"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-12-10T15:35:55.048303885",
+        "timestamp": "2026-08-01T13:53:59.956602577",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     },
     "homo sapiens - 2 VCFs - tbi index - stub": {
@@ -97,15 +97,15 @@
                     [
                         "TRGT_MERGE",
                         "trgt",
-                        "5.0.0-e9acee0"
+                        "5.1.0-ec66463"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-07T09:07:07.22347108",
+        "timestamp": "2026-08-01T13:54:48.752722468",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "homo sapiens - 2 VCFs - stub": {
@@ -126,15 +126,15 @@
                     [
                         "TRGT_MERGE",
                         "trgt",
-                        "5.0.0-e9acee0"
+                        "5.1.0-ec66463"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-07T09:07:35.389858465",
+        "timestamp": "2026-08-01T13:55:08.419404493",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "homo sapiens - 1 VCF - --force-single --output-type z --write-index": {
@@ -147,7 +147,7 @@
                     {
                         "id": "test"
                     },
-                    "test.vcf.gz.tbi:md5,bd5b91195c6b4b92b1727a170a2656e4"
+                    "test.vcf.gz.tbi:md5,16dfc0ecac86aa02e78ac57f40524fe9"
                 ]
             ],
             {
@@ -155,15 +155,15 @@
                     [
                         "TRGT_MERGE",
                         "trgt",
-                        "5.0.0-e9acee0"
+                        "5.1.0-ec66463"
                     ]
                 ]
             }
         ],
-        "timestamp": "2025-12-10T15:42:15.567594151",
+        "timestamp": "2026-08-01T13:54:29.445622495",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     },
     "homo sapiens - 2 VCFs - csi index - stub": {
@@ -189,15 +189,15 @@
                     [
                         "TRGT_MERGE",
                         "trgt",
-                        "5.0.0-e9acee0"
+                        "5.1.0-ec66463"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-07T09:07:21.45085352",
+        "timestamp": "2026-08-01T13:54:58.517381805",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     }
 }


### PR DESCRIPTION
This PR bumps trgt/merge from version `5.0.0` to version `5.1.0`.

## PR checklist
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`