### PR TITLE
Remove duplicate lines in sentieon/coveragemetrics

### DIFF
--- a/modules/nf-core/sentieon/coveragemetrics/main.nf
+++ b/modules/nf-core/sentieon/coveragemetrics/main.nf
@@ -60,8 +60,5 @@ process SENTIEON_COVERAGEMETRICS {
     touch ${prefix}.sample_cumulative_coverage_counts
     touch ${prefix}.sample_cumulative_coverage_proportions
     touch ${prefix}.sample_interval_summary
-    touch ${prefix}.sample_cumulative_coverage_counts
-    touch ${prefix}.sample_cumulative_coverage_proportions
-    touch ${prefix}.sample_interval_summary
     """
 }

--- a/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test
+++ b/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test
@@ -93,7 +93,12 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.per_locus).match() },
+                { assert process.out.sample_summary == [] },
+                { assert process.out.statistics == [] },
+                { assert process.out.coverage_counts == [] },
+                { assert process.out.coverage_proportions == [] },
+                { assert process.out.interval_summary == [] }
             )
         }
     }
@@ -190,7 +195,15 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out.per_locus,
+                    process.out.statistics,
+                    process.out.coverage_counts,
+                    process.out.coverage_proportions,
+                    process.out.interval_summary,
+                    process.out.versions_sentieon
+                ).match() },
+                { assert process.out.sample_summary == [] }
             )
         }
     }

--- a/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test.snap
+++ b/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test.snap
@@ -1,74 +1,20 @@
 {
     "Test omit outputs": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    
-                ],
-                "6": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
-                ],
-                "coverage_counts": [
-                    
-                ],
-                "coverage_proportions": [
-                    
-                ],
-                "interval_summary": [
-                    
-                ],
-                "per_locus": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
-                    ]
-                ],
-                "sample_summary": [
-                    
-                ],
-                "statistics": [
-                    
-                ],
-                "versions_sentieon": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
                 ]
-            }
+            ]
         ],
+        "timestamp": "2026-08-27T11:41:26.424937739",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:54:57.611594148"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.7"
+        }
     },
     "Test with interval": {
         "content": [
@@ -185,11 +131,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-21T06:54:48.537598623",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:54:48.537598623"
+        }
     },
     "Test multiple BAMs": {
         "content": [
@@ -306,122 +252,67 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-21T06:55:15.632397339",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:55:15.632397339"
+        }
     },
     "Test - stub": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_statistics:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_counts:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_proportions:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
-                ],
-                "coverage_counts": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_counts:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "coverage_proportions": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_proportions:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "interval_summary": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "per_locus": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "sample_summary": [
-                    
-                ],
-                "statistics": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_statistics:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "versions_sentieon": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
-            }
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.sample_interval_statistics:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.sample_cumulative_coverage_counts:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.sample_cumulative_coverage_proportions:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.sample_interval_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    "SENTIEON_COVERAGEMETRICS",
+                    "sentieon",
+                    "202503.02"
+                ]
+            ]
         ],
+        "timestamp": "2026-08-27T12:01:35.56802115",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:55:22.931782396"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.7"
+        }
     },
     "Test per sample": {
         "content": [
@@ -538,11 +429,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-21T06:54:39.444896549",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:54:39.444896549"
+        }
     },
     "Test readgroup partition": {
         "content": [
@@ -659,10 +550,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-21T06:55:06.47413819",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:55:06.47413819"
+        }
     }
 }


### PR DESCRIPTION
This PR removes duplicated lines from the `stub` block, and updates the test in order to remove empty lines in the produced test snapshot.

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`