### PR TITLE
Custom eigenvectotsv

### DIFF
--- a/modules/nf-core/custom/eigenvectotsv/environment.yml
+++ b/modules/nf-core/custom/eigenvectotsv/environment.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "conda-forge::gawk=5.3.0"

--- a/modules/nf-core/custom/eigenvectotsv/main.nf
+++ b/modules/nf-core/custom/eigenvectotsv/main.nf
@@ -1,0 +1,43 @@
+process CUSTOM_EIGENVECTOTSV {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/gawk:5.3.0' :
+        'quay.io/biocontainers/gawk:5.3.0' }"
+
+    input:
+    tuple val(meta), path(eigenvec)
+
+    output:
+    tuple val(meta), path("*.tsv"), emit: tsv
+    tuple val("${task.process}"), val('gawk'), eval("awk --version | head -1 | sed 's/GNU Awk //;s/,.*//'"), emit: versions_gawk, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    awk '
+    NR==1 {
+        sub(/^#/, "")
+        if (\$1 == "IID") {
+            \$1="sample_id"
+        }
+        print
+        next
+    }
+    {
+        print
+    }' OFS='\\t' ${args} ${eigenvec} > ${prefix}.tsv
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.tsv
+    """
+}

--- a/modules/nf-core/custom/eigenvectotsv/meta.yml
+++ b/modules/nf-core/custom/eigenvectotsv/meta.yml
@@ -1,0 +1,69 @@
+name: "custom_eigenvectotsv"
+description: Convert a PLINK2 .eigenvec file into a tab-separated file with a standardised sample_id column
+keywords:
+  - pca
+  - eigenvec
+  - plink2
+  - tsv
+  - conversion
+tools:
+  - "gawk":
+      description: "GNU implementation of the awk programming language"
+      homepage: "https://www.gnu.org/software/gawk/"
+      documentation: "https://www.gnu.org/software/gawk/manual/gawk.html"
+      licence:
+        - "GPL-3.0-or-later"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - eigenvec:
+        type: file
+        description: Eigenvector file produced by PLINK2 PCA (--pca), with header starting with '#FID IID PC1 ...'
+        pattern: "*.eigenvec"
+
+        ontologies: []
+output:
+  tsv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.tsv":
+          type: file
+          description: Tab-separated eigenvector file with the IID column renamed to sample_id
+          pattern: "*.tsv"
+
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  versions_gawk:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gawk:
+          type: string
+          description: The name of the tool
+      - awk --version | head -1 | sed 's/GNU Awk //;s/,.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gawk:
+          type: string
+          description: The name of the tool
+      - awk --version | head -1 | sed 's/GNU Awk //;s/,.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@dbaku42"
+maintainers:
+  - "@dbaku42"

--- a/modules/nf-core/custom/eigenvectotsv/tests/main.nf.test
+++ b/modules/nf-core/custom/eigenvectotsv/tests/main.nf.test
@@ -1,0 +1,55 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_EIGENVECTOTSV"
+    script "../main.nf"
+    process "CUSTOM_EIGENVECTOTSV"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "custom/eigenvectotsv"
+
+    test("homo_sapiens - test.eigenvec") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/clustering/test.eigenvec', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("homo_sapiens - test.eigenvec - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/popgen/clustering/test.eigenvec', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/custom/eigenvectotsv/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/eigenvectotsv/tests/main.nf.test.snap
@@ -1,0 +1,84 @@
+{
+    "homo_sapiens - test.eigenvec": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,5b512d0def803d9b95a204edec33cb34"
+                    ]
+                ],
+                "1": [
+                    [
+                        "CUSTOM_EIGENVECTOTSV",
+                        "gawk",
+                        "5.3.0"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,5b512d0def803d9b95a204edec33cb34"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "CUSTOM_EIGENVECTOTSV",
+                        "gawk",
+                        "5.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-22T11:42:49.21056296",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "homo_sapiens - test.eigenvec - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "CUSTOM_EIGENVECTOTSV",
+                        "gawk",
+                        "5.3.0"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "CUSTOM_EIGENVECTOTSV",
+                        "gawk",
+                        "5.3.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-22T11:42:53.045083812",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR extracts `EIGENVEC_TO_TSV` — currently an inline process inside the `snpclustering`
subworkflow (#11879) — into a standalone, reusable nf-core module: `custom/eigenvectotsv`.

The module converts the `.eigenvec` file produced by `plink2/pca` into a tab-separated file,
renaming the `IID` column to `sample_id` for downstream compatibility with the
`custom/pcaclustering`, `custom/clustermetrics`, and `custom/clustervisualization` modules
used later in the `snpclustering` pipeline.

Splitting this out as its own module:
- gives it dedicated nf-test coverage (content-level snapshot, not just filename checks),
  addressing the concern raised by @famosab in #11879 that subworkflow snapshots were only
  checking file names rather than content
- uses the current topic-channel convention for version reporting (`topic: versions`),
  consistent with the topic-based migration already underway in #11879
- allows it to be reused independently of the `snpclustering` subworkflow
