### PR TITLE
Update mgnifam/generatefamilies

### DIFF
--- a/modules/nf-core/mgnifam/generatefamilies/environment.yml
+++ b/modules/nf-core/mgnifam/generatefamilies/environment.yml
@@ -4,7 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::pip=25.3
-  - conda-forge::python=3.14.6
-  - pip:
-      - mgnifam==1.0.0
+  - bioconda::mgnifam=2.0.0

--- a/modules/nf-core/mgnifam/generatefamilies/main.nf
+++ b/modules/nf-core/mgnifam/generatefamilies/main.nf
@@ -8,7 +8,7 @@ process MGNIFAM_GENERATEFAMILIES {
         'quay.io/biocontainers/mgnifam:2.0.0--pyhdfd78af_0' }"
 
     input:
-    tuple val(meta), path(clusters_chunk), path(fasta_file)
+    tuple val(meta), path(clustering), path(fasta_file), path(fasta_index)
 
     output:
     tuple val(meta), path("${prefix}/seed_msa/*.sto.gz")       , emit: seed_msa  , optional: true
@@ -28,15 +28,17 @@ process MGNIFAM_GENERATEFAMILIES {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
-    prefix   = task.ext.prefix ?: "${meta.id}"
+    def args  = task.ext.args ?: ''
+    prefix    = task.ext.prefix ?: "${meta.id}"
+    def index = fasta_index ? "--fasta_index ${fasta_index}" : ''
     """
     mgnifam generate_families \\
-        --clusters_chunk ${clusters_chunk} \\
+        --clusters_chunk ${clustering} \\
         --fasta_file ${fasta_file} \\
         --output_dir ${prefix} \\
         --cpus ${task.cpus} \\
         --chunk_num ${prefix} \\
+        ${index} \\
         ${args}
     """
 

--- a/modules/nf-core/mgnifam/generatefamilies/main.nf
+++ b/modules/nf-core/mgnifam/generatefamilies/main.nf
@@ -4,8 +4,8 @@ process MGNIFAM_GENERATEFAMILIES {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/aa/aa77afddce5309d57c80ddc131bb6ca7232d1227abe608f87011cb1caf36c4ff/data' :
-        'community.wave.seqera.io/library/pip_mgnifam:b23278d764db6a8f' }"
+        'https://depot.galaxyproject.org/singularity/mgnifam:2.0.0--pyhdfd78af_0' :
+        'quay.io/biocontainers/mgnifam:2.0.0--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(clusters_chunk), path(fasta_file)
@@ -23,7 +23,6 @@ process MGNIFAM_GENERATEFAMILIES {
     tuple val(meta), path("${prefix}/${prefix}_discarded.csv") , emit: discarded , optional: true
     tuple val(meta), path("${prefix}/${prefix}_converged.txt") , emit: converged , optional: true
     tuple val("${task.process}"), val('mgnifam'), eval("mgnifam --version 2>&1"), topic: versions, emit: versions_mgnifam
-    tuple val("${task.process}"), val('python'), eval("python3 --version 2>&1 | sed 's/Python //'"), topic: versions, emit: versions_python
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/mgnifam/generatefamilies/meta.yml
+++ b/modules/nf-core/mgnifam/generatefamilies/meta.yml
@@ -187,16 +187,6 @@ output:
       - "mgnifam --version 2>&1":
           type: eval
           description: The expression to obtain the version of the tool
-  versions_python:
-    - - ${task.process}:
-          type: string
-          description: The name of the process
-      - python:
-          type: string
-          description: The name of the tool
-      - python3 --version 2>&1 | sed 's/Python //':
-          type: eval
-          description: The expression to obtain the version of the tool
 topics:
   versions:
     - - ${task.process}:
@@ -206,15 +196,6 @@ topics:
           type: string
           description: The name of the tool
       - "mgnifam --version 2>&1":
-          type: eval
-          description: The expression to obtain the version of the tool
-    - - ${task.process}:
-          type: string
-          description: The name of the process
-      - python:
-          type: string
-          description: The name of the tool
-      - python3 --version 2>&1 | sed 's/Python //':
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/mgnifam/generatefamilies/meta.yml
+++ b/modules/nf-core/mgnifam/generatefamilies/meta.yml
@@ -19,14 +19,15 @@ tools:
       tool_dev_url: "https://github.com/vagkaratzas/mgnifam"
       licence:
         - "MIT"
-      identifier: ""
+      args_id: "$args"
+      identifier: biotools:mgnifam
 input:
   - - meta:
         type: map
         description: |
           Groovy Map containing sample information
           e.g. `[ id:'sample1' ]`
-    - clusters_chunk:
+    - clustering:
         type: file
         description: Headerless TSV file of MMseqs2 sequence clusters, one representative-member
           pair per line (representative<TAB>member)
@@ -40,6 +41,14 @@ input:
         pattern: "*.{fa,fasta,fna,faa}"
         ontologies:
           - edam: http://edamontology.org/format_1929 # FASTA
+    - fasta_index:
+        type: file
+        description: Optional. Precomputed Easel SSI index of the FASTA file, e.g.
+          from `esl-sfetch --index` (hmmer/eslsfetchindex). Used as given and never
+          rebuilt, so parallel chunk tasks can share one read-only index. Built
+          automatically when omitted
+        pattern: "*.ssi"
+        ontologies: []
 output:
   seed_msa:
     - - meta:

--- a/modules/nf-core/mgnifam/generatefamilies/tests/main.nf.test
+++ b/modules/nf-core/mgnifam/generatefamilies/tests/main.nf.test
@@ -8,6 +8,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "mgnifam"
     tag "mgnifam/generatefamilies"
+    tag "hmmer/eslsfetchindex"
 
     config "./nextflow.config"
 
@@ -22,7 +23,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins_trimmed_clustering.tsv', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true),
+                    []
                 ]
                 """
             }
@@ -31,8 +33,77 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                // "log" contains a wall-clock timestamp on every line, so only its
-                // filename is stable across runs.
+                // "log" contains wall-clock timestamps
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
+            )
+        }
+
+    }
+
+    test("mgnify - faa - mgnifams - esl-sfetch index") {
+
+        setup {
+            run("HMMER_ESLSFETCHINDEX") {
+                script "../../../hmmer/eslsfetchindex/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            params {
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = HMMER_ESLSFETCHINDEX.out.ssi.map { meta, ssi ->
+                    [
+                        meta,
+                        file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins_trimmed_clustering.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true),
+                        ssi
+                    ]
+                }
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
+            )
+        }
+
+    }
+
+    test("mgnify - faa - mgnifams - prefetch_targets") {
+
+        when {
+            params {
+                module_args = '--prefetch_targets'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins_trimmed_clustering.tsv', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true),
+                    []
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
                 { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
             )
         }
@@ -52,7 +123,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins_trimmed_clustering.tsv', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true),
+                    []
                 ]
                 """
             }
