### PR TITLE
Add custom/collectstats module

### DIFF
--- a/modules/nf-core/custom/collectstats/.conda-lock/linux_amd64-bd-c1f477e6251c36bb_1.txt
+++ b/modules/nf-core/custom/collectstats/.conda-lock/linux_amd64-bd-c1f477e6251c36bb_1.txt
@@ -1,0 +1,1776 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/conda-forge/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-64:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hcf29cc6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h27c8c51_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-16.1.0-h5fcb69b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-16.1.0-h08e1a1a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-16.1.0-he33a5f8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hcf29cc6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-16.1.0-h69a702a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.1-hebfc3b9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.3-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-16.1.0-hf2715c6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb03c661_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.50.14-ha41ecd1_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r43hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.3.1-h93585b2_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-bit-4.6.0-r43h2b5f3a1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-bit64-4.6.0_1-r43h2b5f3a1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.5-r43h93ab643_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-clipr-0.8.0-r43hc72bb7e_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r43h785f33e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.1.4-r43h0d4f4ea_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.2-r43hb1dbf0f_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.6-r43hb1dbf0f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r43hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.0-r43h2b5f3a1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-hms-1.1.3-r43hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.3-r43hb1dbf0f_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.0-r43hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-prettyunits-1.2.0-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-progress-1.2.3-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.1.0-r43h54b55ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r43hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-readr-2.1.5-r43h0d4f4ea_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.1.6-r43h93ab643_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.4-r43ha8ce623_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.2-r43h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.0-r43h2b5f3a1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.1-r43h0d4f4ea_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tzdb-0.5.0-r43h3697838_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r43h2b5f3a1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.6.5-r43h0d4f4ea_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vroom-1.6.5-r43h0d4f4ea_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h8d826fa_7.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-hb9d3cd8_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.0-hd590300_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-hb9d3cd8_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-hb9d3cd8_1008.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.3-ha02ee65_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.3-ha02ee65_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.3-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+md5: a9f577daf3de00bca7c3c76c0ecbd1de
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28948
+timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+depends:
+- ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+- sysroot_linux-64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 3713752
+timestamp: 1784214522814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+sha256: c88dd33c89b33409ebcd558d78fdc66a63c18f8b06e04d170668ffb6c8ecfabd
+md5: 983b92277d78c0d0ec498e460caa0e6d
+depends:
+- tk
+license: TCL
+size: 129594
+timestamp: 1750261567920
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+md5: e675fabcf81499adc7edf58124fb1e01
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 257808
+timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+sha256: 5139b6afbfaca91c47104ba9a6a40f81211e1c9200e96b73ce3a56f0ca1902f4
+md5: 2cef891b791040aab83e218c7d137679
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- c-ares-static <0a0
+license: MIT
+license_family: MIT
+size: 226755
+timestamp: 1786116641939
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
+depends:
+- __unix
+license: ISC
+size: 131780
+timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
+md5: f907bb958910dc404647326ca80c263e
+depends:
+- fontconfig >=2.14.2,<3.0a0
+- fonts-conda-ecosystem
+- freetype >=2.12.1,<3.0a0
+- icu >=73.2,<74.0a0
+- libgcc-ng >=12
+- libglib >=2.78.0,<3.0a0
+- libpng >=1.6.39,<1.7.0a0
+- libstdcxx-ng >=12
+- libxcb >=1.15,<1.16.0a0
+- libzlib >=1.2.13,<2.0.0a0
+- pixman >=0.42.2,<1.0a0
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.6,<2.0a0
+- xorg-libxext >=1.3.4,<2.0a0
+- xorg-libxrender >=0.9.11,<0.10.0a0
+- zlib
+license: LGPL-2.1-only or MPL-1.1
+size: 982351
+timestamp: 1697028423052
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-hcf29cc6_1.conda
+sha256: 8eb4ebeae7230110569da734e2420aee84f6977850bae4af94dc7f0b382f9d89
+md5: 58609be98a9725cd359a1c63ff329628
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 hcf29cc6_1
+- libgcc >=14
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 194657
+timestamp: 1782802525727
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h27c8c51_0.conda
+sha256: 05b57e2f5aaf3adcccc80653c9795d29974f24dcf9daa40c98b254c99b726227
+md5: bc8843ae1a655600014bb7a09d7b8b89
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.2,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 296480
+timestamp: 1786381145956
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_1.conda
+sha256: d109354d4584aa1ef6e915a8f02cbe13a9708f384aa167c075953b6f8196111c
+md5: 8dd74ae1edf2b6490af0e960be773431
+depends:
+- libfreetype 2.14.3 ha770c72_1
+- libfreetype6 2.14.3 h73754d4_1
+license: GPL-2.0-only OR FTL
+size: 174748
+timestamp: 1785641176027
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+sha256: 4846a3ca0402f3fe33ad84ed50ab213c6aafde4a0faef3c5002f6bf753e21671
+md5: 1cd10eda5692519d01bb20e086e214c9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 61782
+timestamp: 1785912528684
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-16.1.0-h5fcb69b_1.conda
+sha256: 00c87015522248adb5565a1b8f977cfe927831dd7ef0cb0a5d13f896844af719
+md5: 419982d8913246db404319048e062d3e
+depends:
+- binutils_impl_linux-64 >=2.46.1
+- libgcc >=16.1.0
+- libgcc-devel_linux-64 16.1.0 h59071f9_101
+- libgomp >=16.1.0
+- libsanitizer 16.1.0 hf2715c6_1
+- libstdcxx >=16.1.0
+- libstdcxx-devel_linux-64 16.1.0 h41cdd0d_101
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 85161422
+timestamp: 1785375529345
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
+sha256: cbfa8c80771d1842c2687f6016c5e200b52d4ca8f2cc119f6377f64f899ba4ff
+md5: c42356557d7f2e37676e121515417e3b
+depends:
+- __glibc >=2.17,<3.0.a0
+- gettext-tools 0.25.1 h3f43e3d_1
+- libasprintf 0.25.1 h3f43e3d_1
+- libasprintf-devel 0.25.1 h3f43e3d_1
+- libgcc >=14
+- libgettextpo 0.25.1 h3f43e3d_1
+- libgettextpo-devel 0.25.1 h3f43e3d_1
+- libiconv >=1.18,<2.0a0
+- libstdcxx >=14
+license: LGPL-2.1-or-later AND GPL-3.0-or-later
+size: 541357
+timestamp: 1753343006214
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
+sha256: c792729288bdd94f21f25f80802d4c66957b4e00a57f7cb20513f07aadfaff06
+md5: a59c05d22bdcbb4e984bf0c021a2a02f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libiconv >=1.18,<2.0a0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3644103
+timestamp: 1753342966311
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-16.1.0-h08e1a1a_1.conda
+sha256: e4e2e3ae7775b9f6fabcb8b0deb675c2fe5ed036d67713b21759f7f937488153
+md5: dad331198527e6b37015a35221daf18c
+depends:
+- gcc_impl_linux-64 >=16.1.0
+- libgcc >=16.1.0
+- libgfortran5 >=16.1.0
+- libstdcxx >=16.1.0
+- sysroot_linux-64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 21030256
+timestamp: 1785375669882
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
+md5: f9fe2984587fa8235a6af6004760cd18
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 102835
+timestamp: 1786118485753
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-16.1.0-he33a5f8_1.conda
+sha256: 4b7e7a082fab18a58409b05c2611b8edb4aeb06ee07be380a73da5de911da2ba
+md5: aaeab97072d79e7945182dc7d4e1a035
+depends:
+- gcc_impl_linux-64 16.1.0 h5fcb69b_1
+- libstdcxx-devel_linux-64 16.1.0 h41cdd0d_101
+- sysroot_linux-64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16633585
+timestamp: 1785375706410
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
+sha256: 4b55aea03b18a4084b750eee531ad978d4a3690f63019132c26c6ad26bbe3aed
+md5: 5a6f6c00ef982a9bc83558d9ac8f64a0
+depends:
+- cairo >=1.18.0,<2.0a0
+- freetype >=2.12.1,<3.0a0
+- graphite2
+- icu >=73.2,<74.0a0
+- libgcc-ng >=12
+- libglib >=2.78.1,<3.0a0
+- libstdcxx-ng >=12
+license: MIT
+license_family: MIT
+size: 1547473
+timestamp: 1699925311766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
+md5: cc47e1facc155f91abd89b11e48e72ff
+depends:
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+license: MIT
+license_family: MIT
+size: 12089150
+timestamp: 1692900650789
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+md5: 86d9cba083cd041bfbf242a01a7a1999
+constrains:
+- sysroot_linux-64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1278712
+timestamp: 1765578681495
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+md5: b38117a3c920364aff79f870c984b4a3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 134088
+timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+depends:
+- __glibc >=2.17,<3.0.a0
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1388990
+timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+md5: 449500f2c089da11c40f5c21312e3e07
+depends:
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 745303
+timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
+md5: fb9d356b1a57d6d54768be7ebd5fce09
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 271158
+timestamp: 1785036167977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
+sha256: cb728a2a95557bb6a5184be2b8be83a6f2083000d0c7eff4ad5bbe5792133541
+md5: 3b0d184bc9404516d418d4509e418bdc
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.1-or-later
+size: 53582
+timestamp: 1753342901341
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
+sha256: 2fc95060efc3d76547b7872875af0b7212d4b1407165be11c5f830aeeb57fc3a
+md5: fd9cf4a11d07f0ef3e44fc061611b1ed
+depends:
+- __glibc >=2.17,<3.0.a0
+- libasprintf 0.25.1 h3f43e3d_1
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 34734
+timestamp: 1753342921605
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+build_number: 9
+sha256: 39c7b3c5427b435c9c059ede9da61d46d42574e5b846ad37fdc3af4a5eab1e48
+md5: f5c4b041925dea221dc4bad2e50569d9
+depends:
+- libopenblas >=0.3.34,<0.3.35.0a0
+- libopenblas >=0.3.34,<1.0a0
+constrains:
+- blas 2.309   openblas
+- libcblas   3.11.0   9*_openblas
+- liblapack  3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+- mkl <2027
+license: BSD-3-Clause
+license_family: BSD
+size: 18033
+timestamp: 1786059035239
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hcf29cc6_1.conda
+sha256: 7d243f45a48f62cb8e3b871dd336137fe0fb90094a191756fb553508837f6338
+md5: 2c1e55d695b11525c760b486ac0be517
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 478914
+timestamp: 1782802520033
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
+md5: 40f9b31aa9cf007789867df0decd0492
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 73710
+timestamp: 1785908694612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+depends:
+- ncurses
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 134676
+timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+md5: 7bc31538d6e3fb349e897353969237ec
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-2-Clause OR GPL-2.0-or-later
+license_family: GPL
+size: 43220
+timestamp: 1785917328200
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+md5: b24d3c612f71e7aa74158d92106318b2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77856
+timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+md5: 0abe40a9880086ca4d2e5daf09dceff9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 67576
+timestamp: 1783520858222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_1.conda
+sha256: 9f09d889d1021fa0d99968e5f209a7a7b316dee48c97ed0d79e996e1272a6280
+md5: 12a05d10f2e4eadfd7b8f754a17f5e1a
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8419
+timestamp: 1785641173212
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_1.conda
+sha256: 162f1736f9ec7b19915658cbb25a685748932f697418ab85657332de5da5f496
+md5: e63acf9b3849fd9fc2dba64b69849716
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libpng >=1.6.58,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 386042
+timestamp: 1785641172605
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+md5: 5a7d954665c707c93311657cd779c705
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+constrains:
+- libgomp 16.1.0 he0feb66_1
+- libgcc-ng ==16.1.0=*_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1057877
+timestamp: 1785375436766
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
+sha256: b314251d957b16c71ec241119ac09b9530c5c4ce140026ec98d297f55d6c5e08
+md5: 19b0151ecb1d122f706ebd2f82f9a017
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 3096495
+timestamp: 1785375361053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+sha256: 225275c562337a1cd61705da0ee4235dde7bba7504de1c34b74c894adb2b0eee
+md5: 7ed870c014a6f23c7dfafda53d2763a9
+depends:
+- libgcc 16.1.0 ha9f2e26_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28210
+timestamp: 1785375440733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
+sha256: 50a9e9815cf3f5bce1b8c5161c0899cc5b6c6052d6d73a4c27f749119e607100
+md5: 2f4de899028319b27eb7a4023be5dfd2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libiconv >=1.18,<2.0a0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 188293
+timestamp: 1753342911214
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
+sha256: c7ea10326fd450a2a21955987db09dde78c99956a91f6f05386756a7bfe7cc04
+md5: 3f7a43b3160ec0345c9535a9f0d7908e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgettextpo 0.25.1 h3f43e3d_1
+- libiconv >=1.18,<2.0a0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 37407
+timestamp: 1753342931100
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+sha256: 9e82d410a50bd4e5e47cbbb026454c3eb543954baca4db23929575b571bf56a3
+md5: 2fbed65cc90cf0724e1ec4de13696737
+depends:
+- libgfortran5 16.1.0 h79bb938_1
+constrains:
+- libgfortran-ng ==16.1.0=*_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28134
+timestamp: 1785375470055
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-16.1.0-h69a702a_1.conda
+sha256: 0183db0e80ebc9af12a610c9bbff27fba4c31666157e04cdfeef6f29b6675e6c
+md5: 4b1f79588cedd8546a25906898a304e4
+depends:
+- libgfortran 16.1.0 h69a702a_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28223
+timestamp: 1785375627879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+sha256: 05078ab464d506dff971860cb1a553b35bc27c0b5ce8ec29b8bfaca5f2359652
+md5: dd51ed33e8c70995f8e33cc9dc537297
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=16.1.0
+constrains:
+- libgfortran 16.1.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2538696
+timestamp: 1785375448623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.1-hebfc3b9_0.conda
+sha256: 44c5f58593b074886436db7d13fdfcba2fe3731867ea52237f049b8400341a2b
+md5: ddd09e8904fde46b85f41896621803e6
+depends:
+- gettext >=0.21.1,<1.0a0
+- libffi >=3.4,<4.0a0
+- libgcc-ng >=12
+- libiconv >=1.17,<2.0a0
+- libstdcxx-ng >=12
+- libzlib >=1.2.13,<2.0.0a0
+- pcre2 >=10.40,<10.41.0a0
+constrains:
+- glib 2.78.1 *_0
+license: LGPL-2.1-or-later
+size: 2688566
+timestamp: 1699278005640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+md5: 88f2d91cb1533194c323534253094d23
+depends:
+- __glibc >=2.17,<3.0.a0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 640415
+timestamp: 1785375373755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+md5: 915f5995e94f60e9a4826e0b0920ee88
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: LGPL-2.1-only
+size: 790176
+timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
+md5: 898d1c9793eaa52efc4727bd84d2e39a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 650434
+timestamp: 1785896381946
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+build_number: 9
+sha256: ea989e2dabd21d296a5a4ec515e695645aefcdf778ffdb5eeea515421d243ab5
+md5: e51473c2b7e1f9cb61daafccfd912abf
+depends:
+- libblas 3.11.0 9_h4a7cf45_openblas
+constrains:
+- blas 2.309   openblas
+- libcblas   3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18021
+timestamp: 1786059046733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 112995
+timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.3-hb03c661_1.conda
+sha256: adef6e8b60afb684110b06b5310977c6836e1c923ce3ec199f45c0f000b42f20
+md5: 6d83d6a332c19424e9e66b69b180ec11
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- liblzma 5.8.3 hb03c661_1
+license: 0BSD
+size: 491970
+timestamp: 1786348627135
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
+md5: 2a45e7f8af083626f009645a6481f12d
+depends:
+- __glibc >=2.17,<3.0.a0
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 663344
+timestamp: 1773854035739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+sha256: 23392fc4f4e5ba230fcd1ef825878ba5ca7ee4f6259fac0cbb13299134b7bf7a
+md5: c282d68f272927612462b5d626838ef1
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.34,<0.3.35.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5952629
+timestamp: 1784287497473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+md5: eba48a68a1a2b9d3c0d9511548db85db
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 317729
+timestamp: 1776315175087
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-16.1.0-hf2715c6_1.conda
+sha256: 85662ecadd3961bc96cbcc38dbc024a768cc35932c8440677ed028ea6322c36c
+md5: abd77210925872ee084672cf5be1d491
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=16.1.0
+- libstdcxx >=16.1.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 7780843
+timestamp: 1785375481116
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+md5: eecce068c7e4eddeb169591baac20ac4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 304790
+timestamp: 1745608545575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+md5: aed6cf89adc1e9b846e4367ac538e434
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc 16.1.0 ha9f2e26_1
+constrains:
+- libstdcxx-ng ==16.1.0=*_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 6631744
+timestamp: 1785375462643
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
+sha256: c1521172f2fdf5510d79b621ea835064209fe3131518e0d8b2b43362a75e7b4c
+md5: 8593636203272a748b63d56cbd674753
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 22519609
+timestamp: 1785375386152
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+sha256: 2876ca4463d1b394eb969ce4a84d1620aa63fb8202a6397837d1e45ec76c1208
+md5: c94f06123272d8e129d4acf3a25ffb35
+depends:
+- libstdcxx 16.1.0 h934c35e_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28253
+timestamp: 1785375500257
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
+md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
+depends:
+- __glibc >=2.17,<3.0.a0
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 452337
+timestamp: 1783084902636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+md5: 01bb81d12c957de066ea7362007df642
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-3-Clause
+license_family: BSD
+size: 40017
+timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
+md5: 9332b53d0ea93c5d39e33be03a0c611a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 428430
+timestamp: 1785954557217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
+md5: 33277193f5b92bad9fdd230eb700929c
+depends:
+- libgcc-ng >=12
+- pthread-stubs
+- xorg-libxau
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 384238
+timestamp: 1682082368177
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+md5: 0de0122d9570a8ab637c6b73db268389
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- zlib 1.3.2 *_3
+license: Zlib
+license_family: Other
+size: 63713
+timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb03c661_3.conda
+sha256: 4c65d2769847778a6d84db6984ac81bcec6f8958d349f1fe57ae040ccc56a801
+md5: b4a198dc40024de2a59c1343e4ae4144
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: GPL-3.0-or-later
+license_family: GPL
+size: 510695
+timestamp: 1785879853297
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+md5: ee6c0cd80a60961a1f48aa3e0b91f986
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 911196
+timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+md5: c5955c27917ff2234def47f075e71e02
+depends:
+- __glibc >=2.17,<3.0.a0
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3182423
+timestamp: 1785913583650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.50.14-ha41ecd1_2.conda
+sha256: 6ecce306b7ac4acf1184eb5b045e57e613e19e99c27d57f33eb255f8a9120a93
+md5: 1a66c10f6a0da3dbd2f3a68127e7f6a0
+depends:
+- cairo >=1.16.0,<2.0a0
+- fontconfig >=2.14.2,<3.0a0
+- fonts-conda-ecosystem
+- freetype >=2.12.1,<3.0a0
+- fribidi >=1.0.10,<2.0a0
+- harfbuzz >=8.1.1
+- libgcc-ng >=12
+- libglib >=2.76.4,<3.0a0
+- libpng >=1.6.39,<1.7.0a0
+license: LGPL-2.1-or-later
+size: 443648
+timestamp: 1693056071824
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
+sha256: 7a29ec847556eed4faa1646010baae371ced69059a4ade43851367a076d6108a
+md5: 69e2c796349cd9b273890bee0febfe1b
+depends:
+- bzip2 >=1.0.8,<2.0a0
+- libgcc-ng >=12
+- libzlib >=1.2.12,<2.0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2412495
+timestamp: 1665562915343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
+md5: 0ee5bb30034b081a1386c1e2c98ab0a7
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 376704
+timestamp: 1786106621354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+sha256: 4ce2e1ee31a6217998f78c31ce7dc0a3e0557d9238b51d49dd20c52d467a126d
+md5: f2c23a77b25efcad57d377b34bd84941
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 593603
+timestamp: 1769710381284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+sha256: afc3b27b2cbb0487c1d0e963f96e71181ecfb623a24fb393bb19ff974a6382a1
+md5: df2c27f36bdb0dde779f55b5df76a352
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 9115
+timestamp: 1786067714761
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r43hc72bb7e_5.conda
+sha256: 3d223a5f549174bce4085faa75d68550e6cadef8d34691340b7fe59a76a7d1ac
+md5: 830d74ef2014697ec7f95922cd6edcef
+depends:
+- r-base >=4.3,<4.4.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 71213
+timestamp: 1719739411658
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.3.1-h93585b2_6.conda
+sha256: b9c6347bdd0060f2ede394e58a8d2a927e504847e2ed7e0297f280de0edb8ae9
+md5: c14cf30d4f7373dcf225c690b9583a8c
+depends:
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.16.0,<2.0a0
+- curl
+- gcc_impl_linux-64 >=10
+- gfortran_impl_linux-64
+- gxx_impl_linux-64 >=10
+- icu >=73.2,<74.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.3.0,<9.0a0
+- libgcc-ng >=12
+- libgfortran-ng
+- libgfortran5 >=10.4.0
+- libglib >=2.78.0,<3.0a0
+- libiconv >=1.17,<2.0a0
+- libjpeg-turbo >=3.0.0,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- libpng >=1.6.39,<1.7.0a0
+- libstdcxx-ng >=12
+- libtiff >=4.6.0,<4.8.0a0
+- libzlib >=1.2.13,<2.0.0a0
+- make
+- pango >=1.50.14,<2.0a0
+- pcre2 >=10.40,<10.41.0a0
+- readline >=8.2,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- xorg-libxt
+- xz >=5.2.6,<6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 25720044
+timestamp: 1695968775295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-bit-4.6.0-r43h2b5f3a1_0.conda
+sha256: 12d391e4a3a83df0a01d0c3c4e1b7f68d7333c4236b9ffdddd8383857b343896
+md5: 6a3c84f3e9d9fb7c5dc53c6d71d15ccb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 609233
+timestamp: 1741292355555
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-bit64-4.6.0_1-r43h2b5f3a1_0.conda
+sha256: b77f046b4d9edd060518d695befaa2cca02a891eb021ba7d3bb7a36e3fbbef8e
+md5: e8ec46dd5b7da8ffa5c2430032e19a89
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+- r-bit >=4.0.0
+license: GPL-2.0-only
+license_family: GPL2
+size: 494373
+timestamp: 1741792371629
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-cli-3.6.5-r43h93ab643_0.conda
+sha256: 50161a9f3a7c24d27c949329ab7090b4e2e0da2925880371b32500057c1bcd52
+md5: 5d49a07fdd4ca869c4a79082692c4d2a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libstdcxx >=13
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 1291737
+timestamp: 1745422844487
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-clipr-0.8.0-r43hc72bb7e_3.conda
+sha256: 375cd8623a919481fa208a6277dac2e509b97ee72bf1b56e1decbf52bbe559b1
+md5: 57efbe0d7deb70566c3314c2f6be7a22
+depends:
+- r-base >=4.3,<4.4.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 69288
+timestamp: 1719752358221
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r43h785f33e_1.conda
+sha256: df0f798533937a024c560406275d718adf1b063b7ac748449417099d0aec96cb
+md5: 7bc23dbad7c6015d9b2b9c59bb3e5d85
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 234214
+timestamp: 1742373558016
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+sha256: 77764ea98025668e324e334e1095fa7454f6157c0fbb80987749110931f88ad3
+md5: bafc77be1942ea00228cf18d2cb30e35
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 166200
+timestamp: 1719730621224
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-dplyr-1.1.4-r43h0d4f4ea_1.conda
+sha256: 7b0d0477b5d35f1a0fa552d82566ede4e2a0256685b6f8fb8b1ed6bce1365452
+md5: ab942d9107cdd78e74410f9ec48e50c7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1404906
+timestamp: 1721288630062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-ellipsis-0.3.2-r43hb1dbf0f_3.conda
+sha256: f9c29817821721080e1995b9db966b6618372f9c5167e33742289ae97ace35a7
+md5: b8349582a31b17184a7674f4c847a5ad
+depends:
+- libgcc-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 42831
+timestamp: 1719731895073
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-fansi-1.0.6-r43hb1dbf0f_1.conda
+sha256: 21ad2a8e582dc1a11acf078c042f753cbbdc52b07510dd8a3f9d49e673f88902
+md5: 4c17a0f74a974316fdfafa5a9fe91b52
+depends:
+- libgcc-ng >=12
+- r-base >=4.3,<4.4.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 317076
+timestamp: 1719731916014
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r43hc72bb7e_0.conda
+sha256: 74a0d1924f1c697ee32ba5f4c0f71fd79cca378bd00155168db745d4d50304a2
+md5: 9df9346f18ca43dc30488fb2f520999c
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 86435
+timestamp: 1746861655717
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-glue-1.8.0-r43h2b5f3a1_0.conda
+sha256: 386032769e36683b23c360815e2c29048ea71d5a074b3d5f46f8bc6806492073
+md5: 381d612db7519f2a54f1b187e738ac7b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 162436
+timestamp: 1727754867077
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-hms-1.1.3-r43hc72bb7e_2.conda
+sha256: 5226a1f005948a7cc2426183d06f03a55e51abdc78e7574db7d43f9824bdc761
+md5: 5eed9ddd04bbb39ecf29045e2b4cc079
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-ellipsis
+- r-lifecycle
+- r-pkgconfig
+- r-rlang
+- r-vctrs >=0.2.1
+license: MIT
+license_family: MIT
+size: 107595
+timestamp: 1721229074138
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+sha256: 3fa1744d7bbce2f10dfb956f51bf92b11cde4d27b6f94b52d1e77e5e75a1f937
+md5: 7a0a8ba1fe2cf12b39062d8291e2fca8
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 121795
+timestamp: 1721176797340
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-magrittr-2.0.3-r43hb1dbf0f_3.conda
+sha256: 7812c24da1b48c408bcfac9c7b0ea76fec952e8948b4fc28c4579822e8712b60
+md5: fc61bcf37e59037b486c8841a704e9da
+depends:
+- libgcc-ng >=12
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 209001
+timestamp: 1719726090794
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.0-r43hc72bb7e_0.conda
+sha256: 612d2104e30e466439993ee3bf4a3068f5ca81cb3fefa209cd8842ae7820a8ef
+md5: 657672af86f156a821b7a8d5ac88f916
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 626555
+timestamp: 1751664487399
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+sha256: 165008a79554f27704737d56b89b3c7298adaf56d5c70d4004dd95ae99c64b20
+md5: 509adf7f5bc34d77064f28f487d7fa6e
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 26365
+timestamp: 1719725359345
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-prettyunits-1.2.0-r43hc72bb7e_1.conda
+sha256: 24ba3435344c08325190abe3e515364639634639f6772e9aa3c82adba0768bdc
+md5: cf655364ee1c16ad385e829987a67458
+depends:
+- r-assertthat
+- r-base >=4.3,<4.4.0a0
+- r-magrittr
+license: MIT
+license_family: MIT
+size: 162688
+timestamp: 1719751222045
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-progress-1.2.3-r43hc72bb7e_1.conda
+sha256: 4d106ab46647ac469ca879fb1b26bf5e50ed50a40e0aeced67014c7c8a865c21
+md5: e50711aa4ed08fae208148998c92f296
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-crayon
+- r-hms
+- r-prettyunits
+- r-r6
+license: MIT
+license_family: MIT
+size: 93899
+timestamp: 1721251756006
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-purrr-1.1.0-r43h54b55ab_0.conda
+sha256: 10185fd77275eff5df238a716288dd5a6ad6712af4b15894bef8e8f9a350b008
+md5: b38b66e713a00d34363835caab286412
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 538190
+timestamp: 1752219959917
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r43hc72bb7e_0.conda
+sha256: 7da19f2c4302ab73d947604c90c6578d97bb8da769b28d2a493a3900c8cadd9c
+md5: be02712c703445dc5cabbe0f22d0d063
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 94053
+timestamp: 1739604681294
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-readr-2.1.5-r43h0d4f4ea_1.conda
+sha256: 547f68732ea283b802c484ed8b9e2ee4d3945ea7341ced3181c73da878672934
+md5: e3ffadf38171b07d753f0bb4f744d73f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-cli
+- r-clipr
+- r-cpp11
+- r-crayon
+- r-hms >=0.4.1
+- r-lifecycle >=0.2.0
+- r-r6
+- r-rlang
+- r-tibble
+- r-tzdb >=0.1.1
+- r-vroom >=1.5.4
+license: MIT
+license_family: MIT
+size: 787949
+timestamp: 1721319528674
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-rlang-1.1.6-r43h93ab643_0.conda
+sha256: abffd4a1a86b16a3ef3fa56f9eb8a94502f353092e91332fe533a7e14eafbc19
+md5: 057b78b5adfffc99092504a1da563abe
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libstdcxx >=13
+- r-base >=4.3,<4.4.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1525219
+timestamp: 1744386673301
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-stringi-1.8.4-r43ha8ce623_2.conda
+sha256: c1cdddb157899e826142468dd7ea75d8e83d22afb62ddc59b357cd5c59b2488e
+md5: f3cd6969f6b685effb07fa15ce2a0554
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=73.2,<74.0a0
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+license: FOSS
+license_family: OTHER
+size: 898677
+timestamp: 1721122071222
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.2-r43h785f33e_0.conda
+sha256: bc37452f8aa402d40edb58e4974660e6ed37e305eab44b6c52da5776abff199e
+md5: 6607925b2cf647865087a739429ad04e
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 297553
+timestamp: 1757388984150
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tibble-3.3.0-r43h2b5f3a1_0.conda
+sha256: fff2641f31b314a5d1c5f71e2ec36eb2b8e808e0376d5fc3c4db836230ef717e
+md5: e12f4dc87c2ab21d2e4384cbf8f42111
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 614545
+timestamp: 1749412580292
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tidyr-1.3.1-r43h0d4f4ea_1.conda
+sha256: ed3441377e331540aeb2790c741770d2396672751117f665edaa75745b12cae8
+md5: f3e46eed831fa7cbce60dfead1ff6268
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1127111
+timestamp: 1721320374079
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+sha256: 47d2aa15d4dd24630c1d22612717043392b6d7d71f62debdb4b5daada7074761
+md5: f55367f874307bb57575ac1506079178
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 215877
+timestamp: 1721228834603
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-tzdb-0.5.0-r43h3697838_1.conda
+sha256: 6392381fbf8c8d412f2d6567a16ab48413321b9038326113202bfe5a2ae52004
+md5: 4a274c181d15c97ff48421f385f12392
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.3,<4.4.0a0
+- r-cpp11 >=0.5.2
+license: MIT
+license_family: MIT
+size: 553881
+timestamp: 1756541826164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-utf8-1.2.6-r43h2b5f3a1_0.conda
+sha256: fd2677c1425d34fdc02b0b8a1a1559749018ec56a73d7656ad519771367cf8f0
+md5: a2b3283964103f1ff47d6acea6f69e24
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 145920
+timestamp: 1749429252081
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vctrs-0.6.5-r43h0d4f4ea_1.conda
+sha256: f0d086f275bbd590678e3bc43b7a8ac7e4402a15727efdff0308b16efcbeac03
+md5: 7f4c30bb576acec2a682c40790c2d406
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1238483
+timestamp: 1721192068270
+- conda: https://conda.anaconda.org/conda-forge/linux-64/r-vroom-1.6.5-r43h0d4f4ea_1.conda
+sha256: be61c3b6167d4a459fdc03ad0656a39a01413bb288a93dc17e09dfacdda04f7d
+md5: 2fc1d56664063aaa4ffd43a702a71baf
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-bit64
+- r-cli
+- r-cpp11 >=0.2.0
+- r-crayon
+- r-glue
+- r-hms
+- r-lifecycle
+- r-progress >=1.2.1
+- r-rlang >=0.4.2
+- r-tibble >=2.0.0
+- r-tidyselect
+- r-tzdb >=0.1.1
+- r-vctrs >=0.2.0
+- r-withr
+license: MIT
+license_family: MIT
+size: 867373
+timestamp: 1721287578702
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+sha256: a23c7736286776328ba71f2922c533c59e09b8f11516aed13d1b6b282f14f57a
+md5: e503cae9a96ad7771fa6ccd3af90477b
+depends:
+- r-base >=4.3,<4.4.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 231178
+timestamp: 1730138441270
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 345073
+timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+sha256: b013d2085ce4ac01daec7b30472e9f3b6c2d69eb3a3a85a6cee3e01a3cb4f61a
+md5: e4a1ff2e59a5d9b38be71d15c93cf1bd
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 268482
+timestamp: 1776859422619
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+md5: 13dc3adbc692664cd3beabd216434749
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-64 4.18.0 he073ed8_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 24008591
+timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+md5: a0116df4f4ed05c303811a837d5b39d8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+license: TCL
+license_family: BSD
+size: 3285204
+timestamp: 1748387766691
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h8d826fa_7.conda
+sha256: dd5d8aa7f434acbe4ef5a54f5f2c221650f6c25a4c5ad62c46b36267e1b8fb9b
+md5: 3ac51142c19ba95ae0fadefa333c9afb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- tk >=8.6.13,<8.7.0a0
+license: TCL
+size: 92307
+timestamp: 1750266495866
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+sha256: 2bf9a40d86d29fd5c30d0febec99d06398143ddeece9ebb175cc5a6d20279943
+md5: f16d4aec5e8135e8e7bba02ef600149e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 38560
+timestamp: 1779439547766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-hb9d3cd8_1003.conda
+sha256: 849555ddf7fee334a5a6be9f159d2931c9d076ffb310a9e75b9124f789049d3e
+md5: e87bfacb110d85e1eb6099c9ed8e7236
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 30242
+timestamp: 1726846706299
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+md5: fb901ff28063514abb6046c9ec2c4a45
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 58628
+timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+md5: 1c74ff8c35dcadf952a16f752ca5aa49
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 27590
+timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
+sha256: 3e53ba247f1ad68353f18aceba5bf8ce87e3dea930de85d36946844a7658c9fb
+md5: 077b6e8ad6a3ddb741fce2496dd01bec
+depends:
+- libgcc-ng >=12
+- libxcb >=1.15,<1.16.0a0
+- xorg-kbproto
+- xorg-xextproto >=7.3.0,<8.0a0
+- xorg-xproto
+license: MIT
+license_family: MIT
+size: 828060
+timestamp: 1712415742569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
+md5: f06ef439c280a5f90b8bf62355008dbc
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 16419
+timestamp: 1786381001122
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
+md5: 2e66c929f3d879708335b6ea4557c838
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 21120
+timestamp: 1786381006369
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
+md5: 82b6df12252e6f32402b96dacc656fec
+depends:
+- libgcc-ng >=12
+- xorg-libx11 >=1.7.2,<2.0a0
+- xorg-xextproto
+license: MIT
+license_family: MIT
+size: 50143
+timestamp: 1677036907815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
+md5: ed67c36f215b310412b2af935bf3e530
+depends:
+- libgcc-ng >=12
+- xorg-libx11 >=1.8.6,<2.0a0
+- xorg-renderproto
+license: MIT
+license_family: MIT
+size: 37770
+timestamp: 1688300707994
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.0-hd590300_1.conda
+sha256: e7648d1efe2e858c4bc63ccf4a637c841dc971b37ded85a01be97a5e240fecfa
+md5: ae92aab42726eb29d16488924f7312cb
+depends:
+- libgcc-ng >=12
+- xorg-kbproto
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.6,<2.0a0
+- xorg-xproto
+license: MIT
+license_family: MIT
+size: 379256
+timestamp: 1690288540492
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-hb9d3cd8_1003.conda
+sha256: 54dd934b0e1c942e54759eb13672fd59b7e523fabea6e69a32d5bf483e45b329
+md5: bf90782559bce8447609933a7d45995a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 11867
+timestamp: 1726802820431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-hb9d3cd8_1004.conda
+sha256: f302a3f6284ee9ad3b39e45251d7ed15167896564dc33e006077a896fd3458a6
+md5: bc4cd53a083b6720d61a1519a1900878
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 30549
+timestamp: 1726846235301
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-hb9d3cd8_1008.conda
+sha256: ea02425c898d6694167952794e9a865e02e14e9c844efb067374f90b9ce8ce33
+md5: a63f5b66876bb1ec734ab4bdc4d11e86
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 73315
+timestamp: 1726845753874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.3-ha02ee65_1.conda
+sha256: 547b2392d8f7b76efd4a0970946f6da2a1136ad5fe3dc936af81e02eb7181076
+md5: 36a079606b3aaf9d726211825f182452
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- liblzma 5.8.3 hb03c661_1
+- liblzma-devel 5.8.3 hb03c661_1
+- xz-gpl-tools 5.8.3 ha02ee65_1
+- xz-tools 5.8.3 hb03c661_1
+license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+size: 23610
+timestamp: 1786348658246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.3-ha02ee65_1.conda
+sha256: ed6dbec5e4f0f71e7ac629b90dc4c9fba38d194cc88eab891c29e461b408977a
+md5: 137db930adb0b3c5407485e0e1a50cfa
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- liblzma 5.8.3 hb03c661_1
+constrains:
+- xz 5.8.3.*
+license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+size: 40118
+timestamp: 1786348648882
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.3-hb03c661_1.conda
+sha256: c74fa3eddd3ea648456517948f85068d8a07acad7752fd83c7e95b6cebb7114a
+md5: 10d693a2db6e8339e4eebcb3a3dae88d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- liblzma 5.8.3 hb03c661_1
+constrains:
+- xz 5.8.3.*
+license: 0BSD AND LGPL-2.1-or-later
+size: 96459
+timestamp: 1786348637686
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+sha256: 16080a1c7724f7d25727cdc23c7658e0cec2db52448c1dc0c33467ee2c6e1c62
+md5: 6acb86426229f96f93e5468d1df3a5e8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib 1.3.2 h25fd6f3_3
+license: Zlib
+license_family: Other
+size: 96132
+timestamp: 1785362957588
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 601375
+timestamp: 1764777111296

