### PR TITLE
Fix strict-syntax warning  for bbduk module

### DIFF
--- a/modules/nf-core/bbmap/bbduk/main.nf
+++ b/modules/nf-core/bbmap/bbduk/main.nf
@@ -20,7 +20,6 @@ process BBMAP_BBDUK {
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def raw      = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
     def trimmed  = meta.single_end ? "out=${prefix}.fastq.gz" : "out1=${prefix}_1.fastq.gz out2=${prefix}_2.fastq.gz"


### PR DESCRIPTION
Strict-syntax fixes to the bbmap/bbduk module to enable it in nf-core/taxprofiler ( adopting Nextflow strict syntax).

Change:
Removed unused variable declaration