### PR TITLE
Fix error in get number of shards test (seqcluster/collapse)

### DIFF
--- a/modules/nf-core/seqcluster/collapse/tests/main.nf.test
+++ b/modules/nf-core/seqcluster/collapse/tests/main.nf.test
@@ -25,8 +25,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(sanitizeOutput(process.out).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/seqcluster/collapse/tests/main.nf.test.snap
+++ b/modules/nf-core/seqcluster/collapse/tests/main.nf.test.snap
@@ -1,16 +1,16 @@
 {
     "human - fastq": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test_1",
-                        "single_end": false
-                    },
-                    "test_1_seqcluster.fastq.gz:md5,21c736de10e306f14ec296eaeb38ef45"
-                ]
-            ],
             {
+                "fastq": [
+                    [
+                        {
+                            "id": "test_1",
+                            "single_end": false
+                        },
+                        "test_1_seqcluster.fastq.gz:md5,21c736de10e306f14ec296eaeb38ef45"
+                    ]
+                ],
                 "versions_seqcluster": [
                     [
                         "SEQCLUSTER_COLLAPSE",


### PR DESCRIPTION
## PR checklist

Closes #12676

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
