### PR TITLE
sniffles: bump version 2.7.3 -> 2.8.0

### DIFF
--- a/modules/nf-core/sniffles/.conda-lock/linux_amd64-bd-c25a97c10afa095a_1.txt
+++ b/modules/nf-core/sniffles/.conda-lock/linux_amd64-bd-c25a97c10afa095a_1.txt
@@ -1,0 +1,631 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-64:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.2-py313hf6604e3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py313hd42f317_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/pysam-0.24.0-py313h4b224ce_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/pyspoa-0.3.2-py313h7fbb527_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hb101c97_101_cp313.conda
+- conda: https://conda.anaconda.org/bioconda/linux-64/python-edlib-1.3.9.post1-py313hcd54142_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/sniffles-2.8.0-pyhdfd78af_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+md5: a9f577daf3de00bca7c3c76c0ecbd1de
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28948
+timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+md5: e675fabcf81499adc7edf58124fb1e01
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 257808
+timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+md5: 3ad2b403be8fc5612b9159e2ce621f69
+depends:
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 228700
+timestamp: 1787169971173
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
+depends:
+- __unix
+license: ISC
+size: 131780
+timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+md5: 72a381cbad04f24b1c2a43ef707f45b4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 14459115
+timestamp: 1786545741408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
+md5: ba55d1b89fd7775e67de8291029b4059
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: LGPL-2.1-or-later
+size: 135295
+timestamp: 1786739238128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
+md5: 53318d715316929a574f83591308b1f8
+depends:
+- __glibc >=2.17,<3.0.a0
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=15
+- libstdcxx >=15
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1394333
+timestamp: 1786762112514
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+md5: 449500f2c089da11c40f5c21312e3e07
+depends:
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 745303
+timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+build_number: 9
+sha256: 39c7b3c5427b435c9c059ede9da61d46d42574e5b846ad37fdc3af4a5eab1e48
+md5: f5c4b041925dea221dc4bad2e50569d9
+depends:
+- libopenblas >=0.3.34,<0.3.35.0a0
+- libopenblas >=0.3.34,<1.0a0
+constrains:
+- blas 2.309   openblas
+- libcblas   3.11.0   9*_openblas
+- liblapack  3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+- mkl <2027
+license: BSD-3-Clause
+license_family: BSD
+size: 18033
+timestamp: 1786059035239
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+build_number: 9
+sha256: 4c532a70ea9aeff2fa1aabaa4828ebc00c2ed12b22aa8ba19da5302b882fc82b
+md5: 092c5649f3727af436ab0f67f48c3811
+depends:
+- libblas 3.11.0 9_h4a7cf45_openblas
+constrains:
+- blas 2.309   openblas
+- liblapack  3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 17998
+timestamp: 1786059041397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-ha042cf0_5.conda
+sha256: 0b6cc13e36cf19ae9b764740112fc591682e189c99353be9f72f3d96ccf29d79
+md5: 0ed167049513943d078a6c997df2b4e0
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=15
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.23.1,<0.24.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 484517
+timestamp: 1787183722915
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
+md5: 40f9b31aa9cf007789867df0decd0492
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 73710
+timestamp: 1785908694612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+md5: 50708d3b951d0f8e2d7f2df5b5edc040
+depends:
+- ncurses
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- ncurses >=6.6,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 135098
+timestamp: 1786616658086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+md5: 7bc31538d6e3fb349e897353969237ec
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-2-Clause OR GPL-2.0-or-later
+license_family: GPL
+size: 43220
+timestamp: 1785917328200
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+md5: b24d3c612f71e7aa74158d92106318b2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77856
+timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+md5: 0abe40a9880086ca4d2e5daf09dceff9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 67576
+timestamp: 1783520858222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_3.conda
+sha256: af35751596409fc1a1a81a32b7f1e195bca7f648dfe7c64f8ec4848b3a5003f8
+md5: c471b242d299f8bc1e2b3e0f6e9f4b77
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+constrains:
+- libgcc-ng ==16.1.0=*_3
+- libgomp 16.1.0 he0feb66_3
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1058775
+timestamp: 1787329503824
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_3.conda
+sha256: 0731a92037731af603b3653a67ffc98e07efc65765ebb603aa2e8fd1250ef21b
+md5: 3eae88e54adbd0448f865a74b2771192
+depends:
+- libgfortran5 16.1.0 h79bb938_3
+constrains:
+- libgfortran-ng ==16.1.0=*_3
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28260
+timestamp: 1787329533897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_3.conda
+sha256: 879e354ea894fe36c18160b000e35316cb3f196ff597f30dca209027ecf0fac2
+md5: 0f1c5c900eb7fbee86871c1f80dbccd3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=16.1.0
+constrains:
+- libgfortran 16.1.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2539158
+timestamp: 1787329516723
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_3.conda
+sha256: 5998d3e2ef3ffcae6cd794c87f12acdd7220e69f7685a8ccef3cd2c5f6252831
+md5: 593dc8ed1ed687d4ffff6b8d2fce9d9f
+depends:
+- __glibc >=2.17,<3.0.a0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 641537
+timestamp: 1787329444295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+build_number: 9
+sha256: ea989e2dabd21d296a5a4ec515e695645aefcdf778ffdb5eeea515421d243ab5
+md5: e51473c2b7e1f9cb61daafccfd912abf
+depends:
+- libblas 3.11.0 9_h4a7cf45_openblas
+constrains:
+- blas 2.309   openblas
+- libcblas   3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18021
+timestamp: 1786059046733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 112995
+timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+md5: fcfed1dc5053eb1901b66e7b1fc32588
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: BSD-2-Clause
+license_family: BSD
+size: 92759
+timestamp: 1786650399772
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+md5: 75d211f04ac87506f1f43420712a69fe
+depends:
+- __glibc >=2.17,<3.0.a0
+- c-ares >=1.34.8,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=15
+- libstdcxx >=15
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 649974
+timestamp: 1787177490105
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+sha256: 23392fc4f4e5ba230fcd1ef825878ba5ca7ee4f6259fac0cbb13299134b7bf7a
+md5: c282d68f272927612462b5d626838ef1
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.34,<0.3.35.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5952629
+timestamp: 1784287497473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+sha256: 09e8effdc89bc5d021349318d32b85594f5b8d8e3ab8f90a85b81f8fe695a566
+md5: 77be60417aa572afcb48cbe0f967401d
+depends:
+- libstdcxx >=15
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+license: MIT
+license_family: MIT
+size: 72519
+timestamp: 1786970753847
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+md5: e72bbec309c2b0f37823ee7d4fabfcd3
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=15
+- libzlib >=1.3.2,<2.0a0
+license: blessing
+size: 974348
+timestamp: 1787051145557
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+sha256: 7e463000fa1cba3f3a6597b776f6ab301d425a96e3bc20d0d9d76a3b9f237aa3
+md5: 5c526561e1d2a2e071941174eae84557
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 306045
+timestamp: 1786713107897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_3.conda
+sha256: 6e98c0283244b5f8bbc0e86f7cba4d4921136bfbabf8da42b898a7a1f10be949
+md5: 470d16b28d90ad4368df1aa5bc7ec18d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc 16.1.0 ha9f2e26_3
+constrains:
+- libstdcxx-ng ==16.1.0=*_3
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 6626421
+timestamp: 1787329526353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+md5: 01bb81d12c957de066ea7362007df642
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-3-Clause
+license_family: BSD
+size: 40017
+timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+md5: 0de0122d9570a8ab637c6b73db268389
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- zlib 1.3.2 *_3
+license: Zlib
+license_family: Other
+size: 63713
+timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+md5: ee6c0cd80a60961a1f48aa3e0b91f986
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 911196
+timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.2-py313hf6604e3_0.conda
+sha256: fa2d68708991da31e087b9a250ae8227c6b90b31d30b63a5c3d698b879d4b71a
+md5: 29a27a75bfa2f40221f1557dd5e14e65
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+- libblas >=3.9.0,<4.0a0
+- python_abi 3.13.* *_cp313
+- libcblas >=3.9.0,<4.0a0
+- liblapack >=3.9.0,<4.0a0
+constrains:
+- numpy-base <0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 9049057
+timestamp: 1786330627074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+md5: c5955c27917ff2234def47f075e71e02
+depends:
+- __glibc >=2.17,<3.0.a0
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3182423
+timestamp: 1785913583650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+sha256: 4ce2e1ee31a6217998f78c31ce7dc0a3e0557d9238b51d49dd20c52d467a126d
+md5: f2c23a77b25efcad57d377b34bd84941
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 593603
+timestamp: 1769710381284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py313hd42f317_1.conda
+sha256: 23a4931a85e82bd1cfd96267e68a663ee366ed61f5447829616cec38268c2146
+md5: 04b0a2e271f49b0463be6d57ae4c2b56
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- python_abi 3.13.* *_cp313
+license: BSD-3-Clause
+size: 228654
+timestamp: 1787417371911
+- conda: https://conda.anaconda.org/bioconda/linux-64/pysam-0.24.0-py313h4b224ce_1.conda
+sha256: b403d9bd3e323059947f46b49f8fd089c9ef3f8fc0e7ae289a0300510945d48b
+md5: e4c65716cd3a0396374338903f76ca18
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- liblzma >=5.8.3,<6.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- python >=3.13,<3.14.0a0
+- python_abi 3.13.* *_cp313
+license: MIT
+size: 3834397
+timestamp: 1781872972695
+- conda: https://conda.anaconda.org/bioconda/linux-64/pyspoa-0.3.2-py313h7fbb527_1.conda
+sha256: aff751dddf410cd725de3835d7f930c2e32723526df9c09fd2cf2d1b0ce6d813
+md5: 8705f2aa9de91101864c9b24ad950125
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- python >=3.13,<3.14.0a0
+- python_abi 3.13.* *_cp313
+license: MIT
+license_family: MIT
+size: 146607
+timestamp: 1772013275814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hb101c97_101_cp313.conda
+build_number: 101
+sha256: b7c23d7446502a267f341b27e6820d5e2d53e78c61e721f4af713168ee544cb2
+md5: ad58731521aa42f9e70f3fc6c898e134
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- ld_impl_linux-64 >=2.36.1
+- libexpat >=2.8.1,<3.0a0
+- libffi >=3.7.0,<3.8.0a0
+- libgcc >=14
+- liblzma >=5.8.3,<6.0a0
+- libmpdec >=4.0.0,<5.0a0
+- libsqlite >=3.53.4,<4.0a0
+- libuuid >=2.42.2,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- ncurses >=6.6,<7.0a0
+- openssl >=3.5.7,<4.0a0
+- python_abi 3.13.* *_cp313
+- readline >=8.3,<9.0a0
+- tk >=8.6.13,<8.7.0a0
+- tzdata
+license: Python-2.0
+size: 37485991
+timestamp: 1786368232136
+python_site_packages_path: lib/python3.13/site-packages
+- conda: https://conda.anaconda.org/bioconda/linux-64/python-edlib-1.3.9.post1-py313hcd54142_3.conda
+sha256: 923be61f592f597f4437ee77550a8e9e76d45b2bdefca919939652cd05175c5f
+md5: 42cc77fe56226242b681c44d974b1692
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- python >=3.13,<3.14.0a0
+- python_abi 3.13.* *_cp313
+license: MIT
+license_family: MIT
+size: 81269
+timestamp: 1772444328561
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+build_number: 8
+sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
+md5: 94305520c52a4aa3f6c2b1ff6008d9f8
+constrains:
+- python 3.13.* *_cp313
+license: BSD-3-Clause
+license_family: BSD
+size: 7002
+timestamp: 1752805902938
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+md5: 69c01c781e7c8190bbdaf79e3848c5ca
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- ncurses >=6.6,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 348899
+timestamp: 1787033801506
+- conda: https://conda.anaconda.org/bioconda/noarch/sniffles-2.8.0-pyhdfd78af_1.conda
+sha256: 94528711db2156b41785322f9971b7d3ab6eec171f939d9a73ca4f7f7badeefb
+md5: cb759b87e4a52bae0296a1f52b400be0
+depends:
+- numpy >=2.2.0
+- psutil >=5.9.4
+- pysam >=0.21.0
+- pyspoa >=0.2.1
+- python >=3.10,<3.14
+- python-edlib >=1.3.9
+license: MIT
+license_family: MIT
+size: 74309
+timestamp: 1787327597721
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+build_number: 104
+sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+depends:
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3566806
+timestamp: 1787272857910
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+sha256: 2bf9a40d86d29fd5c30d0febec99d06398143ddeece9ebb175cc5a6d20279943
+md5: f16d4aec5e8135e8e7bba02ef600149e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 38560
+timestamp: 1779439547766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+md5: aa459086047c0e5e27023ab19f8cb86a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.2,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 601301
+timestamp: 1786599621503

