### PR TITLE
Support save_domtblout in fasta_hmmsearch_rank_fastas

### DIFF
--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/main.nf
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/main.nf
@@ -5,14 +5,15 @@ include { SEQTK_SUBSEQ    } from '../../../modules/nf-core/seqtk/subseq/main'
 workflow FASTA_HMMSEARCH_RANK_FASTAS {
 
     take:
-    ch_hmms  // channel: [ val(meta), file(hmm) ], i.e. a list of hmm profiles, each with its meta object
-    ch_fasta // channel: file(fasta), a single fasta file
+    ch_hmms         // channel: [ val(meta), file(hmm) ], i.e. a list of hmm profiles, each with its meta object
+    ch_fasta        // channel: file(fasta), a single fasta file
+    save_domtblout  // boolean: also write and emit hmmsearch's per-domain hit table (--domtblout)
 
     main:
 
     ch_hmms
         .combine(ch_fasta)
-        .map { index -> [ index[0], index[1], index[2], false, true, false ] }
+        .map { index -> [ index[0], index[1], index[2], false, true, save_domtblout ] }
         .set { ch_hmmsearch }
 
     HMMER_HMMSEARCH ( ch_hmmsearch )
@@ -43,6 +44,7 @@ workflow FASTA_HMMSEARCH_RANK_FASTAS {
     // SEQTK_SUBSEQ emits version as a topic channel
 
     emit:
-    hmmrank                 = HMMER_HMMRANK.out.hmmrank       // channel: [ [ id: 'rank' ], hmmrank_tsv ]
-    seqfastas               = SEQTK_SUBSEQ.out.sequences      // channel: [ meta, fasta ]
+    hmmrank                 = HMMER_HMMRANK.out.hmmrank             // channel: [ [ id: 'rank' ], hmmrank_tsv ]
+    seqfastas               = SEQTK_SUBSEQ.out.sequences            // channel: [ meta, fasta ]
+    domain_summary          = HMMER_HMMSEARCH.out.domain_summary    // channel: [ meta, domtbl ]
 }

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/meta.yml
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/meta.yml
@@ -21,6 +21,10 @@ input:
       type: file
       description: |
         The input channel containing sequences to be searched and ranked
+  - save_domtblout:
+      type: boolean
+      description: |
+        Whether hmmsearch should also write and emit its per-domain hit table (--domtblout)
 output:
   - hmmrank:
       type: file
@@ -34,6 +38,12 @@ output:
         Channel containing subsets of sequences
         Structure: [ val(meta), path(fasta) ]
       pattern: "*.fa.gz"
+  - domain_summary:
+      type: file
+      description: |
+        Channel containing hmmsearch's per-domain hit table, only present when save_domtblout is true
+        Structure: [ val(meta), path(domtbl) ]
+      pattern: "*.domtbl.gz"
 authors:
   - "@erikrikarddaniel"
 maintainers:

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test
@@ -40,6 +40,7 @@ nextflow_workflow {
                 """
                 input[0] = HMMER_HMMFETCH.out.hmm
                 input[1] = Channel.fromPath("https://raw.githubusercontent.com/nf-core/test-datasets/phyloplace/testdata/domain_16s.fna")
+                input[2] = false
                 """
             }
         }
