### PR TITLE
hmmer/hmmrank: key domain coordinates on the query model

### DIFF
--- a/modules/nf-core/hmmer/hmmrank/main.nf
+++ b/modules/nf-core/hmmer/hmmrank/main.nf
@@ -92,9 +92,12 @@ ${read_domtblouts}
             '\\\\s+',  extra='merge', convert = FALSE
         ) %>%
         transmute(profile = basename(fname) %>% str_remove('^${prefix}\\\\.') %>% str_remove('\\\\.tbl\\\\.gz\$'), accno, profile_desc, evalue = as.double(evalue), score = as.double(score)) %>%
-        # Group and calculate a rank based on score and evalue; let ties be resolved by profile in alphabetical order
+        # Group and calculate a rank based on score and evalue; let ties be resolved by profile and
+        # then model name, in alphabetical order. Both are needed: one file may hold several models,
+        # in which case profile is constant across them and would leave ties on input order, and
+        # rank 1 is what downstream consumers select on.
         group_by(accno) %>%
-        arrange(desc(score), evalue, profile) %>%
+        arrange(desc(score), evalue, profile, profile_desc) %>%
         mutate(rank = row_number()) %>%
         ungroup() %>%
 ${join_domtblouts}        write_tsv('${prefix}.hmmrank.tsv.gz')