--- a/modules/nf-core/sniffles/.conda-lock/linux_arm64-bd-5574c3aedf697468_1.txt
+++ b/modules/nf-core/sniffles/.conda-lock/linux_arm64-bd-5574c3aedf697468_1.txt
@@ -1,0 +1,592 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-aarch64:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-h29ee22c_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-py311h3512406_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h5bc82ec_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h095d8e5_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-9_haddc8a3_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-9_hd72aa62_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h86273da_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-hfa851ae_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321hc48eb74_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h80f16a2_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.1.0-h205dda4_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.1.0-he9431aa_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.1.0-h47adacf_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.1.0-h8acb6b2_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-9_h88aeb00_openblas.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-ha4b982d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.34-pthreads_h9d3fd7e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.23.1-hb8431ed_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.4-h399dd60_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h7572e3e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-16.1.0-hef695bb_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-h2b6f883_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.5.2-py313h839dfd1_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py313he745173_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/pysam-0.24.0-py313h24b3ded_1.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/pyspoa-0.3.2-py313h30571f8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.15-hfc9013d_101_cp313.conda
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/python-edlib-1.3.9.post1-py313haca9121_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-ha7194a6_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/sniffles-2.8.0-pyhdfd78af_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_hf03c496_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h9d15635_7.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: a2527b1d81792a0ccd2c05850960df119c2b6d8f5fdec97f2db7d25dc23b1068
+md5: 468fd3bb9e1f671d36c2cbc677e56f1d
+depends:
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 28926
+timestamp: 1770939656741
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
+sha256: 24eacc8a20fd7c4616566178562bef7f9344eb4a8700cfc3180fa75a6ff9d39f
+md5: fd544ef1c672d645bf78e5819cbb8f91
+depends:
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 194694
+timestamp: 1785906301397
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-h29ee22c_2.conda
+sha256: 3838d10a78c206a1a4ec7ff041880b4f9b8ecde3520c911daae9e06baeb8858e
+md5: eb80eb38625b8552a099aa88f8ba5db7
+depends:
+- libgcc >=15
+license: MIT
+license_family: MIT
+size: 241210
+timestamp: 1787169968125
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
+depends:
+- __unix
+license: ISC
+size: 131780
+timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-py311h3512406_2.conda
+sha256: 54d921defd947adb58a90e10203d3bfe6c1f209f5f1a1ad2c6a9f7617f2fb59e
+md5: b35bbb1b957440ed742f35fb96eb7f1c
+depends:
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 14688525
+timestamp: 1786545779464
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.3-h5bc82ec_1.conda
+sha256: 3999b1472f1e549a0b766428e2823abf20626aac5314b474c9b76bf6eb679def
+md5: 6d9be306ecb8dfc9ff46f02cb367d5c2
+depends:
+- libgcc >=15
+license: LGPL-2.1-or-later
+size: 129546
+timestamp: 1786739205968
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.22.2-h095d8e5_2.conda
+sha256: 601d79af94d9562ba70e2d4947034ba159aae293a3c860855335a7c76c14400e
+md5: a4d0da122ba952abf76981e76d0d283c
+depends:
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=15
+- libstdcxx >=15
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1538590
+timestamp: 1786762058856
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.46.1-default_h1979696_102.conda
+sha256: 2c4901f4227b0850328ed0c69f958b30ad2cd18982f7a31c7c1f911827004d08
+md5: 489444d0acb2a579d2a002d85a08c059
+depends:
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-aarch64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 905305
+timestamp: 1784214534868
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.11.0-9_haddc8a3_openblas.conda
+build_number: 9
+sha256: 5ad8fda537086a842379b7eb8d67770674e3c3afa66b09690ed62b54439fc227
+md5: c2d360534e0377666eaf8f86e605511c
+depends:
+- libopenblas >=0.3.34,<0.3.35.0a0
+- libopenblas >=0.3.34,<1.0a0
+constrains:
+- blas 2.309   openblas
+- libcblas   3.11.0   9*_openblas
+- liblapack  3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+- mkl <2027
+license: BSD-3-Clause
+license_family: BSD
+size: 18024
+timestamp: 1786058936290
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.11.0-9_hd72aa62_openblas.conda
+build_number: 9
+sha256: 9e83c59429296818e7111a9f80f29c2c8a1e5ab9ae2d59aec8e67af9b87ac923
+md5: 1ff91e2252ca15db87a27b7b3ff280ae
+depends:
+- libblas 3.11.0 9_haddc8a3_openblas
+constrains:
+- blas 2.309   openblas
+- liblapack  3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 17977
+timestamp: 1786058941306
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.21.0-h86273da_5.conda
+sha256: d7bc660680aee2ce4011779bdfc00b3f8d0c98acf503aa2982874d81b075ff66
+md5: c2c977033fa833d7f1f83bb34dd52717
+depends:
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=15
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.23.1,<0.24.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 508109
+timestamp: 1787183657716
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.25-hfa851ae_1.conda
+sha256: 4cb3da1d4ce7540604219d2a016253777da66c1a710c41557bc708aae7f54a75
+md5: 8cdf7f7e4908c9b2cf50c58966f2ff64
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 71628
+timestamp: 1785908730449
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20250104-pl5321hc48eb74_1.conda
+sha256: 2d7218da06f1121619335bff25a2669df810dee90d2eb65b17f8b2e6b1c0d372
+md5: 6e06eb2c9fda76721699bcdd759b9c60
+depends:
+- ncurses
+- libgcc >=14
+- ncurses >=6.6,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 149007
+timestamp: 1786616643904
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h80f16a2_3.conda
+sha256: 4475f79a020e9ff2a5a0308c48cb2970a25d55c3dd724a97ab28bfac3be6cd49
+md5: f679b30a53d410d0b5ae0cb8f5b7397e
+depends:
+- libgcc >=14
+license: BSD-2-Clause OR GPL-2.0-or-later
+license_family: GPL
+size: 45746
+timestamp: 1785917328690
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
+sha256: 20a5726bc8705d91437c9e6ef83b30da64a1719b869656d20a1ee818333ea5ac
+md5: fac3b65a605cd253037fdf3daf2de8d9
+depends:
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77649
+timestamp: 1781203572523
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
+sha256: c95b5b5fc13c8d7af2a9908e6c64844f48787a7631f8abcde1813dc21b3b079e
+md5: 81aedbde3ea118c602e8b289bf565ac5
+depends:
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 63746
+timestamp: 1783520889209
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.1.0-h205dda4_3.conda
+sha256: ad3e68e37bf667dc651431fc66fe63624befeb6a418efe33d867a5bdd541ed77
+md5: 3a001a2a07adb1ff35344c8f0749fe32
+depends:
+- _openmp_mutex >=4.5
+constrains:
+- libgcc-ng ==16.1.0=*_3
+- libgomp 16.1.0 h8acb6b2_3
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 627715
+timestamp: 1787329377564
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.1.0-he9431aa_3.conda
+sha256: 656191422862d4dca08474a9d8a23041b20109cc2451e8d91107b51856133751
+md5: ca3a1d1e9664a78c55a807f4a15fe142
+depends:
+- libgfortran5 16.1.0 h47adacf_3
+constrains:
+- libgfortran-ng ==16.1.0=*_3
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28362
+timestamp: 1787329402353
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.1.0-h47adacf_3.conda
+sha256: d86b8422102e4447d4a18bd195da32f95ce96347a79f9b5ddf7d63cbaf98a63a
+md5: 7195cf7a8c6590069822ea5cdd466b5a
+depends:
+- libgcc >=16.1.0
+constrains:
+- libgfortran 16.1.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1495247
+timestamp: 1787329387532
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.1.0-h8acb6b2_3.conda
+sha256: bda451d8c75b086d24c5b9c3f69c2f8d2432df0b6d5a1a42654d82e18b4be078
+md5: 125a83ce4446132c8a34c0542c723b97
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 617657
+timestamp: 1787329311974
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.11.0-9_h88aeb00_openblas.conda
+build_number: 9
+sha256: 562077bf38f962f6b80ec4e021bd2328f603ce0b112d3045b3f3b37f1a110f73
+md5: c560d88ddee90ba4120ac63eda69fbee
+depends:
+- libblas 3.11.0 9_haddc8a3_openblas
+constrains:
+- blas 2.309   openblas
+- libcblas   3.11.0   9*_openblas
+- liblapacke 3.11.0   9*_openblas
+license: BSD-3-Clause
+license_family: BSD
+size: 18007
+timestamp: 1786058945578
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblzma-5.8.3-he30d5cf_1.conda
+sha256: f760669fd1cea27f689f411c0d5488e26ce50e382c9b63e4ad348f959850124a
+md5: e0e6411a60d00186eec7c73f4118ab67
+depends:
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 125578
+timestamp: 1786348561649
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libmpdec-4.0.0-he30d5cf_2.conda
+sha256: 5d6621a2229777824386164b40c67ff804fe98dd4165354cf73ee73e282a2adf
+md5: eaaaec4776cd8a7b987c4b1782220141
+depends:
+- libgcc >=14
+license: BSD-2-Clause
+license_family: BSD
+size: 113885
+timestamp: 1786650485380
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.68.1-ha4b982d_1.conda
+sha256: 0c28d734512fa2c66a232b2f3968eae7124dbd6ad42c594c752f1d08dfb86195
+md5: ff4b2b7c169c438bf648fb14f369c3b9
+depends:
+- c-ares >=1.34.8,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=15
+- libstdcxx >=15
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 734829
+timestamp: 1787177407983
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.34-pthreads_h9d3fd7e_0.conda
+sha256: 0905b8acaff83558e5007351b2de329ce212ef5acbd595fcc22bb7fa1592f277
+md5: c37ba01d9ab7bfaf5f5dddc5d8807454
+depends:
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+constrains:
+- openblas >=0.3.34,<0.3.35.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 5332045
+timestamp: 1784287139395
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpsl-0.23.1-hb8431ed_1.conda
+sha256: 757f79c182ac3080cf416acd91c7643b8074b8b2e5c1eba0ffc5a16897feb84b
+md5: 5ab41e5e70b78eb00ef62cdaa35cd86f
+depends:
+- libgcc >=15
+- libstdcxx >=15
+- icu >=78.3,<79.0a0
+license: MIT
+license_family: MIT
+size: 73118
+timestamp: 1786970733378
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.53.4-h399dd60_1.conda
+sha256: fae75e68e9dbc3c90dcf93d4bae6315f1330c95aaf1404a721e8468266c23475
+md5: 27e16aa1f45c787aa181549be6f209f4
+depends:
+- icu >=78.3,<79.0a0
+- libgcc >=15
+- libzlib >=1.3.2,<2.0a0
+license: blessing
+size: 972932
+timestamp: 1787051100646
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.1-h7572e3e_1.conda
+sha256: f6fef76c1c8899d7976030871b8cd8016b0a306d2b8519834cd6491d6a42fb82
+md5: 833be3f226277d894df3c7a7131d9532
+depends:
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 315682
+timestamp: 1786713068743
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-16.1.0-hef695bb_3.conda
+sha256: f54d8084dcb9f964a9a802114120fdba21b47efb472e495025621b8c529cea8b
+md5: 6bf7491911c80f4bb8dc1ce0106407b2
+depends:
+- libgcc 16.1.0 h205dda4_3
+constrains:
+- libstdcxx-ng ==16.1.0=*_3
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 6257391
+timestamp: 1787329395590
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.42.2-h1022ec0_0.conda
+sha256: 7663489f97c104ae3814db10f384932c74b439f3c1fd4247e4fe3599830c090a
+md5: 58fa42bc4bc71fc329889497ec15effb
+depends:
+- libgcc >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 43248
+timestamp: 1781625528371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_3.conda
+sha256: 76efa6cc9d7e6f5ee3bbca0939f64054af2bdfb3c3632531f8e633cf6c2ea41e
+md5: bd534c2fbe56d8c2ea3b2d8f5e12bca8
+constrains:
+- zlib 1.3.2 *_3
+license: Zlib
+license_family: Other
+size: 70108
+timestamp: 1785276540870
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-h2b6f883_1.conda
+sha256: d69a04914139627f0a6bfd19412d6c7f1e37edc896af84a6011e07e8bc1e69fa
+md5: c3b4349171ca987ff33a1de61f7b3f96
+depends:
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 955422
+timestamp: 1786355019431
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.5.2-py313h839dfd1_0.conda
+sha256: 9c0820c96567f9d47dd593387be0264d6da117f0a133f40fb1bd75e35d8d4648
+md5: 768817f53422960199166ff6dd23f753
+depends:
+- python
+- libstdcxx >=14
+- libgcc >=14
+- libblas >=3.9.0,<4.0a0
+- libcblas >=3.9.0,<4.0a0
+- python_abi 3.13.* *_cp313
+- liblapack >=3.9.0,<4.0a0
+constrains:
+- numpy-base <0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 8123647
+timestamp: 1786330618186
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_1.conda
+sha256: c89e748e8a008e8ca6f25e102362f33319db0c98cc29d98ddada92842f636327
+md5: 1600dfde78c5adba306f8571af62a323
+depends:
+- ca-certificates
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 3719270
+timestamp: 1785913554920
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/procps-ng-4.0.6-h1779866_0.conda
+sha256: e9cbcbc94e151ada3d6dc365380aaaf591f65012c16d9a2abaea4b9b90adc402
+md5: ab7288cc39545556d1bc5e71ab2df9a9
+depends:
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 636733
+timestamp: 1769712412683
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py313he745173_1.conda
+sha256: 54de70c43ad2e331f785246bf22861d3d414b61e3fe8d31eb621839962d4da56
+md5: f4bef8caa5f09035da754d9303f456e6
+depends:
+- python
+- libgcc >=15
+- python_abi 3.13.* *_cp313
+license: BSD-3-Clause
+size: 229742
+timestamp: 1787417371661
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/pysam-0.24.0-py313h24b3ded_1.conda
+sha256: 4ec5e0181de85caca3961a409a6dd84adfdead17ed093a06463f9ee41c0e887f
+md5: e87b6605f0ac876149a7e2f639fc3810
+depends:
+- bzip2 >=1.0.8,<2.0a0
+- libcurl >=8.20.0,<9.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=14
+- liblzma >=5.8.3,<6.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- python >=3.13,<3.14.0a0
+- python_abi 3.13.* *_cp313
+license: MIT
+size: 3789602
+timestamp: 1781872635431
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/pyspoa-0.3.2-py313h30571f8_1.conda
+sha256: 351d199edcc5456d13c0ec6001580923eaee821865295e167c54a92ce5c31722
+md5: 969434ef3c81d2f2754c8216eeb30f5b
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+- python >=3.13,<3.14.0a0
+- python_abi 3.13.* *_cp313
+license: MIT
+license_family: MIT
+size: 144124
+timestamp: 1772011987929
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.15-hfc9013d_101_cp313.conda
+build_number: 101
+sha256: e9bfbf0a71037b637e62800bffa69f3d485285bdba60afff02db907a1118dada
+md5: d5e68eac5e0c5dd3cc13daa2233dfcbc
+depends:
+- bzip2 >=1.0.8,<2.0a0
+- ld_impl_linux-aarch64 >=2.36.1
+- libexpat >=2.8.1,<3.0a0
+- libffi >=3.7.0,<3.8.0a0
+- libgcc >=14
+- liblzma >=5.8.3,<6.0a0
+- libmpdec >=4.0.0,<5.0a0
+- libsqlite >=3.53.4,<4.0a0
+- libuuid >=2.42.2,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- ncurses >=6.6,<7.0a0
+- openssl >=3.5.7,<4.0a0
+- python_abi 3.13.* *_cp313
+- readline >=8.3,<9.0a0
+- tk >=8.6.13,<8.7.0a0
+- tzdata
+license: Python-2.0
+size: 35577508
+timestamp: 1786368204307
+python_site_packages_path: lib/python3.13/site-packages
+- conda: https://conda.anaconda.org/bioconda/linux-aarch64/python-edlib-1.3.9.post1-py313haca9121_3.conda
+sha256: 8a079243a5e21877e12bd2dbac3c53a7939fda49392c39de99dced4e70a1e1ee
+md5: 193916beba43e34fb64339bd07d8d10b
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- python >=3.13,<3.14.0a0
+- python_abi 3.13.* *_cp313
+license: MIT
+license_family: MIT
+size: 79362
+timestamp: 1772444272309
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+build_number: 8
+sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
+md5: 94305520c52a4aa3f6c2b1ff6008d9f8
+constrains:
+- python 3.13.* *_cp313
+license: BSD-3-Clause
+license_family: BSD
+size: 7002
+timestamp: 1752805902938
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-ha7194a6_1.conda
+sha256: 80167dcf73a96b6d0c1bb2298d7b8b9bc21b27cc5bf56979f9c548b49a4d1722
+md5: 5b399a7afa10098f2a6b02263181426e
+depends:
+- libgcc >=15
+- ncurses >=6.6,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 364344
+timestamp: 1787033761576
+- conda: https://conda.anaconda.org/bioconda/noarch/sniffles-2.8.0-pyhdfd78af_1.conda
+sha256: 94528711db2156b41785322f9971b7d3ab6eec171f939d9a73ca4f7f7badeefb
+md5: cb759b87e4a52bae0296a1f52b400be0
+depends:
+- numpy >=2.2.0
+- psutil >=5.9.4
+- pysam >=0.21.0
+- pyspoa >=0.2.1
+- python >=3.10,<3.14
+- python-edlib >=1.3.9
+license: MIT
+license_family: MIT
+size: 74309
+timestamp: 1787327597721
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_hf03c496_4.conda
+build_number: 104
+sha256: a1aa0d0f0b3d539644ff992e6dd0facf950c79df58fc37590ce5be84ff5e3f22
+md5: ebaded4b4b74c2cc43a754ded4eed76f
+depends:
+- libgcc >=15
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3664220
+timestamp: 1787272859143
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/which-2.25-hdc560ac_0.conda
+sha256: 720691eb59b86f11ceb21b236b9402d59c47d156183375d2b24c53a201dd874b
+md5: 6dc4b55fc391a3d51ff12a6fed979562
+depends:
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 40249
+timestamp: 1779439555623
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h9d15635_7.conda
+sha256: 427fd14bcb3b8659796fecc682716617409350fb5a98e5b7b47558a10d1a2fc7
+md5: d942e34ac3920ba83f8b2d0169570187
+depends:
+- libzlib >=1.3.2,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 615477
+timestamp: 1786599613561

