### PR TITLE
New module arcane/filter

### DIFF
--- a/modules/nf-core/arcane/filter/environment.yml
+++ b/modules/nf-core/arcane/filter/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::arcane=1.0.0"

--- a/modules/nf-core/arcane/filter/main.nf
+++ b/modules/nf-core/arcane/filter/main.nf
@@ -12,12 +12,12 @@ process ARCANE_FILTER {
     tuple val(meta2), path(gtf)
 
     output:
-    tuple val(meta), path("*/*_genes.txt"), emit: genes
-    tuple val(meta), path("*/*_mapping_gene_ids.pickle"), emit: pickle
-    tuple val(meta), path("*/*_new_id_to_original.csv"), emit: csv
-    tuple val(meta), path("*/*_ref.fa.gz"), emit: reference
-    tuple val(meta), path("*/*_extracted_genes.fa.gz"), emit: extracted_genes, optional: true
-    tuple val("${task.process}"), val('arcane'), eval("arcane --version"), topic: versions, emit: versions_arcane
+    tuple val(meta), path("*/*_genes.txt"),                                 emit: genes
+    tuple val(meta), path("*/*_mapping_gene_ids.pickle"),                   emit: pickle
+    tuple val(meta), path("*/*_new_id_to_original.csv"),                    emit: csv
+    tuple val(meta), path("*/*_ref.fa.gz"),                                 emit: reference
+    tuple val(meta), path("*/*_extracted_genes.fa.gz"),                     emit: extracted_genes, optional: true
+    tuple val("${task.process}"), val('arcane'), eval("arcane --version"),  topic: versions, emit: versions_arcane
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/arcane/filter/main.nf
+++ b/modules/nf-core/arcane/filter/main.nf
@@ -1,0 +1,47 @@
+process ARCANE_FILTER {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/arcane:1.0.0--pyh106432d_0':
+        'quay.io/biocontainers/arcane:1.0.0--pyh106432d_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+    tuple val(meta2), path(gtf)
+
+    output:
+    tuple val(meta), path("*/*_genes.txt"), emit: genes
+    tuple val(meta), path("*/*_mapping_gene_ids.pickle"), emit: pickle
+    tuple val(meta), path("*/*_new_id_to_original.csv"), emit: csv
+    tuple val(meta), path("*/*_ref.fa.gz"), emit: reference
+    tuple val(meta), path("*/*_extracted_genes.fa.gz"), emit: extracted_genes, optional: true
+    tuple val("${task.process}"), val('arcane'), eval("arcane --version"), topic: versions, emit: versions_arcane
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    arcane filter \\
+        --fasta ${fasta} \\
+        --gtf ${gtf} \\
+        --prefix ${prefix} \\
+        --name ${prefix} \\
+        $args
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p ${prefix}
+    echo "" | gzip > ${prefix}/arcane_${prefix}_ref.fa.gz
+    echo "" | gzip > ${prefix}/arcane_${prefix}_extracted_genes.fa.gz
+    touch ${prefix}/arcane_${prefix}_genes.txt
+    touch ${prefix}/arcane_${prefix}_new_id_to_original.csv
+    touch ${prefix}/arcane_${prefix}_mapping_gene_ids.pickle
+    """
+}

--- a/modules/nf-core/arcane/filter/meta.yml
+++ b/modules/nf-core/arcane/filter/meta.yml
@@ -26,6 +26,8 @@ input:
         type: file
         description: Reference genome FASTA file
         pattern: "*.{fa,fasta,fa.gz,fasta.gz}"
+        ontology:
+        - edam: "http://edamontology.org/format_1929"
   - - meta2:
         type: map
         description: |
@@ -35,6 +37,8 @@ input:
         type: file
         description: Genome annotation GTF file
         pattern: "*.{gtf,gtf.gz}"
+        ontology:
+        - edam: "http://edamontology.org/format_2306"
 
 output:
   genes:
@@ -47,6 +51,8 @@ output:
           type: file
           description: Gene IDs, one per line, in gene_number order
           pattern: "*/*_genes.txt"
+          ontology:
+          - edam: "http://edamontology.org/format_2330"
   pickle:
     - - meta:
           type: map
@@ -67,6 +73,8 @@ output:
           type: file
           description: CSV file mapping internal gene numbers to original annotation gene IDs and coordinates
           pattern: "*/*_new_id_to_original.csv"
+          ontology:
+          - edam: "http://edamontology.org/format_3752"
   reference:
     - - meta:
           type: map
@@ -77,6 +85,8 @@ output:
           type: file
           description: Filtered sequence reference FASTA file ready for indexing
           pattern: "*/*_ref.fa.gz"
+          ontology:
+          - edam: "http://edamontology.org/format_1929"
   extracted_genes:
     - - meta:
           type: map
@@ -89,6 +99,8 @@ output:
             FASTA file containing each gene from start to end including introns.
             Only produced when `--extract_genes` is provided in `task.ext.args`.
           pattern: "*/*_extracted_genes.fa.gz"
+          ontology:
+          - edam: "http://edamontology.org/format_1929"
   versions_arcane:
     - - "${task.process}":
           type: string

--- a/modules/nf-core/arcane/filter/meta.yml
+++ b/modules/nf-core/arcane/filter/meta.yml
@@ -27,7 +27,7 @@ input:
         description: Reference genome FASTA file
         pattern: "*.{fa,fasta,fa.gz,fasta.gz}"
         ontology:
-        - edam: "http://edamontology.org/format_1929"
+          - edam: "http://edamontology.org/format_1929"
   - - meta2:
         type: map
         description: |
@@ -38,7 +38,7 @@ input:
         description: Genome annotation GTF file
         pattern: "*.{gtf,gtf.gz}"
         ontology:
-        - edam: "http://edamontology.org/format_2306"
+          - edam: "http://edamontology.org/format_2306"
 
 output:
   genes:
@@ -52,7 +52,7 @@ output:
           description: Gene IDs, one per line, in gene_number order
           pattern: "*/*_genes.txt"
           ontology:
-          - edam: "http://edamontology.org/format_2330"
+            - edam: "http://edamontology.org/format_2330"
   pickle:
     - - meta:
           type: map
@@ -74,7 +74,7 @@ output:
           description: CSV file mapping internal gene numbers to original annotation gene IDs and coordinates
           pattern: "*/*_new_id_to_original.csv"
           ontology:
-          - edam: "http://edamontology.org/format_3752"
+            - edam: "http://edamontology.org/format_3752"
   reference:
     - - meta:
           type: map
@@ -86,7 +86,7 @@ output:
           description: Filtered sequence reference FASTA file ready for indexing
           pattern: "*/*_ref.fa.gz"
           ontology:
-          - edam: "http://edamontology.org/format_1929"
+            - edam: "http://edamontology.org/format_1929"
   extracted_genes:
     - - meta:
           type: map
@@ -100,7 +100,7 @@ output:
             Only produced when `--extract_genes` is provided in `task.ext.args`.
           pattern: "*/*_extracted_genes.fa.gz"
           ontology:
-          - edam: "http://edamontology.org/format_1929"
+            - edam: "http://edamontology.org/format_1929"
   versions_arcane:
     - - "${task.process}":
           type: string

--- a/modules/nf-core/arcane/filter/meta.yml
+++ b/modules/nf-core/arcane/filter/meta.yml
@@ -1,0 +1,118 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "arcane_filter"
+description: Filter GTF annotations and genome sequence for alignment-free single-cell RNA-seq quantification with Arcane
+keywords:
+  - single-cell
+  - rnaseq
+  - filter
+  - gtf
+  - fasta
+  - transcriptomics
+tools:
+  - "arcane":
+      description: "Arcane: Alignment-free single cell RNA-seq gene expression estimation"
+      homepage: "https://gitlab.com/rahmannlab/arcane"
+      documentation: "https://gitlab.com/rahmannlab/arcane"
+      tool_dev_url: "https://gitlab.com/rahmannlab/arcane"
+      licence: ["MIT"]
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing reference genome metadata
+          e.g. `[ id:'human' ]`
+    - fasta:
+        type: file
+        description: Reference genome FASTA file
+        pattern: "*.{fa,fasta,fa.gz,fasta.gz}"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing annotation metadata
+          e.g. `[ id:'human_annotation' ]`
+    - gtf:
+        type: file
+        description: Genome annotation GTF file
+        pattern: "*.{gtf,gtf.gz}"
+
+output:
+  genes:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*/*_genes.txt":
+          type: file
+          description: Gene IDs, one per line, in gene_number order
+          pattern: "*/*_genes.txt"
+  pickle:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*/*_mapping_gene_ids.pickle":
+          type: file
+          description: Python pickle object mapping gene_number to gene_id
+          pattern: "*/*_mapping_gene_ids.pickle"
+  csv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*/*_new_id_to_original.csv":
+          type: file
+          description: CSV file mapping internal gene numbers to original annotation gene IDs and coordinates
+          pattern: "*/*_new_id_to_original.csv"
+  reference:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*/*_ref.fa.gz":
+          type: file
+          description: Filtered sequence reference FASTA file ready for indexing
+          pattern: "*/*_ref.fa.gz"
+  extracted_genes:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*/*_extracted_genes.fa.gz":
+          type: file
+          description: |
+            FASTA file containing each gene from start to end including introns.
+            Only produced when `--extract_genes` is provided in `task.ext.args`.
+          pattern: "*/*_extracted_genes.fa.gz"
+  versions_arcane:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - "arcane":
+          type: string
+          description: The name of the tool
+      - "arcane --version":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - arcane:
+          type: string
+          description: The name of the tool
+      - arcane --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@LeonHornich"
+maintainers:
+  - "@LeonHornich"

--- a/modules/nf-core/arcane/filter/tests/main.nf.test
+++ b/modules/nf-core/arcane/filter/tests/main.nf.test
@@ -1,0 +1,115 @@
+nextflow_process {
+
+    name "Test Process ARCANE_FILTER"
+    script "../main.nf"
+    process "ARCANE_FILTER"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "arcane"
+    tag "arcane/filter"
+
+    test("sarscov2 - fasta - gtf - default") {
+
+        when {
+            params {
+                module_args = '--kmersize 12'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.genes,
+                    process.out.csv,
+                    process.out.pickle,
+                    process.out.reference,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fasta - gtf - extract_genes") {
+
+        when {
+            params {
+                module_args = '--kmersize 12 --extract_genes'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    process.out.genes,
+                    process.out.csv,
+                    process.out.pickle,
+                    process.out.reference,
+                    process.out.extracted_genes,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fasta - gtf - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                module_args = '--kmersize 12'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/arcane/filter/tests/main.nf.test
+++ b/modules/nf-core/arcane/filter/tests/main.nf.test
@@ -33,13 +33,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(
-                    process.out.genes,
-                    process.out.csv,
-                    process.out.pickle,
-                    process.out.reference,
-                    process.out.findAll { key, val -> key.startsWith('versions') }
-                ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 
@@ -68,14 +62,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(
-                    process.out.genes,
-                    process.out.csv,
-                    process.out.pickle,
-                    process.out.reference,
-                    process.out.extracted_genes,
-                    process.out.findAll { key, val -> key.startsWith('versions') }
-                ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 
@@ -106,7 +93,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/arcane/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/arcane/filter/tests/main.nf.test.snap
@@ -1,0 +1,215 @@
+{
+    "sarscov2 - fasta - gtf - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_genes.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_mapping_gene_ids.pickle:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_new_id_to_original.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_ref.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_extracted_genes.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "5": [
+                    [
+                        "ARCANE_FILTER",
+                        "arcane",
+                        "1.0.0"
+                    ]
+                ],
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_new_id_to_original.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "extracted_genes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_extracted_genes.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "genes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_genes.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "pickle": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_mapping_gene_ids.pickle:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "reference": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_ref.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_arcane": [
+                    [
+                        "ARCANE_FILTER",
+                        "arcane",
+                        "1.0.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-10T17:40:53.1504029",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "sarscov2 - fasta - gtf - extract_genes": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_genes.txt:md5,8552dc6b0e91cb094ae149e5149adc03"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_new_id_to_original.csv:md5,0f6cfbb0daaae471cea908e692d282ff"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_mapping_gene_ids.pickle:md5,64c2815200db22b5c3d00f2908361ae4"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_ref.fa.gz:md5,91e0ee8bf2bb2a8fd67f0450304ed227"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_extracted_genes.fa.gz:md5,3281192734096db5974a0998c6053898"
+                ]
+            ],
+            {
+                "versions_arcane": [
+                    [
+                        "ARCANE_FILTER",
+                        "arcane",
+                        "1.0.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-10T17:47:14.804498146",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "sarscov2 - fasta - gtf - default": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_genes.txt:md5,8552dc6b0e91cb094ae149e5149adc03"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_new_id_to_original.csv:md5,0f6cfbb0daaae471cea908e692d282ff"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_mapping_gene_ids.pickle:md5,64c2815200db22b5c3d00f2908361ae4"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "arcane_test_ref.fa.gz:md5,91e0ee8bf2bb2a8fd67f0450304ed227"
+                ]
+            ],
+            {
+                "versions_arcane": [
+                    [
+                        "ARCANE_FILTER",
+                        "arcane",
+                        "1.0.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-10T17:46:35.166352725",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/modules/nf-core/arcane/filter/tests/main.nf.test.snap
+++ b/modules/nf-core/arcane/filter/tests/main.nf.test.snap
@@ -2,53 +2,6 @@
     "sarscov2 - fasta - gtf - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "arcane_test_genes.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "arcane_test_mapping_gene_ids.pickle:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "arcane_test_new_id_to_original.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "arcane_test_ref.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "arcane_test_extracted_genes.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                    ]
-                ],
-                "5": [
-                    [
-                        "ARCANE_FILTER",
-                        "arcane",
-                        "1.0.0"
-                    ]
-                ],
                 "csv": [
                     [
                         {
@@ -98,7 +51,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-10T17:40:53.1504029",
+        "timestamp": "2026-08-12T10:57:50.107057182",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -106,47 +59,47 @@
     },
     "sarscov2 - fasta - gtf - extract_genes": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_genes.txt:md5,8552dc6b0e91cb094ae149e5149adc03"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_new_id_to_original.csv:md5,0f6cfbb0daaae471cea908e692d282ff"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_mapping_gene_ids.pickle:md5,64c2815200db22b5c3d00f2908361ae4"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_ref.fa.gz:md5,91e0ee8bf2bb2a8fd67f0450304ed227"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_extracted_genes.fa.gz:md5,3281192734096db5974a0998c6053898"
-                ]
-            ],
             {
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_new_id_to_original.csv:md5,0f6cfbb0daaae471cea908e692d282ff"
+                    ]
+                ],
+                "extracted_genes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_extracted_genes.fa.gz:md5,3281192734096db5974a0998c6053898"
+                    ]
+                ],
+                "genes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_genes.txt:md5,8552dc6b0e91cb094ae149e5149adc03"
+                    ]
+                ],
+                "pickle": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_mapping_gene_ids.pickle:md5,64c2815200db22b5c3d00f2908361ae4"
+                    ]
+                ],
+                "reference": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_ref.fa.gz:md5,91e0ee8bf2bb2a8fd67f0450304ed227"
+                    ]
+                ],
                 "versions_arcane": [
                     [
                         "ARCANE_FILTER",
@@ -156,7 +109,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-10T17:47:14.804498146",
+        "timestamp": "2026-08-12T10:57:16.973211394",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -164,39 +117,42 @@
     },
     "sarscov2 - fasta - gtf - default": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_genes.txt:md5,8552dc6b0e91cb094ae149e5149adc03"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_new_id_to_original.csv:md5,0f6cfbb0daaae471cea908e692d282ff"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_mapping_gene_ids.pickle:md5,64c2815200db22b5c3d00f2908361ae4"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "arcane_test_ref.fa.gz:md5,91e0ee8bf2bb2a8fd67f0450304ed227"
-                ]
-            ],
             {
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_new_id_to_original.csv:md5,0f6cfbb0daaae471cea908e692d282ff"
+                    ]
+                ],
+                "extracted_genes": [
+                    
+                ],
+                "genes": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_genes.txt:md5,8552dc6b0e91cb094ae149e5149adc03"
+                    ]
+                ],
+                "pickle": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_mapping_gene_ids.pickle:md5,64c2815200db22b5c3d00f2908361ae4"
+                    ]
+                ],
+                "reference": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "arcane_test_ref.fa.gz:md5,91e0ee8bf2bb2a8fd67f0450304ed227"
+                    ]
+                ],
                 "versions_arcane": [
                     [
                         "ARCANE_FILTER",
@@ -206,7 +162,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-10T17:46:35.166352725",
+        "timestamp": "2026-08-12T10:56:44.615572655",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/modules/nf-core/arcane/filter/tests/nextflow.config
+++ b/modules/nf-core/arcane/filter/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+  withName: 'ARCANE_FILTER' {
+    ext.args = { params.module_args ?: '' }
+  }
+}


### PR DESCRIPTION
Created a new module for the [arcane](https://gitlab.com/rahmannlab/arcane) `/filter` tool.
Arcane is a alignment free tool for scRNAseq quantification. The `/filter` subcommand is the first step towards building an index.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
