### PR TITLE
fix(binette): output bins are optional

### DIFF
--- a/modules/nf-core/binette/main.nf
+++ b/modules/nf-core/binette/main.nf
@@ -12,7 +12,7 @@ process BINETTE {
     tuple val(meta2), path(checkm2_db)
 
     output:
-    tuple val(meta), path("final_bins/*.fa.gz")              , emit: final_bins
+    tuple val(meta), path("final_bins/*.fa.gz")              , emit: final_bins, optional: true
     tuple val(meta), path("*.final_contig_to_bin.tsv")       , emit: contig2bin
     tuple val(meta), path("input_bins_quality_reports/*.tsv"), emit: input_bins_quality_reports
     tuple val(meta), path("*.final_bins_quality_reports.tsv"), emit: final_bins_quality_report
@@ -42,7 +42,9 @@ process BINETTE {
         --outdir . \\
         ${args}
 
-    find final_bins/ -maxdepth 1 -name "*.fa" -type f -exec gzip {} \\;
+    if [ -d final_bins ]; then
+        find final_bins/ -maxdepth 1 -name "*.fa" -type f -exec gzip {} \\;
+    fi
 
     find input_bins_quality_reports/ -maxdepth 1 -name "*.tsv" -type f | while read file; do
         newname="input_bins_quality_reports/${prefix}.\$(basename "\$file")"


### PR DESCRIPTION
Binette has the option `--no-write-fasta-bins` which disables writing the final bins to disk, but the module expects these files to exist. This fixes that.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
