### PR TITLE
Add STAR Suite alignment and genome generation modules

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -9,6 +9,7 @@ container-registry:
   - docker.io/biocontainers
   - docker.io/labsyspharm
   - docker.io/google
+  - docker.io/biodepot
 bump-versions:
   rseqc/junctionannotation: False
   rseqc/bamstat: False

--- a/modules/nf-core/starsuite/align/Dockerfile
+++ b/modules/nf-core/starsuite/align/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.io/biodepot/star-suite@sha256:0ced4e4941b8a7347c1583598381e6abe25d798df09759c59ede0e6c6dc4e1d3

--- a/modules/nf-core/starsuite/align/main.nf
+++ b/modules/nf-core/starsuite/align/main.nf
@@ -1,0 +1,94 @@
+process STARSUITE_ALIGN {
+    tag "$meta.id"
+    label 'process_high'
+
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'docker://biodepot/star-suite@sha256:0ced4e4941b8a7347c1583598381e6abe25d798df09759c59ede0e6c6dc4e1d3' :
+        'docker.io/biodepot/star-suite@sha256:0ced4e4941b8a7347c1583598381e6abe25d798df09759c59ede0e6c6dc4e1d3' }"
+
+    input:
+    tuple val(meta),  path(reads, stageAs: "input*/*")
+    tuple val(meta2), path(index)
+    tuple val(meta3), path(gtf)
+
+    output:
+    tuple val(meta), path("${prefix}")                    , emit: quant_results,        optional: true
+    tuple val(meta), path('*quant.sf')                    , emit: quant_transcripts,    optional: true
+    tuple val(meta), path('*quant.genes.sf')              , emit: quant_genes,          optional: true
+    tuple val(meta), path('*quant.genes.tximport.sf')     , emit: quant_genes_tximport, optional: true
+    tuple val(meta), path('*Aligned.out.bam')             , emit: bam,                  optional: true
+    tuple val(meta), path('*Aligned.sortedByCoord.out.bam'), emit: bam_sorted,           optional: true
+    tuple val(meta), path('*fastq.gz')                    , emit: fastq,                optional: true
+    tuple val(meta), path('*Log.final.out')               , emit: log_final
+    tuple val(meta), path('*Log.out')                     , emit: log_out
+    tuple val(meta), path('*Log.progress.out')            , emit: log_progress
+    tuple val("${task.process}"), val('starsuite'), eval('STAR --version'), emit: versions_starsuite, topic: versions
+    tuple val("${task.process}"), val('star'), eval('STAR --upstream-version'), emit: versions_star, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "STARSUITE_ALIGN does not support Conda. Please use Docker, Singularity, Apptainer, or Podman instead."
+    }
+    def args   = task.ext.args ?: ''
+    prefix     = task.ext.prefix ?: "${meta.id}"
+    def reads1 = []
+    def reads2 = []
+    meta.single_end ? [reads].flatten().each { read -> reads1 << read } : reads.eachWithIndex { read, read_index -> (read_index & 1 ? reads2 : reads1) << read }
+    def include_gtf  = gtf ? "--sjdbGTFfile $gtf" : ''
+    def attr_rg      = args.contains('--outSAMattrRGline') ? '' : "--outSAMattrRGline 'ID:$prefix' 'SM:$prefix'"
+    def out_sam_type = args.contains('--outSAMtype') ? '' : '--outSAMtype BAM Unsorted'
+    def transcriptome_check = args.contains('--quantMode TranscriptVB') ?
+        "test -s $index/transcriptome.fa || { echo 'STAR Suite TranscriptVB quantification requires transcriptome.fa in the genome index.' >&2; exit 1; }" : ''
+    """
+    $transcriptome_check
+
+    STAR \\
+        --genomeDir $index \\
+        --readFilesIn ${reads1.join(',')} ${reads2.join(',')} \\
+        --runThreadN $task.cpus \\
+        --outFileNamePrefix $prefix. \\
+        $out_sam_type \\
+        $include_gtf \\
+        $attr_rg \\
+        $args
+
+    if [ -f ${prefix}.quant.sf ]; then
+        mkdir ${prefix}
+        cp ${prefix}.quant.sf ${prefix}/quant.sf
+    fi
+
+    if [ -f ${prefix}.Unmapped.out.mate1 ]; then
+        mv ${prefix}.Unmapped.out.mate1 ${prefix}.unmapped_1.fastq
+        gzip ${prefix}.unmapped_1.fastq
+    fi
+    if [ -f ${prefix}.Unmapped.out.mate2 ]; then
+        mv ${prefix}.Unmapped.out.mate2 ${prefix}.unmapped_2.fastq
+        gzip ${prefix}.unmapped_2.fastq
+    fi
+    """
+
+    stub:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "STARSUITE_ALIGN does not support Conda. Please use Docker, Singularity, Apptainer, or Podman instead."
+    }
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir ${prefix}
+    touch ${prefix}/quant.sf
+    touch ${prefix}.quant.sf
+    touch ${prefix}.quant.genes.sf
+    touch ${prefix}.quant.genes.tximport.sf
+    touch ${prefix}.Aligned.out.bam
+    touch ${prefix}.Aligned.sortedByCoord.out.bam
+    echo "" | gzip > ${prefix}.unmapped_1.fastq.gz
+    echo "" | gzip > ${prefix}.unmapped_2.fastq.gz
+    touch ${prefix}.Log.final.out
+    touch ${prefix}.Log.out
+    touch ${prefix}.Log.progress.out
+    """
+}

--- a/modules/nf-core/starsuite/align/main.nf
+++ b/modules/nf-core/starsuite/align/main.nf
@@ -41,7 +41,7 @@ process STARSUITE_ALIGN {
     def include_gtf  = gtf ? "--sjdbGTFfile $gtf" : ''
     def attr_rg      = args.contains('--outSAMattrRGline') ? '' : "--outSAMattrRGline 'ID:$prefix' 'SM:$prefix'"
     def out_sam_type = args.contains('--outSAMtype') ? '' : '--outSAMtype BAM Unsorted'
-    def transcriptome_check = args.contains('--quantMode TranscriptVB') ?
+    def transcriptome_check = args.tokenize().contains('TranscriptVB') ?
         "test -s $index/transcriptome.fa || { echo 'STAR Suite TranscriptVB quantification requires transcriptome.fa in the genome index.' >&2; exit 1; }" : ''
     """
     $transcriptome_check

