### PR TITLE
Isolate bot PAT from untrusted PR code in comment-triggered workflows

### DIFF
--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   prepare-fix:
+    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords.
     # The write token is used only before untrusted pull request code runs.
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
@@ -23,6 +24,7 @@ jobs:
       has_patch: ${{ steps.patch.outputs.has_patch }}
       prek_outcome: ${{ steps.prek.outcome }}
     steps:
+      # indication that the linting is being fixed
       - name: React on comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
@@ -33,6 +35,8 @@ jobs:
         with:
           persist-credentials: false
 
+      # Action runs on the issue comment, so we don't get the PR by default.
+      # Use the gh cli to check out the PR.
       - name: Checkout pull request
         id: pr
         env:
@@ -137,6 +141,7 @@ jobs:
           git -c core.hooksPath=/dev/null -c commit.gpgsign=false commit --no-verify -m "[automated] Fix code linting"
           git -c core.hooksPath=/dev/null push --no-verify
 
+      # indication that the linting has finished
       - name: React if linting finished successfully
         if: needs.prepare-fix.outputs.prek_outcome == 'success'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -4,76 +4,162 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
-  fix-linting:
-    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
+  prepare-fix:
+    # The write token is used only before untrusted pull request code runs.
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
       contains(github.event.comment.body, '@nf-core-bot fix linting') &&
       github.repository == 'nf-core/modules'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      has_patch: ${{ steps.patch.outputs.has_patch }}
+      prek_outcome: ${{ steps.prek.outcome }}
     steps:
-      # Use the @nf-core-bot token to check out so we can push later
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          token: ${{ secrets.nf_core_bot_auth_token }}
-
-      # indication that the linting is being fixed
       - name: React on comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: eyes
 
