### PR TITLE
VEP: Support annotating from a GTF instead of a cache

### DIFF
--- a/modules/nf-core/ensemblvep/filtervep/tests/main.nf.test
+++ b/modules/nf-core/ensemblvep/filtervep/tests/main.nf.test
@@ -39,6 +39,7 @@ nextflow_process {
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ])
                     input[6] = []
+                    input[7] = [[], []]
                     """
                 }
             }
@@ -91,6 +92,7 @@ nextflow_process {
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                     ])
                     input[6] = []
+                    input[7] = [[], []]
                     """
                 }
             }

--- a/modules/nf-core/ensemblvep/vep/main.nf
+++ b/modules/nf-core/ensemblvep/vep/main.nf
@@ -15,6 +15,7 @@ process ENSEMBLVEP_VEP {
     tuple val(meta2), path(cache)
     tuple val(meta3), path(fasta)
     path extra_files
+    tuple path(gtf), path(gtf_tbi) // optional: [ path(gtf), path(gtf_tbi) ] -- mutually exclusive with cache
 
     output:
     tuple val(meta), path("${prefix}.vcf.gz"), emit: vcf, optional: true
@@ -37,6 +38,11 @@ process ENSEMBLVEP_VEP {
     prefix = task.ext.prefix ?: "${meta.id}"
     def dir_cache = cache ? "\${PWD}/${cache}" : "/.vep"
     def reference = fasta ? "--fasta ${fasta}" : ""
+    // gtf and cache are mutually exclusive annotation sources: use a GTF
+    // (e.g. for a custom/non-standard reference with no Ensembl cache)
+    // when supplied, otherwise fall back to the existing cache behaviour
+    // unchanged.
+    def annotation_source = gtf ? "--gtf ${gtf}" : "--cache --cache_version ${cache_version} --dir_cache ${dir_cache}"
     def create_index = file_extension == "vcf" ? "tabix ${args2} ${prefix}.${file_extension}.gz" : ""
     """
     vep \\
@@ -47,9 +53,7 @@ process ENSEMBLVEP_VEP {
         ${reference} \\
         --assembly ${genome} \\
         --species ${species} \\
-        --cache \\
-        --cache_version ${cache_version} \\
-        --dir_cache ${dir_cache} \\
+        ${annotation_source} \\
         --fork ${task.cpus}
 
     ${create_index}

--- a/modules/nf-core/ensemblvep/vep/meta.yml
+++ b/modules/nf-core/ensemblvep/vep/meta.yml
@@ -71,6 +71,19 @@ input:
       description: |
         path to file(s) needed for plugins  (optional)
       ontologies: []
+  - - gtf:
+        type: file
+        description: |
+          sorted, bgzipped GTF file to annotate with instead of a cache (optional).
+          Mutually exclusive with `cache`.
+        pattern: "*.gtf.gz"
+        ontologies: []
+    - gtf_tbi:
+        type: file
+        description: |
+          tabix index of the GTF file (optional)
+        pattern: "*.gtf.gz.tbi"
+        ontologies: []
 output:
   vcf:
     - - meta:

--- a/modules/nf-core/ensemblvep/vep/tests/main.nf.test
+++ b/modules/nf-core/ensemblvep/vep/tests/main.nf.test
@@ -35,6 +35,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ])
                 input[6] = []
+                input[7] = [[], []]
                 """
             }
         }
@@ -77,6 +78,7 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                 ])
                 input[6] = []
