### PR TITLE
Map Ribo-TISH's colon-qualified ORF types on their location

### DIFF
--- a/modules/nf-core/custom/orfnormalise/meta.yml
+++ b/modules/nf-core/custom/orfnormalise/meta.yml
@@ -35,9 +35,8 @@ description: |
   `orf_type_native` carries the caller's own ORF-type label verbatim, so every
   harmonisation decision below stays auditable without re-running the caller.
   ORF-type tokens are matched exactly (casefolded) against each caller's closed
-  vocabulary. Where a caller qualifies a positional label after a colon, as
-  Ribo-TISH does with `Novel:CDSFrameOverlap`, only the part before the colon is
-  matched and the qualifier survives in `orf_type_native`. Tokens whose location
+  vocabulary, on the part before any colon so that a qualified label such as
+  Ribo-TISH's `Novel:CDSFrameOverlap` matches on `Novel`. Tokens whose location
   matches no entry cause the process to fail; successful outputs report
   `unmapped_orf_type=0` on the `# parser_columns:` provenance line.
 

--- a/modules/nf-core/custom/orfnormalise/meta.yml
+++ b/modules/nf-core/custom/orfnormalise/meta.yml
@@ -35,8 +35,11 @@ description: |
   `orf_type_native` carries the caller's own ORF-type label verbatim, so every
   harmonisation decision below stays auditable without re-running the caller.
   ORF-type tokens are matched exactly (casefolded) against each caller's closed
-  vocabulary. Tokens matching no entry cause the process to fail; successful
-  outputs report `unmapped_orf_type=0` on the `# parser_columns:` provenance line.
+  vocabulary. Where a caller qualifies a positional label after a colon, as
+  Ribo-TISH does with `Novel:CDSFrameOverlap`, only the part before the colon is
+  matched and the qualifier survives in `orf_type_native`. Tokens whose location
+  matches no entry cause the process to fail; successful outputs report
+  `unmapped_orf_type=0` on the `# parser_columns:` provenance line.
 
   `orf_class` is purely positional: it records where the ORF sits relative to
   the annotated CDS and never encodes its length. Select small ORFs with the