--- a/modules/nf-core/starsuite/align/meta.yml
+++ b/modules/nf-core/starsuite/align/meta.yml
@@ -1,0 +1,179 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: starsuite_align
+description: Align reads and optionally quantify transcripts and genes with STAR Suite
+keywords:
+  - align
+  - rnaseq
+  - quantification
+  - star
+  - salmon
+tools:
+  - starsuite:
+      description: STAR Suite extends the STAR aligner with integrated transcript quantification and additional transcriptomics workflows.
+      homepage: https://github.com/morphic-bio/STAR-suite
+      documentation: https://github.com/morphic-bio/STAR-suite/blob/master/README.md
+      tool_dev_url: https://github.com/morphic-bio/STAR-suite
+      doi: 10.64898/2026.03.09.710580
+      licence: ["MIT"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: Groovy Map with sample metadata, e.g. `[ id:'sample', single_end:false ]`
+    - reads:
+        type: file
+        description: FastQ files (gzip supported natively; no zcat needed)
+        pattern: "*.{fastq,fq}{,.gz}"
+  - - meta2:
+        type: map
+        description: Groovy Map for the reference index
+    - index:
+        type: directory
+        description: STAR-Suite genome index (from STARSUITE_GENOMEGENERATE)
+  - - meta3:
+        type: map
+        description: Groovy Map for the annotation
+    - gtf:
+        type: file
+        description: Gene annotation GTF
+        pattern: "*.gtf"
+
+output:
+  quant_results:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "${prefix}":
+          type: directory
+          description: Transcript-level quantification directory containing quant.sf
+          pattern: "*"
+  quant_transcripts:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*quant.sf":
+          type: file
+          description: Transcript-level quantification in Salmon quant.sf format
+          pattern: "*quant.sf"
+          ontologies: []
+  quant_genes:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*quant.genes.sf":
+          type: file
+          description: Gene-level quantification in Salmon quant.sf format
+          pattern: "*quant.genes.sf"
+          ontologies: []
+  quant_genes_tximport:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*quant.genes.tximport.sf":
+          type: file
+          description: Gene-level tximport summary emitted by STAR Suite
+          pattern: "*quant.genes.tximport.sf"
+          ontologies: []
+  bam:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*Aligned.out.bam":
+          type: file
+          description: Unsorted genome BAM
+          pattern: "*Aligned.out.bam"
+          ontologies:
+            - edam: http://edamontology.org/format_2572 # BAM
+  bam_sorted:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*Aligned.sortedByCoord.out.bam":
+          type: file
+          description: Coordinate-sorted genome BAM
+          pattern: "*Aligned.sortedByCoord.out.bam"
+          ontologies:
+            - edam: http://edamontology.org/format_2572 # BAM
+  fastq:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*fastq.gz":
+          type: file
+          description: Unmapped FASTQ files
+          pattern: "*fastq.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  log_final:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*Log.final.out":
+          type: file
+          description: STAR final alignment summary
+          pattern: "*Log.final.out"
+          ontologies: []
+  log_out:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*Log.out":
+          type: file
+          description: STAR main log
+          pattern: "*Log.out"
+          ontologies: []
+  log_progress:
+    - - meta:
+          type: map
+          description: Groovy Map with sample metadata
+      - "*Log.progress.out":
+          type: file
+          description: STAR progress log
+          pattern: "*Log.progress.out"
+          ontologies: []
+  versions_starsuite:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - starsuite:
+          type: string
+          description: The name of the tool
+      - STAR --version:
+          type: eval
+          description: The expression used to obtain the tool version
+  versions_star:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - star:
+          type: string
+          description: The name of the upstream aligner
+      - STAR --upstream-version:
+          type: eval
+          description: The expression used to obtain the upstream STAR version
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - starsuite:
+          type: string
+          description: The name of the tool
+      - STAR --version:
+          type: eval
+          description: The expression used to obtain the tool version
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - star:
+          type: string
+          description: The name of the upstream aligner
+      - STAR --upstream-version:
+          type: eval
+          description: The expression used to obtain the upstream STAR version
+
+authors:
+  - "@lhhunghimself"
+maintainers:
+  - "@lhhunghimself"

--- a/modules/nf-core/starsuite/align/tests/main.nf.test
+++ b/modules/nf-core/starsuite/align/tests/main.nf.test
@@ -111,7 +111,7 @@ nextflow_process {
         when {
             params {
                 genomegenerate_args = '--genomeSAindexNbases 9'
-                module_args = '--outSAMtype BAM SortedByCoordinate --outBAMsortMethod samtools --quantMode TranscriptVB'
+                module_args = '--outSAMtype BAM SortedByCoordinate --outBAMsortMethod samtools --quantMode TranscriptomeSAM TranscriptVB'
             }
             process {
                 """

--- a/modules/nf-core/starsuite/align/tests/main.nf.test
+++ b/modules/nf-core/starsuite/align/tests/main.nf.test
@@ -1,0 +1,157 @@
+nextflow_process {
+
+    name "Test Process STARSUITE_ALIGN"
+    script "../main.nf"
+    process "STARSUITE_ALIGN"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "starsuite"
+    tag "starsuite/align"
+    tag "starsuite/genomegenerate"
+    config "./nextflow.config"
+
+    setup {
+        run("STARSUITE_GENOMEGENERATE") {
+            script "../../genomegenerate/main.nf"
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test_fasta' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ])
+                input[1] = Channel.of([ [ id:'test_gtf' ],   file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf',   checkIfExists: true) ])
+                """
+            }
+        }
+    }
+
+    test("homo_sapiens - paired_end - transcriptvb") {
+        when {
+            params {
+                genomegenerate_args = '--genomeSAindexNbases 9 --genomeGenerateTranscriptome Yes'
+                module_args = '--outSAMtype BAM SortedByCoordinate --outBAMsortMethod samtools --outReadsUnmapped Fastx --quantMode TranscriptVB --quantVBgenes 1 --quantVBgenesMode Tximport'
+            }
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test', single_end:false ], [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true) ] ])
+                input[1] = STARSUITE_GENOMEGENERATE.out.index
+                input[2] = Channel.of([ [ id:'test_gtf' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.quant_transcripts.get(0).get(1)).exists() },
+                { assert path(process.out.quant_genes.get(0).get(1)).exists() },
+                { assert path(process.out.quant_genes_tximport.get(0).get(1)).exists() },
+                { assert path(process.out.quant_transcripts.get(0).get(1)).readLines().first() == 'Name\tLength\tEffectiveLength\tTPM\tNumReads' },
+                { assert bam(process.out.bam_sorted.get(0).get(1)).getReadsMD5() },
+                { assert process.out.fastq.get(0).get(1).size() == 2 },
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("versions") }
+            )
+        }
+    }
+
+    test("homo_sapiens - paired_end - alignment_only") {
+        when {
+            params {
+                genomegenerate_args = '--genomeSAindexNbases 9'
+                module_args = ''
+            }
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test', single_end:false ], [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true) ] ])
+                input[1] = STARSUITE_GENOMEGENERATE.out.index
+                input[2] = Channel.of([ [ id:'test_gtf' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                // No quant flags → no quant.sf. Proves "just STAR" is the default.
+                { assert process.out.quant_transcripts.size() == 0 },
+                { assert process.out.quant_genes.size() == 0 },
+                { assert process.out.quant_genes_tximport.size() == 0 },
+                { assert bam(process.out.bam.get(0).get(1)).getReadsMD5() },
+                { assert process.out.log_final.get(0).get(1) ==~ ".*Log.final.out" }
+            )
+        }
+    }
+
+    test("homo_sapiens - single_end - transcriptvb") {
+        when {
+            params {
+                genomegenerate_args = '--genomeSAindexNbases 9 --genomeGenerateTranscriptome Yes'
+                module_args = '--outSAMtype BAM SortedByCoordinate --outBAMsortMethod samtools --quantMode TranscriptVB --quantVBgenes 1 --quantVBgenesMode Tximport'
+            }
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test', single_end:true ], [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true) ] ])
+                input[1] = STARSUITE_GENOMEGENERATE.out.index
+                input[2] = Channel.of([ [ id:'test_gtf' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.quant_transcripts.get(0).get(1)).exists() },
+                { assert bam(process.out.bam_sorted.get(0).get(1)).getReadsMD5() },
+                { assert process.out.log_final.get(0).get(1) ==~ ".*Log.final.out" }
+            )
+        }
+    }
+
+    test("homo_sapiens - transcriptvb - index missing transcriptome") {
+        when {
+            params {
+                genomegenerate_args = '--genomeSAindexNbases 9'
+                module_args = '--outSAMtype BAM SortedByCoordinate --outBAMsortMethod samtools --quantMode TranscriptVB'
+            }
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test', single_end:true ], [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true) ] ])
+                input[1] = STARSUITE_GENOMEGENERATE.out.index
+                input[2] = Channel.of([ [ id:'test_gtf' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.failed },
+                { assert process.stdout.toString().contains('TranscriptVB quantification requires transcriptome.fa') }
+            )
+        }
+    }
+
+    test("homo_sapiens - paired_end - transcriptvb - stub") {
+        options "-stub"
+        when {
+            params {
+                genomegenerate_args = '--genomeSAindexNbases 9 --genomeGenerateTranscriptome Yes'
+                module_args = '--outSAMtype BAM SortedByCoordinate --outBAMsortMethod samtools --quantMode TranscriptVB --quantVBgenes 1 --quantVBgenesMode Tximport'
+            }
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test', single_end:false ], [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true) ] ])
+                input[1] = STARSUITE_GENOMEGENERATE.out.index
+                input[2] = Channel.of([ [ id:'test_gtf' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/starsuite/align/tests/main.nf.test.snap
+++ b/modules/nf-core/starsuite/align/tests/main.nf.test.snap
@@ -1,0 +1,256 @@
+{
+    "homo_sapiens - paired_end - transcriptvb - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "quant.sf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.quant.sf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "10": [
+                    [
+                        "STARSUITE_ALIGN",
+                        "starsuite",
+                        "1.7.1"
+                    ]
+                ],
+                "11": [
+                    [
+                        "STARSUITE_ALIGN",
+                        "star",
+                        "2.7.11b"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.quant.genes.sf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.quant.genes.tximport.sf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Aligned.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Aligned.sortedByCoord.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.unmapped_1.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test.unmapped_2.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "7": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.final.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "9": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.progress.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Aligned.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam_sorted": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Aligned.sortedByCoord.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fastq": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.unmapped_1.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test.unmapped_2.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "log_final": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.final.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_progress": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.progress.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "quant_genes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.quant.genes.sf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "quant_genes_tximport": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.quant.genes.tximport.sf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "quant_results": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "quant.sf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "quant_transcripts": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.quant.sf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "STARSUITE_ALIGN",
+                        "star",
+                        "2.7.11b"
+                    ]
+                ],
+                "versions_starsuite": [
+                    [
+                        "STARSUITE_ALIGN",
+                        "starsuite",
+                        "1.7.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-12T07:32:01.111688273",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "versions": {
+        "content": [
+            {
+                "versions_star": [
+                    [
+                        "STARSUITE_ALIGN",
+                        "star",
+                        "2.7.11b"
+                    ]
+                ],
+                "versions_starsuite": [
+                    [
+                        "STARSUITE_ALIGN",
+                        "starsuite",
+                        "1.7.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-12T07:13:57.482961496",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    }
+}

--- a/modules/nf-core/starsuite/align/tests/nextflow.config
+++ b/modules/nf-core/starsuite/align/tests/nextflow.config
@@ -1,0 +1,14 @@
+params {
+    genomegenerate_args = '--genomeSAindexNbases 9'
+    module_args         = ''
+}
+
+process {
+    withName: STARSUITE_GENOMEGENERATE {
+        ext.args = params.genomegenerate_args
+    }
+
+    withName: STARSUITE_ALIGN {
+        ext.args = params.module_args
+    }
+}

--- a/modules/nf-core/starsuite/genomegenerate/Dockerfile
+++ b/modules/nf-core/starsuite/genomegenerate/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.io/biodepot/star-suite@sha256:0ced4e4941b8a7347c1583598381e6abe25d798df09759c59ede0e6c6dc4e1d3

--- a/modules/nf-core/starsuite/genomegenerate/main.nf
+++ b/modules/nf-core/starsuite/genomegenerate/main.nf
@@ -1,0 +1,55 @@
+process STARSUITE_GENOMEGENERATE {
+    tag "$fasta"
+    label 'process_high'
+
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'docker://biodepot/star-suite@sha256:0ced4e4941b8a7347c1583598381e6abe25d798df09759c59ede0e6c6dc4e1d3' :
+        'docker.io/biodepot/star-suite@sha256:0ced4e4941b8a7347c1583598381e6abe25d798df09759c59ede0e6c6dc4e1d3' }"
+
+    input:
+    tuple val(meta),  path(fasta)
+    tuple val(meta2), path(gtf)
+
+    output:
+    tuple val(meta), path("starsuite"), emit: index
+    tuple val("${task.process}"), val('starsuite'), eval('STAR --version'), emit: versions_starsuite, topic: versions
+    tuple val("${task.process}"), val('star'), eval('STAR --upstream-version'), emit: versions_star, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "STARSUITE_GENOMEGENERATE does not support Conda. Please use Docker, Singularity, Apptainer, or Podman instead."
+    }
+    def args   = task.ext.args ?: ''
+    def memory = task.memory ? "--limitGenomeGenerateRAM ${task.memory.toBytes() - 100000000}" : ''
+    """
+    mkdir starsuite
+    STAR \\
+        --runMode genomeGenerate \\
+        --genomeDir starsuite/ \\
+        --genomeFastaFiles $fasta \\
+        --sjdbGTFfile $gtf \\
+        --runThreadN $task.cpus \\
+        $memory \\
+        $args
+    """
+
+    stub:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error "STARSUITE_GENOMEGENERATE does not support Conda. Please use Docker, Singularity, Apptainer, or Podman instead."
+    }
+    """
+    mkdir starsuite
+    touch starsuite/Genome
+    touch starsuite/Log.out
+    touch starsuite/SA
+    touch starsuite/SAindex
+    touch starsuite/genomeParameters.txt
+    touch starsuite/sjdbList.out.tab
+    touch starsuite/transcriptome.fa
+    """
+}

--- a/modules/nf-core/starsuite/genomegenerate/meta.yml
+++ b/modules/nf-core/starsuite/genomegenerate/meta.yml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: starsuite_genomegenerate
+description: Build a STAR Suite genome index, optionally including a transcriptome FASTA for TranscriptVB quantification
+keywords:
+  - index
+  - genome
+  - reference
+  - star
+tools:
+  - starsuite:
+      description: STAR Suite extends the STAR aligner with integrated transcript quantification and additional transcriptomics workflows.
+      homepage: https://github.com/morphic-bio/STAR-suite
+      documentation: https://github.com/morphic-bio/STAR-suite/blob/master/README.md
+      tool_dev_url: https://github.com/morphic-bio/STAR-suite
+      doi: 10.64898/2026.03.09.710580
+      licence: ["MIT"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: Groovy Map for the genome FASTA
+    - fasta:
+        type: file
+        description: Genome FASTA
+        pattern: "*.{fa,fasta}"
+  - - meta2:
+        type: map
+        description: Groovy Map for the annotation
+    - gtf:
+        type: file
+        description: Gene annotation GTF
+        pattern: "*.gtf"
+
+output:
+  index:
+    - - meta:
+          type: map
+          description: Groovy Map with reference metadata
+      - "starsuite":
+          type: directory
+          description: STAR-Suite genome index directory, optionally including transcriptome.fa
+          pattern: "starsuite"
+  versions_starsuite:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - starsuite:
+          type: string
+          description: The name of the tool
+      - STAR --version:
+          type: eval
+          description: The expression used to obtain the tool version
+  versions_star:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - star:
+          type: string
+          description: The name of the upstream aligner
+      - STAR --upstream-version:
+          type: eval
+          description: The expression used to obtain the upstream STAR version
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - starsuite:
+          type: string
+          description: The name of the tool
+      - STAR --version:
+          type: eval
+          description: The expression used to obtain the tool version
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - star:
+          type: string
+          description: The name of the upstream aligner
+      - STAR --upstream-version:
+          type: eval
+          description: The expression used to obtain the upstream STAR version
+
+authors:
+  - "@lhhunghimself"
+maintainers:
+  - "@lhhunghimself"

--- a/modules/nf-core/starsuite/genomegenerate/tests/main.nf.test
+++ b/modules/nf-core/starsuite/genomegenerate/tests/main.nf.test
@@ -1,0 +1,73 @@
+nextflow_process {
+
+    name "Test Process STARSUITE_GENOMEGENERATE"
+    script "../main.nf"
+    process "STARSUITE_GENOMEGENERATE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "starsuite"
+    tag "starsuite/genomegenerate"
+    config "./nextflow.config"
+
+    test("homo_sapiens - genome - gtf") {
+        when {
+            params {
+                module_args = '--genomeSAindexNbases 9'
+            }
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test_fasta' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ])
+                input[1] = Channel.of([ [ id:'test_gtf' ],   file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf',   checkIfExists: true) ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("versions") },
+                { assert file(process.out.index.get(0).get(1)).name == "starsuite" },
+                { assert !path(process.out.index.get(0).get(1) + "/transcriptome.fa").exists() }
+            )
+        }
+    }
+
+    test("homo_sapiens - genome - gtf - transcriptome") {
+        when {
+            params {
+                module_args = '--genomeSAindexNbases 9 --genomeGenerateTranscriptome Yes'
+            }
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test_fasta' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ])
+                input[1] = Channel.of([ [ id:'test_gtf' ],   file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf',   checkIfExists: true) ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                // transcriptome.fa must be written into the index dir when enabled
+                { assert path(process.out.index.get(0).get(1) + "/transcriptome.fa").exists() }
+            )
+        }
+    }
+
+    test("homo_sapiens - genome - gtf - stub") {
+        options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([ [ id:'test_fasta' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ])
+                input[1] = Channel.of([ [ id:'test_gtf' ],   file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf',   checkIfExists: true) ])
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/starsuite/genomegenerate/tests/main.nf.test.snap
+++ b/modules/nf-core/starsuite/genomegenerate/tests/main.nf.test.snap
@@ -1,0 +1,98 @@
+{
+    "homo_sapiens - genome - gtf - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_fasta"
+                        },
+                        [
+                            "Genome:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Log.out:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "SA:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "SAindex:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genomeParameters.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "sjdbList.out.tab:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "transcriptome.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        "STARSUITE_GENOMEGENERATE",
+                        "starsuite",
+                        "1.7.1"
+                    ]
+                ],
+                "2": [
+                    [
+                        "STARSUITE_GENOMEGENERATE",
+                        "star",
+                        "2.7.11b"
+                    ]
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test_fasta"
+                        },
+                        [
+                            "Genome:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Log.out:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "SA:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "SAindex:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genomeParameters.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "sjdbList.out.tab:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "transcriptome.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "versions_star": [
+                    [
+                        "STARSUITE_GENOMEGENERATE",
+                        "star",
+                        "2.7.11b"
+                    ]
+                ],
+                "versions_starsuite": [
+                    [
+                        "STARSUITE_GENOMEGENERATE",
+                        "starsuite",
+                        "1.7.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-12T07:13:15.360786147",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    },
+    "versions": {
+        "content": [
+            {
+                "versions_star": [
+                    [
+                        "STARSUITE_GENOMEGENERATE",
+                        "star",
+                        "2.7.11b"
+                    ]
+                ],
+                "versions_starsuite": [
+                    [
+                        "STARSUITE_GENOMEGENERATE",
+                        "starsuite",
+                        "1.7.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-12T07:13:08.317325069",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.2"
+        }
+    }
+}

--- a/modules/nf-core/starsuite/genomegenerate/tests/nextflow.config
+++ b/modules/nf-core/starsuite/genomegenerate/tests/nextflow.config
@@ -1,0 +1,9 @@
+params {
+    module_args = '--genomeSAindexNbases 9'
+}
+
+process {
+    withName: STARSUITE_GENOMEGENERATE {
+        ext.args = params.module_args
+    }
+}


### PR DESCRIPTION

### Description

Closes nf-core/modules#12825.

Adds two container-only modules for [STAR Suite](https://github.com/morphic-bio/STAR-suite):

- `starsuite/genomegenerate` builds a STAR Suite genome index and can include the
  transcriptome required by TranscriptVB.
- `starsuite/align` performs STAR alignment and optionally integrated TranscriptVB
  transcript/gene quantification.

STAR Suite 1.7.1 extends upstream STAR 2.7.11b and is MIT-licensed. The modules
use the existing multi-architecture Biodepot release image pinned by OCI digest:

```text
docker.io/biodepot/star-suite@sha256:0ced4e4941b8a7347c1583598381e6abe25d798df09759c59ede0e6c6dc4e1d3
```

There is deliberately no Conda environment. Each module includes the Dockerfile
required for software not distributed through Bioconda, and Conda/Mamba profiles
fail with a clear message. This keeps the nf-core component on the same artefact
built and versioned by STAR Suite's existing Biodepot CI/CD pipeline.

The two components are intentionally submitted together because the alignment
tests build their small TranscriptVB-capable reference with
`starsuite/genomegenerate`.

**Container review requested:** the current implementation intentionally uses
the project-maintained Biodepot image pinned by immutable digest. Please confirm
whether this reference is acceptable or whether the release must be mirrored
under `quay.io/nf-core`; I will update the PR if a mirror is required.

The alignment module remains generic: without quantification arguments it behaves
as an alignment-only STAR replacement. TranscriptVB outputs are Salmon-compatible
`quant.sf` files and an additional results directory suitable for tximport.

### Testing

- nf-core/tools 4.1.0: both module lints pass with no warnings or failures.
- nf-test 0.9.5 / Nextflow 25.10.2: 8/8 real and stub tests pass with Docker.
- nf-test 0.9.5 / Nextflow 25.10.4: 8/8 pass with Singularity.
- Paired-end, single-end, alignment-only, sorted BAM, unmapped reads,
  transcriptome indexing and missing-transcriptome failure are covered.
- `nf-core modules lint starsuite/align`: 56 passed, no warnings/failures.
- `nf-core modules lint starsuite/genomegenerate`: 54 passed, no warnings/failures.
- Both Dockerfiles build successfully.

### Citation

Hung LH, Baker D, Flynn B, Huangfu D, Luo R, Robson P, Zhou T, Yeung KY. STAR
Suite: an open-source single-executable transcriptomics engine for reproducible,
AI agent-assisted processing. bioRxiv. 2026.
https://doi.org/10.64898/2026.03.09.710580

### Checklist

- [x] This comment describes the change and its motivation.
- [x] Tests cover the new code and failure modes.
- [x] The modules follow the contribution conventions and naming rules.
- [x] No new test-data repository files are required.
- [x] No TODO statements remain in the submitted components.
- [x] STAR Suite and upstream STAR versions are broadcast to `topic: versions`.
- [x] Inputs, outputs, `ext.args`, `ext.prefix` and resource labels follow the
  module specifications.
- [x] Dockerfiles are included because STAR Suite is not on Bioconda.
- [x] Docker tests pass.
- [x] Singularity tests pass.
- [x] Conda testing is not applicable; the modules fail early with an explicit
  container-runtime requirement.
- [ ] Resolve the disclosed container-review question and apply any required
  `quay.io/nf-core` mirror before merge.
