### PR TITLE
transdecoder/predict: fix module never resuming and failing on re-execution

### DIFF
--- a/modules/nf-core/transdecoder/predict/main.nf
+++ b/modules/nf-core/transdecoder/predict/main.nf
@@ -24,6 +24,15 @@ process TRANSDECODER_PREDICT {
     script:
     def args = task.ext.args ?: ''
     """
+    # \$fold is staged as a symlink into TRANSDECODER_LONGORF's own work directory.
+    # TransDecoder.Predict writes its checkpoints and intermediates there, which mutates
+    # that other task's output and makes this task uncacheable across -resume
+    # (nf-core/modules#12799). Give it a private, writable directory of symlinks instead.
+    real_fold=\$(readlink -f $fold)
+    rm $fold
+    mkdir $fold
+    ln -s "\$real_fold"/* $fold/
+
     TransDecoder.Predict \\
         $args \\
         -O . \\


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #12799

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`

## Description

`TransDecoder.Predict` writes its checkpoint directory into the LongOrfs directory it receives via `-O`.
That directory is staged as a symlink into `TRANSDECODER_LONGORF`'s own work directory, so writing through it there mutates another task's output after the fact.

Two consequences, both reproducible from a clean run and both explained in #12799 with a full trace:

1. **Predict itself never resumes.** Because it modifies its own staged input, a following `-resume` sees a changed input and re-executes it even when nothing upstream changed.
2. **The re-execution then fails.** Nextflow wipes the Predict task directory before re-running, but not the LongOrfs directory the symlink points at, so the stale `__checkpoints_TDpredict` from the first run survives. `TransDecoder.Predict` sees a complete checkpoint set, skips every step -- including the ones that write `*.transdecoder.pep`/`.gff3`/`.cds`/`.bed` -- and exits **0** with nothing produced. The failure then surfaces as a generic "missing output file" error that points at the module rather than at the real cause.

### Fix

Give Predict a private, writable directory of symlinks to the same files, instead of writing through the staged symlink directly:

```bash
real_fold=$(readlink -f $fold)
rm $fold
mkdir $fold
ln -s "$real_fold"/* $fold/
```

Reads still resolve through the per-file symlinks to the original LongOrfs outputs. Every write Predict makes -- the checkpoint directory and its intermediates -- lands in this new, task-local directory instead, so the LongOrfs task's own output is never touched and Predict's declared input stays byte-identical across runs (making it correctly cacheable), while a genuine re-execution always starts from a fresh directory with no stale checkpoints to short-circuit it.

### Testing

- All three existing `transdecoder/predict` module tests (`sarscov2 - uncompressed`, `sarscov2 - compressed`, `sarscov2 - uncompressed - stub`) pass unmodified against the pre-existing committed snapshot -- confirming output content is unchanged, not just plausibly so.
- Reproduced the original bug end-to-end and verified the fix against a full pipeline, not just the module in isolation: ran nf-core/metatdenovo's `test,docker` profile with `--orf_caller transdecoder`, then `-resume` with no changes.
  - **Before this fix:** `TRANSDECODER_PREDICT` fails on resume with `Missing output file(s) '*.transdecoder.pep'`, `Command exit status: 0` -- exactly as described in #12799.
  - **After this fix:** the trace report shows `TRANSDECODER:TRANSDECODER_PREDICT (megahit.transdecoder)` as `CACHED`, and the whole pipeline resumes cleanly (`completed=1 failed=0 cached=76`, only MULTIQC re-running as expected).
- `nf-core modules lint transdecoder/predict`: clean except one pre-existing, unrelated warning (bioconda `transdecoder` 5.7.1 -> 6.0.0 available) that this PR doesn't touch.
- `prek run` on the changed file: clean.

Reported and fixed with help from Claude Code.