--- a/modules/nf-core/custom/collectstats/.conda-lock/linux_arm64-bd-a98d93b78fdd37b9_1.txt
+++ b/modules/nf-core/custom/collectstats/.conda-lock/linux_arm64-bd-a98d93b78fdd37b9_1.txt
@@ -1,0 +1,1687 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/conda-forge/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-aarch64:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-h80f16a2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-hc57f145_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.3-hba86a56_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-16.1.0-h04da0f0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.25.1-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.25.1-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-16.1.0-h693a0ec_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-h7ac5ae9_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-16.1.0-hd5c6868_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.2.0-h52b7260_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.25.1-h5e0f5ae_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.25.1-h5e0f5ae_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-9_haddc8a3_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-hc57f145_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-hfa851ae_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h80f16a2_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.1.0-h205dda4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-16.1.0-hd673532_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.1.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.25.1-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.25.1-h5ad3122_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.1.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-16.1.0-he9431aa_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.1.0-h47adacf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.78.1-h0464669_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.1.0-h8acb6b2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-9_h88aeb00_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-devel-5.8.3-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.34-pthreads_h9d3fd7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-16.1.0-h2510bd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-16.1.0-hef695bb_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-16.1.0-h2445e1f_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-16.1.0-hdbbeba8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-he30d5cf_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-h2b6f883_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.50.14-h11ef544_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.40-he7b27c6_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-he30d5cf_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r43hc72bb7e_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.3.1-hbff713c_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-bit-4.6.0-r43hdd76399_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-bit64-4.6.0_1-r43hdd76399_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.5-r43h21d2c02_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-clipr-0.8.0-r43hc72bb7e_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r43h785f33e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.1.4-r43h6170684_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.2-r43hc1cf72c_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.6-r43hc1cf72c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r43hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.0-r43hdd76399_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-hms-1.1.3-r43hc72bb7e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.3-r43hc1cf72c_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.0-r43hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-prettyunits-1.2.0-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-progress-1.2.3-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.1.0-r43h0557e7b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r43hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-readr-2.1.5-r43h6170684_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.1.6-r43h21d2c02_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.4-r43hefc5dee_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.2-r43h785f33e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.0-r43hdd76399_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.1-r43h6170684_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tzdb-0.5.0-r43h08b74da_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r43hdd76399_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.6.5-r43h6170684_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vroom-1.6.5-r43h6170684_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h89546af_7.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h57736b2_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-h055a233_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2025.1-h80f16a2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.8.3-hd704e39_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-gpl-tools-5.8.3-hd704e39_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-tools-5.8.3-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: a2527b1d81792a0ccd2c05850960df119c2b6d8f5fdec97f2db7d25dc23b1068
+md5: 468fd3bb9e1f671d36c2cbc677e56f1d
+depends:
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28926
+timestamp: 1770939656741
+- conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+license: BSD
+size: 3566
+timestamp: 1562343890778
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.46.1-default_h5f4c503_102.conda
+sha256: eebe159bf600943552e4319ff4ce27b6a2dadf0dcc5443e76dcee9259a408e11
+md5: 58f37d76b8234c69dbf2939d511bea0b
+depends:
+- ld_impl_linux-aarch64 2.46.1 default_h1979696_102
+- sysroot_linux-aarch64
+- zstd >=1.5.7,<1.6.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 4677171
+timestamp: 1784214549910
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bwidget-1.10.1-h8af1aa0_1.conda
+sha256: d9def28d376d13033e0e78d731091a85a49a2297bf5efe15f0ef0d4533a6adeb
+md5: 585e14e544be02d0baceffecd31c7882
+depends:
+- tk
+license: TCL
+size: 129724
+timestamp: 1750262711538
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
+sha256: 24eacc8a20fd7c4616566178562bef7f9344eb4a8700cfc3180fa75a6ff9d39f
+md5: fd544ef1c672d645bf78e5819cbb8f91
+depends:
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 194694
+timestamp: 1785906301397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-h80f16a2_1.conda
+sha256: 537be62d1835ba3d211941537a13302f6c827d9b1316ca11384c0f47ca755cc8
+md5: 9aaa63e98eb2cf6d22d1d2f87ec9adba
+depends:
+- libgcc >=14
+constrains:
+- c-ares-static <0a0
+license: MIT
+license_family: MIT
+size: 236990
+timestamp: 1786116643290
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
+depends:
+- __unix
+license: ISC
+size: 131780
+timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
+sha256: 79b6323661b535d90aaec0eac0e91ccda88cc5917d9e597a03d7de183bc22f26
+md5: 425111f8cc6945c5d1307357dd819b9b
+depends:
+- fontconfig >=2.14.2,<3.0a0
+- fonts-conda-ecosystem
+- freetype >=2.12.1,<3.0a0
+- icu >=73.2,<74.0a0
+- libgcc-ng >=12
+- libglib >=2.78.0,<3.0a0
+- libpng >=1.6.39,<1.7.0a0
+- libstdcxx-ng >=12
+- libxcb >=1.15,<1.16.0a0
+- libzlib >=1.2.13,<2.0.0a0
+- pixman >=0.42.2,<1.0a0
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.6,<2.0a0
+- xorg-libxext >=1.3.4,<2.0a0
+- xorg-libxrender >=0.9.11,<0.10.0a0
+- zlib
+license: LGPL-2.1-only or MPL-1.1
+size: 983779
+timestamp: 1697028424329
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/curl-8.21.0-hc57f145_1.conda
+sha256: 7175d31e45b1e8cd9fdb9776148e32abe8896e2958157c4db33657ed842c1ce9
+md5: 5798f8c1e9853376cbb7a655043f3122
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libcurl 8.21.0 hc57f145_1
+- libgcc >=14
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 201186
+timestamp: 1782802484339
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.18.3-hba86a56_0.conda
+sha256: 0e680e617b891385de651bb1860acf61a3d0e97b8c20e703597bae8ed0868331
+md5: 9b15532d2cdc4652c552aa915f3e4dd2
+depends:
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libuuid >=2.42.2,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 304582
+timestamp: 1786381155108
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.14.3-h8af1aa0_1.conda
+sha256: 1112c56bc19cbce233b30d9d31ce8eb6fcc100c9baa5145315aaa1e3a25b5178
+md5: 5e8e88bfb3fbb0df0f9f8bb890721e07
+depends:
+- libfreetype 2.14.3 h8af1aa0_1
+- libfreetype6 2.14.3 hdae7a39_1
+license: GPL-2.0-only OR FTL
+size: 174060
+timestamp: 1780933507786
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.16-he30d5cf_1.conda
+sha256: 0b11eca89f8143a1eed1cb64876c2015aaccc1e794394706dae2978dfdee148e
+md5: a53fb4bfd0bc371eab779e79152fea74
+depends:
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 63507
+timestamp: 1785912512987
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-16.1.0-h04da0f0_1.conda
+sha256: ad024e118ed57e7277547fd03a913b981e9bb9a6db258b8943293b13329d4489
+md5: e5551bb5b75bcc4031e40f2b69baab84
+depends:
+- binutils_impl_linux-aarch64 >=2.46.1
+- libgcc >=16.1.0
+- libgcc-devel_linux-aarch64 16.1.0 hd673532_101
+- libgomp >=16.1.0
+- libsanitizer 16.1.0 h2510bd8_1
+- libstdcxx >=16.1.0
+- libstdcxx-devel_linux-aarch64 16.1.0 h2445e1f_101
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 75102801
+timestamp: 1785374604361
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.25.1-h5ad3122_0.conda
+sha256: 510e7eba15e6ba71cd5a2ae403128d56b3bb990878c8110f3abc652f823b4af8
+md5: 1e99d353785a5302bce1a5a86d249b2b
+depends:
+- gettext-tools 0.25.1 h5ad3122_0
+- libasprintf 0.25.1 h5e0f5ae_0
+- libasprintf-devel 0.25.1 h5e0f5ae_0
+- libgcc >=13
+- libgettextpo 0.25.1 h5ad3122_0
+- libgettextpo-devel 0.25.1 h5ad3122_0
+- libstdcxx >=13
+license: LGPL-2.1-or-later AND GPL-3.0-or-later
+size: 534760
+timestamp: 1751557634743
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.25.1-h5ad3122_0.conda
+sha256: 7b03cc531c9c2d567eb81dffe9f5688c83fbcdfa4882eec3a2045ec43218806f
+md5: 4215d91c0eaae5274a36a3f211898c91
+depends:
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 3999301
+timestamp: 1751557600737
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-16.1.0-h693a0ec_1.conda
+sha256: 2d09173274748d6d442a6466ad84bc642dbe85ae758d4530244260c4296fbbc0
+md5: 39e040d74f33a538ac90fca7b6edf1d4
+depends:
+- gcc_impl_linux-aarch64 >=16.1.0
+- libgcc >=16.1.0
+- libgfortran5 >=16.1.0
+- libstdcxx >=16.1.0
+- sysroot_linux-aarch64
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 16451115
+timestamp: 1785374752905
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.15-h7ac5ae9_1.conda
+sha256: 5be01914b445dfbde85a4751b1d12b331740e7af68a86e4ef6313ab38a870fdd
+md5: c5835ff5788e0d772d67a97bd5fe001b
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 119414
+timestamp: 1786118514013
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-16.1.0-hd5c6868_1.conda
+sha256: 9a8b38dc912b6952e52b554e1eb851da279fd4ead6fee7eac78ee2397be19d40
+md5: b7d0e87c50859580781ed98eb0a70180
+depends:
+- gcc_impl_linux-aarch64 16.1.0 h04da0f0_1
+- libstdcxx-devel_linux-aarch64 16.1.0 h2445e1f_101
+- sysroot_linux-aarch64
+- tzdata
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 15592564
+timestamp: 1785374786297
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
+sha256: f6f39bb13d0070565e8975ad5f23005ce894655422a1c50089e6d754c69be084
+md5: 1c06a74f88f085c2af16809fe4c31b73
+depends:
+- cairo >=1.18.0,<2.0a0
+- freetype >=2.12.1,<3.0a0
+- graphite2
+- icu >=73.2,<74.0a0
+- libgcc-ng >=12
+- libglib >=2.78.1,<3.0a0
+- libstdcxx-ng >=12
+license: MIT
+license_family: MIT
+size: 1583124
+timestamp: 1699927567410
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
+sha256: aedb9c911ede5596c87e1abd763ed940fab680d71fdb953bce8e4094119d47b3
+md5: 9d3c29d71f28452a2e843aff8cbe09d2
+depends:
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+license: MIT
+license_family: MIT
+size: 12237094
+timestamp: 1692900632394
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h05a177a_9.conda
+sha256: 5d224bf4df9bac24e69de41897c53756108c5271a0e5d2d2f66fd4e2fbc1d84b
+md5: bb3b7cad9005f2cbf9d169fb30263f3e
+constrains:
+- sysroot_linux-aarch64 ==2.28
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 1248134
+timestamp: 1765578613607
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
+sha256: 5ce830ca274b67de11a7075430a72020c1fb7d486161a82839be15c2b84e9988
+md5: e7df0aab10b9cbb73ab2a467ebfaf8c7
+depends:
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 129048
+timestamp: 1754906002667
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
+sha256: b644718416a22b5d57c1194ea7207b7f8d33d6a2b42775763782d76cd7457aea
+md5: 5fd2304064ef6199d1f91ec60ee7b820
+depends:
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1518484
+timestamp: 1781859412954
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+sha256: 2c4901f4227b0850328ed0c69f958b30ad2cd18982f7a31c7c1f911827004d08
+md5: 489444d0acb2a579d2a002d85a08c059
+depends:
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-aarch64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 905305
+timestamp: 1784214534868
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.2.0-h52b7260_0.conda
+sha256: 0176a71d64fcb5aec43c9e8ab4ae72faa6c6b0b1cda8f40b65e19429ce13c84d
+md5: 9fcfe6be4f752b72be7abc69842ca396
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 244850
+timestamp: 1785038308130
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.25.1-h5e0f5ae_0.conda
+sha256: 146be90c237cf3d8399e44afe5f5d21ef9a15a7983ccea90e72d4ae0362f9b28
+md5: 1c5813f6be57f087b6659593248daf00
+depends:
+- libgcc >=13
+- libstdcxx >=13
+license: LGPL-2.1-or-later
+size: 53434
+timestamp: 1751557548397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.25.1-h5e0f5ae_0.conda
+sha256: cc2bb8ca349ba4dd4af7971a3dba006bc8643353acd9757b4d645a817ec0f899
+md5: 5df92d925fba917586f3ca31c96d8e6d
+depends:
+- libasprintf 0.25.1 h5e0f5ae_0
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 34824
+timestamp: 1751557562978
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-9_haddc8a3_openblas.conda
+build_number: 9
+sha256: 5ad8fda537086a842379b7eb8d67770674e3c3afa66b09690ed62b54439fc227
+md5: c2d360534e0377666eaf8f86e605511c
+depends:
+- libopenblas >=0.3.34,<0.3.35.0a0
+- libopenblas >=0.3.34,<1.0a0
+constrains:
+- blas 2.309   openblas
+- libcblas   3.11.0   9*_openblas
+- liblapack  3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+- mkl <2027
+license: BSD-3-Clause
+license_family: BSD
+size: 18024
+timestamp: 1786058936290
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-hc57f145_1.conda
+sha256: 277a4c0277ae4cd31307d50332aa7f975bd5df3bb6b9710a388ac4bab255c824
+md5: 24f82179a8c74c644c01df15f158bc1b
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libnghttp2 >=1.68.1,<2.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 504521
+timestamp: 1782802479892
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-hfa851ae_1.conda
+sha256: 4cb3da1d4ce7540604219d2a016253777da66c1a710c41557bc708aae7f54a75
+md5: 8cdf7f7e4908c9b2cf50c58966f2ff64
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 71628
+timestamp: 1785908730449
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321h976ea20_0.conda
+sha256: c0b27546aa3a23d47919226b3a1635fccdb4f24b94e72e206a751b33f46fd8d6
+md5: fb640d776fc92b682a14e001980825b1
+depends:
+- ncurses
+- libgcc >=13
+- ncurses >=6.5,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 148125
+timestamp: 1738479808948
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h80f16a2_3.conda
+sha256: 4475f79a020e9ff2a5a0308c48cb2970a25d55c3dd724a97ab28bfac3be6cd49
+md5: f679b30a53d410d0b5ae0cb8f5b7397e
+depends:
+- libgcc >=14
+license: BSD-2-Clause OR GPL-2.0-or-later
+license_family: GPL
+size: 45746
+timestamp: 1785917328690
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+sha256: 20a5726bc8705d91437c9e6ef83b30da64a1719b869656d20a1ee818333ea5ac
+md5: fac3b65a605cd253037fdf3daf2de8d9
+depends:
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77649
+timestamp: 1781203572523
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
+sha256: c95b5b5fc13c8d7af2a9908e6c64844f48787a7631f8abcde1813dc21b3b079e
+md5: 81aedbde3ea118c602e8b289bf565ac5
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 63746
+timestamp: 1783520889209
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype-2.14.3-h8af1aa0_1.conda
+sha256: db75d0fc080992dc67db8e24d7bb2a2f2a0b25bfce8870fa45a82a4b5f6111a2
+md5: a13e600f9d18488b1fd1257344dbfdaa
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8381
+timestamp: 1780933505754
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libfreetype6-2.14.3-hdae7a39_1.conda
+sha256: 34fe8276befd6c42956c4acd969caeddbdc7ea8e6ed054b8388709b6c3e94ba4
+md5: 426cc33f8745ce11a73baf73db3954a7
+depends:
+- libgcc >=14
+- libpng >=1.6.58,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 424236
+timestamp: 1780933505195
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.1.0-h205dda4_1.conda
+sha256: 88a3d400c678df034c9d498f32503779977d5ea826063687c663e42c945abed5
+md5: 91eb209af1098d652fc69b8a3fc7cbaa
+depends:
+- _openmp_mutex >=4.5
+constrains:
+- libgomp 16.1.0 h8acb6b2_1
+- libgcc-ng ==16.1.0=*_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 628785
+timestamp: 1785374520532
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-16.1.0-hd673532_101.conda
+sha256: 885f0d8a47f7ea50d7b33d07a240f2301935602b9d2a39a35b5018b13e934100
+md5: 00cdfad75c8331e103f830fb17184da1
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2357226
+timestamp: 1785374433650
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.1.0-he9431aa_1.conda
+sha256: e0456b4b49e8f9f9ffc04b1b412101ea2c38476eaceb9a0e4e16792d7cfdd929
+md5: e4489d8717b51cee8a33f2b66d10fa6a
+depends:
+- libgcc 16.1.0 h205dda4_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28123
+timestamp: 1785374523851
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.25.1-h5ad3122_0.conda
+sha256: c8e5590166f4931a3ab01e444632f326e1bb00058c98078eb46b6e8968f1b1e9
+md5: ad7b109fbbff1407b1a7eeaa60d7086a
+depends:
+- libgcc >=13
+license: GPL-3.0-or-later
+license_family: GPL
+size: 225352
+timestamp: 1751557555903
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.25.1-h5ad3122_0.conda
+sha256: a26e1982d062daba5bdd3a90a2ef77b323803d21d27cf4e941135f07037d6649
+md5: 0d9d56bac6e4249da2bede0588ae1c1b
+depends:
+- libgcc >=13
+- libgettextpo 0.25.1 h5ad3122_0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 37460
+timestamp: 1751557569909
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.1.0-he9431aa_1.conda
+sha256: 2cef8ffd270434043daf8f481d0c64d3285286e5d3e7c3d43770fec93eddac05
+md5: 8ae8f954eb026b1f0734bea5f9fdfca2
+depends:
+- libgfortran5 16.1.0 h47adacf_1
+constrains:
+- libgfortran-ng ==16.1.0=*_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28122
+timestamp: 1785374551480
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-16.1.0-he9431aa_1.conda
+sha256: ea38b47ed038e62d6dce8ce46ad4508820c0ef96c4f90cb4592cb4ff0ace59eb
+md5: ff2868a6b40d30aba7202d61dbdcbb5e
+depends:
+- libgfortran 16.1.0 he9431aa_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28154
+timestamp: 1785374714093
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.1.0-h47adacf_1.conda
+sha256: abf2248fd6b2863dc3c9eade2dcf1f7e0662334e9a6f211af1816c166dc45a93
+md5: ad336824ac53098bf5004b2fa080467e
+depends:
+- libgcc >=16.1.0
+constrains:
+- libgfortran 16.1.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1496461
+timestamp: 1785374532738
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.78.1-h0464669_0.conda
+sha256: a3aca54b45fb258b94a1ce8bff6bbed3621c7dfbd93542b683be5a4e7c2649f8
+md5: 57f467b0b577893823feed0f4a5d14b1
+depends:
+- gettext >=0.21.1,<1.0a0
+- libffi >=3.4,<4.0a0
+- libgcc-ng >=12
+- libiconv >=1.17,<2.0a0
+- libstdcxx-ng >=12
+- libzlib >=1.2.13,<2.0.0a0
+- pcre2 >=10.40,<10.41.0a0
+constrains:
+- glib 2.78.1 *_0
+license: LGPL-2.1-or-later
+size: 2780353
+timestamp: 1699277796402
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.1.0-h8acb6b2_1.conda
+sha256: 1c609a4a72597350317b92c4d9dfb85d21740219048e2b1d458925a6ccfa3d7a
+md5: 4c9b02fc9fe27704777e260157003653
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 617180
+timestamp: 1785374444877
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
+sha256: 1473451cd282b48d24515795a595801c9b65b567fe399d7e12d50b2d6cdb04d9
+md5: 5a86bf847b9b926f3a4f203339748d78
+depends:
+- libgcc >=14
+license: LGPL-2.1-only
+size: 791226
+timestamp: 1754910975665
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.2.0-he30d5cf_1.conda
+sha256: c5626ea672be2e59784f9be20dc8ceb7961b8ab0053651ded2dffec64e4b8245
+md5: 8730e25aa7eab80ca86dfb9a6bedf1ba
+depends:
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 716519
+timestamp: 1785896318334
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-9_h88aeb00_openblas.conda
+build_number: 9
+sha256: 562077bf38f962f6b80ec4e021bd2328f603ce0b112d3045b3f3b37f1a110f73
+md5: c560d88ddee90ba4120ac63eda69fbee
+depends:
+- libblas 3.11.0 9_haddc8a3_openblas
+constrains:
+- blas 2.309   openblas
+- libcblas   3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18007
+timestamp: 1786058945578
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_1.conda
+sha256: f760669fd1cea27f689f411c0d5488e26ce50e382c9b63e4ad348f959850124a
+md5: e0e6411a60d00186eec7c73f4118ab67
+depends:
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 125578
+timestamp: 1786348561649
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-devel-5.8.3-he30d5cf_1.conda
+sha256: f4e81e49d092f95e68e25c7dcca6643c7cfa23c9984b5d39a7e749c3426103e2
+md5: ab7c85535f5924315a7528efeb2011a0
+depends:
+- libgcc >=14
+- liblzma 5.8.3 he30d5cf_1
+license: 0BSD
+size: 491291
+timestamp: 1786348569607
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-hd3077d7_0.conda
+sha256: 13782715b9eeebc4ad16d36e84ca569d1495e3516aea3fe546a32caa0a597d82
+md5: be5f0f007a4500a226ef001115535a3d
+depends:
+- c-ares >=1.34.6,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 726928
+timestamp: 1773854039807
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.34-pthreads_h9d3fd7e_0.conda
+sha256: 0905b8acaff83558e5007351b2de329ce212ef5acbd595fcc22bb7fa1592f277
+md5: c37ba01d9ab7bfaf5f5dddc5d8807454
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.34,<0.3.35.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5332045
+timestamp: 1784287139395
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
+sha256: 483eaa53da40a6a3e558709d9f7b1ca388735364ae21a1ba58cf942514649c92
+md5: f51503ac45a4888bce71af9027a2ecc9
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 341202
+timestamp: 1776315188425
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-16.1.0-h2510bd8_1.conda
+sha256: 3dfccbcd3bf34923df7482df41bcdbe599675f2de6f03a554dbc238476693854
+md5: ae3d9771453f2ec660dd79e5728129b3
+depends:
+- libgcc >=16.1.0
+- libstdcxx >=16.1.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 8123895
+timestamp: 1785374560390
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h18c354c_0.conda
+sha256: 1e289bcce4ee6a5817a19c66e296f3c644dcfa6e562e5c1cba807270798814e7
+md5: eecc495bcfdd9da8058969656f916cc2
+depends:
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+- openssl >=3.5.0,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 311396
+timestamp: 1745609845915
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-16.1.0-hef695bb_1.conda
+sha256: 81ef9a10a0e01ffc7e03d429ed048410153411b2d8bbf95c334bdf3dcf175ab0
+md5: 0bfd287b881e05351a01c7ebf7bf8f1b
+depends:
+- libgcc 16.1.0 h205dda4_1
+constrains:
+- libstdcxx-ng ==16.1.0=*_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 6255794
+timestamp: 1785374543663
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-16.1.0-h2445e1f_101.conda
+sha256: 926d2c2dedfca7334804d5c8a0727a3746ef580be8763f51ccc2ece24c7be56c
+md5: d2cd8c4b92b4e6dbcb2616d855107aca
+depends:
+- __unix
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 19792513
+timestamp: 1785374457502
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-16.1.0-hdbbeba8_1.conda
+sha256: cb88eb500022e01f835209e771d455d2296e10a18a749f518c257dfcab7d46ba
+md5: a728408241f9db99bad0d1642c908714
+depends:
+- libstdcxx 16.1.0 hef695bb_1
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28182
+timestamp: 1785374577436
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.7.2-hdb009f0_0.conda
+sha256: ef1006578ef7e3f7c420e89d87846213ceb3fdcef2626af2558cbede53d36839
+md5: 20166e2297c1cac346b544d5f6197440
+depends:
+- lerc >=4.1.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=14
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 508982
+timestamp: 1783084925965
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+sha256: 7663489f97c104ae3814db10f384932c74b439f3c1fd4247e4fe3599830c090a
+md5: 58fa42bc4bc71fc329889497ec15effb
+depends:
+- libgcc >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 43248
+timestamp: 1781625528371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.6.0-ha2e29f5_1.conda
+sha256: 4c64e6843d64876d054a28ecbab70abdf145da3c2cbdaa4a43db26cdf0fd760b
+md5: 548943c39851543734ce0d20eeb469b0
+depends:
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 357551
+timestamp: 1785956962809
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
+sha256: d159fcdb8b74187b0bd32f2d9b3a9191bc8b786a97e413aa66e19c39ba7050a0
+md5: eb3d8c8170e3d03f2564ed2024aa00c8
+depends:
+- libgcc-ng >=12
+- pthread-stubs
+- xorg-libxau
+- xorg-libxdmcp
+license: MIT
+license_family: MIT
+size: 388526
+timestamp: 1682083614077
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_3.conda
+sha256: 76efa6cc9d7e6f5ee3bbca0939f64054af2bdfb3c3632531f8e633cf6c2ea41e
+md5: bd534c2fbe56d8c2ea3b2d8f5e12bca8
+constrains:
+- zlib 1.3.2 *_3
+license: Zlib
+license_family: Other
+size: 70108
+timestamp: 1785276540870
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/make-4.4.1-he30d5cf_3.conda
+sha256: b008fb8ba5c93478dacf36d60eed1b2de341d69773c3f73621d2a9e56f834d9d
+md5: 9d82bf3d9bf57d56906354e2ad58204a
+depends:
+- libgcc >=14
+license: GPL-3.0-or-later
+license_family: GPL
+size: 531874
+timestamp: 1785879822550
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-h2b6f883_1.conda
+sha256: d69a04914139627f0a6bfd19412d6c7f1e37edc896af84a6011e07e8bc1e69fa
+md5: c3b4349171ca987ff33a1de61f7b3f96
+depends:
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 955422
+timestamp: 1786355019431
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_1.conda
+sha256: c89e748e8a008e8ca6f25e102362f33319db0c98cc29d98ddada92842f636327
+md5: 1600dfde78c5adba306f8571af62a323
+depends:
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3719270
+timestamp: 1785913554920
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pango-1.50.14-h11ef544_2.conda
+sha256: f3fd2b473eea4cb374461bbde322c921a97cda853a100b5f5bf6c6f8fb73cd67
+md5: 2fe79e8224e0fd83f0660af9fa13f8ed
+depends:
+- cairo >=1.16.0,<2.0a0
+- fontconfig >=2.14.2,<3.0a0
+- fonts-conda-ecosystem
+- freetype >=2.12.1,<3.0a0
+- fribidi >=1.0.10,<2.0a0
+- harfbuzz >=8.1.1
+- libgcc-ng >=12
+- libglib >=2.76.4,<3.0a0
+- libpng >=1.6.39,<1.7.0a0
+license: LGPL-2.1-or-later
+size: 454095
+timestamp: 1693057499830
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.40-he7b27c6_0.tar.bz2
+sha256: 1c9967f4a1641801b9f976c264e6d3ad92ceb856d244d89e7b5ff3cd893e8751
+md5: 2bb3167087f621daefab01b6a2ddc7f9
+depends:
+- bzip2 >=1.0.8,<2.0a0
+- libgcc-ng >=12
+- libzlib >=1.2.12,<2.0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2379344
+timestamp: 1665562938782
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.46.4-h7ac5ae9_3.conda
+sha256: ed718d35c744ceef33063b5686f27b4b8d30d4065485e24efafb248658ee83b5
+md5: c5f34596fc05afb9ccc2782c42bcfcc5
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 304657
+timestamp: 1786106625126
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+sha256: e9cbcbc94e151ada3d6dc365380aaaf591f65012c16d9a2abaea4b9b90adc402
+md5: ab7288cc39545556d1bc5e71ab2df9a9
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 636733
+timestamp: 1769712412683
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-he30d5cf_1003.conda
+sha256: 6138ca8729e6af8658c7e184c38370bec9b0b7840272deff79a3d0c1090f07e4
+md5: 75ad6624c7f795b828227672ca4b5f0b
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 9235
+timestamp: 1786069420166
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-assertthat-0.2.1-r43hc72bb7e_5.conda
+sha256: 3d223a5f549174bce4085faa75d68550e6cadef8d34691340b7fe59a76a7d1ac
+md5: 830d74ef2014697ec7f95922cd6edcef
+depends:
+- r-base >=4.3,<4.4.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 71213
+timestamp: 1719739411658
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-base-4.3.1-hbff713c_6.conda
+sha256: 62475768e2d7ccd7d71b8ceb1a6f383700ae76fba377ece5b028fef69539a629
+md5: 09d098353342c43e5aea6ee57fe2fd16
+depends:
+- _openmp_mutex >=4.5
+- _r-mutex 1.* anacondar_1
+- bwidget
+- bzip2 >=1.0.8,<2.0a0
+- cairo >=1.16.0,<2.0a0
+- curl
+- gcc_impl_linux-aarch64 >=10
+- gfortran_impl_linux-aarch64
+- gxx_impl_linux-aarch64 >=10
+- icu >=73.2,<74.0a0
+- libblas >=3.9.0,<4.0a0
+- libcurl >=8.3.0,<9.0a0
+- libgcc-ng >=12
+- libgfortran-ng
+- libgfortran5 >=10.4.0
+- libglib >=2.78.0,<3.0a0
+- libiconv >=1.17,<2.0a0
+- libjpeg-turbo >=3.0.0,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+- libpng >=1.6.39,<1.7.0a0
+- libstdcxx-ng >=12
+- libtiff >=4.6.0,<4.8.0a0
+- libzlib >=1.2.13,<2.0.0a0
+- make
+- pango >=1.50.14,<2.0a0
+- pcre2 >=10.40,<10.41.0a0
+- readline >=8.2,<9.0a0
+- sed
+- tk >=8.6.13,<8.7.0a0
+- tktable
+- xorg-libxt
+- xz >=5.2.6,<6.0a0
+license: GPL-2.0-or-later
+license_family: GPL
+size: 25847216
+timestamp: 1695968685395
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-bit-4.6.0-r43hdd76399_0.conda
+sha256: a7ff1346f1469839b48728150c084335ec11889569c999333fa8baefecdecea9
+md5: 5654de20f487cbb3305844fee99ead94
+depends:
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 605969
+timestamp: 1741292405427
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-bit64-4.6.0_1-r43hdd76399_0.conda
+sha256: d0bcaafca67fe7c2daedb0e710cb25e684a599e9175ffdb71fed8bf8c640d09d
+md5: 487ee269bf85aed5cc4e057ef6e85f67
+depends:
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+- r-bit >=4.0.0
+license: GPL-2.0-only
+license_family: GPL2
+size: 520155
+timestamp: 1741792454303
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-cli-3.6.5-r43h21d2c02_0.conda
+sha256: 213e2b32df53e3a057dea2e9d71ee02b957b62a4742718db6796fd3a3c7f1cc4
+md5: f558897f5e04ce8a04b0cb493554d09d
+depends:
+- libgcc >=13
+- libstdcxx >=13
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 1311780
+timestamp: 1745422995896
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-clipr-0.8.0-r43hc72bb7e_3.conda
+sha256: 375cd8623a919481fa208a6277dac2e509b97ee72bf1b56e1decbf52bbe559b1
+md5: 57efbe0d7deb70566c3314c2f6be7a22
+depends:
+- r-base >=4.3,<4.4.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 69288
+timestamp: 1719752358221
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-cpp11-0.5.2-r43h785f33e_1.conda
+sha256: df0f798533937a024c560406275d718adf1b063b7ac748449417099d0aec96cb
+md5: 7bc23dbad7c6015d9b2b9c59bb3e5d85
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 234214
+timestamp: 1742373558016
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-crayon-1.5.3-r43hc72bb7e_1.conda
+sha256: 77764ea98025668e324e334e1095fa7454f6157c0fbb80987749110931f88ad3
+md5: bafc77be1942ea00228cf18d2cb30e35
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 166200
+timestamp: 1719730621224
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-dplyr-1.1.4-r43h6170684_1.conda
+sha256: 8a35beb8c34e34d5d8859cb9328d10e1f470c29c74908fdfecb3904f65c563d8
+md5: d68dea9a4341a1c1aa5068e4d6baa23a
+depends:
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-ellipsis
+- r-generics
+- r-glue >=1.3.2
+- r-lifecycle >=1.0.0
+- r-magrittr >=1.5
+- r-pillar >=1.5.1
+- r-r6
+- r-rlang >=0.4.10
+- r-tibble >=2.1.3
+- r-tidyselect >=1.1.0
+- r-vctrs >=0.3.5
+license: MIT
+license_family: MIT
+size: 1404644
+timestamp: 1721288789256
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-ellipsis-0.3.2-r43hc1cf72c_3.conda
+sha256: e495b3786a93e26fbd938327407bf72a746bb2355a04a3e17a4f8c237a1f3459
+md5: 1b05cc26249d8951bc4b5a38891486cf
+depends:
+- libgcc-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-rlang >=0.3.0
+license: MIT
+license_family: MIT
+size: 44234
+timestamp: 1719731910945
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-fansi-1.0.6-r43hc1cf72c_1.conda
+sha256: f774f4fe2fbe762f531aa17043fa0dfc16d3a78f5531c6059cee43d4816d89e8
+md5: 401de246b71cdc2f9350e04264ff79c8
+depends:
+- libgcc-ng >=12
+- r-base >=4.3,<4.4.0a0
+license: GPL-2.0-or-later
+license_family: GPL3
+size: 321793
+timestamp: 1719732038792
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-generics-0.1.4-r43hc72bb7e_0.conda
+sha256: 74a0d1924f1c697ee32ba5f4c0f71fd79cca378bd00155168db745d4d50304a2
+md5: 9df9346f18ca43dc30488fb2f520999c
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 86435
+timestamp: 1746861655717
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-glue-1.8.0-r43hdd76399_0.conda
+sha256: 8247f969561a11d0fedd1880aef46fd791ab79773de43ebbfbd726a5553041d3
+md5: dc43a78433ed854b0b4da73374698782
+depends:
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 164033
+timestamp: 1727754886388
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-hms-1.1.3-r43hc72bb7e_2.conda
+sha256: 5226a1f005948a7cc2426183d06f03a55e51abdc78e7574db7d43f9824bdc761
+md5: 5eed9ddd04bbb39ecf29045e2b4cc079
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-ellipsis
+- r-lifecycle
+- r-pkgconfig
+- r-rlang
+- r-vctrs >=0.2.1
+license: MIT
+license_family: MIT
+size: 107595
+timestamp: 1721229074138
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-lifecycle-1.0.4-r43hc72bb7e_1.conda
+sha256: 3fa1744d7bbce2f10dfb956f51bf92b11cde4d27b6f94b52d1e77e5e75a1f937
+md5: 7a0a8ba1fe2cf12b39062d8291e2fca8
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-rlang >=1.0.6
+license: MIT
+license_family: GPL3
+size: 121795
+timestamp: 1721176797340
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-magrittr-2.0.3-r43hc1cf72c_3.conda
+sha256: 986ae0ed81a94aab54eea373bc3514db0c6d06f48bd04b076535093ffdca1406
+md5: af8643f1082d67798e48e5eaf1b4443b
+depends:
+- libgcc-ng >=12
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 209314
+timestamp: 1719726151098
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pillar-1.11.0-r43hc72bb7e_0.conda
+sha256: 612d2104e30e466439993ee3bf4a3068f5ca81cb3fefa209cd8842ae7820a8ef
+md5: 657672af86f156a821b7a8d5ac88f916
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-cli
+- r-crayon >=1.3.4
+- r-ellipsis
+- r-fansi
+- r-lifecycle
+- r-rlang >=0.3.0
+- r-utf8 >=1.1.0
+- r-vctrs >=0.2.0
+license: GPL-3.0-only
+license_family: GPL3
+size: 626555
+timestamp: 1751664487399
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-pkgconfig-2.0.3-r43hc72bb7e_4.conda
+sha256: 165008a79554f27704737d56b89b3c7298adaf56d5c70d4004dd95ae99c64b20
+md5: 509adf7f5bc34d77064f28f487d7fa6e
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 26365
+timestamp: 1719725359345
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-prettyunits-1.2.0-r43hc72bb7e_1.conda
+sha256: 24ba3435344c08325190abe3e515364639634639f6772e9aa3c82adba0768bdc
+md5: cf655364ee1c16ad385e829987a67458
+depends:
+- r-assertthat
+- r-base >=4.3,<4.4.0a0
+- r-magrittr
+license: MIT
+license_family: MIT
+size: 162688
+timestamp: 1719751222045
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-progress-1.2.3-r43hc72bb7e_1.conda
+sha256: 4d106ab46647ac469ca879fb1b26bf5e50ed50a40e0aeced67014c7c8a865c21
+md5: e50711aa4ed08fae208148998c92f296
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-crayon
+- r-hms
+- r-prettyunits
+- r-r6
+license: MIT
+license_family: MIT
+size: 93899
+timestamp: 1721251756006
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-purrr-1.1.0-r43h0557e7b_0.conda
+sha256: 877a086b4d68585a24c6a79eac7d8b374e198922a665ad40eb26dc31c0bdec2d
+md5: ccc98812bc14cb9525d92f22b3fd807d
+depends:
+- libgcc >=14
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.4
+- r-lifecycle >=1.0.3
+- r-magrittr >=1.5
+- r-rlang >=0.4.10
+- r-vctrs >=0.5
+license: MIT
+license_family: MIT
+size: 542118
+timestamp: 1752220009118
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-r6-2.6.1-r43hc72bb7e_0.conda
+sha256: 7da19f2c4302ab73d947604c90c6578d97bb8da769b28d2a493a3900c8cadd9c
+md5: be02712c703445dc5cabbe0f22d0d063
+depends:
+- r-base >=4.3,<4.4.0a0
+license: MIT
+license_family: MIT
+size: 94053
+timestamp: 1739604681294
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-readr-2.1.5-r43h6170684_1.conda
+sha256: c83e0859d2dc5cb02b442e44439b3dbee5163c106bca57aebcdf75699fbc26f1
+md5: 0a06640a12e2dc7f0296546d80a7b9a0
+depends:
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-cli
+- r-clipr
+- r-cpp11
+- r-crayon
+- r-hms >=0.4.1
+- r-lifecycle >=0.2.0
+- r-r6
+- r-rlang
+- r-tibble
+- r-tzdb >=0.1.1
+- r-vroom >=1.5.4
+license: MIT
+license_family: MIT
+size: 776203
+timestamp: 1721319680651
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-rlang-1.1.6-r43h21d2c02_0.conda
+sha256: 12fa8fe786aa7e0f8945325d4d79c1aca0e8c3c6bda83ac3e7aba4d01ba46adc
+md5: 0f0bbb10207b43d1265ef1452c0d3c6a
+depends:
+- libgcc >=13
+- libstdcxx >=13
+- r-base >=4.3,<4.4.0a0
+license: GPL-3.0-only
+license_family: GPL3
+size: 1551590
+timestamp: 1744386735640
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-stringi-1.8.4-r43hefc5dee_2.conda
+sha256: 8fc53c35041a8bd4072d78dd6edd4df97e7709a9b325a050523f6e8cbb5b9a09
+md5: 01f78186013b03a34101d0ede1414df2
+depends:
+- icu >=73.2,<74.0a0
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+license: FOSS
+license_family: OTHER
+size: 896139
+timestamp: 1721124080802
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-stringr-1.5.2-r43h785f33e_0.conda
+sha256: bc37452f8aa402d40edb58e4974660e6ed37e305eab44b6c52da5776abff199e
+md5: 6607925b2cf647865087a739429ad04e
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-cli
+- r-glue >=1.6.1
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-rlang >=1.0.0
+- r-stringi >=1.5.3
+- r-vctrs
+license: MIT
+license_family: MIT
+size: 297553
+timestamp: 1757388984150
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tibble-3.3.0-r43hdd76399_0.conda
+sha256: a91f432d8adc8e504b281658e4b844bd914e64c4fa853dfdbff89c449e21fa61
+md5: d396f72bdf1a341aa54512c79ae0ef57
+depends:
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+- r-fansi >=0.4.0
+- r-lifecycle >=1.0.0
+- r-magrittr
+- r-pillar >=1.8.1
+- r-pkgconfig
+- r-rlang >=1.0.2
+- r-vctrs >=0.4.2
+license: MIT
+license_family: MIT
+size: 615611
+timestamp: 1749412642050
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tidyr-1.3.1-r43h6170684_1.conda
+sha256: e2e3744769ec38d1d0dc81cee9fa93a403a7eb4fafba73e4d4718a55d89d7715
+md5: 9f20e08e5513355c398d5aef2f0b5ef8
+depends:
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.4.1
+- r-dplyr >=1.0.10
+- r-glue
+- r-lifecycle >=1.0.3
+- r-magrittr
+- r-purrr >=1.0.1
+- r-rlang >=1.0.4
+- r-stringr >=1.5.0
+- r-tibble >=2.1.1
+- r-tidyselect >=1.2.0
+- r-vctrs >=0.5.2
+license: MIT
+license_family: MIT
+size: 1131250
+timestamp: 1721320489553
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-tidyselect-1.2.1-r43hc72bb7e_1.conda
+sha256: 47d2aa15d4dd24630c1d22612717043392b6d7d71f62debdb4b5daada7074761
+md5: f55367f874307bb57575ac1506079178
+depends:
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.3.0
+- r-glue >=1.3.0
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.4
+- r-vctrs >=0.5.2
+- r-withr
+license: MIT
+license_family: MIT
+size: 215877
+timestamp: 1721228834603
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-tzdb-0.5.0-r43h08b74da_1.conda
+sha256: 7496532bc0130f2aac5da856200cc08b1f6b1518ca0bc3079b8e52b208cb2240
+md5: 8ea2a3e12a5eecb8b28346c91875c644
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- r-base >=4.3,<4.4.0a0
+- r-cpp11 >=0.5.2
+license: MIT
+license_family: MIT
+size: 551550
+timestamp: 1756541920264
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-utf8-1.2.6-r43hdd76399_0.conda
+sha256: be1c7fc6fb7e493ce5103195e7d7d218627f38fff3f890a021318e12c54db227
+md5: 088a4e96cd9212f93926edd508142739
+depends:
+- libgcc >=13
+- r-base >=4.3,<4.4.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 151313
+timestamp: 1749429221801
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vctrs-0.6.5-r43h6170684_1.conda
+sha256: 688ba9ff91c680dcc0618b8e3ff41eb056dee4bc9ed694104689cb02af219f9d
+md5: d9b12e8b549435ee1dc664c287979c60
+depends:
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-cli >=3.4.0
+- r-glue
+- r-lifecycle >=1.0.3
+- r-rlang >=1.0.6
+license: MIT
+license_family: MIT
+size: 1271483
+timestamp: 1721192163902
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/r-vroom-1.6.5-r43h6170684_1.conda
+sha256: 29914c4a239f146f4e23601cdca873d0d036f72174a9a364839f61c797e5e0a0
+md5: 06fb4840a15c6680afde8e454f09a4e5
+depends:
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+- r-base >=4.3,<4.4.0a0
+- r-bit64
+- r-cli
+- r-cpp11 >=0.2.0
+- r-crayon
+- r-glue
+- r-hms
+- r-lifecycle
+- r-progress >=1.2.1
+- r-rlang >=0.4.2
+- r-tibble >=2.0.0
+- r-tidyselect
+- r-tzdb >=0.1.1
+- r-vctrs >=0.2.0
+- r-withr
+license: MIT
+license_family: MIT
+size: 889721
+timestamp: 1721287778934
+- conda: https://conda.anaconda.org/conda-forge/noarch/r-withr-3.0.2-r43hc72bb7e_0.conda
+sha256: a23c7736286776328ba71f2922c533c59e09b8f11516aed13d1b6b282f14f57a
+md5: e503cae9a96ad7771fa6ccd3af90477b
+depends:
+- r-base >=4.3,<4.4.0a0
+license: GPL-2.0-or-later
+license_family: GPL2
+size: 231178
+timestamp: 1730138441270
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
+sha256: fe695f9d215e9a2e3dd0ca7f56435ab4df24f5504b83865e3d295df36e88d216
+md5: 3d49cad61f829f4f0e0611547a9cda12
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 357597
+timestamp: 1765815673644
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sed-4.10-he1c5539_0.conda
+sha256: 7b2d9835a79bd67c0b2966cedf246c85bf650dc961125c8e31f073646d4ac797
+md5: 59f2c90c66b956d9bc3e625df3ad8a0a
+depends:
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 288685
+timestamp: 1776861726084
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
+sha256: 1bd2db6b2e451247bab103e4a0128cf6c7595dd72cb26d70f7fadd9edd1d1bc3
+md5: fdf07ab944a222ff28c754914fdb0740
+depends:
+- __glibc >=2.28
+- kernel-headers_linux-aarch64 4.18.0 h05a177a_9
+- tzdata
+license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+license_family: GPL
+size: 23644746
+timestamp: 1765578629426
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h5688188_102.conda
+sha256: 46e10488e9254092c655257c18fcec0a9864043bdfbe935a9fbf4fb2028b8514
+md5: 2562c9bfd1de3f9c590f0fe53858d85c
+depends:
+- libgcc >=13
+- libzlib >=1.3.1,<2.0a0
+license: TCL
+license_family: BSD
+size: 3342845
+timestamp: 1748393219221
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tktable-2.10-h89546af_7.conda
+sha256: d4f8f194750878ac0c038b81a108fef28348f583d83e6d689e2c924b531310bb
+md5: f63f48249b44bf644ee8e05728637671
+depends:
+- libgcc >=13
+- tk >=8.6.13,<8.7.0a0
+license: TCL
+size: 93890
+timestamp: 1750267800908
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+sha256: 720691eb59b86f11ceb21b236b9402d59c47d156183375d2b24c53a201dd874b
+md5: 6dc4b55fc391a3d51ff12a6fed979562
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 40249
+timestamp: 1779439555623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h57736b2_1003.conda
+sha256: f4118db498f8333e88952da920fd1a90a4a7ccb979085f5a6fdac0d64e46d450
+md5: 034897696bebad405b3f01580af14c7e
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 30365
+timestamp: 1726847878179
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
+sha256: a2ba1864403c7eb4194dacbfe2777acf3d596feae43aada8d1b478617ce45031
+md5: c8d8ec3e00cd0fd8a231789b91a7c5b7
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 60433
+timestamp: 1734229908988
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
+sha256: b86a819cd16f90c01d9d81892155126d01555a20dabd5f3091da59d6309afd0a
+md5: 2d1409c50882819cb1af2de82e2b7208
+depends:
+- libgcc >=13
+- libuuid >=2.38.1,<3.0a0
+- xorg-libice >=1.1.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 28701
+timestamp: 1741897678254
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-h055a233_0.conda
+sha256: fe6adc8f0ab7ea026b8ccd5c8c8843e5a01f49bcd193eacec9af1626f0db1194
+md5: d5f0529d3568a2ce38a9aed44a9a8029
+depends:
+- libgcc-ng >=12
+- libxcb >=1.15,<1.16.0a0
+- xorg-kbproto
+- xorg-xextproto >=7.3.0,<8.0a0
+- xorg-xproto
+license: MIT
+license_family: MIT
+size: 851567
+timestamp: 1712415736293
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.12-he30d5cf_2.conda
+sha256: 0822f3a8eb2a54bb41e1133f010e09d4a3242f8f12a372dfff7ad7248c5dbd29
+md5: b03af9d9dfe7aec9e27db74fc41a4ba9
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 17413
+timestamp: 1786382929588
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.5-he30d5cf_2.conda
+sha256: 681465a02be4ac256c05cd5b32ce9812da1563b75be1bfc8884d991454194df3
+md5: 044c398bf4b3b9c01741d8afe4ce1c3e
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 21558
+timestamp: 1786383120543
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.6-h57736b2_0.conda
+sha256: 8e216b024f52e367463b4173f237af97cf7053c77d9ce3e958bc62473a053f71
+md5: bd1e86dd8aa3afd78a4bfdb4ef918165
+depends:
+- libgcc >=13
+- xorg-libx11 >=1.8.9,<2.0a0
+license: MIT
+license_family: MIT
+size: 50746
+timestamp: 1727754268156
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h57736b2_1.conda
+sha256: 50c000a26e828313b668902c2ae5ff7956d9d34418b4fc6fc15f73cba31b45e0
+md5: 19fb476dc5cdd51b67719a6342fab237
+depends:
+- libgcc >=13
+- xorg-libx11 >=1.8.9,<2.0a0
+- xorg-xorgproto
+license: MIT
+license_family: MIT
+size: 38052
+timestamp: 1727530023529
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxt-1.3.1-h57736b2_0.conda
+sha256: 7c109792b60720809a580612aba7f8eb2a0bd425b9fc078748a9d6ffc97cbfa8
+md5: a9e4852c8e0b68ee783e7240030b696f
+depends:
+- libgcc >=13
+- xorg-libice >=1.1.1,<2.0a0
+- xorg-libsm >=1.2.4,<2.0a0
+- xorg-libx11 >=1.8.9,<2.0a0
+license: MIT
+license_family: MIT
+size: 384752
+timestamp: 1731860572314
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h57736b2_1004.conda
+sha256: 00e2bb1f05e7737002165a4523300c1c28dda127de099288c38ce4a62789183e
+md5: 4589bf66785ace0f78e8d59d403aad98
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 30717
+timestamp: 1726847443586
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xorgproto-2025.1-h80f16a2_1.conda
+sha256: a2616bc01953c1f59d45eb4d5802b13edc24e8b4d7f1fc53ab34f3fd65040168
+md5: f2fb3e02f33803df14d7bf2a63266aa6
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 595067
+timestamp: 1786115602624
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h57736b2_1008.conda
+sha256: 3415c89f81a03c26c0f2327c6d9b34a77de2e584d88a9157a5fd940f8cae0292
+md5: 3dd2b75fd06be7955bd3b0c0afa4fb8f
+depends:
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 73800
+timestamp: 1726845752367
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.8.3-hd704e39_1.conda
+sha256: 4e9b4a2eabf215c052d57a54c279a1d79343ae3b961d3f81f834e0bf76e5c7d4
+md5: 96a51f4137a543fd14fe96e1e560a5ac
+depends:
+- libgcc >=14
+- liblzma 5.8.3 he30d5cf_1
+- liblzma-devel 5.8.3 he30d5cf_1
+- xz-gpl-tools 5.8.3 hd704e39_1
+- xz-tools 5.8.3 he30d5cf_1
+license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+size: 23459
+timestamp: 1786348594461
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-gpl-tools-5.8.3-hd704e39_1.conda
+sha256: 3f0b45a1039c86265f41f3bb5f248cd4d901acff49164f86122fab7cc4efc049
+md5: 6543af33661ff21061b6db52c84a86fa
+depends:
+- libgcc >=14
+- liblzma 5.8.3 he30d5cf_1
+constrains:
+- xz 5.8.3.*
+license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+size: 40115
+timestamp: 1786348586456
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-tools-5.8.3-he30d5cf_1.conda
+sha256: 1619ea83757336aaaac4cde221e4cd0982551c82def3276c91d0d53b0b7159db
+md5: 7c211f37ed725871ce3043090d5addd8
+depends:
+- libgcc >=14
+- liblzma 5.8.3 he30d5cf_1
+constrains:
+- xz 5.8.3.*
+license: 0BSD AND LGPL-2.1-or-later
+size: 103133
+timestamp: 1786348578460
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_3.conda
+sha256: 3f3c296477cf26474660942f4d8ec104a8eee2cb1abc7c5bfec9ac1102c66451
+md5: 254c54ac18eca7bf4f865e661306dc43
+depends:
+- libzlib 1.3.2 hdc9db2a_3
+license: Zlib
+license_family: Other
+size: 100332
+timestamp: 1785276566528
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+sha256: 569990cf12e46f9df540275146da567d9c618c1e9c7a0bc9d9cfefadaed20b75
+md5: c3655f82dcea2aa179b291e7099c1fcc
+depends:
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 614429
+timestamp: 1764777145593

