### PR TITLE
fix(bam_stringtie_merge): skip empty merges

### DIFF
--- a/subworkflows/nf-core/bam_stringtie_merge/main.nf
+++ b/subworkflows/nf-core/bam_stringtie_merge/main.nf
@@ -19,6 +19,7 @@ workflow BAM_STRINGTIE_MERGE {
     STRINGTIE_STRINGTIE.out.transcript_gtf
         .map { _meta, gtf -> gtf }
         .toSortedList { a, b -> a.name <=> b.name }
+        .filter { gtfs -> gtfs.size() > 0 }
         .map { gtfs -> [ [id: 'stringtie_merge'], gtfs ] }
         .set { collected_gtfs }
 

--- a/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_stringtie_merge/tests/main.nf.test
@@ -37,4 +37,28 @@ nextflow_workflow {
         }
     }
 
+    test("Should skip merge when no BAM files are provided") {
+        tag "empty_input"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.empty()
+                input[1] = Channel.value("mix-reads-assembly")
+                input[2] = Channel.of([
+                                [ id:'annotation' ],
+                                file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/genome.gtf", checkIfExists: true)
+                            ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.stringtie_gtf.size() == 0 },
+            )
+        }
+    }
+
 }


### PR DESCRIPTION
When no BAMs reach `BAM_STRINGTIE_MERGE`, `toSortedList()` emits an empty list and triggers `STRINGTIE_MERGE` without input GTFs. This can happen when an upstream pipeline filters every sample.

Filter that empty list so the subworkflow performs no merge, matching the expected empty-channel behaviour. Add a regression test covering the no-BAM path.

Related to nf-core/rnaseq#1901.

Generated by Codex

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you have fixed a bug or added code that should be tested, add tests.
- [x] Remove all TODO statements.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] `nf-core subworkflows lint bam_stringtie_merge`
- [x] `nf-test test subworkflows/nf-core/bam_stringtie_merge/tests --profile=+docker --stop-on-first-failure`