### PR TITLE
Update fastaguard to 0.7.0

### DIFF
--- a/modules/nf-core/fastaguard/environment.yml
+++ b/modules/nf-core/fastaguard/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fastaguard=0.6.0
+  - bioconda::fastaguard=0.7.0

--- a/modules/nf-core/fastaguard/main.nf
+++ b/modules/nf-core/fastaguard/main.nf
@@ -4,8 +4,8 @@ process FASTAGUARD {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastaguard:0.6.0--hfa8f182_0':
-        'quay.io/biocontainers/fastaguard:0.6.0--hfa8f182_0' }"
+        'https://depot.galaxyproject.org/singularity/fastaguard:0.7.0--hfa8f182_0':
+        'quay.io/biocontainers/fastaguard:0.7.0--hfa8f182_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/fastaguard/tests/main.nf.test.snap
+++ b/modules/nf-core/fastaguard/tests/main.nf.test.snap
@@ -38,7 +38,7 @@
                     [
                         "FASTAGUARD",
                         "fastaguard",
-                        "0.6.0"
+                        "0.7.0"
                     ]
                 ]
             }
@@ -88,7 +88,7 @@
                     [
                         "FASTAGUARD",
                         "fastaguard",
-                        "0.6.0"
+                        "0.7.0"
                     ]
                 ]
             }
@@ -138,7 +138,7 @@
                     [
                         "FASTAGUARD",
                         "fastaguard",
-                        "0.6.0"
+                        "0.7.0"
                     ]
                 ]
             }
@@ -188,7 +188,7 @@
                     [
                         "FASTAGUARD",
                         "fastaguard",
-                        "0.6.0"
+                        "0.7.0"
                     ]
                 ]
             }


### PR DESCRIPTION
Updates FASTAGUARD from 0.6.0 to 0.7.0 now that the Bioconda package and BioContainer are published.

The module command, four report outputs, arguments, and conventional exit behaviour are unchanged.

## PR checklist

- [x] This comment contains a description of the change and its reason.
- [x] Existing tests cover PASS, WARN, policy FAIL, and invalid FASTA reports.
- [x] The software version is broadcast to the versions topic.
- [x] Naming, inputs, outputs, and the process label remain unchanged.
- [x] The module uses the published Bioconda package and BioContainer.

Testing:

- [x] `nf-core modules lint fastaguard`
- [x] `nf-test test modules/nf-core/fastaguard/tests --profile=+docker --stop-on-first-failure`
- [x] `nf-test test modules/nf-core/fastaguard/tests --profile=+conda --stop-on-first-failure`
- [ ] Singularity test will run in CI.