### PR TITLE
Sort outputs in `rclone` modules

### DIFF
--- a/modules/nf-core/rclone/check/main.nf
+++ b/modules/nf-core/rclone/check/main.nf
@@ -42,6 +42,13 @@ process RCLONE_CHECK {
         ${source} \\
         ${destination} || echo \$? > ${prefix}.exit_code.txt
 
+    sort -k2 ${prefix}.combined.txt -o ${prefix}.combined.txt
+    sort ${prefix}.differ.txt -o ${prefix}.differ.txt
+    sort ${prefix}.missing_on_dst.txt -o ${prefix}.missing_on_dst.txt
+    sort ${prefix}.missing_on_src.txt -o ${prefix}.missing_on_src.txt
+    sort ${prefix}.match.txt -o ${prefix}.match.txt
+    sort ${prefix}.error.txt -o ${prefix}.error.txt
+
     # Do not emit empty output files
     for f in *.txt; do
         [ -s "\$f" ] || rm -f "\$f"

--- a/modules/nf-core/rclone/check/tests/main.nf.test
+++ b/modules/nf-core/rclone/check/tests/main.nf.test
@@ -25,7 +25,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["combined", "differ", "match", "missing_on_dst", "missing_on_src", "error"])).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -45,7 +45,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["combined", "match", "differ", "missing_on_dst", "missing_on_src", "error"])).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -65,7 +65,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["combined", "match", "missing_on_dst", "missing_on_src", "error"])).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -85,7 +85,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["combined", "differ", "missing_on_dst", "missing_on_src", "error"])).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/rclone/check/tests/main.nf.test.snap
+++ b/modules/nf-core/rclone/check/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.combined.txt"
+                        "test.combined.txt:md5,6518ec1170e94cd1e9d2ef4a4ba5a9e8"
                     ]
                 ],
                 "differ": [
@@ -24,7 +24,7 @@
                         {
                             "id": "test"
                         },
-                        "test.match.txt"
+                        "test.match.txt:md5,66c7833b0fd04a059b29a116474c021c"
                     ]
                 ],
                 "missing_on_dst": [
@@ -42,10 +42,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-22T14:46:30.042575576",
+        "timestamp": "2026-08-04T11:26:36.792274751",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.0"
         }
     },
     "sarscov2 - fastq - stub": {
@@ -56,7 +56,7 @@
                         {
                             "id": "test"
                         },
-                        "test.combined.txt"
+                        "test.combined.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "differ": [
@@ -64,7 +64,7 @@
                         {
                             "id": "test"
                         },
-                        "test.differ.txt"
+                        "test.differ.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "error": [
@@ -72,7 +72,7 @@
                         {
                             "id": "test"
                         },
-                        "test.error.txt"
+                        "test.error.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "exit_code": [
@@ -83,7 +83,7 @@
                         {
                             "id": "test"
                         },
-                        "test.match.txt"
+                        "test.match.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "missing_on_dst": [
@@ -91,7 +91,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_dst.txt"
+                        "test.missing_on_dst.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "missing_on_src": [
@@ -99,7 +99,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_src.txt"
+                        "test.missing_on_src.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions_rclone": [
@@ -111,10 +111,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-21T21:03:37.410543015",
+        "timestamp": "2026-08-04T11:26:42.333790108",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.0"
         }
     },
     "different files": {
@@ -125,7 +125,7 @@
                         {
                             "id": "test"
                         },
-                        "test.combined.txt"
+                        "test.combined.txt:md5,750454d95092af361bdb1c3e8c113251"
                     ]
                 ],
                 "differ": [
@@ -150,7 +150,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_dst.txt"
+                        "test.missing_on_dst.txt:md5,66c7833b0fd04a059b29a116474c021c"
                     ]
                 ],
                 "missing_on_src": [
@@ -158,7 +158,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_src.txt"
+                        "test.missing_on_src.txt:md5,1dd18b615ae0c9abf940ad0739fb8950"
                     ]
                 ],
                 "versions_rclone": [
@@ -170,10 +170,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-21T21:03:45.979925514",
+        "timestamp": "2026-08-04T11:26:48.79499383",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.0"
         }
     },
     "differ and missing": {
@@ -184,7 +184,7 @@
                         {
                             "id": "test"
                         },
-                        "test.combined.txt"
+                        "test.combined.txt:md5,74c774156fdfa62f1ba14c780adf89f4"
                     ]
                 ],
                 "differ": [
@@ -192,7 +192,7 @@
                         {
                             "id": "test"
                         },
-                        "test.differ.txt"
+                        "test.differ.txt:md5,ac036608c5c402f92926505d0f0ab0e4"
                     ]
                 ],
                 "error": [
@@ -214,7 +214,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_dst.txt"
+                        "test.missing_on_dst.txt:md5,6435d60effdac7ca6fbdfad40ffe2535"
                     ]
                 ],
                 "missing_on_src": [
@@ -222,7 +222,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_src.txt"
+                        "test.missing_on_src.txt:md5,89fcd615fd22b904204dafd407daf015"
                     ]
                 ],
                 "versions_rclone": [
@@ -234,10 +234,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-22T14:46:52.993591106",
+        "timestamp": "2026-08-04T11:26:55.797148658",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/modules/nf-core/rclone/checksum/main.nf
+++ b/modules/nf-core/rclone/checksum/main.nf
@@ -44,6 +44,13 @@ process RCLONE_CHECKSUM {
         $sumfile \\
         ${destination} || echo \$? > ${prefix}.exit_code.txt
 
+    sort -k2 ${prefix}.combined.txt -o ${prefix}.combined.txt
+    sort ${prefix}.differ.txt -o ${prefix}.differ.txt
+    sort ${prefix}.missing_on_dst.txt -o ${prefix}.missing_on_dst.txt
+    sort ${prefix}.missing_on_src.txt -o ${prefix}.missing_on_src.txt
+    sort ${prefix}.match.txt -o ${prefix}.match.txt
+    sort ${prefix}.error.txt -o ${prefix}.error.txt
+
     # Do not emit empty output files
     for f in *.txt; do
         [ -s "\$f" ] || rm -f "\$f"

--- a/modules/nf-core/rclone/checksum/tests/main.nf.test
+++ b/modules/nf-core/rclone/checksum/tests/main.nf.test
@@ -26,7 +26,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["combined", "match", "differ", "missing_on_dst", "missing_on_src", "error"]) ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -48,7 +48,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["match", "combined", "differ", "missing_on_dst", "missing_on_src", "error"]) ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -69,7 +69,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["combined", "match", "missing_on_dst", "missing_on_src", "error"]) ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/rclone/checksum/tests/main.nf.test.snap
+++ b/modules/nf-core/rclone/checksum/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "test.combined.txt"
+                        "test.combined.txt:md5,4b849f0b6831d6561da709ca6f626b7d"
                     ]
                 ],
                 "differ": [
@@ -24,7 +24,7 @@
                         {
                             "id": "test"
                         },
-                        "test.match.txt"
+                        "test.match.txt:md5,2458aa282a426dec085359d209d5077c"
                     ]
                 ],
                 "missing_on_dst": [
@@ -42,10 +42,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-21T23:18:32.247989694",
+        "timestamp": "2026-08-04T11:27:09.176178267",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.0"
         }
     },
     "test - md5 - differs": {
@@ -56,7 +56,7 @@
                         {
                             "id": "test"
                         },
-                        "test.combined.txt"
+                        "test.combined.txt:md5,d79adc0e541e01c95735769c919ae993"
                     ]
                 ],
                 "differ": [
@@ -81,7 +81,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_dst.txt"
+                        "test.missing_on_dst.txt:md5,a438474115db37daf9d8e1307c06eb4a"
                     ]
                 ],
                 "missing_on_src": [
@@ -96,10 +96,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-21T23:20:27.477738495",
+        "timestamp": "2026-08-04T11:27:20.066820454",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.0"
         }
     },
     "test - md5 - stub": {
@@ -110,7 +110,7 @@
                         {
                             "id": "test"
                         },
-                        "test.combined.txt"
+                        "test.combined.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "differ": [
@@ -118,7 +118,7 @@
                         {
                             "id": "test"
                         },
-                        "test.differ.txt"
+                        "test.differ.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "error": [
@@ -126,7 +126,7 @@
                         {
                             "id": "test"
                         },
-                        "test.error.txt"
+                        "test.error.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "exit_code": [
@@ -137,7 +137,7 @@
                         {
                             "id": "test"
                         },
-                        "test.match.txt"
+                        "test.match.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "missing_on_dst": [
@@ -145,7 +145,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_dst.txt"
+                        "test.missing_on_dst.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "missing_on_src": [
@@ -153,7 +153,7 @@
                         {
                             "id": "test"
                         },
-                        "test.missing_on_src.txt"
+                        "test.missing_on_src.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions_rclone": [
@@ -165,10 +165,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-21T23:19:49.064384002",
+        "timestamp": "2026-08-04T11:27:14.250267458",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.0"
         }
     }
 }


### PR DESCRIPTION
Sort files to ensure stable content.

For: https://github.com/nf-core/datasync/issues/36