--- a/modules/nf-core/custom/collectstats/environment.yml
+++ b/modules/nf-core/custom/collectstats/environment.yml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::r-base=4.3.1
+  - conda-forge::r-dplyr=1.1.4
+  - conda-forge::r-purrr=1.1.0
+  - conda-forge::r-readr=2.1.5
+  - conda-forge::r-stringr=1.5.2
+  - conda-forge::r-tidyr=1.3.1

--- a/modules/nf-core/custom/collectstats/main.nf
+++ b/modules/nf-core/custom/collectstats/main.nf
@@ -16,7 +16,7 @@ process CUSTOM_COLLECTSTATS {
 :         'community.wave.seqera.io/library/custom_collectstats:c1f477e6251c36bb' }"
 
     input:
-    tuple val(meta), val(samples), path(trimlogs), path(bblogs), path(idxstats), path(fcs), path(mergetab)
+    tuple val(meta), val(samples_meta), path(trimlogs), path(bblogs), path(idxstats), path(fcs), path(mergetab)
 
     output:
     tuple val(meta), path("${outfile}"), emit: overall_stats
@@ -31,10 +31,10 @@ process CUSTOM_COLLECTSTATS {
 
     def read_trimlogs = ""
     if ( trimlogs ) {
-        def se_trimlogs = samples
+        def se_trimlogs = samples_meta
             .findAll { s -> s.single_end }
             .collect { s -> "${rq(s.id)}, ${rq(s.id + '.*_trimming_report.txt')}, 1," }
-        def pe_trimlogs = samples
+        def pe_trimlogs = samples_meta
             .findAll { s -> ! s.single_end }
             .collect { s -> "${rq(s.id)}, ${rq(s.id + '_1.*_trimming_report.txt')}, 2," }
 
@@ -93,7 +93,7 @@ process CUSTOM_COLLECTSTATS {
     library(tidyr)
     library(stringr)
 
-    start    <- tibble(sample = c(${samples.collect { s -> rq(s.id) }.join(', ')}))
+    start    <- tibble(sample = c(${samples_meta.collect { s -> rq(s.id) }.join(', ')}))
 
     ${read_trimlogs}
 

--- a/modules/nf-core/custom/collectstats/main.nf
+++ b/modules/nf-core/custom/collectstats/main.nf
@@ -1,0 +1,188 @@
+// Safely quote a Groovy value as a single-quoted R string literal. Used everywhere
+// below that a sample ID or other user-controlled value gets embedded into generated
+// R source -- without this, a value containing a quote could break the generated R
+// syntax, or worse.
+def rq(v) {
+    return "'" + v.toString().replace('\\', '\\\\').replace("'", "\\'") + "'"
+}
+
+process CUSTOM_COLLECTSTATS {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+?         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9d/9d1a8065dcebe35c513db5eb4a5237795aa4bae4756086f3c4319a820a8a647c/data'
+:         'community.wave.seqera.io/library/custom_collectstats:c1f477e6251c36bb' }"
+
+    input:
+    tuple val(meta), val(samples), path(trimlogs), path(bblogs), path(idxstats), path(fcs), path(mergetab)
+
+    output:
+    tuple val(meta), path("${outfile}"), emit: overall_stats
+    path "versions.yml"                , emit: versions, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    outfile    = "${prefix}.overall_stats.tsv.gz"
+
+    def read_trimlogs = ""
+    if ( trimlogs ) {
+        def se_trimlogs = samples
+            .findAll { s -> s.single_end }
+            .collect { s -> "${rq(s.id)}, ${rq(s.id + '.*_trimming_report.txt')}, 1," }
+        def pe_trimlogs = samples
+            .findAll { s -> ! s.single_end }
+            .collect { s -> "${rq(s.id)}, ${rq(s.id + '_1.*_trimming_report.txt')}, 2," }
+
+        read_trimlogs = """
+        trimming <- tribble(
+            ~sample, ~tlogglob, ~mult,
+            ${se_trimlogs.join("\n")}
+            ${pe_trimlogs.join("\n")}
+        ) %>%
+            mutate(
+                d = map(
+                    tlogglob,
+                    function(g) {
+                        # Deliberately using Sys.glob() + readLines() rather than shelling
+                        # out to grep/sed via pipe(sprintf(...)): the glob and file content
+                        # are only ever passed as R function arguments here, never
+                        # interpolated into a shell command string.
+                        f <- Sys.glob(g)[1]
+                        line <- grep('Reads written \\\\(passing filters\\\\)', readLines(f), value = TRUE)
+                        n <- as.integer(gsub(',', '', sub(' .*', '', sub('.*: *', '', line))))
+                        tibble(n_post_trimming = n)
+                    }
+                )
+            ) %>%
+            unnest(d) %>%
+            transmute(sample, n_post_trimming = n_post_trimming * mult)
+        """
+    } else {
+        read_trimlogs = "trimming <- tibble(sample = character(), n_post_trimming = integer())"
+    }
+
+    if ( mergetab ) {
+        read_mergetab = """
+        mergetab <- read_tsv("${mergetab}", show_col_types = FALSE)
+        """
+    } else {
+        read_mergetab = """
+        mergetab <- tibble(sample = character())
+        """
+    }
+
+    """
+    #!/usr/bin/env Rscript
+
+    # All read counts joined into this table (n_post_trimming, n_non_contaminated,
+    # idxs_n_mapped/idxs_n_unmapped, and the featureCounts columns) are expected to use
+    # the same unit -- individual reads, with both mates of a pair counted separately,
+    # never fragments/pairs as a single unit -- so the columns stay directly comparable.
+    # This depends on how the upstream trimming/decontamination/alignment/counting steps
+    # are invoked (e.g. whether a paired-end-aware counting tool is asked to count reads
+    # or fragments), not on anything this module itself controls.
+
+    library(dplyr)
+    library(readr)
+    library(purrr)
+    library(tidyr)
+    library(stringr)
+
+    start    <- tibble(sample = c(${samples.collect { s -> rq(s.id) }.join(', ')}))
+
+    ${read_trimlogs}
+
+    # Reading each idxstats file directly instead of shelling out to grep, to avoid
+    # passing a sample-derived filename through a shell command string.
+    idxs <- tibble(fname = Sys.glob('*.idxstats')) %>%
+        mutate(
+            sample = str_remove(basename(fname), '.idxstats'),
+            d = map(
+                fname,
+                \\(f) {
+                    read_tsv(f, col_names = c('chr', 'length', 'idxs_n_mapped', 'idxs_n_unmapped'), col_types = 'ciii') %>%
+                        filter(chr != '*') %>%
+                        summarise(idxs_n_mapped = sum(idxs_n_mapped), idxs_n_unmapped = sum(idxs_n_unmapped))
+                }
+            )
+        ) %>%
+        unnest(d) %>%
+        select(-fname)
+
+    # Column types given by name rather than position: this only depends on the
+    # feature-counts input's columns existing and being correctly typed, not also on
+    # their order, so a future column reorder upstream won't silently misparse here.
+    counts <- read_tsv(
+        c('${fcs.join("', '")}'),
+        id = 'fname',
+        col_types = cols(
+            .default = col_guess(),
+            sample   = col_character(),
+            count    = col_integer()
+        )
+    ) %>%
+        mutate(feature = str_replace(fname, '^[^.]+\\\\.([^.]+)\\\\..*', '\\\\1')) %>%
+        group_by(sample, feature) %>%
+        summarise(count = sum(count), .groups = 'drop') %>%
+        pivot_wider(names_from = feature, values_from = count, values_fill = 0)
+
+    # Reading each bbduk log directly (instead of shelling out to grep/sed) avoids
+    # passing a sample-derived filename through a shell command string.
+    bbduk <- tibble(sample = character(), n_non_contaminated = integer())
+    for ( f in Sys.glob('*.bbduk.log') ) {
+        s <- str_remove(f, '.bbduk.log')
+        line <- grep('Result:', readLines(f), value = TRUE)
+        n <- as.integer(sub(' reads.*', '', sub('Result:[[:space:]]*', '', line)))
+        bbduk <- bbduk %>% union(tibble(n_non_contaminated = n, sample = s))
+    }
+    if ( nrow(bbduk) == 0 ) bbduk <- bbduk %>% select(sample)
+
+    # Add in stats from taxonomy and function, if provided
+    ${read_mergetab}
+
+    # Write output
+    start %>%
+        left_join(trimming, by = join_by(sample)) %>%
+        left_join(bbduk, by = join_by(sample)) %>%
+        left_join(idxs, by = join_by(sample)) %>%
+        left_join(counts, by = join_by(sample)) %>%
+        left_join(mergetab, by = join_by(sample)) %>%
+        arrange(sample) %>%
+        write_tsv("${outfile}")
+
+    writeLines(
+        c(
+            "\\"${task.process}\\":",
+            paste0("    R: ", paste0(R.Version()[c("major","minor")], collapse = ".")),
+            paste0("    dplyr: ", packageVersion('dplyr')),
+            paste0("    readr: ", packageVersion('readr')),
+            paste0("    purrr: ", packageVersion('purrr')),
+            paste0("    tidyr: ", packageVersion('tidyr')),
+            paste0("    stringr: ", packageVersion('stringr'))
+        ),
+        "versions.yml"
+    )
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    outfile    = "${prefix}.overall_stats.tsv.gz"
+    """
+    cat /dev/null | gzip -c > ${outfile}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        R: 4.1.0
+        dplyr: 1.0.7
+        readr: 2.0.0
+        purrr: 0.3.4
+        tidyr: 1.1.3
+        stringr: 1.4.0
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/custom/collectstats/meta.yml
+++ b/modules/nf-core/custom/collectstats/meta.yml
@@ -1,0 +1,123 @@
+name: "custom_collectstats"
+description: |
+  Collects per-sample read-processing statistics (trimming, decontamination, alignment,
+  feature counting, and optionally taxonomy/function summaries) from a set of
+  heterogeneous log/table files into one overall-stats table per run.
+keywords:
+  - stats
+  - collect
+  - summary
+  - qc
+tools:
+  - "collectstats":
+      description: |
+        In-house R script that joins per-sample read-processing statistics from
+        several upstream tools into a single wide table.
+      tool_dev_url: "https://github.com/nf-core/modules/blob/master/modules/nf-core/custom/collectstats/main.nf"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing run-level information
+          e.g. `[ id:'run' ]`
+    - samples:
+        type: list
+        description: |
+          List of per-sample meta maps for every sample included in the run, each with
+          at least `id` and `single_end`
+          e.g. `[ [ id:'sample1', single_end:false ], [ id:'sample2', single_end:true ] ]`
+    - trimlogs:
+        type: file
+        description: |
+          Trim Galore trimming report(s), one (single-end) or two (paired-end, only the
+          R1 report is read) per sample. Pass an empty list to skip trimming stats.
+        pattern: "*_trimming_report.txt"
+        ontologies: []
+    - bblogs:
+        type: file
+        description: |
+          BBDuk log file(s), one per decontaminated sample. Pass an empty list to skip
+          decontamination stats.
+        pattern: "*.bbduk.log"
+        ontologies: []
+    - idxstats:
+        type: file
+        description: One samtools idxstats output file per sample.
+        pattern: "*.idxstats"
+        ontologies: []
+    - fcs:
+        type: file
+        description: |
+          One or more featureCounts-derived long-format count tables (as produced e.g.
+          by a "collect featurecounts"-style step), each with at minimum `sample` and
+          `count` columns. Aggregated per input file, keyed by a feature-type label
+          parsed from each file's name (the text between the first and second `.`).
+        pattern: "*.tsv"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+    - mergetab:
+        type: file
+        description: |
+          Optional wide-format per-sample summary table (e.g. taxonomy/function
+          classification counts) to left-join into the output alongside the other
+          statistics. Pass an empty list to skip.
+        pattern: "*.tsv"
+        ontologies:
+          - edam: "http://edamontology.org/format_3475" # TSV
+output:
+  overall_stats:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing run-level information
+            e.g. `[ id:'run' ]`
+      - "${outfile}":
+          type: file
+          description: One row per sample, columns from every input source left-joined together.
+          pattern: "*.overall_stats.tsv.gz"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: "http://edamontology.org/format_3750" # YAML
+topics:
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: "http://edamontology.org/format_3750" # YAML
+authors:
+  - "@erikrikarddaniel"
+maintainers:
+  - "@erikrikarddaniel"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/custom_collectstats:c1f477e6251c36bb
+      build_id: bd-c1f477e6251c36bb_1
+      scan_id: sc-b838afdb854a848f_1
+    linux/arm64:
+      name: community.wave.seqera.io/library/custom_collectstats:a98d93b78fdd37b9
+      build_id: bd-a98d93b78fdd37b9_1
+      scan_id: sc-c0f8f9b47818500b_1
+  singularity:
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/custom_collectstats:45b9f247facbfda0
+      build_id: bd-45b9f247facbfda0_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/9d/9d1a8065dcebe35c513db5eb4a5237795aa4bae4756086f3c4319a820a8a647c/data
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/custom_collectstats:8fc2c1667001d110
+      build_id: bd-8fc2c1667001d110_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e3/e34aa7be0b16814f54d24c73317d6755a15fa039bbe99e44bd469a753f46a287/data
+  conda:
+    linux/amd64:
+      lock_file: modules/nf-core/custom/collectstats/.conda-lock/linux_amd64-bd-c1f477e6251c36bb_1.txt
+    linux/arm64:
+      lock_file: modules/nf-core/custom/collectstats/.conda-lock/linux_arm64-bd-a98d93b78fdd37b9_1.txt

--- a/modules/nf-core/custom/collectstats/meta.yml
+++ b/modules/nf-core/custom/collectstats/meta.yml
@@ -2,7 +2,7 @@ name: "custom_collectstats"
 description: |
   Collects per-sample read-processing statistics (trimming, decontamination, alignment,
   feature counting, and optionally taxonomy/function summaries) from a set of
-  heterogeneous log/table files into one overall-stats table per run.
+  heterogeneous log/table files into a single overall-stats table per run.
 keywords:
   - stats
   - collect

--- a/modules/nf-core/custom/collectstats/meta.yml
+++ b/modules/nf-core/custom/collectstats/meta.yml
@@ -21,7 +21,7 @@ input:
         description: |
           Groovy Map containing run-level information
           e.g. `[ id:'run' ]`
-    - samples:
+    - samples_meta:
         type: list
         description: |
           List of per-sample meta maps for every sample included in the run, each with

--- a/modules/nf-core/custom/collectstats/tests/main.nf.test
+++ b/modules/nf-core/custom/collectstats/tests/main.nf.test
@@ -35,8 +35,16 @@ nextflow_process {
                     [
                         file(params.modules_testdata_base_path + 'generic/tsv/sample1.CDS.featureCounts.tsv', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'generic/tsv/sample1.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_NoFeatures.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_Ambiguity.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_MultiMapping.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_Unmapped.featureCounts.tsv', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'generic/tsv/sample2.CDS.featureCounts.tsv', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_NoFeatures.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_Ambiguity.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_MultiMapping.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_Unmapped.featureCounts.tsv', checkIfExists: true)
                     ],
                     file(params.modules_testdata_base_path + 'generic/tsv/mergetab.tsv', checkIfExists: true)
                 ]
@@ -76,8 +84,16 @@ nextflow_process {
                     [
                         file(params.modules_testdata_base_path + 'generic/tsv/sample1.CDS.featureCounts.tsv', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'generic/tsv/sample1.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_NoFeatures.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_Ambiguity.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_MultiMapping.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_Unmapped.featureCounts.tsv', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'generic/tsv/sample2.CDS.featureCounts.tsv', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_NoFeatures.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_Ambiguity.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_MultiMapping.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_Unmapped.featureCounts.tsv', checkIfExists: true)
                     ],
                     []
                 ]
@@ -125,8 +141,16 @@ nextflow_process {
                     [
                         file(params.modules_testdata_base_path + 'generic/tsv/sample1.CDS.featureCounts.tsv', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'generic/tsv/sample1.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_NoFeatures.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_Ambiguity.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_MultiMapping.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.Unassigned_Unmapped.featureCounts.tsv', checkIfExists: true),
                         file(params.modules_testdata_base_path + 'generic/tsv/sample2.CDS.featureCounts.tsv', checkIfExists: true),
-                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_NoFeatures.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_Ambiguity.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_MultiMapping.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.Unassigned_Unmapped.featureCounts.tsv', checkIfExists: true)
                     ],
                     file(params.modules_testdata_base_path + 'generic/tsv/mergetab.tsv', checkIfExists: true)
                 ]

--- a/modules/nf-core/custom/collectstats/tests/main.nf.test
+++ b/modules/nf-core/custom/collectstats/tests/main.nf.test
@@ -1,0 +1,146 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_COLLECTSTATS"
+    script "../main.nf"
+    process "CUSTOM_COLLECTSTATS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "custom/collectstats"
+
+    test("two samples - all optional inputs provided") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'run' ],
+                    [
+                        [ id: 'sample1', single_end: false ],
+                        [ id: 'sample2', single_end: true ]
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/txt/sample1_1.fastq.gz_trimming_report.txt', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/txt/sample2.fastq.gz_trimming_report.txt', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/txt/sample1.bbduk.log', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/txt/sample2.bbduk.log', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/txt/sample1.idxstats', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/txt/sample2.idxstats', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.CDS.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.CDS.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true)
+                    ],
+                    file(params.modules_testdata_base_path + 'generic/tsv/mergetab.tsv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.overall_stats,
+                    path(process.out.overall_stats.get(0).get(1)).linesGzip
+                ).match() }
+            )
+        }
+
+    }
+
+    test("two samples - optional inputs absent") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'run' ],
+                    [
+                        [ id: 'sample1', single_end: false ],
+                        [ id: 'sample2', single_end: true ]
+                    ],
+                    [],
+                    [],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/txt/sample1.idxstats', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/txt/sample2.idxstats', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.CDS.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.CDS.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true)
+                    ],
+                    []
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.overall_stats,
+                    path(process.out.overall_stats.get(0).get(1)).linesGzip
+                ).match() }
+            )
+        }
+
+    }
+
+    test("two samples - all optional inputs provided - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id: 'run' ],
+                    [
+                        [ id: 'sample1', single_end: false ],
+                        [ id: 'sample2', single_end: true ]
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/txt/sample1_1.fastq.gz_trimming_report.txt', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/txt/sample2.fastq.gz_trimming_report.txt', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/txt/sample1.bbduk.log', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/txt/sample2.bbduk.log', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/txt/sample1.idxstats', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/txt/sample2.idxstats', checkIfExists: true)
+                    ],
+                    [
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.CDS.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample1.rRNA.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.CDS.featureCounts.tsv', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'generic/tsv/sample2.rRNA.featureCounts.tsv', checkIfExists: true)
+                    ],
+                    file(params.modules_testdata_base_path + 'generic/tsv/mergetab.tsv', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/custom/collectstats/tests/main.nf.test
+++ b/modules/nf-core/custom/collectstats/tests/main.nf.test
@@ -161,7 +161,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/custom/collectstats/tests/main.nf.test
+++ b/modules/nf-core/custom/collectstats/tests/main.nf.test
@@ -57,7 +57,8 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.overall_stats,
-                    path(process.out.overall_stats.get(0).get(1)).linesGzip
+                    path(process.out.overall_stats.get(0).get(1)).linesGzip,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -106,7 +107,8 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.overall_stats,
-                    path(process.out.overall_stats.get(0).get(1)).linesGzip
+                    path(process.out.overall_stats.get(0).get(1)).linesGzip,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }

--- a/modules/nf-core/custom/collectstats/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/collectstats/tests/main.nf.test.snap
@@ -13,9 +13,14 @@
                 "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\tUnassigned_Ambiguity\tUnassigned_MultiMapping\tUnassigned_NoFeatures\tUnassigned_Unmapped\trRNA",
                 "sample1\tNA\t550\t15\t200\t3\t7\t15\t20\t30",
                 "sample2\tNA\t180\t5\t40\t1\t2\t8\t5\t10"
-            ]
+            ],
+            {
+                "versions": [
+                    "versions.yml:md5,a304032a876790b9ed28e8ac89682bae"
+                ]
+            }
         ],
-        "timestamp": "2026-08-11T18:41:00.77480636",
+        "timestamp": "2026-08-12T11:55:40.096271521",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -35,9 +40,14 @@
                 "sample\tn_post_trimming\tn_non_contaminated\tidxs_n_mapped\tidxs_n_unmapped\tCDS\tUnassigned_Ambiguity\tUnassigned_MultiMapping\tUnassigned_NoFeatures\tUnassigned_Unmapped\trRNA\tn_annotated_taxa\tn_annotated_functions",
                 "sample1\t600\t580\t550\t15\t200\t3\t7\t15\t20\t30\t42\t17",
                 "sample2\t150\t150\t180\t5\t40\t1\t2\t8\t5\t10\t30\t12"