--- a/modules/nf-core/sniffles/environment.yml
+++ b/modules/nf-core/sniffles/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sniffles=2.7.3
+  - bioconda::sniffles=2.8.0

--- a/modules/nf-core/sniffles/main.nf
+++ b/modules/nf-core/sniffles/main.nf
@@ -3,9 +3,9 @@ process SNIFFLES {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/73/73397171642c8f96d79b94a16d5142eee4b389473aba7a04ca4493e62aa6e4ac/data' :
-        'community.wave.seqera.io/library/sniffles:2.7.3--4d6ef29e260d91be' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+?         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a3/a392a64ae046bd1b8679f2ae590f88d84fed26d569ab70810df969741722dbcc/data'
+:         'community.wave.seqera.io/library/sniffles:2.8.0--c25a97c10afa095a' }"
 
     input:
     tuple val(meta), path(input), path(index)

--- a/modules/nf-core/sniffles/meta.yml
+++ b/modules/nf-core/sniffles/meta.yml
@@ -21,9 +21,7 @@ input:
           e.g. [ id:'test' ]
     - input:
         type: file
-        description: A single .bam/.cram file - OR - one or more .snf files - OR -
-          a single .tsv file containing a list of .snf files and optional sample
-          ids as input
+        description: A single .bam/.cram file - OR - one or more .snf files - OR - a single .tsv file containing a list of .snf files and optional sample ids as input
         pattern: "*.{bam,cram,snf,tsv}"
         ontologies:
           - edam: http://edamontology.org/format_3475
