### PR TITLE
Improved the output document/image channels

### DIFF
--- a/modules/nf-core/bcftools/plotvcfstats/main.nf
+++ b/modules/nf-core/bcftools/plotvcfstats/main.nf
@@ -11,8 +11,10 @@ process BCFTOOLS_PLOTVCFSTATS {
     tuple val(meta), path(stats)
 
     output:
-    tuple val(meta), path("*plots*"), emit: plot_dir
-    tuple val(meta), path("*.pdf")  , emit: plot_pdf
+    tuple val(meta), path("${prefix}_plots"),             emit: plot_dir
+    tuple val(meta), path("${prefix}.plot-vcfstats.pdf"), optional:true, emit: plot_pdf
+    tuple val(meta), path("${prefix}_plots/*.pdf"),       optional:true, emit: images_pdf
+    tuple val(meta), path("${prefix}_plots/*.png"),       optional:true, emit: images_png
     tuple val("${task.process}"), val('bcftools'), eval("bcftools --version | sed '1!d; s/^.*bcftools //'"), topic: versions, emit: versions_bcftools
 
     when:
@@ -20,7 +22,7 @@ process BCFTOOLS_PLOTVCFSTATS {
 
     script:
     def args = task.ext.args ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
 
     // plot-vcfstats requires an output directory, so create one with the prefix
     // The PDF output is also copied to the results directory with a standard name
@@ -36,11 +38,14 @@ process BCFTOOLS_PLOTVCFSTATS {
         $args \\
         $stats
 
-    ln -s ${prefix}_plots/*.pdf ${prefix}.plot-vcfstats.pdf
+    if [ -e ${prefix}_plots/summary.pdf ]
+    then
+      mv ${prefix}_plots/summary.pdf ${prefix}.plot-vcfstats.pdf
+    fi
     """
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
 
     """
     mkdir ${prefix}_plots

--- a/modules/nf-core/bcftools/plotvcfstats/meta.yml
+++ b/modules/nf-core/bcftools/plotvcfstats/meta.yml
@@ -33,7 +33,7 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'sample1' ]
-      - "*plots*":
+      - ${prefix}_plots:
           type: directory
           description: Output directory containing plots, raw data, and log files
           pattern: "*plots*"
@@ -44,12 +44,36 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'sample1' ]
-      - "*.pdf":
+      - ${prefix}.plot-vcfstats.pdf:
           type: file
-          description: (Link to the original) summary output in PDF
+          description: Summary output in PDF
           pattern: "*.pdf"
           ontologies:
             - edam: "http://edamontology.org/format_3508"
+  images_pdf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'sample1' ]
+      - ${prefix}_plots/*.pdf:
+          type: file
+          description: All the individual PDF images generated (no summary PDF)
+          pattern: "*.pdf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3508"
+  images_png:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'sample1' ]
+      - ${prefix}_plots/*.png:
+          type: file
+          description: All the individual PNG images generated
+          pattern: "*.png"
+          ontologies:
+            - edam: "http://edamontology.org/format_3603"
   versions_bcftools:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/bcftools/plotvcfstats/tests/individual_pdf.config
+++ b/modules/nf-core/bcftools/plotvcfstats/tests/individual_pdf.config
@@ -1,0 +1,5 @@
+process {
+    withName: BCFTOOLS_PLOTVCFSTATS {
+        ext.args = '--no-PDF --vectors'
+    }
+}

--- a/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test
+++ b/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test
@@ -58,6 +58,37 @@ nextflow_process {
 
     }
 
+
+    test("sarscov2 - bcftools - only individual pdf") {
+        config "./individual_pdf.config"
+
+        when {
+            process {
+                """
+                input[0] = BCFTOOLS_STATS.out.stats
+                """
+            }
+
+        }
+
+
+        then {
+            def stable_name = getAllFilesFromDir(process.out.plot_dir.get(0).get(1), relative: true, includeDir: true )
+            def stable_data_output = getAllFilesFromDir(process.out.plot_dir.get(0).get(1), ignore: [ '*.{aux,tex,log,pdf,png}' ] )
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    stable_name,
+                    process.out.plot_pdf.collect { meta, files -> [meta, file(files).name] },
+                    process.out.images_pdf.collect { meta, files -> [meta, files.collect { file(it).name }] },
+                    process.out.images_png,
+                    stable_data_output,
+                    process.out.findAll { key, val -> key.startsWith("versions")}
+                ).match() }
+            )
+        }
+    }
+
     test("sarscov2 - bcftools - stub") {
 
         options "-stub"

--- a/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test
+++ b/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test
@@ -47,8 +47,8 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     stable_name,
-                    process.out.plot_pdf,
-                    process.out.images_pdf,
+                    process.out.plot_pdf.collect { meta, files -> [meta, file(files).name] },
+                    process.out.images_pdf.collect { meta, files -> [meta, file(files).name] },
                     process.out.images_png,
                     stable_data_output,
                     process.out.findAll { key, val -> key.startsWith("versions")}

--- a/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test
+++ b/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test
@@ -41,12 +41,15 @@ nextflow_process {
         }
 
         then {
-            def stable_name = getAllFilesFromDir(process.out.plot_dir.get(0).get(1), relative: true, includeDir: true, ignore: [ '*.{aux,tex,log,pdf}' ])
+            def stable_name = getAllFilesFromDir(process.out.plot_dir.get(0).get(1), relative: true, includeDir: true )
             def stable_data_output = getAllFilesFromDir(process.out.plot_dir.get(0).get(1), ignore: [ '*.{aux,tex,log,pdf,png}' ] )
             assertAll(
                 { assert process.success },
                 { assert snapshot(
                     stable_name,
+                    process.out.plot_pdf,
+                    process.out.images_pdf,
+                    process.out.images_png,
                     stable_data_output,
                     process.out.findAll { key, val -> key.startsWith("versions")}
                 ).match() }

--- a/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test.snap
@@ -136,5 +136,76 @@
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"
         }
+    },
+    "sarscov2 - bcftools - only individual pdf": {
+        "content": [
+            [
+                "",
+                "counts_by_af.indels.dat",
+                "counts_by_af.snps.dat",
+                "depth.0.dat",
+                "depth.0.pdf",
+                "depth.0.png",
+                "indels.0.dat",
+                "indels.0.pdf",
+                "indels.0.png",
+                "plot-vcfstats.log",
+                "plot.py",
+                "substitutions.0.pdf",
+                "substitutions.0.png",
+                "tstv_by_af.0.dat",
+                "tstv_by_qual.0.dat"
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        "depth.0.pdf",
+                        "indels.0.pdf",
+                        "substitutions.0.pdf"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        "depth.0.png:md5,763a6e9f8cad019ae3fee55afad9a16f",
+                        "indels.0.png:md5,5153a779d76aba6e6848b2c17989ead4",
+                        "substitutions.0.png:md5,8e509db6947f31eacfea03149fe2a3cc"
+                    ]
+                ]
+            ],
+            [
+                "counts_by_af.indels.dat:md5,82fae810b86c20ff99616c58ff3b3596",
+                "counts_by_af.snps.dat:md5,2d67d9037c0201912501da281e345719",
+                "depth.0.dat:md5,376f5fa0e18ad1bed94392f35a279622",
+                "indels.0.dat:md5,e7e57c9a2709bfd3a32e8800d18c8eac",
+                "plot.py:md5,bb53a182ed524897584174dcf1db10c0",
+                "tstv_by_af.0.dat:md5,a0720408cad0e871e95c121b1b660caf",
+                "tstv_by_qual.0.dat:md5,297e400d8c9e94b1c035719c4a015081"
+            ],
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_PLOTVCFSTATS",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-20T16:17:41.199836016",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test.snap
@@ -94,7 +94,7 @@
                     {
                         "id": "test"
                     },
-                    "test.plot-vcfstats.pdf:md5,58faa76b0ff1ec6abc331d28600fa1c1"
+                    "test.plot-vcfstats.pdf"
                 ]
             ],
             [
@@ -131,7 +131,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-20T16:32:02.122105031",
+        "timestamp": "2026-08-20T16:33:33.414111099",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/plotvcfstats/tests/main.nf.test.snap
@@ -21,11 +21,23 @@
                     ]
                 ],
                 "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
                     [
                         "BCFTOOLS_PLOTVCFSTATS",
                         "bcftools",
                         "1.23.1"
                     ]
+                ],
+                "images_pdf": [
+                    
+                ],
+                "images_png": [
+                    
                 ],
                 "plot_dir": [
                     [
@@ -54,10 +66,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-23T03:07:15.522329858",
+        "timestamp": "2026-08-20T16:32:13.417424519",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "sarscov2 - bcftools": {
@@ -70,10 +82,35 @@
                 "depth.0.png",
                 "indels.0.dat",
                 "indels.0.png",
+                "plot-vcfstats.log",
                 "plot.py",
                 "substitutions.0.png",
+                "summary.tex",
                 "tstv_by_af.0.dat",
                 "tstv_by_qual.0.dat"
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.plot-vcfstats.pdf:md5,58faa76b0ff1ec6abc331d28600fa1c1"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        "depth.0.png:md5,763a6e9f8cad019ae3fee55afad9a16f",
+                        "indels.0.png:md5,5153a779d76aba6e6848b2c17989ead4",
+                        "substitutions.0.png:md5,8e509db6947f31eacfea03149fe2a3cc"
+                    ]
+                ]
             ],
             [
                 "counts_by_af.indels.dat:md5,82fae810b86c20ff99616c58ff3b3596",
@@ -94,10 +131,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-23T03:06:57.656175973",
+        "timestamp": "2026-08-20T16:32:02.122105031",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     }
 }


### PR DESCRIPTION
1. `plot-vcfstats` doesn't always output this summary PDF. It's indeed skipped if the `-P` option is provided. So this channel must be made optional
2. When disabled, the interest is in getting the individual images that exist in the plots directory. For that, I'm adding two extra channels that emit all PNGs and PDFs found there (images can be in either format)

<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