-            ]
+            ],
+            {
+                "versions": [
+                    "versions.yml:md5,a304032a876790b9ed28e8ac89682bae"
+                ]
+            }
         ],
-        "timestamp": "2026-08-11T18:40:18.785389982",
+        "timestamp": "2026-08-12T11:55:30.731242905",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/modules/nf-core/custom/collectstats/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/collectstats/tests/main.nf.test.snap
@@ -1,0 +1,79 @@
+{
+    "two samples - optional inputs absent": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "run"
+                    },
+                    "run.overall_stats.tsv.gz:md5,5416d3f0dffa3daf38f8b94a9d05901f"
+                ]
+            ],
+            [
+                "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA",
+                "sample1\tNA\t550\t15\t200\t30",
+                "sample2\tNA\t180\t5\t40\t10"
+            ]
+        ],
+        "timestamp": "2026-08-11T18:01:26.181733702",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "two samples - all optional inputs provided": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "run"
+                    },
+                    "run.overall_stats.tsv.gz:md5,a8b49c37b2ba7f951b8f59049032f28d"
+                ]
+            ],
+            [
+                "sample\tn_post_trimming\tn_non_contaminated\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA\tn_annotated_taxa\tn_annotated_functions",
+                "sample1\t600\t580\t550\t15\t200\t30\t42\t17",
+                "sample2\t150\t150\t180\t5\t40\t10\t30\t12"
+            ]
+        ],
+        "timestamp": "2026-08-11T18:01:12.836767669",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "two samples - all optional inputs provided - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "run"
+                        },
+                        "run.overall_stats.tsv.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,001066e0d0280c54be5b59207f58c713"
+                ],
+                "overall_stats": [
+                    [
+                        {
+                            "id": "run"
+                        },
+                        "run.overall_stats.tsv.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,001066e0d0280c54be5b59207f58c713"
+                ]
+            }
+        ],
+        "timestamp": "2026-08-11T18:01:38.464349767",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/modules/nf-core/custom/collectstats/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/collectstats/tests/main.nf.test.snap
@@ -46,17 +46,6 @@
     "two samples - all optional inputs provided - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "run"