@@ -69,8 +141,8 @@ nextflow_process {
 
     // Extra `generate_families --help` options that main.nf does not already
     // hardcode, as documentation (default values as comments):
-    // `--fasta_index` is skipped: it takes a path to a precomputed sequence
-    // index, not a tunable value, and is optional (auto-built when omitted).
+    // `--fasta_index` is skipped here: it is a module input, not an ext.arg,
+    // and is covered by the `esl-sfetch index` test below.
     test("mgnify - faa - mgnifams - custom_args - stub") {
 
         options "-stub"
@@ -93,7 +165,8 @@ nextflow_process {
                 input[0] = [
                     [ id:'test' ],
                     file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins_trimmed_clustering.tsv', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true)
+                    file(params.modules_testdata_base_path + 'proteomics/proteinfamilies/mgnify_proteins.faa', checkIfExists: true),
+                    []
                 ]
                 """
             }

--- a/modules/nf-core/mgnifam/generatefamilies/tests/main.nf.test.snap
+++ b/modules/nf-core/mgnifam/generatefamilies/tests/main.nf.test.snap
@@ -1,4 +1,150 @@
 {
+    "mgnify - faa - mgnifams - esl-sfetch index": {
+        "content": [
+            {
+                "converged": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_converged.txt:md5,9c23343a9b58782cc1aab5046737db94"
+                    ]
+                ],
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_metadata.csv:md5,e667640a42565cec94faa4575d3b8fdd"
+                    ]
+                ],
+                "discarded": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_discarded.csv:md5,e22d5364cee2e59aa8d8dc1788e871e9"
+                    ]
+                ],
+                "full_msa": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test_1.sto.gz:md5,c5cbbba2a38f76a5c1cb68b07904adfe",
+                            "test_2.sto.gz:md5,7d4d8120cf70ebf483fbb6dfa574b399",
+                            "test_3.sto.gz:md5,714b712b687a38198e21ec38be27ee53",
+                            "test_4.sto.gz:md5,6c9e3965051c7478b88eb30b89a86576",
+                            "test_5.sto.gz:md5,211f672d5cb6c30c7930e74757b126f0",
+                            "test_6.sto.gz:md5,a53d033b230e1614625e15605270443d",
+                            "test_7.sto.gz:md5,04a864e7c15c0dc4f3a07ef1cecf5827",
+                            "test_8.sto.gz:md5,5a9f35db9a87558143e19e6744059a26",
+                            "test_9.sto.gz:md5,e288d0d93e033dbd9e6c8fc04c9c7536"
+                        ]
+                    ]
+                ],
+                "hmm": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test_1.hmm.gz:md5,678567b321cf7eee615cd379973ad4ee",
+                            "test_2.hmm.gz:md5,f43f95f769f88f7ee38a3ba9527842a8",
+                            "test_3.hmm.gz:md5,2d5b5f6ae86838ddb533cfe7f671b6cf",
+                            "test_4.hmm.gz:md5,adb16ddc40811ccf335701b1292eabfd",
+                            "test_5.hmm.gz:md5,238306dacf3f4c2bdc4b4713f28c2c4c",
+                            "test_6.hmm.gz:md5,1e9959d503bc262870558202ea3366e2",
+                            "test_7.hmm.gz:md5,149ca280f557496b02b345f825055668",
+                            "test_8.hmm.gz:md5,4b77146390d7a973c5caaceddf8a93e7",
+                            "test_9.hmm.gz:md5,3f1f5766c7674eb188147fb4eac31d4e"
+                        ]
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log"
+                    ]
+                ],
+                "reps_fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_reps.fasta.gz:md5,f9c52e85ecd9b7ca3651801584cebeb5"
+                    ]
+                ],
+                "rf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test_1.txt:md5,5c50c2b316dd413b3c3921f1bab84b8c",
+                            "test_2.txt:md5,a8de4ad7599e74d4e3459a1ca405cb1f",
+                            "test_3.txt:md5,bb6d3d37d8ad3aa983f7e85990991e0b",
+                            "test_4.txt:md5,197656079e2fc679fd987632d79dd2b8",
+                            "test_5.txt:md5,e766b28d59bc873f8e54d246bd375ce9",
+                            "test_6.txt:md5,dff2fdf7a9f45c94cd7c110487322c23",
+                            "test_7.txt:md5,36e272978769d4ca26f9bc545625021f",
+                            "test_8.txt:md5,be4c95323e3da4130ff938ae8e81efc3",
+                            "test_9.txt:md5,acdfbe7d162f80a5133e9b10dac869b2"
+                        ]
+                    ]
+                ],
+                "seed_msa": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test_1.sto.gz:md5,ca2b7d83b573f9ecea81bbadcf20056b",
+                            "test_2.sto.gz:md5,efdb1a88939e93ccb27316f72fbf9877",
+                            "test_3.sto.gz:md5,d4af6fb4656b796000c2e30435130977",
+                            "test_4.sto.gz:md5,95b4dfeb2574190e99c1b3fd39625156",
+                            "test_5.sto.gz:md5,c39515900a7fbfd3da4c565fbc8b10e1",
+                            "test_6.sto.gz:md5,8f1ff690d44c3b98e7e6773455749664",
+                            "test_7.sto.gz:md5,213351a99b1d69e5ac798fda5bb20623",
+                            "test_8.sto.gz:md5,aa8ff1a005eeb2244b0ca6c5ee7edd9c",
+                            "test_9.sto.gz:md5,e58ceca6683130fda471b0e4595869f1"
+                        ]
+                    ]
+                ],
+                "successful": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_successful.txt:md5,2a987074e3666639c71f1855313698c8"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_families.tsv:md5,90957ba9c2ca14c482e2b13d6bb72b15"
+                    ]
+                ],
+                "versions_mgnifam": [
+                    [
+                        "MGNIFAM_GENERATEFAMILIES",
+                        "mgnifam",
+                        "2.0.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-04T13:50:06.691804296",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
     "mgnify - faa - mgnifams": {
         "content": [
             {
@@ -246,6 +392,152 @@
             }
         ],
         "timestamp": "2026-07-23T14:24:05.348240238",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "mgnify - faa - mgnifams - prefetch_targets": {
+        "content": [
+            {
+                "converged": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_converged.txt:md5,9c23343a9b58782cc1aab5046737db94"
+                    ]
+                ],
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_metadata.csv:md5,e667640a42565cec94faa4575d3b8fdd"
+                    ]
+                ],
+                "discarded": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_discarded.csv:md5,e22d5364cee2e59aa8d8dc1788e871e9"
+                    ]
+                ],
+                "full_msa": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test_1.sto.gz:md5,c5cbbba2a38f76a5c1cb68b07904adfe",
+                            "test_2.sto.gz:md5,7d4d8120cf70ebf483fbb6dfa574b399",
+                            "test_3.sto.gz:md5,714b712b687a38198e21ec38be27ee53",
+                            "test_4.sto.gz:md5,6c9e3965051c7478b88eb30b89a86576",
+                            "test_5.sto.gz:md5,211f672d5cb6c30c7930e74757b126f0",
+                            "test_6.sto.gz:md5,a53d033b230e1614625e15605270443d",
+                            "test_7.sto.gz:md5,04a864e7c15c0dc4f3a07ef1cecf5827",
+                            "test_8.sto.gz:md5,5a9f35db9a87558143e19e6744059a26",
+                            "test_9.sto.gz:md5,e288d0d93e033dbd9e6c8fc04c9c7536"
+                        ]
+                    ]
+                ],
+                "hmm": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test_1.hmm.gz:md5,678567b321cf7eee615cd379973ad4ee",
+                            "test_2.hmm.gz:md5,f43f95f769f88f7ee38a3ba9527842a8",
+                            "test_3.hmm.gz:md5,2d5b5f6ae86838ddb533cfe7f671b6cf",
+                            "test_4.hmm.gz:md5,adb16ddc40811ccf335701b1292eabfd",
+                            "test_5.hmm.gz:md5,238306dacf3f4c2bdc4b4713f28c2c4c",
+                            "test_6.hmm.gz:md5,1e9959d503bc262870558202ea3366e2",
+                            "test_7.hmm.gz:md5,149ca280f557496b02b345f825055668",
+                            "test_8.hmm.gz:md5,4b77146390d7a973c5caaceddf8a93e7",
+                            "test_9.hmm.gz:md5,3f1f5766c7674eb188147fb4eac31d4e"
+                        ]
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log"
+                    ]
+                ],
+                "reps_fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_reps.fasta.gz:md5,f9c52e85ecd9b7ca3651801584cebeb5"
+                    ]
+                ],
+                "rf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test_1.txt:md5,5c50c2b316dd413b3c3921f1bab84b8c",
+                            "test_2.txt:md5,a8de4ad7599e74d4e3459a1ca405cb1f",
+                            "test_3.txt:md5,bb6d3d37d8ad3aa983f7e85990991e0b",
+                            "test_4.txt:md5,197656079e2fc679fd987632d79dd2b8",
+                            "test_5.txt:md5,e766b28d59bc873f8e54d246bd375ce9",
+                            "test_6.txt:md5,dff2fdf7a9f45c94cd7c110487322c23",
+                            "test_7.txt:md5,36e272978769d4ca26f9bc545625021f",
+                            "test_8.txt:md5,be4c95323e3da4130ff938ae8e81efc3",
+                            "test_9.txt:md5,acdfbe7d162f80a5133e9b10dac869b2"
+                        ]
+                    ]
+                ],
+                "seed_msa": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "test_1.sto.gz:md5,ca2b7d83b573f9ecea81bbadcf20056b",
+                            "test_2.sto.gz:md5,efdb1a88939e93ccb27316f72fbf9877",
+                            "test_3.sto.gz:md5,d4af6fb4656b796000c2e30435130977",
+                            "test_4.sto.gz:md5,95b4dfeb2574190e99c1b3fd39625156",
+                            "test_5.sto.gz:md5,c39515900a7fbfd3da4c565fbc8b10e1",
+                            "test_6.sto.gz:md5,8f1ff690d44c3b98e7e6773455749664",
+                            "test_7.sto.gz:md5,213351a99b1d69e5ac798fda5bb20623",
+                            "test_8.sto.gz:md5,aa8ff1a005eeb2244b0ca6c5ee7edd9c",
+                            "test_9.sto.gz:md5,e58ceca6683130fda471b0e4595869f1"
+                        ]
+                    ]
+                ],
+                "successful": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_successful.txt:md5,2a987074e3666639c71f1855313698c8"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_families.tsv:md5,90957ba9c2ca14c482e2b13d6bb72b15"
+                    ]
+                ],
+                "versions_mgnifam": [
+                    [
+                        "MGNIFAM_GENERATEFAMILIES",
+                        "mgnifam",
+                        "2.0.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-04T13:50:26.134209433",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/modules/nf-core/mgnifam/generatefamilies/tests/main.nf.test.snap
+++ b/modules/nf-core/mgnifam/generatefamilies/tests/main.nf.test.snap
@@ -15,7 +15,7 @@
                         {
                             "id": "test"
                         },
-                        "test_metadata.csv:md5,6e9ca2150e880a85d345796436c47cb3"
+                        "test_metadata.csv:md5,e667640a42565cec94faa4575d3b8fdd"
                     ]
                 ],
                 "discarded": [
@@ -23,7 +23,7 @@
                         {
                             "id": "test"
                         },
-                        "test_discarded.csv:md5,b725f8e8f895722c89be12e8fc6e2a28"
+                        "test_discarded.csv:md5,e22d5364cee2e59aa8d8dc1788e871e9"
                     ]
                 ],
                 "full_msa": [
@@ -134,19 +134,12 @@
                     [
                         "MGNIFAM_GENERATEFAMILIES",
                         "mgnifam",
-                        "1.0.0"
-                    ]
-                ],
-                "versions_python": [
-                    [
-                        "MGNIFAM_GENERATEFAMILIES",
-                        "python",
-                        "3.14.6"
+                        "2.0.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-23T14:23:55.141704015",
+        "timestamp": "2026-08-04T13:36:08.354966765",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"
@@ -247,14 +240,7 @@
                     [
                         "MGNIFAM_GENERATEFAMILIES",
                         "mgnifam",
-                        "1.0.0"
-                    ]
-                ],
-                "versions_python": [
-                    [
-                        "MGNIFAM_GENERATEFAMILIES",
-                        "python",
-                        "3.14.6"
+                        "2.0.0"
                     ]
                 ]
             }
@@ -360,14 +346,7 @@
                     [
                         "MGNIFAM_GENERATEFAMILIES",
                         "mgnifam",
-                        "1.0.0"
-                    ]
-                ],
-                "versions_python": [
-                    [
-                        "MGNIFAM_GENERATEFAMILIES",
-                        "python",
-                        "3.14.6"
+                        "2.0.0"
                     ]
                 ]
             }


### PR DESCRIPTION
`mgnifam` package from bioconda instead of `pip`.

- Added a missing input file for pre-existing `fasta_index`.
- Added bio.tools reference
- Added two new nf-tests; for fasta_index and prefetch_targets
- Changed `clusters_chunks` input apram name to `clustering` which makes more sense to users.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