@@ -125,3 +123,27 @@ maintainers:
   - "@christopher-hakkaart"
   - "@yuukiiwa"
   - "@fellen31"
+containers:
+  docker:
+    linux/amd64:
+      name: community.wave.seqera.io/library/sniffles:2.8.0--c25a97c10afa095a
+      build_id: bd-c25a97c10afa095a_1
+      scan_id: sc-1ed8ecc96bfef818_1
+    linux/arm64:
+      name: community.wave.seqera.io/library/sniffles:2.8.0--5574c3aedf697468
+      build_id: bd-5574c3aedf697468_1
+      scan_id: sc-991b8341772825a8_1
+  singularity:
+    linux/arm64:
+      name: oras://community.wave.seqera.io/library/sniffles:2.8.0--2f9e9de84854e212
+      build_id: bd-2f9e9de84854e212_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/54/5442fefaf2312352bfc30a28db3189f6065bdaff622e235305cd7e4142323f0a/data
+    linux/amd64:
+      name: oras://community.wave.seqera.io/library/sniffles:2.8.0--78237e804565135a
+      build_id: bd-78237e804565135a_1
+      https: https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a3/a392a64ae046bd1b8679f2ae590f88d84fed26d569ab70810df969741722dbcc/data
+  conda:
+    linux/amd64:
+      lock_file: modules/nf-core/sniffles/.conda-lock/linux_amd64-bd-c25a97c10afa095a_1.txt
+    linux/arm64:
+      lock_file: modules/nf-core/sniffles/.conda-lock/linux_arm64-bd-5574c3aedf697468_1.txt

