### PR TITLE
fix(seqkit/grep): stub emits the same filename as a real run

### DIFF
--- a/modules/nf-core/seqkit/grep/main.nf
+++ b/modules/nf-core/seqkit/grep/main.nf
@@ -48,6 +48,10 @@ process SEQKIT_GREP {
     """
     echo ${args}
 
-    echo "" | gzip > ${prefix}.${suffix}.gz
+    if [ "${compression_suffix}" = ".gz" ]; then
+        echo "" | gzip > ${prefix}.${suffix}
+    else
+        touch ${prefix}.${suffix}
+    fi
     """
 }

--- a/modules/nf-core/seqkit/grep/tests/main.nf.test
+++ b/modules/nf-core/seqkit/grep/tests/main.nf.test
@@ -111,4 +111,31 @@ nextflow_process {
             )
         }
     }
+
+    test("with_file - gzipped input - stub") {
+        options '-stub'
+
+        when {
+            params {
+                modules_args = ''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.header', checkIfExists: true)
+                input[2] = ''
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
 }

--- a/modules/nf-core/seqkit/grep/tests/main.nf.test.snap
+++ b/modules/nf-core/seqkit/grep/tests/main.nf.test.snap
@@ -26,6 +26,33 @@
             "nextflow": "26.04.3"
         }
     },
+    "with_file - gzipped input - stub": {
+        "content": [
+            {
+                "filter": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_GREP",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-26T08:42:47.44205795",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "with_pattern": {
         "content": [
             {
@@ -62,7 +89,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions_seqkit": [
@@ -74,10 +101,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-06-15T10:19:55.658854642",
+        "timestamp": "2026-08-26T08:42:38.938100201",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.6"
         }
     },
     "with_file - ungzipped input": {


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

## Description

`seqkit/grep`'s stub does not write the filename the process declares.

It builds `suffix = output_type + compression_suffix` and then appends another `.gz`:

```groovy
def compression_suffix = sequence.getExtension() == "gz" ? ".gz" : ""
def suffix = output_type + compression_suffix
"""
echo "" | gzip > ${prefix}.${suffix}.gz
"""
```

so the two cases come out as:

| input | real run writes | stub writes |
| --- | --- | --- |
| `genome.fasta.gz` | `test.fa.gz` | `test.fa.gz.gz` |
| `genome.fasta` | `test.fa` | `test.fa.gz` |

`test.fa.gz.gz` does not match the declared `path("*.{fa,fq,fa.gz,fq.gz}")`, so any `-stub` run with gzipped input fails with a missing output while the task exits 0 -- which makes it look like a pipeline problem rather than a stub problem.

The ungzipped case happened to match the glob, and the existing `with_file - stub` test uses `genome.fasta`, so the gzipped path was never covered.

### Changes

- The stub writes `${prefix}.${suffix}`, gzipped only when the input is gzipped.
- New `with_file - gzipped input - stub` test. On master it fails with `cmd: echo echo "" | gzip > test.fa.gz.gz`; with this change it passes.
- The existing stub snapshot changes from `test.fa.gz` to `test.fa`, which is what a real run produces for that input.

Ran `nf-test test modules/nf-core/seqkit/grep/tests/main.nf.test --profile docker` -- 5 tests pass. Docker only; I have not run the singularity or conda profiles.

Found in nf-core/metatdenovo, where `seqkit/grep` selects protein-cluster representatives from a gzipped FASTA and this blocked a stub run of the whole pipeline.

Fix drafted with help from Claude Code.
