### PR TITLE
Remove varianble's 'def' from samtool sort 'output_file'

### DIFF
--- a/modules/nf-core/samtools/sort/main.nf
+++ b/modules/nf-core/samtools/sort/main.nf
@@ -33,7 +33,7 @@ process SAMTOOLS_SORT {
     def reference = fasta ? "--reference ${fasta}" : ""
     //setting default values
     def write_index = ""
-    def output_file = "${prefix}.${extension}"
+    output_file = "${prefix}.${extension}"
 
     // Update if index is requested
     if (index_format != '' && index_format) {

--- a/modules/nf-core/samtools/sort/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/sort/tests/main.nf.test.snap
@@ -46,7 +46,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.sorted.bam.csi:md5,43f545200e545ca2075c475d194a5130"
+                    "test.sorted.bam.csi:md5,01394e702c729cb478df914ffaf9f7f8"
                 ]
             ],
             {
@@ -59,10 +59,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-07-10T17:05:03.136300204",
+        "timestamp": "2026-08-04T18:55:54.454541192",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.4"
+            "nextflow": "26.04.6"
         }
     },
     "bam - stub": {


### PR DESCRIPTION
This PR removes a variable's `def` to fix an error encountered while running samtools/sort using Nextflow 24.04.2:

```bash
ERROR ~ Module compilation error
- file : /path/to/pipeline/./workflows/../modules/nf-core/samtools/sort/main.nf
- cause: Variable `prefix` already defined in the process scope @ line 36, column 26.
       def output_file = "${prefix}.${extension}"
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`