### PR TITLE
samplesheetparser: bump modules to 2.5.2 and drop warning exit-code workaround

### DIFF
--- a/modules/nf-core/samplesheetparser/diff/environment.yml
+++ b/modules/nf-core/samplesheetparser/diff/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::samplesheet-parser=2.5.1
+  - bioconda::samplesheet-parser=2.5.2

--- a/modules/nf-core/samplesheetparser/diff/main.nf
+++ b/modules/nf-core/samplesheetparser/diff/main.nf
@@ -4,8 +4,8 @@ process SAMPLESHEETPARSER_DIFF {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/samplesheet-parser:2.5.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.2--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:2.5.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(old_sheet, stageAs: "old/*"), path(new_sheet, stageAs: "new/*")

--- a/modules/nf-core/samplesheetparser/diff/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/diff/tests/main.nf.test.snap
@@ -14,12 +14,12 @@
                     [
                         "SAMPLESHEETPARSER_DIFF",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:42:33.877739",
+        "timestamp": "2026-08-26T17:20:03.297903",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -40,12 +40,12 @@
                     [
                         "SAMPLESHEETPARSER_DIFF",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:42:41.993486",
+        "timestamp": "2026-08-26T17:20:11.739593",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -66,12 +66,12 @@
                     [
                         "SAMPLESHEETPARSER_DIFF",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:42:24.718647",
+        "timestamp": "2026-08-26T17:19:54.194571",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/samplesheetparser/info/environment.yml
+++ b/modules/nf-core/samplesheetparser/info/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::samplesheet-parser=2.5.1
+  - bioconda::samplesheet-parser=2.5.2

--- a/modules/nf-core/samplesheetparser/info/main.nf
+++ b/modules/nf-core/samplesheetparser/info/main.nf
@@ -4,8 +4,8 @@ process SAMPLESHEETPARSER_INFO {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/samplesheet-parser:2.5.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.2--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:2.5.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(samplesheet)

--- a/modules/nf-core/samplesheetparser/info/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/info/tests/main.nf.test.snap
@@ -14,12 +14,12 @@
                     [
                         "SAMPLESHEETPARSER_INFO",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:42:50.223073",
+        "timestamp": "2026-08-26T17:20:20.772868",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -40,12 +40,12 @@
                     [
                         "SAMPLESHEETPARSER_INFO",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:42:58.456585",
+        "timestamp": "2026-08-26T17:20:28.650412",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -66,12 +66,12 @@
                     [
                         "SAMPLESHEETPARSER_INFO",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:43:06.781916",
+        "timestamp": "2026-08-26T17:20:35.411106",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/samplesheetparser/merge/environment.yml
+++ b/modules/nf-core/samplesheetparser/merge/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::samplesheet-parser=2.5.1
+  - bioconda::samplesheet-parser=2.5.2

--- a/modules/nf-core/samplesheetparser/merge/main.nf
+++ b/modules/nf-core/samplesheetparser/merge/main.nf
@@ -4,8 +4,8 @@ process SAMPLESHEETPARSER_MERGE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/samplesheet-parser:2.5.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.2--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:2.5.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(samplesheets, stageAs: "input*/*")
@@ -30,16 +30,16 @@ process SAMPLESHEETPARSER_MERGE {
     if (sheets.size() < 2) {
         error "SAMPLESHEETPARSER_MERGE requires at least two input sheets, got ${sheets.size()}"
     }
-    // `samplesheet merge` exits 1 when the report contains conflicts or warnings
-    // (and 2 on hard errors). Tolerate exit 1 so a warning does not kill the task;
-    // downstream code should inspect `has_conflicts` in the JSON report.
+    // samplesheet-parser >=2.5.2 exits 0 on a successful merge (warnings are
+    // advisory) and non-zero only on conflicts (1) or hard errors (2), so no
+    // exit-code handling is needed here.
     """
     samplesheet merge \\
         --to ${to_norm} \\
         --output ${prefix}.merged.csv \\
         --format json \\
         ${args} \\
-        ${samplesheets} > ${prefix}.merge.json || [ \$? -eq 1 ]
+        ${samplesheets} > ${prefix}.merge.json
     """
 
     stub:

--- a/modules/nf-core/samplesheetparser/merge/tests/main.nf.test
+++ b/modules/nf-core/samplesheetparser/merge/tests/main.nf.test
@@ -151,8 +151,8 @@ nextflow_process {
             process {
                 """
                 // Mixed V1 + V2 inputs on different lanes merge cleanly but emit
-                // warnings (e.g. MIXED_FORMAT), so the CLI exits 1. The module
-                // tolerates exit 1, so the task must still succeed.
+                // warnings (e.g. MIXED_FORMAT). Warnings are advisory in
+                // samplesheet-parser >=2.5.2 (exit 0), so the task must succeed.
                 input[0] = [
                     [ id:'test_warn' ],
                     [

--- a/modules/nf-core/samplesheetparser/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/merge/tests/main.nf.test.snap
@@ -22,12 +22,12 @@
                     [
                         "SAMPLESHEETPARSER_MERGE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:43:40.957926",
+        "timestamp": "2026-08-26T17:21:04.336995",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -56,12 +56,12 @@
                     [
                         "SAMPLESHEETPARSER_MERGE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-25T07:13:39.256983",
+        "timestamp": "2026-08-26T17:20:50.446382",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -90,12 +90,12 @@
                     [
                         "SAMPLESHEETPARSER_MERGE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-25T07:13:30.18708",
+        "timestamp": "2026-08-26T17:20:42.628643",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -124,12 +124,12 @@
                     [
                         "SAMPLESHEETPARSER_MERGE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-25T07:13:48.383281",
+        "timestamp": "2026-08-26T17:20:57.820554",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -158,12 +158,12 @@
                     [
                         "SAMPLESHEETPARSER_MERGE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-26T11:16:25.121571",
+        "timestamp": "2026-08-26T17:21:18.597498",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -192,12 +192,12 @@
                     [
                         "SAMPLESHEETPARSER_MERGE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-26T06:34:30.015043",
+        "timestamp": "2026-08-26T17:21:11.566735",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/samplesheetparser/split/environment.yml
+++ b/modules/nf-core/samplesheetparser/split/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::samplesheet-parser=2.5.1
+  - bioconda::samplesheet-parser=2.5.2

--- a/modules/nf-core/samplesheetparser/split/main.nf
+++ b/modules/nf-core/samplesheetparser/split/main.nf
@@ -4,8 +4,8 @@ process SAMPLESHEETPARSER_SPLIT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/samplesheet-parser:2.5.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.2--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:2.5.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(samplesheet)
@@ -31,8 +31,8 @@ process SAMPLESHEETPARSER_SPLIT {
     if (!['v1', 'v2'].contains(to_norm)) {
         error "to must be 'v1' or 'v2', got: ${to}"
     }
-    // `samplesheet split` exits 1 when the report contains warnings (and 2 on
-    // hard errors). Tolerate exit 1 so a warning does not kill the task.
+    // samplesheet-parser >=2.5.2 exits 0 on a successful split (warnings are
+    // advisory), so no exit-code handling is needed here.
     """
     mkdir -p split
 
@@ -42,7 +42,7 @@ process SAMPLESHEETPARSER_SPLIT {
         --output-dir split \\
         --format json \\
         ${args} \\
-        ${samplesheet} > ${prefix}.split.json || [ \$? -eq 1 ]
+        ${samplesheet} > ${prefix}.split.json
     """
 
     stub:

--- a/modules/nf-core/samplesheetparser/split/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/split/tests/main.nf.test.snap
@@ -22,12 +22,12 @@
                     [
                         "SAMPLESHEETPARSER_SPLIT",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:44:05.617102",
+        "timestamp": "2026-08-26T17:21:38.599268",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -59,12 +59,12 @@
                     [
                         "SAMPLESHEETPARSER_SPLIT",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-25T07:14:05.348674",
+        "timestamp": "2026-08-26T17:21:25.290017",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -96,12 +96,12 @@
                     [
                         "SAMPLESHEETPARSER_SPLIT",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:43:57.337404",
+        "timestamp": "2026-08-26T17:21:32.151334",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/modules/nf-core/samplesheetparser/validate/environment.yml
+++ b/modules/nf-core/samplesheetparser/validate/environment.yml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::samplesheet-parser=2.5.1
+  - bioconda::samplesheet-parser=2.5.2

--- a/modules/nf-core/samplesheetparser/validate/main.nf
+++ b/modules/nf-core/samplesheetparser/validate/main.nf
@@ -4,8 +4,8 @@ process SAMPLESHEETPARSER_VALIDATE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/samplesheet-parser:2.5.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/samplesheet-parser:2.5.2--pyhdfd78af_0' :
+        'quay.io/biocontainers/samplesheet-parser:2.5.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(samplesheet)

--- a/modules/nf-core/samplesheetparser/validate/tests/main.nf.test.snap
+++ b/modules/nf-core/samplesheetparser/validate/tests/main.nf.test.snap
@@ -14,12 +14,12 @@
                     [
                         "SAMPLESHEETPARSER_VALIDATE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:44:30.660787",
+        "timestamp": "2026-08-26T17:21:58.415355",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -40,12 +40,12 @@
                     [
                         "SAMPLESHEETPARSER_VALIDATE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:44:13.900816",
+        "timestamp": "2026-08-26T17:21:45.151209",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -66,12 +66,12 @@
                     [
                         "SAMPLESHEETPARSER_VALIDATE",
                         "samplesheet-parser",
-                        "2.5.1"
+                        "2.5.2"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-24T08:44:22.118005",
+        "timestamp": "2026-08-26T17:21:51.963555",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"


### PR DESCRIPTION


<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->
<!-- Follow-up to #12774 (merged). No issue to close, so the "Closes" line is removed. -->

### Description of changes

Bumps the existing `samplesheetparser` modules (`diff`, `info`, `merge`, `split`, `validate`) from `samplesheet-parser` **2.5.1 → 2.5.2** (BioConda + BioContainers; `2.5.2--pyhdfd78af_0` is published).

The 2.5.2 release fixes the exit-code contract at the tool level: `merge` and `split` now exit `0` on a successful run (warnings are advisory) and non-zero only on genuine conflicts (`1`, merge) or hard errors (`2`). Previously a warning-only run exited `1`, which killed the Nextflow task even though valid output was written.

As a result, this PR also **removes the module-level `|| [ $? -eq 1 ]` workaround** that #12774 added to `merge/main.nf` and `split/main.nf` — it is no longer needed now that the tool exits `0` on warnings. The existing `merge` warning test (mixed V1 + V2 inputs producing `MIXED_FORMAT`) still asserts `process.success`, so the behaviour stays covered. Snapshots regenerated against the 2.5.2 container.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests! <!-- existing merge warning test covers the change -->
- [ ] ~If you've added a new tool~ — N/A, version bump of existing modules.
- [ ] ~If necessary, include test data~ — N/A, no new test data (uses existing test-datasets + in-test restaging).
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions`.
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`