--- a/modules/nf-core/hmmer/hmmrank/main.nf
+++ b/modules/nf-core/hmmer/hmmrank/main.nf
@@ -21,14 +21,16 @@ process HMMER_HMMRANK {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def domtbl_list = domtblouts ? "c('${domtblouts.join("','")}')" : ''
     def read_domtblouts = domtblouts ? """
-    # Read the domtblout files and reduce each (accno, profile) pair's domains to one row per
-    # coordinate set: the outer bounds of the pair, plus the size of the union of its domains.
+    # Read the domtblout files and reduce each hit's domains to one row per coordinate set: the
+    # outer bounds of the hit, plus the size of the union of its domains. A hit is keyed on the
+    # query name as well as the file, since one HMM file may hold several models and the whole
+    # file is then searched in one go, putting several models in the same table.
 
     islands <- function(d, set) {
         d %>%
-            select(accno, profile, f = !!sym(paste0(set, '_from')), t = !!sym(paste0(set, '_to'))) %>%
-            arrange(accno, profile, f) %>%
-            group_by(accno, profile) %>%
+            select(accno, profile, query, f = !!sym(paste0(set, '_from')), t = !!sym(paste0(set, '_to'))) %>%
+            arrange(accno, profile, query, f) %>%
+            group_by(accno, profile, query) %>%
             # Sorted by start, so anything overlapping a row lies before it. cummax(t) is how far
             # right the rows up to here reach; lag() shifts that so each row sees how far
             # everything before it reached. A start past that opens a new island, and since
@@ -37,7 +39,7 @@ process HMMER_HMMRANK {
             # continues it rather than opening a gap: hence the + 1L. Note the default must be
             # 0L, not 0: lag() casts it to the column type and errors on a lossy double cast.
             mutate(island = cumsum(f > lag(cummax(t), default = 0L) + 1L)) %>%
-            group_by(accno, profile, island) %>%
+            group_by(accno, profile, query, island) %>%
             summarise(s = min(f), e = max(t), .groups = 'drop_last') %>%
             summarise(
                 from = min(s), to = max(e), len = sum(e - s + 1), n_islands = n(),
@@ -54,24 +56,24 @@ process HMMER_HMMRANK {
         separate(
             content,
             c(
-                'accno', 'd0', 'tlen', 'd1', 'd2', 'qlen', 'd3', 'd4', 'd5', 'd6', 'd7', 'd8', 'd9', 'd10', 'd11',
-                'hmm_from', 'hmm_to', 'ali_from', 'ali_to', 'env_from', 'env_to', 'd12', 'rest'
+                'accno', 'd0', 'tlen', 'query', 'd1', 'qlen', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7', 'd8', 'd9', 'd10',
+                'hmm_from', 'hmm_to', 'ali_from', 'ali_to', 'env_from', 'env_to', 'd11', 'rest'
             ),
             '\\\\s+', extra = 'merge', convert = FALSE
         ) %>%
         transmute(
             profile = basename(fname) %>% str_remove('^${prefix}\\\\.') %>% str_remove('\\\\.domtbl\\\\.gz\$'),
-            accno,
+            accno, query,
             across(c(tlen, qlen, hmm_from, hmm_to, ali_from, ali_to, env_from, env_to), as.integer)
         )
 
     domain_coords <- domains %>%
-        distinct(accno, profile, tlen, qlen) %>%
-        left_join(islands(domains, 'hmm'), by = c('accno', 'profile')) %>%
-        left_join(islands(domains, 'ali'), by = c('accno', 'profile')) %>%
-        left_join(islands(domains, 'env'), by = c('accno', 'profile'))
+        distinct(accno, profile, query, tlen, qlen) %>%
+        left_join(islands(domains, 'hmm'), by = c('accno', 'profile', 'query')) %>%
+        left_join(islands(domains, 'ali'), by = c('accno', 'profile', 'query')) %>%
+        left_join(islands(domains, 'env'), by = c('accno', 'profile', 'query'))
 """ : ''
-    def join_domtblouts = domtblouts ? "        left_join(domain_coords, by = c('accno', 'profile')) %>%\n" : ''
+    def join_domtblouts = domtblouts ? "        left_join(domain_coords, by = c('accno', 'profile', 'profile_desc' = 'query')) %>%\n" : ''
 
     """
     #!/usr/bin/env Rscript

--- a/modules/nf-core/hmmer/hmmrank/meta.yml
+++ b/modules/nf-core/hmmer/hmmrank/meta.yml
@@ -67,9 +67,11 @@ output:
       - "*.hmmrank.tsv.gz":
           type: file
           description: |
-            TSV file with ranked hmmer results: one row per (accno, profile) pair with
-            profile, accno, profile_desc, evalue, score and rank. When domtblouts are
-            supplied it also carries tlen and qlen, plus from, to, len and n_islands for
+            TSV file with ranked hmmer results: one row per (accno, profile, profile_desc)
+            combination -- profile_desc holds the query name, i.e. the model, which one file
+            may hold several of -- with profile, accno, profile_desc, evalue, score and rank.
+            When domtblouts are supplied it also carries tlen and qlen, plus from, to,
+            len and n_islands for
             each of the hmm, ali and env coordinate sets. n_islands is 1 when the domains
             merge into a single continuous stretch and rises as they scatter; coordinates
             are inclusive, so domains that abut with no gap between them count as one.

--- a/modules/nf-core/hmmer/hmmrank/meta.yml
+++ b/modules/nf-core/hmmer/hmmrank/meta.yml
@@ -51,7 +51,9 @@ input:
           pair's domains, and the number of separate stretches that union spans. Every
           domain hmmsearch reported is counted, whatever its own significance: a hit can
           clear the full-sequence threshold while each of its domains is weak in isolation,
-          and dropping those would leave exactly such hits without coordinates.
+          and dropping those would leave exactly such hits without coordinates. Domains are
+          grouped by query name as well as by file, so an HMM file holding several models
+          searched in one go still yields one row per (sequence, model).
         pattern: "*.domtbl.gz"
         ontologies:
           - edam: http://edamontology.org/format_3989 # GZIP format
@@ -71,6 +73,9 @@ output:
             each of the hmm, ali and env coordinate sets. n_islands is 1 when the domains
             merge into a single continuous stretch and rises as they scatter; coordinates
             are inclusive, so domains that abut with no gap between them count as one.
+            All fourteen are NA where a hit has no domain records behind it: hmmsearch
+            reports a sequence on the per-sequence threshold, while a domain also has to
+            clear the per-domain one, so the two tables need not agree on every hit.
           pattern: "*.hmmrank.tsv.gz"
           ontologies:
             - edam: http://edamontology.org/format_3989 # GZIP format

--- a/modules/nf-core/hmmer/hmmrank/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmrank/tests/main.nf.test
@@ -89,12 +89,12 @@ nextflow_process {
                 { assert path(process.out.hmmrank[0][1]).linesGzip.size() > 1 },
                 { def rows = path(process.out.hmmrank[0][1]).linesGzip
                   def header = rows[0].split('\t') as List
+                  def hmmLens = rows[1..-1].collect { it.split('\t')[header.indexOf('hmm_len')] }
                   // NA is a legitimate value: hmmsearch reports a sequence on the per-sequence
-                  // threshold, so a hit can be ranked with no domain records behind it at all
-                  assert rows[1..-1].every {
-                      def v = it.split('\t')[header.indexOf('hmm_len')]
-                      v.isInteger() || v == 'NA'
-                  } },
+                  // threshold, so a hit can be ranked with no domain records behind it at all.
+                  // any() as well as every(), since all-NA is what a broken join looks like
+                  assert hmmLens.every { it.isInteger() || it == 'NA' }
+                  assert hmmLens.any { it.isInteger() } },
                 { assert snapshot(
                     sanitizeOutput(process.out),
                     path(process.out.versions[0]).yaml
@@ -174,11 +174,13 @@ nextflow_process {
                 def combine = { name, srcs ->
                     def out = file("\${workDir}/multimodel/\${name}")
                     out.parent.mkdirs()
-                    def os = new java.util.zip.GZIPOutputStream(out.newOutputStream())
-                    srcs.each { src ->
-                        os.write(new java.util.zip.GZIPInputStream(file(src, checkIfExists: true).newInputStream()).bytes)
+                    new java.util.zip.GZIPOutputStream(out.newOutputStream()).withStream { os ->
+                        srcs.each { src ->
+                            new java.util.zip.GZIPInputStream(file(src, checkIfExists: true).newInputStream()).withStream { gz ->
+                                os.write(gz.bytes)
+                            }
+                        }
                     }
-                    os.close()
                     out
                 }
                 def base = params.phyloplace_testdata_base_path + 'hmmrank/'

--- a/modules/nf-core/hmmer/hmmrank/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmrank/tests/main.nf.test
@@ -75,20 +75,26 @@ nextflow_process {
         }
 
         then {
-            def rows = path(process.out.hmmrank[0][1]).linesGzip
-            def header = rows[0].split('\t') as List
-
+            // read the output only inside the assertions, so a failed process is reported as
+            // such instead of throwing out of this block and hiding its log
             assertAll(
                 { assert process.success },
                 // the coordinate columns are present and populated
-                { assert header.containsAll([
+                { assert path(process.out.hmmrank[0][1]).linesGzip[0].split('\t').toList().containsAll([
                     'tlen', 'qlen',
                     'hmm_from', 'hmm_to', 'hmm_len', 'hmm_n_islands',
                     'ali_from', 'ali_to', 'ali_len', 'ali_n_islands',
                     'env_from', 'env_to', 'env_len', 'env_n_islands'
                 ]) },
-                { assert rows.size() > 1 },
-                { assert rows[1..-1].every { it.split('\t')[header.indexOf('hmm_len')].isInteger() } },
+                { assert path(process.out.hmmrank[0][1]).linesGzip.size() > 1 },
+                { def rows = path(process.out.hmmrank[0][1]).linesGzip
+                  def header = rows[0].split('\t') as List
+                  // NA is a legitimate value: hmmsearch reports a sequence on the per-sequence
+                  // threshold, so a hit can be ranked with no domain records behind it at all
+                  assert rows[1..-1].every {
+                      def v = it.split('\t')[header.indexOf('hmm_len')]
+                      v.isInteger() || v == 'NA'
+                  } },
                 { assert snapshot(
                     sanitizeOutput(process.out),
                     path(process.out.versions[0]).yaml
@@ -142,16 +148,79 @@ nextflow_process {
                 'MNMMFBCN_00658 NrdJm1  1 748 748 1  42  792 751 1  42  792 751 1  798 748'
             ].collect { it.split(/ +/).join(' ') }.sort()
 
-            def rows = path(process.out.hmmrank[0][1]).linesGzip
-            def header = rows[0].split('\t') as List
-            def got = rows[1..-1].collect { line ->
-                def f = line.split('\t')
-                cols.collect { f[header.indexOf(it)] }.join(' ')
-            }.sort()
+            // read the output only inside the assertion, so a failed process is reported as
+            // such instead of throwing out of this block and hiding its log
+            assertAll(
+                { assert process.success },
+                { def rows = path(process.out.hmmrank[0][1]).linesGzip
+                  def header = rows[0].split('\t') as List
+                  assert rows[1..-1].collect { line ->
+                      def f = line.split('\t')
+                      cols.collect { f[header.indexOf(it)] }.join(' ')
+                  }.sort() == expected }
+            )
+        }
+    }
+
+    // One HMM file may hold several models, in which case the whole file is searched in one go
+    // and both tables carry rows for several query names under one file-derived profile. The
+    // two fixtures above are concatenated here to make exactly that, so the expected table is
+    // the same as above, keyed on the query name rather than the file.
+    test("hmmrank - several models in one table") {
+        when {
+            process {
+                """
+                // gunzip, concatenate and re-gzip, rather than carrying a near-duplicate fixture
+                def combine = { name, srcs ->
+                    def out = file("\${workDir}/multimodel/\${name}")
+                    out.parent.mkdirs()
+                    def os = new java.util.zip.GZIPOutputStream(out.newOutputStream())
+                    srcs.each { src ->
+                        os.write(new java.util.zip.GZIPInputStream(file(src, checkIfExists: true).newInputStream()).bytes)
+                    }
+                    os.close()
+                    out
+                }
+                def base = params.phyloplace_testdata_base_path + 'hmmrank/'
+                input[0] = [
+                    [ id: 'nrdj' ],
+                    [ combine('NrdJboth.tbl.gz',    [ base + 'NrdJ.tbl.gz',    base + 'NrdJm1.tbl.gz' ]) ],
+                    [ combine('NrdJboth.domtbl.gz', [ base + 'NrdJ.domtbl.gz', base + 'NrdJm1.domtbl.gz' ]) ]
+                ]
+                """
+            }
+        }
+
+        then {
+            def cols = [
+                'accno', 'profile_desc',
+                'hmm_from', 'hmm_to', 'hmm_len', 'hmm_n_islands',
+                'ali_from', 'ali_to', 'ali_len', 'ali_n_islands',
+                'env_from', 'env_to', 'env_len', 'env_n_islands',
+                'tlen', 'qlen'
+            ]
+            def expected = [
+                'AACBMDAH_04658 NrdJ   11  95  68 2  57  238  67 2  40  242 128 2  805 407',
+                'AACBMDAH_04658 NrdJm1  1 397 397 1  14  803 400 2  14  805 425 2  805 748',
+                'AACBMDAH_04659 NrdJm1 513 748 236 1   1  620 239 2   1  620 249 2  626 748',
+                'AAGAFPGM_00302 NrdJ   12 406 379 3 176  724 377 5 156  725 489 5  780 407',
+                'AAGAFPGM_00302 NrdJm1  6 711 588 4 134  735 555 4 129  770 615 2  780 748',
+                'DPHPGHLN_02900 NrdJ   62 384 306 2 205 1379 327 4 190 1397 401 4 1460 407',
+                'DPHPGHLN_02900 NrdJm1  1 747 747 1  14 1454 752 3  14 1455 791 3 1460 748',
+                'MNMMFBCN_00658 NrdJ   11 386 353 3  84  718 374 5  67  732 485 4  798 407',
+                'MNMMFBCN_00658 NrdJm1  1 748 748 1  42  792 751 1  42  792 751 1  798 748'
+            ].collect { it.split(/ +/).join(' ') }.sort()
 
             assertAll(
                 { assert process.success },
-                { assert got == expected }
+                // one row per (target, model): no multiplication from the shared profile name
+                { assert path(process.out.hmmrank[0][1]).linesGzip.size() == expected.size() + 1 },
+                { def rows = path(process.out.hmmrank[0][1]).linesGzip
+                  def header = rows[0].split('\t') as List
+                  assert rows[1..-1].collect { line ->
+                      def f = line.split('\t')
+                      cols.collect { f[header.indexOf(it)] }.join(' ')
+                  }.sort() == expected }
             )
         }
     }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

## Description

Fixes a bug in the coordinate columns added to `hmmer/hmmrank` in #12781, found while reviewing the pipeline PR that vendors them (nf-core/phyloplace#72).

### The bug

`hmmrank` takes its `profile` column from the **file name** of each table. But an HMM file may hold several models, and the whole file is then searched in one go, so a single `*.tbl.gz` / `*.domtbl.gz` pair can carry rows for several query names under one file-derived `p
rofile`. The new coordinate code keyed on `(accno, profile)` alone, which breaks in two ways:
   
- `distinct(accno, profile, tlen, qlen)` returns one row per model, since `qlen` differs between models. The `left_join` against a tblout side that likewise has one row per model is then a cartesian product.
- `islands()` grouped by `(accno, profile)` only, so it unioned domains belonging to *different* models. `hmm_from`/`hmm_to` are positions in the profile, so a union across two profiles is not meaningful.

Concatenating the two existing `NrdJ` fixtures into one file reproduces it — **17 rows instead of 9, and every coordinate corrupted**:
  
| accno | model | `hmm_from` `hmm_to` `hmm_len` | correct |
| --- | --- | --- | --- | 
| `AACBMDAH_04658` | NrdJ | 1 397 397 | 11 95 68 | 
| `AAGAFPGM_00302` | NrdJ | 6 711 676 | 12 406 379 |
| `AAGAFPGM_00302` | NrdJm1 | 6 711 676 | 6 711 588 |

`AACBMDAH_04658`/NrdJ simply reports NrdJm1's coordinates. `AAGAFPGM_00302` gets `hmm_len` 676 for both models — a cross-model union matching neither.

Nothing fires without `--domtblout`, so output from before #12781 is unaffected.

### The fix

The query name is already present on both sides and distinguishes the models: column 3 of the tblout, parsed as `profile_desc`, and column 4 of the domtblout, until now discarded as a dummy. Keeping it and carrying it through `islands()` and the joins closes both halves.

**Output columns are unchanged.** The final join maps `profile_desc` onto the domtblout query (`by = c('accno', 'profile', 'profile_desc' = 'query')`), so no new column is emitted and single-model input produces byte-identical output. All existing `hmmer/hmmrank` and `fasta_hmmsearch_rank_fastas` snapshots pass untouched — worth stating explicitly, since nf-core/ampliseq vendors both.

### Tests

A regression test builds the multi-model case by gunzipping, concatenating and re-gzipping the two existing fixtures inline, so no near-duplicate test data is needed. It fails on the previous code (`17 != 9`) and passes here, asserting the same per-model coordinate table as the single-file test, keyed on the query name.

### Two smaller things from the same review

- `tests/main.nf.test` read the process output in the `then` block, before `assert process.success` ran inside `assertAll`. On a failure `process.out.hmmrank` is empty and that line threw `IndexOutOfBoundsException`, hiding the real failure and its log. The reads now happen inside the assertions.
- The `hmm_len` assertion required an integer on every row, which rules out the `NA` a hit legitimately gets when it has no domain records — `hmmsearch` reports a sequence on the per-sequence threshold, while a domain also has to clear the per-domain one. `NA` is the intended behaviour there, being the clearest signal that no domains were reported for the hit, so the assertion now allows it and `meta.yml` says so.

<sub>Prepared with help from Claude Code.</sub>
