### PR TITLE
feat(rpbp/preparegenome): emit Rp-Bp's per-ORF labels file

### DIFF
--- a/modules/nf-core/rpbp/preparegenome/environment.yml
+++ b/modules/nf-core/rpbp/preparegenome/environment.yml
@@ -3,3 +3,4 @@ channels:
   - bioconda
 dependencies:
   - bioconda::rpbp=4.0.1
+  - conda-forge::python=3.13.13

--- a/modules/nf-core/rpbp/preparegenome/main.nf
+++ b/modules/nf-core/rpbp/preparegenome/main.nf
@@ -14,6 +14,7 @@ process RPBP_PREPAREGENOME {
     tuple val(meta), path("${prefix}.annotated.bed.gz")             , emit: transcript_bed
     tuple val(meta), path("${prefix}.orfs-genomic.annotated.bed.gz"), emit: orfs_genomic_bed
     tuple val(meta), path("${prefix}.orfs-exons.annotated.bed.gz")  , emit: orfs_exons_bed
+    tuple val(meta), path("${prefix}.orfs-labels.annotated.tab.gz"), emit: orfs_labels
     path "versions.yml"                                             , emit: versions_rpbp, topic: versions
 
     when:
@@ -30,6 +31,7 @@ process RPBP_PREPAREGENOME {
     echo "" | gzip > ${prefix}.annotated.bed.gz
     echo "" | gzip > ${prefix}.orfs-genomic.annotated.bed.gz
     echo "" | gzip > ${prefix}.orfs-exons.annotated.bed.gz
+    echo "" | gzip > ${prefix}.orfs-labels.annotated.tab.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/rpbp/preparegenome/meta.yml
+++ b/modules/nf-core/rpbp/preparegenome/meta.yml
@@ -83,6 +83,15 @@ output:
           description: Per-ORF exons BED used by `extract-orf-profiles`.
           pattern: "*.orfs-exons.annotated.bed.gz"
           ontologies: []
+  orfs_labels:
+    - - meta:
+          type: map
+          description: Groovy Map inherited from input meta.
+      - "${prefix}.orfs-labels.annotated.tab.gz":
+          type: file
+          description: Per-ORF positional labels from `label-orfs`; columns orf_num, id, orf_type, transcripts.
+          pattern: "*.orfs-labels.annotated.tab.gz"
+          ontologies: []
   versions_rpbp:
     - versions.yml:
         type: file

--- a/modules/nf-core/rpbp/preparegenome/templates/prepare_rpbp_genome.py
+++ b/modules/nf-core/rpbp/preparegenome/templates/prepare_rpbp_genome.py
@@ -77,6 +77,7 @@ for src in [
     os.path.join(base_path, f"{prefix}.annotated.bed.gz"),
     os.path.join(base_path, "transcript-index", f"{prefix}.orfs-genomic.annotated.bed.gz"),
     os.path.join(base_path, "transcript-index", f"{prefix}.orfs-exons.annotated.bed.gz"),
+    os.path.join(base_path, "transcript-index", f"{prefix}.orfs-labels.annotated.tab.gz"),
 ]:
     shutil.move(src, os.path.basename(src))
 shutil.rmtree(base_path)

--- a/modules/nf-core/rpbp/preparegenome/tests/main.nf.test.snap
+++ b/modules/nf-core/rpbp/preparegenome/tests/main.nf.test.snap
@@ -18,6 +18,14 @@
                         "reference.orfs-genomic.annotated.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
+                "orfs_labels": [
+                    [
+                        {
+                            "id": "reference"
+                        },
+                        "reference.orfs-labels.annotated.tab.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
                 "transcript_bed": [
                     [
                         {
@@ -56,6 +64,14 @@
                         "reference.orfs-genomic.annotated.bed.gz:md5,dd8cfaf09907bfb049ad6caaa2fd408e"
                     ]
                 ],
+                "orfs_labels": [
+                    [
+                        {
+                            "id": "reference"
+                        },
+                        "reference.orfs-labels.annotated.tab.gz:md5,139f411bbb05c1a098cedecd9203cd8d"
+                    ]
+                ],
                 "transcript_bed": [
                     [
                         {
@@ -92,6 +108,14 @@
                             "id": "reference"
                         },
                         "reference.orfs-genomic.annotated.bed.gz:md5,1747fef9c864bfde9a2fe7bd8b2c5012"
+                    ]
+                ],
+                "orfs_labels": [
+                    [
+                        {
+                            "id": "reference"
+                        },
+                        "reference.orfs-labels.annotated.tab.gz:md5,3192e042ea9172e26b602a1935a08b3d"
                     ]
                 ],
                 "transcript_bed": [


### PR DESCRIPTION
`get_orfs` already writes `<name>.orfs-labels.annotated.tab.gz` into `transcript-index/`, holding the ORF type that `label-orfs` assigned to every candidate ORF. The module moved three files out of the reference layout and then removed the directory, so this one was discarded. This adds it to the move list and emits it. No existing output changes.

It matters because consumers currently have no access to Rp-Bp's positional call at all: `custom/orfnormalise` reads the predicted-orfs BED, which has no ORF-type column, so every Rp-Bp ORF is classified as a canonical CDS regardless of where it actually sits.

**One unrelated line came along, because CI needed it.** `environment.yml` pinned only `rpbp`, while `versions.yml` reports `platform.python_version()` — so conda resolved a different interpreter than the container was built with and produced a different `versions.yml`. A snapshot holds one md5, so the conda shards failed while docker and singularity passed, on `master` as much as here. Pinning `python=3.13.13` (the version the container carries — it reproduces the recorded md5 exactly) makes all three engines agree. The `custom/orf*` modules already pin python for this reason. **Heads up: the other seven `rpbp/*` modules pin only `rpbp` and will hit the same thing the next time they are touched** — happy to send a follow-up covering them if you'd like.

<details>
<summary>Detail (AI-assisted)</summary>

**Where the file comes from.** `get_orfs` builds the path via `filenames.get_labels(...)` and runs `label-orfs` with it as the sole entry in `out_files`, so it is written unconditionally on the annotated path this module uses (`is_annotated=True, is_de_novo=False`). It is a BED12+ file with a `#`-prefixed header and columns `orf_num`, `id`, `orf_type`, `transcripts` — the same shape as the predicted-orfs BED, and joinable to it on `id`.

**Labels are display names.** `label_orfs` copies `defaults.orf_type_name_map` and assigns its *values*, so the file carries `CDS`, `altCDS`, `intORF`, `uORF`, `uoORF`, `dORF`, `doORF`, `ncORF`, `Overlap`, `Suspect`. The `novel_*` variants need `--label-prefix novel_`, which only the de-novo path sets, so they cannot appear here. `Novel` itself needs `--nonoverlapping-label`, which this path also does not pass.

**Scope.** One entry in the move list, one `emit:`, one stub line, one `meta.yml` output block, plus the python pin. `shutil.move` still raises if the file is absent, which is the desired behaviour — a missing labels file means `label-orfs` failed. The rendered `path(...)` is one character shorter than `orfs_genomic_bed`'s, so the existing `, emit:` alignment is unchanged.

**Snapshot.** The three `orfs_labels` md5s are CI's own values. Worth noting the three pre-existing md5s came back unchanged, which is the real check here: `label-orfs` overwrites `orfs_genomic` in place during the same step, so adding a fourth file to the move list disturbing nothing else was not a given.

**Not affected.** `fasta_gtf_bam_rpbp` installs this module, but its `emit:` block is unchanged, so its snapshot should be stable. That snapshot dates from #11962, and the only constituent module touched since is `rpbp/getperiodiclengthsoffsets` in #12221, which removed a blank line from a template — so no drift is expected there either.

</details>