--- a/modules/nf-core/custom/orfnormalise/templates/orfnormalise.py
+++ b/modules/nf-core/custom/orfnormalise/templates/orfnormalise.py
@@ -414,8 +414,7 @@ def write_outputs(bed_path, tsv_path, bed_lines, tsv_rows, parser_columns, unmap
 # exactly (casefolded) rather than by substring. Substring matching mis-fired
 # on the overlap forms, because "uorf" is a substring of "overlap_uorf".
 #
-# Keys hold the positional part only. Ribo-TISH qualifies it after a colon
-# (`Novel:CDSFrameOverlap`); classify() splits there, so no key may contain one.
+# No key may contain a colon: classify() matches only the part before one.
 # ----------------------------------------------------------------------------
 
 CLASS_TOKENS = {
@@ -501,12 +500,8 @@ CLASS_TOKENS = {
 def classify(caller, orf_type):
     """Map a caller's native ORF-type token to the harmonised class.
 
-    Callers may qualify a positional label rather than replace it: Ribo-TISH
-    emits `Novel:CDSFrameOverlap`, `3'UTR:CDSFrameOverlap` and similar. Only the
-    part before the first colon describes where the ORF sits, and `orf_class`
-    is positional, so the qualifier is dropped here and preserved verbatim in
-    `orf_type_native`. No CLASS_TOKENS key contains a colon, so this cannot
-    shorten a token that was meant to match whole.
+    Only the part before the first colon is matched; the full token survives in
+    `orf_type_native`.
 
     Returns (orf_class, matched); `matched` is False when a non-empty token's
     location matched no entry, so unmapped labels can be counted rather than

--- a/modules/nf-core/custom/orfnormalise/templates/orfnormalise.py
+++ b/modules/nf-core/custom/orfnormalise/templates/orfnormalise.py
@@ -413,6 +413,9 @@ def write_outputs(bed_path, tsv_path, bed_lines, tsv_rows, parser_columns, unmap
 # Every caller's ORF-type vocabulary is a closed enum, so tokens are matched
 # exactly (casefolded) rather than by substring. Substring matching mis-fired
 # on the overlap forms, because "uorf" is a substring of "overlap_uorf".
+#
+# Keys hold the positional part only. Ribo-TISH qualifies it after a colon
+# (`Novel:CDSFrameOverlap`); classify() splits there, so no key may contain one.
 # ----------------------------------------------------------------------------
 
 CLASS_TOKENS = {
@@ -498,13 +501,21 @@ CLASS_TOKENS = {
 def classify(caller, orf_type):
     """Map a caller's native ORF-type token to the harmonised class.
 
-    Returns (orf_class, matched); `matched` is False when a non-empty token
-    matched no entry, so unmapped labels can be counted rather than silently
-    absorbed into `other`.
+    Callers may qualify a positional label rather than replace it: Ribo-TISH
+    emits `Novel:CDSFrameOverlap`, `3'UTR:CDSFrameOverlap` and similar. Only the
+    part before the first colon describes where the ORF sits, and `orf_class`
+    is positional, so the qualifier is dropped here and preserved verbatim in
+    `orf_type_native`. No CLASS_TOKENS key contains a colon, so this cannot
+    shorten a token that was meant to match whole.
+
+    Returns (orf_class, matched); `matched` is False when a non-empty token's
+    location matched no entry, so unmapped labels can be counted rather than
+    silently absorbed into `other`.
     """
     if not orf_type:
         return "other", True
-    cls = CLASS_TOKENS[caller].get(orf_type.strip().casefold())
+    location = orf_type.split(":", 1)[0]
+    cls = CLASS_TOKENS[caller].get(location.strip().casefold())
     if cls is None:
         return "other", False
     return cls, True

--- a/modules/nf-core/custom/orfnormalise/tests/main.nf.test
+++ b/modules/nf-core/custom/orfnormalise/tests/main.nf.test
@@ -431,4 +431,51 @@ nextflow_process {
         }
     }
 
+    test("ribotish composite ORF types map on the location, keeping the qualifier native") {
+
+        when {
+            process {
+                """
+                input[0] = channel
+                    .of(
+                        'Tid\tGid\tGenomePos\tTisType\tAALen\tFisherPvalue',
+                        't1\tg1\tchr1:1000-1100:+\tNovel:CDSFrameOverlap\t30\t0.001',
+                        "t1\tg1\tchr1:1100-1200:+\t3'UTR:CDSFrameOverlap\t30\t0.001",
+                        't1\tg1\tchr1:1200-1300:+\tInternal:CDSFrameOverlap\t30\t0.001',
+                        't1\tg1\tchr1:1300-1400:+\tNovel:Known\t30\t0.001'
+                    )
+                    .collectFile(name: 'composite.ribotish.pred.txt', newLine: true, sort: false)
+                    .map { orfs -> [[id: 'sample1'], orfs, 'ribotish'] }
+                input[1] = channel
+                    .of('chr1\ttest\texon\t1001\t2000\t.\t+\t.\tgene_id "g1"; transcript_id "t1";')
+                    .collectFile(name: 'composite.gtf', newLine: true)
+                    .map { gtf -> [[id: 'reference'], gtf] }
+                """
+            }
+        }
+
+        then {
+            def lines = path(process.out.tsv[0][1]).text.readLines()
+            def header = lines.find { it.startsWith('orf_id') }.split('\t') as List
+            def data = lines.findAll { !it.startsWith('#') && !it.startsWith('orf_id') }
+            def i_class = header.indexOf('orf_class')
+            def i_native = header.indexOf('orf_type_native')
+            def classes = data.collect { it.split('\t')[i_class] } as Set
+            def natives = data.collect { it.split('\t')[i_native] }
+            def qualified = natives.findAll { it.contains(':') }
+            def provenance = lines.find { it.startsWith('# parser_columns:') }
+
+            assertAll(
+                // The colon-qualified tokens no longer abort the process: only the part
+                // before the colon is positional, so it alone selects the class.
+                { assert process.success },
+                { assert classes == ['novel_u', 'dORF', 'intORF'] as Set },
+                // The qualifier is dropped from orf_class but not lost.
+                { assert qualified.size() == natives.size() },
+                { assert natives.contains('Novel:CDSFrameOverlap') },
+                { assert provenance.contains('unmapped_orf_type=0') }
+            )
+        }
+    }
+
 }

--- a/modules/nf-core/custom/orfnormalise/tests/main.nf.test
+++ b/modules/nf-core/custom/orfnormalise/tests/main.nf.test
@@ -466,11 +466,10 @@ nextflow_process {
             def provenance = lines.find { it.startsWith('# parser_columns:') }
 
             assertAll(
-                // The colon-qualified tokens no longer abort the process: only the part
-                // before the colon is positional, so it alone selects the class.
+                // The part before the colon selects the class; the qualifier survives
+                // in orf_type_native.
                 { assert process.success },
                 { assert classes == ['novel_u', 'dORF', 'intORF'] as Set },
-                // The qualifier is dropped from orf_class but not lost.
                 { assert qualified.size() == natives.size() },
                 { assert natives.contains('Novel:CDSFrameOverlap') },
                 { assert provenance.contains('unmapped_orf_type=0') }

--- a/modules/nf-core/custom/orfnormalise/tests/main.nf.test
+++ b/modules/nf-core/custom/orfnormalise/tests/main.nf.test
@@ -436,20 +436,15 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = channel
-                    .of(
-                        'Tid\tGid\tGenomePos\tTisType\tAALen\tFisherPvalue',
-                        't1\tg1\tchr1:1000-1100:+\tNovel:CDSFrameOverlap\t30\t0.001',
-                        "t1\tg1\tchr1:1100-1200:+\t3'UTR:CDSFrameOverlap\t30\t0.001",
-                        't1\tg1\tchr1:1200-1300:+\tInternal:CDSFrameOverlap\t30\t0.001',
-                        't1\tg1\tchr1:1300-1400:+\tNovel:Known\t30\t0.001'
-                    )
-                    .collectFile(name: 'composite.ribotish.pred.txt', newLine: true, sort: false)
-                    .map { orfs -> [[id: 'sample1'], orfs, 'ribotish'] }
-                input[1] = channel
-                    .of('chr1\ttest\texon\t1001\t2000\t.\t+\t.\tgene_id "g1"; transcript_id "t1";')
-                    .collectFile(name: 'composite.gtf', newLine: true)
-                    .map { gtf -> [[id: 'reference'], gtf] }
+                input[0] = channel.of([
+                    [id: 'sample1'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/orf_predictions/sample1.ribotish.extended.pred.txt', checkIfExists: true),
+                    'ribotish'
+                ])
+                input[1] = channel.of([
+                    [id: 'reference'],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/riboseq_expression/Homo_sapiens.GRCh38.111_chr20.gtf', checkIfExists: true)
+                ])
                 """
             }
         }
@@ -464,14 +459,25 @@ nextflow_process {
             def natives = data.collect { it.split('\t')[i_native] }
             def qualified = natives.findAll { it.contains(':') }
             def provenance = lines.find { it.startsWith('# parser_columns:') }
+            def class_carries_qualifier = classes.any { it.contains(':') }
+            def expected_qualified = [
+                "Novel:CDSFrameOverlap",
+                "5'UTR:Known",
+                "5'UTR:CDSFrameOverlap",
+                "3'UTR:CDSFrameOverlap",
+                "Truncated:Known",
+                "Novel:Known",
+                "Internal:CDSFrameOverlap",
+            ]
 
             assertAll(
                 // The part before the colon selects the class; the qualifier survives
                 // in orf_type_native.
                 { assert process.success },
-                { assert classes == ['novel_u', 'dORF', 'intORF'] as Set },
-                { assert qualified.size() == natives.size() },
-                { assert natives.contains('Novel:CDSFrameOverlap') },
+                { assert classes == ['canonical_cds', 'uORF', 'dORF', 'intORF', 'novel_u'] as Set },
+                { assert !class_carries_qualifier },
+                { assert natives.containsAll(expected_qualified) },
+                { assert qualified.size() == expected_qualified.size() },
                 { assert provenance.contains('unmapped_orf_type=0') }
             )
         }


### PR DESCRIPTION
Ribo-TISH qualifies a positional ORF-type label after a colon rather than replacing it — `Novel:CDSFrameOverlap`, `3'UTR:CDSFrameOverlap`, `Internal:CDSFrameOverlap`, `Novel:Known`. `CLASS_TOKENS` holds only the bare locations and `classify()` matched the whole token, so all of those fell through unmatched; since #12498 made an unmatched token fatal, real Ribo-TISH output now aborts the process. This matches on the part before the first colon instead. `orf_class` is positional and `CDSFrameOverlap` describes a frame relationship rather than a position, so the qualifier does not belong in the class — and `orf_type_native` already carries the full token verbatim, so nothing is lost. No new vocabulary entries are needed.

Found by four nf-core/riboseq pipeline tests failing on real chr20 data, with 3–33 offending rows each.

<details>
<summary>Verification notes (AI-assisted)</summary>

**Why the existing tests didn't catch it.** The module fixtures use bare tokens; only genuine Ribo-TISH output produces the composite form, so #12498 was 63/63 green while this was already broken for real data. The added test uses the four tokens observed in production and **fails without this change with the same message the pipeline produced**:

```
orfnormalise: unmapped ORF type value(s) for caller 'ribotish':
  "3'UTR:CDSFrameOverlap" (1), 'Internal:CDSFrameOverlap' (1),
  'Novel:CDSFrameOverlap' (1), 'Novel:Known' (1)
```

**Why location-only, rather than enumerating the composites.** Taking the location keeps `orf_class` purely positional, which is the invariant #12498 established when it split length out into `is_smorf`. Enumerating `<location>:<qualifier>` pairs would need a decision per combination and would reintroduce the brittleness that exact-token matching removed. The four observed tokens resolve through the **existing** table with no additions:

| token | location | → `orf_class` |
|---|---|---|
| `Novel:CDSFrameOverlap` | `Novel` | `novel_u` |
| `Novel:Known` | `Novel` | `novel_u` |
| `3'UTR:CDSFrameOverlap` | `3'UTR` | `dORF` |
| `Internal:CDSFrameOverlap` | `Internal` | `intORF` |

**Why the split is safe for every caller.** Checked all 52 `CLASS_TOKENS` keys across the five callers: none contains a colon, so splitting cannot shorten a token that was meant to match whole. A comment on the table records that constraint for anyone adding keys later.

**A location that matches nothing still fails**, so the guard #12498 added keeps its value — only the qualifier is permitted to be unknown, which is what makes this robust to Ribo-TISH adding qualifiers.

`nf-test test modules/nf-core/custom/orfnormalise` — 11/11 pass locally (10 pre-existing plus the new one).

</details>