+                input[7] = [[], []]
                 """
             }
         }

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep/main.nf
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep/main.nf
@@ -13,6 +13,7 @@ workflow VCF_ANNOTATE_ENSEMBLVEP {
     val_cache_version   //   value: cache version to use
     ch_cache            // channel: [ val(meta3), path(cache) ] (optional)
     ch_extra_files      // channel: [ path(file1), path(file2)... ] (optional)
+    ch_gtf              // channel: [ path(gtf), path(gtf_tbi) ] (optional) -- mutually exclusive with ch_cache
 
     main:
     ENSEMBLVEP_VEP(
@@ -23,6 +24,7 @@ workflow VCF_ANNOTATE_ENSEMBLVEP {
         ch_cache,
         ch_fasta,
         ch_extra_files,
+        ch_gtf,
     )
 
     ch_vcf_tbi = ENSEMBLVEP_VEP.out.vcf.join(ENSEMBLVEP_VEP.out.tbi, failOnDuplicate: true, failOnMismatch: true)

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep/meta.yml
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep/meta.yml
@@ -34,6 +34,11 @@ input:
       description: |
         any extra files needed by plugins for ensemblvep (optional)
         Structure: [ path(file1), path(file2)... ]
+  - ch_gtf:
+      description: |
+        sorted, bgzipped GTF file (+ tabix index) to annotate with instead of a cache (optional).
+        Mutually exclusive with ch_cache.
+        Structure: [ path(gtf), path(gtf_tbi) ]
 output:
   - vcf_tbi:
       description: |

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep/tests/main.nf.test
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep/tests/main.nf.test
@@ -32,6 +32,7 @@ nextflow_workflow {
                 input[4] = "115"
                 input[5] = vep_cache
                 input[6] = []
+                input[7] = [[], []]
                 """
             }
         }
@@ -72,6 +73,7 @@ nextflow_workflow {
                 input[4] = "115"
                 input[5] = vep_cache
                 input[6] = []
+                input[7] = [[], []]
                 """
             }
         }

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/main.nf
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/main.nf
@@ -23,6 +23,7 @@ workflow VCF_ANNOTATE_ENSEMBLVEP_SNPEFF {
     ch_snpeff_cache // channel: [ path(cache) ] (optional)
     val_tools_to_use //   value: a list of tools to use options are: ["ensemblvep", "snpeff"]
     val_sites_per_chunk //   value: the amount of variants per scattered VCF
+    ch_vep_gtf // channel: [ path(gtf), path(gtf_tbi) ] (optional) -- mutually exclusive with ch_vep_cache
 
     main:
     def ch_vep_input = channel.empty()
@@ -91,6 +92,7 @@ workflow VCF_ANNOTATE_ENSEMBLVEP_SNPEFF {
             ch_vep_cache,
             ch_fasta,
             ch_vep_extra_files,
+            ch_vep_gtf,
         )
         ch_vep_output = ENSEMBLVEP_VEP.out.vcf
         ch_vep_reports = ENSEMBLVEP_VEP.out.report

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/meta.yml
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/meta.yml
@@ -59,6 +59,11 @@ input:
       description: |
         The amount of variants per scattered VCF.
         Set this value to `null`, `[]` or `false` to disable scattering.
+  - ch_vep_gtf:
+      description: |
+        sorted, bgzipped GTF file (+ tabix index) to annotate with instead of a cache for ensemblvep (optional).
+        Mutually exclusive with ch_vep_cache.
+        Structure: [ path(gtf), path(gtf_tbi) ]
 output:
   - vcf_tbi:
       description: |

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/tests/main.nf.test
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/tests/main.nf.test
@@ -45,6 +45,7 @@ nextflow_workflow {
                 input[8] = []
                 input[9] = ["ensemblvep"]
                 input[10] = 5
+                input[11] = [[], []]
                 """
             }
         }
@@ -99,6 +100,7 @@ nextflow_workflow {
                 input[8] = snpeff_cache
                 input[9] = ["snpeff"]
                 input[10] = 5
+                input[11] = [[], []]
                 """
             }
         }
@@ -151,6 +153,7 @@ nextflow_workflow {
                 input[8] = snpeff_cache
                 input[9] = ["snpeff", "ensemblvep"]
                 input[10] = 5
+                input[11] = [[], []]
                 """
             }
         }
@@ -199,6 +202,7 @@ nextflow_workflow {
                 input[8] = []
                 input[9] = ["ensemblvep"]
                 input[10] = 100
+                input[11] = [[], []]
                 """
             }
         }
@@ -247,6 +251,7 @@ nextflow_workflow {
                 input[8] = []
                 input[9] = ["ensemblvep"]
                 input[10] = []
+                input[11] = [[], []]
                 """
             }
         }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

Adds an optional gtf/gtf_tbi input to VEP, allowing it to annotate using a sorted, bgzipped GTF file (--gtf) instead of an ensembl cache.

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