--- a/modules/nf-core/sniffles/tests/main.nf.test.snap
+++ b/modules/nf-core/sniffles/tests/main.nf.test.snap
@@ -30,16 +30,16 @@
                     [
                         "SNIFFLES",
                         "sniffles",
-                        "2.7.3"
+                        "2.8.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-08-23T19:30:26.36794",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-20T09:49:13.462734483"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "homo_sapiens - [bam, bai], fasta, [], true, false": {
         "content": [
@@ -48,14 +48,14 @@
                     [
                         "SNIFFLES",
                         "sniffles",
-                        "2.7.3"
+                        "2.8.0"
                     ]
                 ]
             },
             "test.vcf.gz.tbi",
             [
                 "##fileformat=VCFv4.2",
-                "##source=Sniffles2_2.7.3"
+                "##source=Sniffles2_2.8.0"
             ],
             [
                 "##ALT=<ID=INS,Description=\"Insertion\">",
@@ -94,6 +94,9 @@
                 "##FILTER=<ID=SVLEN_MIN_MOSAIC,Description=\"SV length filter for mosaic SVs (min)\">",
                 "##FILTER=<ID=SVLEN_MAX_MOSAIC,Description=\"SV length filter for mosaic SVs (max)\">",
                 "##FILTER=<ID=SINGLE_BREAK,Description=\"A single break point was detected but not classified as an SV.\">",
+                "##FILTER=<ID=INLINE_SA,Description=\"INLINE/CIGAR-based SV is mostly supported by SA reads\">",
+                "##FILTER=<ID=MOSAIC_SV_CLOSE_EDGE,Description=\"For mosaic SVs, the location is close to the end of the read (either end)\">",
+                "##FILTER=<ID=GT_FAILED,Description=\"Sniffles was unable to genotype this call.\">",
                 "##INFO=<ID=PRECISE,Number=0,Type=Flag,Description=\"Structural variation with precise breakpoints\">",
                 "##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description=\"Structural variation with imprecise breakpoints\">",
                 "##INFO=<ID=MOSAIC,Number=0,Type=Flag,Description=\"Structural variation classified as putative mosaic\">",
@@ -113,17 +116,14 @@
                 "##INFO=<ID=SUPP_VEC,Number=1,Type=String,Description=\"List of read support for all samples\">",
                 "##INFO=<ID=CONSENSUS_SUPPORT,Number=1,Type=Integer,Description=\"Number of reads that support the generated insertion (INS) consensus sequence\">",
                 "##INFO=<ID=RNAMES,Number=.,Type=String,Description=\"Names of supporting reads (if enabled with --output-rnames)\">",
-                "##INFO=<ID=VAF,Number=1,Type=Float,Description=\"Variant Allele Fraction\">",
-                "##INFO=<ID=COVERAGE_VAR,Number=1,Type=Float,Description=\"Variance of coverage across large events\">",
-                "##INFO=<ID=NM,Number=.,Type=Float,Description=\"Mean number of query alignment length adjusted mismatches of supporting reads\">",
-                "##INFO=<ID=PHASE,Number=.,Type=String,Description=\"Phasing information derived from supporting reads, represented as list of: HAPLOTYPE,PHASESET,HAPLOTYPE_SUPPORT,PHASESET_SUPPORT,HAPLOTYPE_FILTER,PHASESET_FILTER\">"
+                "##INFO=<ID=VAF,Number=1,Type=Float,Description=\"Variant Allele Fraction\">"
             ]
         ],