-      # Action runs on the issue comment, so we don't get the PR by default
-      # Use the gh cli to check out the PR
-      - name: Checkout Pull Request
-        run: gh pr checkout ${{ github.event.issue.number }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Checkout pull request
+        id: pr
         env:
-          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh pr checkout "$PR_NUMBER"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Nextflow
+        uses: nf-core/setup-nextflow@893c28b667aedeba26e37f296d260ccc5bc4d914 # v3
+        with:
+          version: "latest-stable"
 
       - name: Run prek
         id: prek
         uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
         continue-on-error: true
 
-      # indication that the linting has finished
-      - name: react if linting finished succesfully
-        if: steps.prek.outcome == 'success'
+      - name: Create lint fix patch
+        id: patch
+        if: steps.prek.outcome == 'failure'
+        env:
+          PATCH_FILE: ${{ runner.temp }}/lint-fix.patch
+        run: |
+          git add --all
+          git diff --cached --binary --full-index --no-ext-diff > "$PATCH_FILE"
+          if [ ! -s "$PATCH_FILE" ]; then
+            echo "Prek failed without producing a fix."
+            exit 1
+          fi
+          echo "has_patch=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload lint fix patch
+        if: steps.patch.outputs.has_patch == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: lint-fix
+          path: ${{ runner.temp }}/lint-fix.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  push-fix:
+    # This job runs on a fresh runner and never executes pull request code.
+    needs: prepare-fix
+    if: ${{ always() && needs.prepare-fix.result != 'skipped' }}
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        with:
+          persist-credentials: false
+
+      - name: Checkout exact pull request head
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.prepare-fix.outputs.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh pr checkout "$PR_NUMBER"
+          if [ "$(git rev-parse HEAD)" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "The pull request head changed after prek ran."
+            exit 1
+          fi
+
+      - name: Download lint fix patch
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lint-fix
+          path: ${{ runner.temp }}/lint-fix
+
+      - name: Apply lint fix patch
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        env:
+          PATCH_FILE: ${{ runner.temp }}/lint-fix/lint-fix.patch
+        run: |
+          if [ ! -f "$PATCH_FILE" ] || [ -L "$PATCH_FILE" ]; then
+            echo "The lint fix artifact does not contain a regular patch file."
+            exit 1
+          fi
+          git apply --check --index "$PATCH_FILE"
+          git apply --index "$PATCH_FILE"
+
+      - name: Commit and push changes
+        id: commit-and-push
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+        run: |
+          gh auth setup-git
+          git config user.email "core@nf-co.re"
+          git config user.name "nf-core-bot"
+          git config push.default upstream
+          git status
+          git -c core.hooksPath=/dev/null -c commit.gpgsign=false commit --no-verify -m "[automated] Fix code linting"
+          git -c core.hooksPath=/dev/null push --no-verify
+
+      - name: React if linting finished successfully
+        if: needs.prepare-fix.outputs.prek_outcome == 'success'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: "+1"
 
-      - name: Commit & push changes
-        id: commit-and-push
-        if: steps.prek.outcome == 'failure'
-        run: |
-          git config user.email "core@nf-co.re"
-          git config user.name "nf-core-bot"
-          git config push.default upstream
-          git add .
-          git status
-          git commit -m "[automated] Fix code linting"
-          git push
-
-      - name: react if linting errors were fixed
-        id: react-if-fixed
+      - name: React if linting errors were fixed
         if: steps.commit-and-push.outcome == 'success'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: hooray
 
-      - name: react if linting errors were not fixed
-        if: steps.commit-and-push.outcome == 'failure'
+      - name: React if linting errors were not fixed
+        if: ${{ always() && (failure() || needs.prepare-fix.result != 'success') }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: confused
 
-      - name: react if linting errors were not fixed
-        if: steps.commit-and-push.outcome  == 'failure'
+      - name: Comment if linting errors were not fixed
+        if: ${{ always() && (failure() || needs.prepare-fix.result != 'success') }}
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/update-gpu-snapshot.yml
+++ b/.github/workflows/update-gpu-snapshot.yml
@@ -4,8 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # renovate: datasource=github-releases depName=askimed/nf-test versioning=semver
   NFT_VER: "0.9.5"
   NXF_ANSI_LOG: false
@@ -13,47 +14,115 @@ env:
   NXF_VER: "25.10.2"
 
 jobs:
-  update-gpu-snapshot:
-    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
+  prepare-gpu-update:
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
       contains(github.event.comment.body, '@nf-core-bot update gpu snapshot') &&
       github.repository == 'nf-core/modules'
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.xlarge/image=ubuntu24-gpu-x64"
+    permissions:
+      issues: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    outputs:
+      head_repo: ${{ steps.pr.outputs.head_repo }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      test_path: ${{ steps.path.outputs.test_path }}
+      valid_path: ${{ steps.path.outputs.valid_path }}
     steps:
-      # indication that the snapshot is being updated
       - name: React on comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: eyes
-      # Use the @nf-core-bot token to check out so we can push later
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          token: ${{ secrets.nf_core_bot_auth_token }}
 
-      - name: Get the test path from the comment (after "@nf-core-bot update gpu snapshot path:")
-        id: get-test-path
+      - name: Record pull request head
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          echo "test_path=$(echo ${{ github.event.comment.body }} | grep -oP 'path:\s*\K[^ ]+')" >> $GITHUB_OUTPUT
+          pr_json=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+          head_sha=$(jq -r '.head.sha // empty' <<< "$pr_json")
+          head_repo=$(jq -r '.head.repo.full_name // empty' <<< "$pr_json")
+          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || [ -z "$head_repo" ]; then
+            echo "The pull request head metadata is invalid."
+            exit 1
+          fi
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "head_repo=$head_repo" >> "$GITHUB_OUTPUT"
 
-      - name: if test path is empty, exit
+      - name: Parse and validate test path
+        id: path
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        shell: bash
+        run: |
+          command_pattern='^[[:space:]]*@nf-core-bot[[:space:]]+update[[:space:]]+gpu[[:space:]]+snapshot[[:space:]]+path:[[:space:]]*([^[:space:]]+)[[:space:]]*$'
+          module_path_pattern='^modules/nf-core/[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)?/tests$'
+          subworkflow_path_pattern='^subworkflows/nf-core/[a-z0-9][a-z0-9_-]*/tests$'
+          match_count=0
+          test_path=''
+
+          while IFS= read -r line; do
+            if [[ "$line" =~ $command_pattern ]]; then
+              match_count=$((match_count + 1))
+              test_path=${BASH_REMATCH[1]}
+            fi
+          done <<< "$COMMENT_BODY"
+
+          if [ "$match_count" -ne 1 ] || [ -z "$test_path" ] || [[ "$test_path" == /* ]] || [[ "$test_path" == *..* ]]; then
+            echo "valid_path=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! [[ "$test_path" =~ $module_path_pattern || "$test_path" =~ $subworkflow_path_pattern ]]; then
+            echo "valid_path=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "test_path=$test_path" >> "$GITHUB_OUTPUT"
+          echo "valid_path=true" >> "$GITHUB_OUTPUT"
+
+      - name: React if test path is invalid
+        if: steps.path.outputs.valid_path != 'true'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
-        if: steps.get-test-path.outputs.test_path == ''
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: "-1"
 
-      - name: if test path is empty, exit
-        if: steps.get-test-path.outputs.test_path == ''
-        run: exit 0
+  update-gpu-snapshot:
+    needs: prepare-gpu-update
+    if: needs.prepare-gpu-update.outputs.valid_path == 'true'
+    permissions:
+      contents: read
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.xlarge/image=ubuntu24-gpu-x64"
+    outputs:
+      has_patch: ${{ steps.patch.outputs.has_patch }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: ${{ needs.prepare-gpu-update.outputs.head_repo }}
+          ref: ${{ needs.prepare-gpu-update.outputs.head_sha }}
+          persist-credentials: false
 
-      # Action runs on the issue comment, so we don't get the PR by default
-      # Use the gh cli to check out the PR
-      - name: Checkout Pull Request
-        run: gh pr checkout ${{ github.event.issue.number }}
+      - name: Verify test path
         env:
-          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+          TEST_PATH: ${{ needs.prepare-gpu-update.outputs.test_path }}
+        run: |
+          workspace=$(realpath --canonicalize-existing "$GITHUB_WORKSPACE")
+          test_path=$(realpath --canonicalize-existing "$TEST_PATH")
+          if [ "$test_path" != "${workspace}/${TEST_PATH}" ]; then
+            echo "The test path contains a symlink or is outside the workspace."
+            exit 1
+          fi
+          if [ ! -f "$TEST_PATH/main.nf.test" ] || [ -L "$TEST_PATH/main.nf.test" ]; then
+            echo "The test path does not contain a regular main.nf.test file."
+            exit 1
+          fi
+          if [ ! -f "$TEST_PATH/main.nf.test.snap" ] || [ -L "$TEST_PATH/main.nf.test.snap" ]; then
+            echo "The test path does not contain a regular snapshot file."
+            exit 1
+          fi
 
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
@@ -76,28 +145,100 @@ jobs:
           version: "${{ env.NFT_VER }}"
           install-fast-diff: true
 
-      - name: Update gpu snapshot
-        id: update-gpu-snapshot
+      - name: Update GPU snapshot
+        env:
+          TEST_PATH: ${{ needs.prepare-gpu-update.outputs.test_path }}
         run: |
           nf-test test \
-          --profile=docker,gpu \
-          --verbose \
-          --ci \
-          --update-snapshot \
-          --filter process,workflow \
-          --tag gpu \
-          ${{ steps.get-test-path.outputs.test_path }}
+            --profile=docker,gpu \
+            --verbose \
+            --ci \
+            --update-snapshot \
+            --filter process,workflow \
+            --tag gpu \
+            "$TEST_PATH"
 
-      - name: clean up
+      - name: Create GPU snapshot patch
+        id: patch
+        env:
+          PATCH_FILE: ${{ runner.temp }}/gpu-snapshot.patch
+          TEST_PATH: ${{ needs.prepare-gpu-update.outputs.test_path }}
         run: |
-          rm -rf setup-nextflow
+          snapshot_file="${TEST_PATH}/main.nf.test.snap"
+          git diff --binary --full-index --no-ext-diff -- "$snapshot_file" > "$PATCH_FILE"
+          if [ ! -s "$PATCH_FILE" ]; then
+            echo "The GPU test did not update its snapshot."
+            exit 1
+          fi
+          echo "has_patch=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit & push changes
+      - name: Upload GPU snapshot patch
+        if: steps.patch.outputs.has_patch == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: gpu-snapshot-patch
+          path: ${{ runner.temp }}/gpu-snapshot.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  push-gpu-snapshot:
+    needs: [prepare-gpu-update, update-gpu-snapshot]
+    if: needs.update-gpu-snapshot.outputs.has_patch == 'true'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Checkout exact pull request head
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.prepare-gpu-update.outputs.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
+          gh pr checkout "$PR_NUMBER"
+          if [ "$(git rev-parse HEAD)" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "The pull request head changed after the GPU test ran."
+            exit 1
+          fi
+
+      - name: Download GPU snapshot patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gpu-snapshot-patch
+          path: ${{ runner.temp }}/gpu-snapshot
+
+      - name: Validate and apply GPU snapshot patch
+        env:
+          PATCH_FILE: ${{ runner.temp }}/gpu-snapshot/gpu-snapshot.patch
+          TEST_PATH: ${{ needs.prepare-gpu-update.outputs.test_path }}
+        run: |
+          if [ ! -f "$PATCH_FILE" ] || [ -L "$PATCH_FILE" ]; then
+            echo "The artifact does not contain a regular GPU snapshot patch."
+            exit 1
+          fi
+          git apply --check --index "$PATCH_FILE"
+          git apply --index "$PATCH_FILE"
+
+          expected_file="${TEST_PATH}/main.nf.test.snap"
+          changed_files=$(git diff --cached --name-only)
+          if [ "$changed_files" != "$expected_file" ]; then
+            echo "The patch changes a file outside the requested snapshot."
+            exit 1
+          fi
+
+      - name: Commit and push GPU snapshot
+        env:
+          GH_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+        run: |
+          gh auth setup-git
           git config user.email "core@nf-co.re"
           git config user.name "nf-core-bot"
           git config push.default upstream
-          git add .
           git status
-          git commit -m "[automated] Update gpu snapshot"
-          git push
+          git -c core.hooksPath=/dev/null -c commit.gpgsign=false commit --no-verify -m "[automated] Update gpu snapshot"
+          git -c core.hooksPath=/dev/null push --no-verify

--- a/.github/workflows/update-gpu-snapshot.yml
+++ b/.github/workflows/update-gpu-snapshot.yml
@@ -18,7 +18,8 @@ jobs:
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
       contains(github.event.comment.body, '@nf-core-bot update gpu snapshot') &&
-      github.repository == 'nf-core/modules'
+      github.repository == 'nf-core/modules' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     permissions:
       issues: write
       pull-requests: read

--- a/.github/workflows/update-gpu-snapshot.yml
+++ b/.github/workflows/update-gpu-snapshot.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   prepare-gpu-update:
+    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords.
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
       contains(github.event.comment.body, '@nf-core-bot update gpu snapshot') &&
@@ -30,6 +31,7 @@ jobs:
       test_path: ${{ steps.path.outputs.test_path }}
       valid_path: ${{ steps.path.outputs.valid_path }}
     steps:
+      # indication that the snapshot is being updated
       - name: React on comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
@@ -195,6 +197,8 @@ jobs:
         with:
           persist-credentials: false
 
+      # Action runs on the issue comment, so we don't get the PR by default.
+      # Use the gh cli to check out the PR.
       - name: Checkout exact pull request head
         env:
           EXPECTED_HEAD_SHA: ${{ needs.prepare-gpu-update.outputs.head_sha }}

--- a/.github/workflows/update-sentieon-snapshot.yml
+++ b/.github/workflows/update-sentieon-snapshot.yml
@@ -4,8 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # renovate: datasource=github-releases depName=askimed/nf-test versioning=semver
   NFT_VER: "0.9.5"
   NXF_ANSI_LOG: false
@@ -13,50 +14,122 @@ env:
   NXF_VER: "25.10.2"
 
 jobs:
-  update-sentieon-snapshot:
-    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
+  prepare-sentieon-update:
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
       contains(github.event.comment.body, '@nf-core-bot update sentieon snapshot') &&
       github.repository == 'nf-core/modules'
-    runs-on:
-      - runs-on=${{ github.run_id }}-nf-test-changes
-      - runner=4cpu-linux-x64
-      - image=ubuntu22-full-x64
+    permissions:
+      issues: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    outputs:
+      head_repo: ${{ steps.pr.outputs.head_repo }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      test_path: ${{ steps.path.outputs.test_path }}
+      valid_path: ${{ steps.path.outputs.valid_path }}
     steps:
-      # indication that the snapshot is being updated
       - name: React on comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: eyes
-      # Use the @nf-core-bot token to check out so we can push later
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          token: ${{ secrets.nf_core_bot_auth_token }}
 
-      - name: Get the test path from the comment (after "@nf-core-bot update sentieon snapshot path:")
-        id: get-test-path
+      - name: Record pull request head
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          echo "test_path=$(echo ${{ github.event.comment.body }} | grep -oP 'path:\s*\K[^ ]+')" >> $GITHUB_OUTPUT
+          pr_json=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+          head_sha=$(jq -r '.head.sha // empty' <<< "$pr_json")
+          head_repo=$(jq -r '.head.repo.full_name // empty' <<< "$pr_json")
+          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || [ -z "$head_repo" ]; then
+            echo "The pull request head metadata is invalid."
+            exit 1
+          fi
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "head_repo=$head_repo" >> "$GITHUB_OUTPUT"
 
-      - name: if test path is empty, exit
+      - name: Parse and validate test path
+        id: path
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        shell: bash
+        run: |
+          command_pattern='^[[:space:]]*@nf-core-bot[[:space:]]+update[[:space:]]+sentieon[[:space:]]+snapshot[[:space:]]+path:[[:space:]]*([^[:space:]]+)[[:space:]]*$'
+          module_path_pattern='^modules/nf-core/[a-z0-9][a-z0-9-]*(/[a-z0-9][a-z0-9-]*)?/tests$'
+          subworkflow_path_pattern='^subworkflows/nf-core/[a-z0-9][a-z0-9_-]*/tests$'
+          match_count=0
+          test_path=''
+
+          while IFS= read -r line; do
+            if [[ "$line" =~ $command_pattern ]]; then
+              match_count=$((match_count + 1))
+              test_path=${BASH_REMATCH[1]}
+            fi
+          done <<< "$COMMENT_BODY"
+
+          if [ "$match_count" -ne 1 ] || [ -z "$test_path" ] || [[ "$test_path" == /* ]] || [[ "$test_path" == *..* ]]; then
+            echo "valid_path=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! [[ "$test_path" =~ $module_path_pattern || "$test_path" =~ $subworkflow_path_pattern ]]; then
+            echo "valid_path=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "test_path=$test_path" >> "$GITHUB_OUTPUT"
+          echo "valid_path=true" >> "$GITHUB_OUTPUT"
+
+      - name: React if test path is invalid
+        if: steps.path.outputs.valid_path != 'true'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
-        if: steps.get-test-path.outputs.test_path == ''
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: "-1"
 
-      - name: if test path is empty, exit
-        if: steps.get-test-path.outputs.test_path == ''
-        run: exit 0
+  # Sentieon secrets are available only to pull requests whose head branch is in nf-core/modules.
+  # A maintainer must copy a fork change to an internal branch before this workflow can test it.
+  update-sentieon-snapshot:
+    needs: prepare-sentieon-update
+    if: >
+      needs.prepare-sentieon-update.outputs.valid_path == 'true' &&
+      needs.prepare-sentieon-update.outputs.head_repo == 'nf-core/modules'
+    permissions:
+      contents: read
+    runs-on:
+      - runs-on=${{ github.run_id }}-nf-test-changes
+      - runner=4cpu-linux-x64
+      - image=ubuntu22-full-x64
+    outputs:
+      has_patch: ${{ steps.patch.outputs.has_patch }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: nf-core/modules
+          ref: ${{ needs.prepare-sentieon-update.outputs.head_sha }}
+          persist-credentials: false
 
-      # Action runs on the issue comment, so we don't get the PR by default
-      # Use the gh cli to check out the PR
-      - name: Checkout Pull Request
-        run: gh pr checkout ${{ github.event.issue.number }}
+      - name: Verify test path
         env:
-          GITHUB_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+          TEST_PATH: ${{ needs.prepare-sentieon-update.outputs.test_path }}
+        run: |
+          workspace=$(realpath --canonicalize-existing "$GITHUB_WORKSPACE")
+          test_path=$(realpath --canonicalize-existing "$TEST_PATH")
+          if [ "$test_path" != "${workspace}/${TEST_PATH}" ]; then
+            echo "The test path contains a symlink or is outside the workspace."
+            exit 1
+          fi
+          if [ ! -f "$TEST_PATH/main.nf.test" ] || [ -L "$TEST_PATH/main.nf.test" ]; then
+            echo "The test path does not contain a regular main.nf.test file."
+            exit 1
+          fi
+          if [ ! -f "$TEST_PATH/main.nf.test.snap" ] || [ -L "$TEST_PATH/main.nf.test.snap" ]; then
+            echo "The test path does not contain a regular snapshot file."
+            exit 1
+          fi
 
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
@@ -79,42 +152,120 @@ jobs:
           version: "${{ env.NFT_VER }}"
           install-fast-diff: true
 
-      # Set up secrets
+      - name: Install Sentieon encryption dependency
+        run: python -m pip install cryptography
+
       - name: Set up Nextflow secrets
         env:
           SENTIEON_ENCRYPTION_KEY: ${{ secrets.SENTIEON_ENCRYPTION_KEY }}
           SENTIEON_LICENSE_MESSAGE: ${{ secrets.SENTIEON_LICENSE_MESSAGE }}
-        if: env.SENTIEON_ENCRYPTION_KEY != '' && env.SENTIEON_LICENSE_MESSAGE != ''
-        shell: bash
         run: |
-          python -m pip install cryptography
-          nextflow secrets set SENTIEON_AUTH_DATA $(python3 modules/nf-core/sentieon/license_message.py encrypt --key "$SENTIEON_ENCRYPTION_KEY" --message "$SENTIEON_LICENSE_MESSAGE")
-      - name: Update sentieon snapshot
-        id: update-sentieon-snapshot
+          if [ -z "$SENTIEON_ENCRYPTION_KEY" ] || [ -z "$SENTIEON_LICENSE_MESSAGE" ]; then
+            echo "The required Sentieon secrets are not available."
+            exit 1
+          fi
+          sentieon_auth_data=$(python3 modules/nf-core/sentieon/license_message.py encrypt \
+            --key "$SENTIEON_ENCRYPTION_KEY" \
+            --message "$SENTIEON_LICENSE_MESSAGE")
+          nextflow secrets set SENTIEON_AUTH_DATA "$sentieon_auth_data"
+
+      - name: Update Sentieon snapshot
         env:
-          SENTIEON_LICSRVR_IP: ${{ secrets.SENTIEON_LICSRVR_IP }}
           SENTIEON_AUTH_MECH: "GitHub Actions - token"
+          SENTIEON_LICSRVR_IP: ${{ secrets.SENTIEON_LICSRVR_IP }}
+          TEST_PATH: ${{ needs.prepare-sentieon-update.outputs.test_path }}
         run: |
           nf-test test \
-          --profile=docker \
-          --verbose \
-          --ci \
-          --update-snapshot \
-          --clean-snapshot \
-          --filter process,workflow \
-          --tag sentieon \
-          ${{ steps.get-test-path.outputs.test_path }}
+            --profile=docker \
+            --verbose \
+            --ci \
+            --update-snapshot \
+            --clean-snapshot \
+            --filter process,workflow \
+            --tag sentieon \
+            "$TEST_PATH"
 
-      - name: clean up
+      - name: Create Sentieon snapshot patch
+        id: patch
+        env:
+          PATCH_FILE: ${{ runner.temp }}/sentieon-snapshot.patch
+          TEST_PATH: ${{ needs.prepare-sentieon-update.outputs.test_path }}
         run: |
-          rm -rf setup-nextflow
+          snapshot_file="${TEST_PATH}/main.nf.test.snap"
+          git diff --binary --full-index --no-ext-diff -- "$snapshot_file" > "$PATCH_FILE"
+          if [ ! -s "$PATCH_FILE" ]; then
+            echo "The Sentieon test did not update its snapshot."
+            exit 1
+          fi
+          echo "has_patch=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit & push changes
+      - name: Upload Sentieon snapshot patch
+        if: steps.patch.outputs.has_patch == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sentieon-snapshot-patch
+          path: ${{ runner.temp }}/sentieon-snapshot.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  push-sentieon-snapshot:
+    needs: [prepare-sentieon-update, update-sentieon-snapshot]
+    if: needs.update-sentieon-snapshot.outputs.has_patch == 'true'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Checkout exact pull request head
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.prepare-sentieon-update.outputs.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
+          gh pr checkout "$PR_NUMBER"
+          if [ "$(git rev-parse HEAD)" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "The pull request head changed after the Sentieon test ran."
+            exit 1
+          fi
+
+      - name: Download Sentieon snapshot patch
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sentieon-snapshot-patch
+          path: ${{ runner.temp }}/sentieon-snapshot
+
+      - name: Validate and apply Sentieon snapshot patch
+        env:
+          PATCH_FILE: ${{ runner.temp }}/sentieon-snapshot/sentieon-snapshot.patch
+          TEST_PATH: ${{ needs.prepare-sentieon-update.outputs.test_path }}
+        run: |
+          if [ ! -f "$PATCH_FILE" ] || [ -L "$PATCH_FILE" ]; then
+            echo "The artifact does not contain a regular Sentieon snapshot patch."
+            exit 1
+          fi
+          git apply --check --index "$PATCH_FILE"
+          git apply --index "$PATCH_FILE"
+
+          expected_file="${TEST_PATH}/main.nf.test.snap"
+          changed_files=$(git diff --cached --name-only)
+          if [ "$changed_files" != "$expected_file" ]; then
+            echo "The patch changes a file outside the requested snapshot."
+            exit 1
+          fi
+
+      - name: Commit and push Sentieon snapshot
+        env:
+          GH_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+        run: |
+          gh auth setup-git
           git config user.email "core@nf-co.re"
           git config user.name "nf-core-bot"
           git config push.default upstream
-          git add .
           git status
-          git commit -m "[automated] Update sentieon snapshot"
-          git push
+          git -c core.hooksPath=/dev/null -c commit.gpgsign=false commit --no-verify -m "[automated] Update sentieon snapshot"
+          git -c core.hooksPath=/dev/null push --no-verify

--- a/.github/workflows/update-sentieon-snapshot.yml
+++ b/.github/workflows/update-sentieon-snapshot.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   prepare-sentieon-update:
+    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords.
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
       contains(github.event.comment.body, '@nf-core-bot update sentieon snapshot') &&
@@ -29,6 +30,7 @@ jobs:
       test_path: ${{ steps.path.outputs.test_path }}
       valid_path: ${{ steps.path.outputs.valid_path }}
     steps:
+      # indication that the snapshot is being updated
       - name: React on comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
@@ -152,6 +154,7 @@ jobs:
           version: "${{ env.NFT_VER }}"
           install-fast-diff: true
 
+      # Set up secrets
       - name: Install Sentieon encryption dependency
         run: python -m pip install cryptography
 
@@ -221,6 +224,8 @@ jobs:
         with:
           persist-credentials: false
 
+      # Action runs on the issue comment, so we don't get the PR by default.
+      # Use the gh cli to check out the PR.
       - name: Checkout exact pull request head
         env:
           EXPECTED_HEAD_SHA: ${{ needs.prepare-sentieon-update.outputs.head_sha }}


### PR DESCRIPTION
## PR checklist

<!-- This PR only touches repository CI workflows, not a module/subworkflow, so the standard module checklist doesn't apply. -->

### What changed

`fix-linting.yml`, `update-gpu-snapshot.yml`, and `update-sentieon-snapshot.yml` are triggered by public PR comments (`issue_comment`) and previously checked out and executed pull-request-controlled code (`prek` hooks, `nf-test`) in the same job that held the `nf-core-bot` PAT. Because `actions/checkout` persists credentials into the local git config by default, PR-controlled code running in that job could read the bot's push-capable token — a classic "pwn request" pattern.

Each workflow is now split into:
- an **untrusted prepare/test job** — no bot PAT, `persist-credentials: false` — that runs the untrusted code and produces a patch artifact (never a full checkout token)
- a separate **privileged push job** — re-verifies the PR head SHA hasn't moved, applies the patch (data only, no code execution), and only then uses the bot PAT to commit and push with git hooks disabled

Also:
- `permissions: {}` set at the workflow level, with minimal per-job grants
- User-supplied snapshot test paths (from the comment body) are now parsed with an anchored allowlist regex and checked for symlinks/traversal before being passed to `nf-test`
- Sentieon secrets are now only used for pull requests whose head branch is in `nf-core/modules` (fork PRs no longer get Sentieon credentials)

No change to the contributor-facing commands or reactions — `@nf-core-bot fix linting` / `update gpu snapshot path: ...` / `update sentieon snapshot path: ...` behave the same from a comment author's perspective.

### Testing

- YAML/workflow syntax validated
- Verified job `permissions:`/`needs:` graphs match the intended trust boundaries (untrusted jobs never hold the bot PAT; the push jobs never execute PR-controlled code)
- Could not exercise the `issue_comment` trigger itself outside GitHub, so please review the job structure carefully before merging — happy to iterate based on feedback.