### PR TITLE
fix(seqtk/subseq): let ext.prefix name the output file

### DIFF
--- a/modules/nf-core/seqtk/subseq/main.nf
+++ b/modules/nf-core/seqtk/subseq/main.nf
@@ -31,7 +31,7 @@ process SEQTK_SUBSEQ {
         $args \\
         $sequences \\
         $filter_list | \\
-        gzip --no-name > ${sequences}${prefix}.${ext}.gz
+        gzip --no-name > ${prefix}.${ext}.gz
     """
 
     stub:
@@ -41,6 +41,6 @@ process SEQTK_SUBSEQ {
         ext = "fq"
     }
     """
-    echo "" | gzip > ${sequences}${prefix}.${ext}.gz
+    echo "" | gzip > ${prefix}.${ext}.gz
     """
 }

--- a/modules/nf-core/seqtk/subseq/tests/main.nf.test.snap
+++ b/modules/nf-core/seqtk/subseq/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "genome.fasta.filtered.fa.gz:md5,31c95c4d686526cf002f6119bc55b2b2"
+                        "test.filtered.fa.gz:md5,31c95c4d686526cf002f6119bc55b2b2"
                     ]
                 ],
                 "1": [
@@ -22,7 +22,7 @@
                         {
                             "id": "test"
                         },
-                        "genome.fasta.filtered.fa.gz:md5,31c95c4d686526cf002f6119bc55b2b2"
+                        "test.filtered.fa.gz:md5,31c95c4d686526cf002f6119bc55b2b2"
                     ]
                 ],
                 "versions_seqtk": [
@@ -34,11 +34,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-08-26T09:12:10.98619525",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-14T10:29:32.149681094"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "sarscov2_subseq_fa_stub": {
         "content": [
@@ -48,7 +48,7 @@
                         {
                             "id": "test"
                         },
-                        "genome.fasta.filtered.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test.filtered.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "1": [
@@ -63,7 +63,7 @@
                         {
                             "id": "test"
                         },
-                        "genome.fasta.filtered.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test.filtered.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "versions_seqtk": [
@@ -75,10 +75,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-08-26T09:12:16.481993305",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-14T10:29:46.028543522"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     }
 }

--- a/modules/nf-core/seqtk/subseq/tests/standard.config
+++ b/modules/nf-core/seqtk/subseq/tests/standard.config
@@ -1,5 +1,5 @@
 process {
     withName: SEQTK_SUBSEQ {
-        ext.prefix = { ".filtered" }
+        ext.prefix = { "${meta.id}.filtered" }
     }
 }

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test.snap
@@ -6,23 +6,23 @@
                     {
                         "id": "arc16s"
                     },
-                    "domain_16s.fnaarc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
+                    "arc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
                 ],
                 [
                     {
                         "id": "bac16s"
                     },
-                    "domain_16s.fnabac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
+                    "bac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
                 ],
                 [
                     {
                         "id": "euk18s"
                     },
-                    "domain_16s.fnaeuk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
+                    "euk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
                 ]
             ]
         ],
-        "timestamp": "2026-08-21T18:11:11.258078897",
+        "timestamp": "2026-08-26T09:14:14.636250271",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -72,24 +72,24 @@
                         {
                             "id": "arc16s"
                         },
-                        "domain_16s.fnaarc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
+                        "arc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
                     ],
                     [
                         {
                             "id": "bac16s"
                         },
-                        "domain_16s.fnabac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
+                        "bac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
                     ],
                     [
                         {
                             "id": "euk18s"
                         },
-                        "domain_16s.fnaeuk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
+                        "euk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-21T16:52:27.022872526",
+        "timestamp": "2026-08-26T09:14:02.918378183",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #12779

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

## Description

Fixes #12779: `seqtk/subseq` built its output filename by concatenating the input filename and `ext.prefix` with no separator.

```groovy
gzip --no-name > ${sequences}${prefix}.${ext}.gz
```

`$sequences` is the input file's full name, extension included, and `prefix` defaults to `${meta.id}`, so the default produced names like `domain_16s.fnaarc16s.fa.gz` -- the input extension stranded in the middle, the id glued straight onto it.
The module's own test hid this by setting a prefix that carried its own leading dot (`ext.prefix = { ".filtered" }`), which made the implicit contract "`ext.prefix` is a suffix and must supply its own separator": the opposite of what `ext.prefix` means everywhere else, undocumented in `meta.yml`, and it left the default value unable to produce a well-formed name at all.

This takes the first of the two options in the issue, the one that follows the usual convention.

### Changes

- `${prefix}.${ext}.gz` in both the `script` and the `stub` block.
- `tests/standard.config` sets `ext.prefix = { "${meta.id}.filtered" }`, so the test exercises a prefix shaped the way callers actually write one, rather than one compensating for the bug.

### Snapshots

Output files are renamed, so both consumers in this repository move:

| | before | after |
| --- | --- | --- |
| `seqtk/subseq` | `genome.fasta.filtered.fa.gz` | `test.filtered.fa.gz` |
| `fasta_hmmsearch_rank_fastas` | `domain_16s.fnaarc16s.fa.gz` | `arc16s.fa.gz` |

**Every md5 is unchanged**, so this is a pure rename with no change in content.
`fasta_hmmsearch_rank_fastas` calls the module with the default prefix, so its snapshot is also the coverage for the default path this fixes.

Downstream pipelines that consume `seqtk/subseq` will need a snapshot update for the same reason.

Ran `nf-test test modules/nf-core/seqtk/subseq --profile docker` (2 tests) and `nf-test test subworkflows/nf-core/fasta_hmmsearch_rank_fastas --profile docker` (3 tests), all passing; `nf-core modules lint seqtk/subseq` and `nf-core subworkflows lint fasta_hmmsearch_rank_fastas` clean apart from a pre-existing `has_meta_containers` warning. Docker only -- I have not run the singularity or conda profiles.

Fix drafted with help from Claude Code.