+        "timestamp": "2026-08-23T19:29:24.376423",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-20T09:48:10.355303818"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "homo_sapiens - [bam, bai], fasta, [], false, true -stub": {
         "content": [
@@ -146,16 +146,16 @@
                     [
                         "SNIFFLES",
                         "sniffles",
-                        "2.7.3"
+                        "2.8.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-08-23T19:30:12.10492",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-20T09:48:56.815803593"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "homo_sapiens - [bam, bai], fasta, bed, true, true": {
         "content": [
@@ -164,7 +164,7 @@
                     [
                         "SNIFFLES",
                         "sniffles",
-                        "2.7.3"
+                        "2.8.0"
                     ]
                 ]
             },
@@ -172,7 +172,7 @@
             "test.vcf.gz.tbi",
             [
                 "##fileformat=VCFv4.2",
-                "##source=Sniffles2_2.7.3"
+                "##source=Sniffles2_2.8.0"
             ],
             [
                 "##ALT=<ID=INS,Description=\"Insertion\">",
@@ -211,6 +211,9 @@
                 "##FILTER=<ID=SVLEN_MIN_MOSAIC,Description=\"SV length filter for mosaic SVs (min)\">",
                 "##FILTER=<ID=SVLEN_MAX_MOSAIC,Description=\"SV length filter for mosaic SVs (max)\">",
                 "##FILTER=<ID=SINGLE_BREAK,Description=\"A single break point was detected but not classified as an SV.\">",
+                "##FILTER=<ID=INLINE_SA,Description=\"INLINE/CIGAR-based SV is mostly supported by SA reads\">",
+                "##FILTER=<ID=MOSAIC_SV_CLOSE_EDGE,Description=\"For mosaic SVs, the location is close to the end of the read (either end)\">",
+                "##FILTER=<ID=GT_FAILED,Description=\"Sniffles was unable to genotype this call.\">",
                 "##INFO=<ID=PRECISE,Number=0,Type=Flag,Description=\"Structural variation with precise breakpoints\">",
                 "##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description=\"Structural variation with imprecise breakpoints\">",
                 "##INFO=<ID=MOSAIC,Number=0,Type=Flag,Description=\"Structural variation classified as putative mosaic\">",
@@ -230,17 +233,14 @@
                 "##INFO=<ID=SUPP_VEC,Number=1,Type=String,Description=\"List of read support for all samples\">",
                 "##INFO=<ID=CONSENSUS_SUPPORT,Number=1,Type=Integer,Description=\"Number of reads that support the generated insertion (INS) consensus sequence\">",
                 "##INFO=<ID=RNAMES,Number=.,Type=String,Description=\"Names of supporting reads (if enabled with --output-rnames)\">",
-                "##INFO=<ID=VAF,Number=1,Type=Float,Description=\"Variant Allele Fraction\">",
-                "##INFO=<ID=COVERAGE_VAR,Number=1,Type=Float,Description=\"Variance of coverage across large events\">",
-                "##INFO=<ID=NM,Number=.,Type=Float,Description=\"Mean number of query alignment length adjusted mismatches of supporting reads\">",
-                "##INFO=<ID=PHASE,Number=.,Type=String,Description=\"Phasing information derived from supporting reads, represented as list of: HAPLOTYPE,PHASESET,HAPLOTYPE_SUPPORT,PHASESET_SUPPORT,HAPLOTYPE_FILTER,PHASESET_FILTER\">"
+                "##INFO=<ID=VAF,Number=1,Type=Float,Description=\"Variant Allele Fraction\">"
             ]
         ],
