### PR TITLE
Fix custom/resolvetaxonomy: malformed output filename for extensionless input

### DIFF
--- a/modules/nf-core/custom/resolvetaxonomy/main.nf
+++ b/modules/nf-core/custom/resolvetaxonomy/main.nf
@@ -11,9 +11,12 @@ process CUSTOM_RESOLVETAXONOMY {
     tuple val(meta), path(taxonomy), path(sequences), val(taxonomy_required)
 
     output:
-    tuple val(meta), path("*.resolved.tax"),                    emit: taxonomy
-    tuple val(meta), path("*.resolved.${sequences.extension}"), emit: sequences
-    tuple val(meta), path("*.warnings.txt"),                    emit: warnings
+    // The fallback to 'fasta' matters when sequences has no extension at all (e.g. a
+    // download URL with no filename suffix) -- Path.extension is '' there, which
+    // would otherwise produce a malformed "*.resolved." glob matching nothing.
+    tuple val(meta), path("*.resolved.tax"),                                emit: taxonomy
+    tuple val(meta), path("*.resolved.${sequences.extension ?: 'fasta'}"),  emit: sequences
+    tuple val(meta), path("*.warnings.txt"),                                emit: warnings
     tuple val("${task.process}"), val('biopython'), eval("python3 -c 'import Bio; print(Bio.__version__)'"), emit: versions_biopython, topic: versions
 
     when:
@@ -21,13 +24,17 @@ process CUSTOM_RESOLVETAXONOMY {
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    // Falls back to 'fasta' when sequences has no extension at all (e.g. a
+    // download URL with no filename suffix) -- Path.extension is '' there, which
+    // would otherwise produce a malformed "${prefix}.resolved." output name.
+    def ext = sequences.extension ?: 'fasta'
     // Nextflow stages an absent optional path(taxonomy) as an empty list -- falsy in
     // Groovy -- rather than as a file, so this correctly distinguishes "no taxonomy
     // file given" from a real one, without ever interpolating the literal text "[]"
     // into the command line.
     def taxonomy_in = taxonomy ? "${taxonomy}" : ''
     """
-    python3 - "${taxonomy_in}" "${sequences}" "${taxonomy_required}" "${prefix}.resolved.tax" "${prefix}.resolved.${sequences.extension}" "${prefix}.warnings.txt" << 'PYEOF'
+    python3 - "${taxonomy_in}" "${sequences}" "${taxonomy_required}" "${prefix}.resolved.tax" "${prefix}.resolved.${ext}" "${prefix}.warnings.txt" << 'PYEOF'
 import sys
 from Bio import SeqIO
 
@@ -96,7 +103,8 @@ PYEOF
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def ext = sequences.extension ?: 'fasta'
     """
-    touch ${prefix}.resolved.tax ${prefix}.resolved.${sequences.extension} ${prefix}.warnings.txt
+    touch ${prefix}.resolved.tax ${prefix}.resolved.${ext} ${prefix}.warnings.txt
     """
 }

--- a/modules/nf-core/custom/resolvetaxonomy/meta.yml
+++ b/modules/nf-core/custom/resolvetaxonomy/meta.yml
@@ -65,7 +65,7 @@ output:
     - - meta:
           type: map
           description: Groovy Map containing sample information. e.g. `[ id:'sample1' ]`
-      - "*.resolved.${sequences.extension}":
+      - "*.resolved.${sequences.extension ?: 'fasta'}":
           type: file
           description: The input sequences (same format as the input), headers stripped down to a bare id.
           pattern: "*.resolved.*"

--- a/modules/nf-core/custom/resolvetaxonomy/tests/main.nf.test
+++ b/modules/nf-core/custom/resolvetaxonomy/tests/main.nf.test
@@ -189,6 +189,39 @@ nextflow_process {
 
     }
 
+    test("sequences file with no extension at all") {
+
+        when {
+            process {
+                """
+                def noExtPath = java.nio.file.Files.createTempDirectory('resolvetaxonomy_test').resolve('resolvetaxonomy_embedded')
+                noExtPath.toFile().text = file(params.modules_testdata_base_path + 'generic/fasta/resolvetaxonomy_embedded.fasta', checkIfExists: true).text
+
+                input[0] = [
+                    [ id:'test' ],
+                    [],
+                    file(noExtPath.toString()),
+                    true,
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+
+            def sequences = path(process.out.sequences[0][1])
+
+            assertAll(
+                // Falls back to '.resolved.fasta', not a malformed '.resolved.' with
+                // no extension.
+                { assert sequences.toFile().name.endsWith('.resolved.fasta') },
+                { assert sequences.text.contains('>SeqA\n') },
+            )
+        }
+
+    }
+
     test("embedded taxonomy - stub") {
 
         options "-stub"


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test custom/resolvetaxonomy --profile docker`
    - [ ] `nf-core modules test custom/resolvetaxonomy --profile singularity`
    - [ ] `nf-core modules test custom/resolvetaxonomy --profile conda`

## Description

Found while wiring `custom/resolvetaxonomy` (merged in #12817) into nf-core/phyloplace: its `sequences` output is named `"*.resolved.${sequences.extension}"`, but `Path.extension` is `''` (not null) when the input file has no extension at all -- e.g. a bare download URL whose path is just a numeric file id (`.../files/47244067`, no filename suffix). That produced a malformed `"${prefix}.resolved."` output name, matching nothing, so the process silently failed to produce a usable `sequences` output.

Fix: fall back to `'fasta'` via `sequences.extension ?: 'fasta'`.

One thing worth flagging for other module authors: I first tried factoring this into a single `def ext = sequences.extension ?: 'fasta'` in the `script:` block and reusing `${ext}` in the `output:` declaration (the same pattern `def prefix = task.ext.prefix ?: ...` uses everywhere) -- that's a compile-time error, `` `ext` is not defined ``. `output:` glob patterns can only reference input-bound variables (`sequences`, `meta`, etc.) directly, not `script:`-scoped `def` locals. Confirmed this empirically rather than assuming from the `prefix` precedent, since `prefix` itself is only ever used in `script:`/`stub:`, never in an `output:` pattern, in this module or apparently elsewhere. So the fallback is duplicated inline in `script:`, `stub:` and the `output:` glob itself.

Added a test case with a synthesized extension-less input file (no new fixture needed -- built inline in the test from the existing `resolvetaxonomy_embedded.fasta` fixture) covering the regression.

Ran `nf-test test modules/nf-core/custom/resolvetaxonomy --profile docker` (8/8 passing, including the new case) twice to confirm stability, and `nf-core modules lint custom/resolvetaxonomy` (clean). Docker only -- I have not run the singularity or conda profiles.

Generated by Claude