@@ -48,6 +49,52 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(sanitizeOutput(workflow.out)).match() }
+            )
+        }
+    }
+
+    test("SSU rRNA - hmm/fasta - save_domtblout") {
+
+        setup {
+            run("HMMER_HMMFETCH") {
+                script "../../../../modules/nf-core/hmmer/hmmfetch/main.nf"
+                process {
+                    """
+                    input[0] = Channel.fromList([
+                        tuple([ id: 'arc16s' ], file("https://raw.githubusercontent.com/tseemann/barrnap/f843d17d39561eda7ce27cc43e3c6a8104aeb9ce/db/arc.hmm")),
+                        tuple([ id: 'bac16s' ], file("https://raw.githubusercontent.com/tseemann/barrnap/f843d17d39561eda7ce27cc43e3c6a8104aeb9ce/db/bac.hmm")),
+                        tuple([ id: 'euk18s' ], file("https://raw.githubusercontent.com/tseemann/barrnap/f843d17d39561eda7ce27cc43e3c6a8104aeb9ce/db/euk.hmm")),
+                        tuple([ id: 'mito12s' ], file("https://raw.githubusercontent.com/tseemann/barrnap/f843d17d39561eda7ce27cc43e3c6a8104aeb9ce/db/mito.hmm"))
+                    ])
+                    input[1] = Channel.of('16S_rRNA', '16S_rRNA', '18S_rRNA', '12S_rRNA')
+                    input[2] = []
+                    input[3] = []
+                    """
+                }
+            }
+        }
+
+        when {
+            workflow {
+                """
+                input[0] = HMMER_HMMFETCH.out.hmm
+                input[1] = Channel.fromPath("https://raw.githubusercontent.com/nf-core/test-datasets/phyloplace/testdata/domain_16s.fna")
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            // hmmsearch's --domtblout footer embeds the work directory path and a
+            // run timestamp, so its content (and gzip md5) is never reproducible
+            // across runs -- snapshot the filenames only, like fasta_newick_epang_gappa
+            // does for its own non-reproducible outputs.
+            def sanitized = sanitizeOutput(workflow.out)
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(sanitized.hmmrank).match("hmmrank") },
+                { assert snapshot(sanitized.seqfastas).match("seqfastas") },
+                { assert snapshot(workflow.out.domain_summary.collect { meta, domtbl -> [ meta, file(domtbl).name ] }.sort { it[0].id }).match("domain_summary_filenames") }
             )
         }
     }
@@ -76,6 +123,7 @@ nextflow_workflow {
                 """
                 input[0] = HMMER_HMMFETCH.out.hmm
                 input[1] = Channel.fromPath("https://raw.githubusercontent.com/nf-core/test-datasets/phyloplace/testdata/domain_16s.fna")
+                input[2] = false
                 """
             }
         }

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test.snap
@@ -1,7 +1,39 @@
 {
+    "seqfastas": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "arc16s"
+                    },
+                    "domain_16s.fnaarc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
+                ],
+                [
+                    {
+                        "id": "bac16s"
+                    },
+                    "domain_16s.fnabac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
+                ],
+                [
+                    {
+                        "id": "euk18s"
+                    },
+                    "domain_16s.fnaeuk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-21T18:11:11.258078897",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "LSU rRNA - hmm/fasta": {
         "content": [
             {
+                "domain_summary": [
+                    
+                ],
                 "hmmrank": [
                     [
                         {
@@ -15,15 +47,18 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-12T19:10:08.534716007",
+        "timestamp": "2026-08-21T16:52:52.353601704",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "SSU rRNA - hmm/fasta": {
         "content": [
             {
+                "domain_summary": [
+                    
+                ],
                 "hmmrank": [
                     [
                         {
@@ -54,10 +89,62 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-12T19:09:52.39032913",
+        "timestamp": "2026-08-21T16:52:27.022872526",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
+        }
+    },
+    "hmmrank": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "rank"
+                    },
+                    "rank.hmmrank.tsv.gz:md5,c9839df4d2ddbef1686ab52ed354ab87"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-21T18:11:11.249815077",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "domain_summary_filenames": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "arc16s"
+                    },
+                    "arc16s.domtbl.gz"
+                ],
+                [
+                    {
+                        "id": "bac16s"
+                    },
+                    "bac16s.domtbl.gz"
+                ],
+                [
+                    {
+                        "id": "euk18s"
+                    },
+                    "euk18s.domtbl.gz"
+                ],
+                [
+                    {
+                        "id": "mito12s"
+                    },
+                    "mito12s.domtbl.gz"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-21T18:11:11.296683107",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }


### PR DESCRIPTION
## PR checklist

Relates to https://github.com/nf-core/phyloplace/issues/69 (different repo, so this won't auto-close it)

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For subworkflows:
    - [x] `nf-core subworkflows test fasta_hmmsearch_rank_fastas --profile docker`
    - [ ] `nf-core subworkflows test fasta_hmmsearch_rank_fastas --profile singularity`
    - [ ] `nf-core subworkflows test fasta_hmmsearch_rank_fastas --profile conda`

## Description

Surfaced while adding `--save_domtblout` support to nf-core/phyloplace ([issue](https://github.com/nf-core/phyloplace/issues/69)).

`HMMER_HMMSEARCH` already supports writing a gzipped per-domain hit table (`write_domain` on its input tuple), but `fasta_hmmsearch_rank_fastas` hardcoded it to `false` with no way for a calling pipeline to turn it on. This adds `save_domtblout` as a `take:` parameter and emits the resulting `domain_summary` channel. `write_align` stays hardcoded `false` and `write_target` stays hardcoded `true` — nothing in this subworkflow needs those to be configurable, so kept the change minimal.

Note on the new test: hmmsearch's `--domtblout` footer embeds the work directory path and a run timestamp, so its content (and gzip md5) is never reproducible across runs. The new "save_domtblout" test snapshots `domain_summary` filenames only, the same pattern `fasta_newick_epang_gappa` already uses for its own non-reproducible outputs — verified stable across repeated non-`--update-snapshot` runs, not just recorded once.

Verified with `nf-core subworkflows lint` (clean) and `nf-test --profile=+docker`.