-                        },
-                        "run.overall_stats.tsv.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,001066e0d0280c54be5b59207f58c713"
-                ],
                 "overall_stats": [
                     [
                         {
@@ -70,7 +59,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-11T18:41:38.789069246",
+        "timestamp": "2026-08-12T10:31:53.939983288",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/modules/nf-core/custom/collectstats/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/collectstats/tests/main.nf.test.snap
@@ -6,16 +6,16 @@
                     {
                         "id": "run"
                     },
-                    "run.overall_stats.tsv.gz:md5,5416d3f0dffa3daf38f8b94a9d05901f"
+                    "run.overall_stats.tsv.gz:md5,d6557299fc03c8fc59045c5ef665379a"
                 ]
             ],
             [
-                "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA",
-                "sample1\tNA\t550\t15\t200\t30",
-                "sample2\tNA\t180\t5\t40\t10"
+                "sample\tn_post_trimming\tidxs_n_mapped\tidxs_n_unmapped\tCDS\tUnassigned_Ambiguity\tUnassigned_MultiMapping\tUnassigned_NoFeatures\tUnassigned_Unmapped\trRNA",
+                "sample1\tNA\t550\t15\t200\t3\t7\t15\t20\t30",
+                "sample2\tNA\t180\t5\t40\t1\t2\t8\t5\t10"
             ]
         ],