+        "timestamp": "2026-08-23T19:29:56.486401",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-20T09:48:39.352200695"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "homo_sapiens - [bam, bai], fasta, [], true, false -stub": {
         "content": [
@@ -268,16 +268,16 @@
                     [
                         "SNIFFLES",
                         "sniffles",
-                        "2.7.3"
+                        "2.8.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-08-23T19:30:03.342205",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-20T09:48:48.221342424"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "homo_sapiens - [bam, bai], fasta, [], true, true -stub": {
         "content": [
@@ -310,16 +310,16 @@
                     [
                         "SNIFFLES",
                         "sniffles",
-                        "2.7.3"
+                        "2.8.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-08-23T19:30:19.184308",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-20T09:49:06.162346127"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "homo_sapiens - [bam, bai], fasta, [], false, true": {
         "content": [
@@ -328,17 +328,17 @@
                     [
                         "SNIFFLES",
                         "sniffles",
-                        "2.7.3"
+                        "2.8.0"
                     ]
                 ]
             },
             "test.snf"
         ],
+        "timestamp": "2026-08-23T19:29:34.678862",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-20T09:48:21.571097723"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     },
     "homo_sapiens - [bam, bai], fasta, [], true, true": {
         "content": [
@@ -347,7 +347,7 @@
                     [
                         "SNIFFLES",
                         "sniffles",
-                        "2.7.3"
+                        "2.8.0"
                     ]
                 ]
             },
@@ -355,7 +355,7 @@
             "test.vcf.gz.tbi",
             [
                 "##fileformat=VCFv4.2",
-                "##source=Sniffles2_2.7.3"
+                "##source=Sniffles2_2.8.0"
             ],
             [
                 "##ALT=<ID=INS,Description=\"Insertion\">",
@@ -394,6 +394,9 @@
                 "##FILTER=<ID=SVLEN_MIN_MOSAIC,Description=\"SV length filter for mosaic SVs (min)\">",
                 "##FILTER=<ID=SVLEN_MAX_MOSAIC,Description=\"SV length filter for mosaic SVs (max)\">",
                 "##FILTER=<ID=SINGLE_BREAK,Description=\"A single break point was detected but not classified as an SV.\">",
+                "##FILTER=<ID=INLINE_SA,Description=\"INLINE/CIGAR-based SV is mostly supported by SA reads\">",
+                "##FILTER=<ID=MOSAIC_SV_CLOSE_EDGE,Description=\"For mosaic SVs, the location is close to the end of the read (either end)\">",
+                "##FILTER=<ID=GT_FAILED,Description=\"Sniffles was unable to genotype this call.\">",
                 "##INFO=<ID=PRECISE,Number=0,Type=Flag,Description=\"Structural variation with precise breakpoints\">",
                 "##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description=\"Structural variation with imprecise breakpoints\">",
                 "##INFO=<ID=MOSAIC,Number=0,Type=Flag,Description=\"Structural variation classified as putative mosaic\">",
@@ -413,16 +416,13 @@
                 "##INFO=<ID=SUPP_VEC,Number=1,Type=String,Description=\"List of read support for all samples\">",
                 "##INFO=<ID=CONSENSUS_SUPPORT,Number=1,Type=Integer,Description=\"Number of reads that support the generated insertion (INS) consensus sequence\">",
                 "##INFO=<ID=RNAMES,Number=.,Type=String,Description=\"Names of supporting reads (if enabled with --output-rnames)\">",
-                "##INFO=<ID=VAF,Number=1,Type=Float,Description=\"Variant Allele Fraction\">",
-                "##INFO=<ID=COVERAGE_VAR,Number=1,Type=Float,Description=\"Variance of coverage across large events\">",
-                "##INFO=<ID=NM,Number=.,Type=Float,Description=\"Mean number of query alignment length adjusted mismatches of supporting reads\">",
-                "##INFO=<ID=PHASE,Number=.,Type=String,Description=\"Phasing information derived from supporting reads, represented as list of: HAPLOTYPE,PHASESET,HAPLOTYPE_SUPPORT,PHASESET_SUPPORT,HAPLOTYPE_FILTER,PHASESET_FILTER\">"
+                "##INFO=<ID=VAF,Number=1,Type=Float,Description=\"Variant Allele Fraction\">"
             ]
         ],
+        "timestamp": "2026-08-23T19:29:45.050345",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.4"
-        },
-        "timestamp": "2026-03-20T09:48:30.406264548"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
     }
 }


### PR DESCRIPTION
## Description

Bumps Sniffles from 2.7.3 to 2.8.0.

### Changes

- Updated `environment.yml` to `bioconda::sniffles=2.8.0`
- Updated Wave container URLs via `nf-core modules containers create` (Docker amd64: `sniffles:2.8.0--c25a97c10afa095a`, Singularity amd64 blob updated)
- Added conda lock files for linux/amd64 and linux/arm64
- Updated `meta.yml` container metadata
- Updated test snapshots (all 8 tests passed locally on ARM64 with Docker)

### PR checklist
 - [x] This PR contains a description of the change and its reason.
  - [x] Existing tests cover PASS, WARN, policy FAIL, and invalid FASTA reports.
  - [x] The software version is broadcast to the versions topic.
  - [x] Naming, inputs, outputs, and the process label remain unchanged.
  - [x] The module uses the published Bioconda package and BioContainer.

### Testing

- [x] `nf-core modules lint sniffles`
- [x] All 8 tests passed locally with `--update-snapshot`