### PR TITLE
fix(fastq_qc_trim_filter_setstrandedness): stop genome fasta channel leaking sample meta into Salmon index

### DIFF
--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -379,10 +379,6 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     // SUBWORKFLOW: Sub-sample FastQ files and pseudoalign with Salmon to auto-infer strandedness
     //
     // Return empty channel if ch_strand_fastq.auto_strand is empty so salmon index isn't created
-    //
-    // Wrapped in a singleton list because combine() splices list-valued items into the result;
-    // an unwrapped `[]` (no genome fasta supplied) would otherwise vanish and leave the sample
-    // meta map as `items[0]`.
     ch_fasta
         .map { fasta -> [fasta] }
         .combine(ch_strand_fastq.auto_strand)

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -379,10 +379,14 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     // SUBWORKFLOW: Sub-sample FastQ files and pseudoalign with Salmon to auto-infer strandedness
     //
     // Return empty channel if ch_strand_fastq.auto_strand is empty so salmon index isn't created
-
+    //
+    // Wrapped in a singleton list because combine() splices list-valued items into the result;
+    // an unwrapped `[]` (no genome fasta supplied) would otherwise vanish and leave the sample
+    // meta map as `items[0]`.
     ch_fasta
+        .map { fasta -> [fasta] }
         .combine(ch_strand_fastq.auto_strand)
-        .map { items -> items.first() }
+        .map { items -> items[0] }
         .first()
         .set { ch_genome_fasta }
 

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
@@ -502,6 +502,71 @@ nextflow_workflow {
         }
     }
 
+    test("auto strandedness - should infer strandedness when no genome fasta is supplied") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false, strandedness:'auto' ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true),
+                    ]
+                ])
+                input[1] = Channel.of([]) // ch_fasta: no genome fasta supplied (e.g. pseudoalignment-only run)
+                input[2] = Channel.of(file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/transcriptome.fasta", checkIfExists: true))
+                input[3] = Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true))
+                input[4] = []              // ch_salmon_index
+                input[5] = []              // ch_sortmerna_index
+                input[6] = []              // ch_bowtie2_index
+                input[7] = []              // ch_bbsplit_index
+                input[8] = []              // ch_rrna_fastas
+
+                // Skip options
+                input[9] = true            // skip_bbsplit
+                input[10] = true           // skip_fastqc
+                input[11] = true           // skip_trimming
+                input[12] = true           // skip_umi_extract
+                input[13] = true           // skip_linting
+
+                // Index generation
+                input[14] = true           // make_salmon_index
+                input[15] = false          // make_sortmerna_index
+                input[16] = false          // make_bowtie2_index
+
+                // Trimming options
+                input[17] = 'fastp'        // trimmer
+                input[18] = 10             // min_trimmed_reads
+                input[19] = false          // save_trimmed
+                input[20] = false          // fastp_merge
+
+                // rRNA removal options
+                input[21] = false          // remove_ribo_rna
+                input[22] = 'sortmerna'    // ribo_removal_tool
+
+                // UMI options
+                input[23] = false          // with_umi
+                input[24] = 0              // umi_discard_read
+
+                // Merging options
+                input[25] = false          // save_merged_fastq
+
+                // Strandedness thresholds
+                input[26] = 0.8            // stranded_threshold
+                input[27] = 0.1            // unstranded_threshold
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.reads[0][0].strandedness != 'auto' }
+            )
+        }
+    }
+
     test("homo_sapiens single-end [fastq] fastp bowtie2") {
 
         setup {


### PR DESCRIPTION
When no genome fasta is supplied (e.g. a pseudoalignment-only run with kallisto), `ch_fasta` carries the sentinel value `[]`. The subworkflow derives the fasta to use for auto-strandedness Salmon indexing with:

```groovy
ch_fasta
    .combine(ch_strand_fastq.auto_strand)
    .map { items -> items.first() }
    .first()
    .set { ch_genome_fasta }
```

`combine()` splices list-valued items into the result. An empty list contributes zero elements, so `items.first()` resolves to the sample meta map from `ch_strand_fastq.auto_strand` instead of the fasta. That meta map then reaches `SALMON_INDEX` as the `genome_fasta` path input, which fails with `Not a valid path value type: java.util.LinkedHashMap`. Reproduces for any sample with `strandedness: auto` when no genome fasta and no pre-built Salmon index are supplied.

Fix wraps `ch_fasta`'s value in a singleton list before combining, so `[]` survives as its own tuple element instead of being flattened away. This also gives the right behaviour downstream: `SALMON_INDEX` already treats a bare `[]` `genome_fasta` as "build a decoy-free, transcript-only index", which is what should happen when there's no genome fasta.

Added a regression test for auto strandedness with no genome fasta supplied.

Found via an nf-core/rnaseq user report.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Remove all TODO statements.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] `nf-test test subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test --profile docker`