-        "timestamp": "2026-08-11T18:01:26.181733702",
+        "timestamp": "2026-08-11T18:41:00.77480636",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -28,16 +28,16 @@
                     {
                         "id": "run"
                     },
-                    "run.overall_stats.tsv.gz:md5,a8b49c37b2ba7f951b8f59049032f28d"
+                    "run.overall_stats.tsv.gz:md5,cd5981bb0f52f78c799fd2168e6eef8b"
                 ]
             ],
             [
-                "sample\tn_post_trimming\tn_non_contaminated\tidxs_n_mapped\tidxs_n_unmapped\tCDS\trRNA\tn_annotated_taxa\tn_annotated_functions",
-                "sample1\t600\t580\t550\t15\t200\t30\t42\t17",
-                "sample2\t150\t150\t180\t5\t40\t10\t30\t12"
+                "sample\tn_post_trimming\tn_non_contaminated\tidxs_n_mapped\tidxs_n_unmapped\tCDS\tUnassigned_Ambiguity\tUnassigned_MultiMapping\tUnassigned_NoFeatures\tUnassigned_Unmapped\trRNA\tn_annotated_taxa\tn_annotated_functions",
+                "sample1\t600\t580\t550\t15\t200\t3\t7\t15\t20\t30\t42\t17",
+                "sample2\t150\t150\t180\t5\t40\t1\t2\t8\t5\t10\t30\t12"
             ]
         ],
