### PR TITLE
Use canonical dotseq test data path

### DIFF
--- a/modules/nf-core/dotseq/dotseq/tests/dou_only.config
+++ b/modules/nf-core/dotseq/dotseq/tests/dou_only.config
@@ -1,5 +1,3 @@
-includeConfig './nextflow.config'
-
 process {
     withName: 'DOTSEQ_DOTSEQ' {
         ext.args = '--modules DOU'

--- a/modules/nf-core/dotseq/dotseq/tests/main.nf.test
+++ b/modules/nf-core/dotseq/dotseq/tests/main.nf.test
@@ -3,7 +3,6 @@ nextflow_process {
     name "Test Process DOTSEQ_DOTSEQ"
     script "../main.nf"
     process "DOTSEQ_DOTSEQ"
-    config "./nextflow.config"
 
     tag "modules"
     tag "modules_nfcore"

--- a/modules/nf-core/dotseq/dotseq/tests/nextflow.config
+++ b/modules/nf-core/dotseq/dotseq/tests/nextflow.config
@@ -1,6 +1,0 @@
-// TEMPORARY: point at the test-datasets PR branch until
-// https://github.com/nf-core/test-datasets/pull/2072 merges.
-// Revert this block once the canonical `modules` branch carries the fixtures.
-params {
-    modules_testdata_base_path = 'https://raw.githubusercontent.com/pinin4fjords/test-datasets/add-dotseq-testdata/data/'
-}

--- a/modules/nf-core/dotseq/dotseq/tests/non_morf_main.config
+++ b/modules/nf-core/dotseq/dotseq/tests/non_morf_main.config
@@ -1,5 +1,3 @@
-includeConfig './nextflow.config'
-
 process {
     withName: 'DOTSEQ_DOTSEQ' {
         ext.args = '--orf_type_main_value canonical_cds'


### PR DESCRIPTION
#11742 should not have been merged before nf-core/test-datasets#2072 was finalised. It pointed dotseq/dotseq's tests at a fork branch instead of the canonical test-datasets fixtures. That PR has now merged, so this removes the fork override and the now-unused `tests/nextflow.config` file entirely, falling back to the default `modules_testdata_base_path`.