-        "timestamp": "2026-08-11T18:01:12.836767669",
+        "timestamp": "2026-08-11T18:40:18.785389982",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -70,7 +70,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-11T18:01:38.464349767",
+        "timestamp": "2026-08-11T18:41:38.789069246",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Related to nf-core/magmap#237 (not "Closes", it's phase 1 of a larger consolidation effort)

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions`
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test custom/collectstats --profile docker`
    - [ ] `nf-core modules test custom/collectstats --profile singularity`
    - [ ] `nf-core modules test custom/collectstats --profile conda`

## Description

New shared component to join per-sample read-processing statistics (trimming, decontamination, alignment, feature counting, and optionally taxonomy/function summaries) from several upstream tools into a single overall-stats table.

This is phase 1 of the consolidation plan discussed in nf-core/magmap#237: `nf-core/magmap` and `nf-core/metatdenovo` each independently maintain a local `COLLECT_STATS` module that turned out to be the same script, evolved separately from a common ancestor. Ported from magmap's version, the more hardened of the two (avoids shelling out via `pipe(sprintf(...))` with sample-derived filenames in favour of `Sys.glob()`+`readLines()`; named-column `read_tsv` types instead of positional). Once this merges, both pipelines will adopt it in follow-up PRs to their own repos, removing their local duplicates.

It's a hand-rolled R aggregation script rather than a tool wrapper -- following the precedent already set by other `custom/*` modules (`custom/rsemmergecounts`, `custom/matrixfilter`, etc.).

Test data (small two-sample fixtures: Trim Galore reports, BBDuk logs, samtools idxstats, featureCounts-derived tables, an optional merge table) is in a separate PR to `nf-core/test-datasets`' `modules` branch: nf-core/test-datasets#2210. **This PR depends on that one merging first** -- CI here will fail to resolve the fixture paths until it does. Verified locally against both PRs' branches directly (all 3 nf-test cases pass with real Docker execution, including the optional-inputs-absent path), and separately verified the R aggregation logic by hand against the fixtures before either PR was opened.
