### PR TITLE
transdecoder/predict: fix cloud/copy-staging failure (follow-up to #12829)

### DIFF
--- a/modules/nf-core/transdecoder/predict/main.nf
+++ b/modules/nf-core/transdecoder/predict/main.nf
@@ -30,13 +30,13 @@ process TRANSDECODER_PREDICT {
     # task's output and makes this task uncacheable across -resume (nf-core/modules#12799). Give it a
     # private, writable directory of symlinks instead. mv handles both staging modes: it moves a
     # symlink as a symlink, and renames a real directory in place, so nothing is deleted either way.
-    shopt -s dotglob nullglob
+    # find avoids the dotglob/nullglob shell-option juggling that caused three earlier bugs here.
     mv "$fold" "${fold}.staged"
     real_fold=\$(readlink -f "${fold}.staged")
+    [ -d "\$real_fold" ] || { echo "TRANSDECODER_LONGORF's directory is missing: \$real_fold" >&2; exit 1; }
     [ -n "\$(ls -A "\$real_fold")" ] || { echo "TRANSDECODER_LONGORF produced an empty directory: \$real_fold" >&2; exit 1; }
     mkdir "$fold"
-    ln -s "\$real_fold"/* "$fold"/
-    shopt -u dotglob nullglob
+    find "\$real_fold" -mindepth 1 -maxdepth 1 -exec ln -s {} "$fold"/ \\;
 
     TransDecoder.Predict \\
         $args \\

--- a/modules/nf-core/transdecoder/predict/main.nf
+++ b/modules/nf-core/transdecoder/predict/main.nf
@@ -31,10 +31,12 @@ process TRANSDECODER_PREDICT {
     # private, writable directory of symlinks instead. mv handles both staging modes: it moves a
     # symlink as a symlink, and renames a real directory in place, so nothing is deleted either way.
     shopt -s dotglob nullglob
-    mv $fold ${fold}.staged
-    real_fold=\$(readlink -f ${fold}.staged)
-    mkdir $fold
-    ln -s "\$real_fold"/* $fold/
+    mv "$fold" "${fold}.staged"
+    real_fold=\$(readlink -f "${fold}.staged")
+    [ -n "\$(ls -A "\$real_fold")" ] || { echo "TRANSDECODER_LONGORF produced an empty directory: \$real_fold" >&2; exit 1; }
+    mkdir "$fold"
+    ln -s "\$real_fold"/* "$fold"/
+    shopt -u dotglob nullglob
 
     TransDecoder.Predict \\
         $args \\

--- a/modules/nf-core/transdecoder/predict/main.nf
+++ b/modules/nf-core/transdecoder/predict/main.nf
@@ -24,12 +24,15 @@ process TRANSDECODER_PREDICT {
     script:
     def args = task.ext.args ?: ''
     """
-    # \$fold is staged as a symlink into TRANSDECODER_LONGORF's own work directory.
-    # TransDecoder.Predict writes its checkpoints and intermediates there, which mutates
-    # that other task's output and makes this task uncacheable across -resume
-    # (nf-core/modules#12799). Give it a private, writable directory of symlinks instead.
-    real_fold=\$(readlink -f $fold)
-    rm $fold
+    # \$fold is staged into TRANSDECODER_LONGORF's own output -- a symlink under local/shared-filesystem
+    # staging, but a real copy under stageInMode 'copy' (the default for cloud storage without Fusion).
+    # TransDecoder.Predict writes its checkpoints and intermediates there, which mutates that other
+    # task's output and makes this task uncacheable across -resume (nf-core/modules#12799). Give it a
+    # private, writable directory of symlinks instead. mv handles both staging modes: it moves a
+    # symlink as a symlink, and renames a real directory in place, so nothing is deleted either way.
+    shopt -s dotglob nullglob
+    mv $fold ${fold}.staged
+    real_fold=\$(readlink -f ${fold}.staged)
     mkdir $fold
     ln -s "\$real_fold"/* $fold/
 

--- a/modules/nf-core/transdecoder/predict/tests/main.nf.test
+++ b/modules/nf-core/transdecoder/predict/tests/main.nf.test
@@ -98,6 +98,52 @@ nextflow_process {
 
     }
 
+    test("sarscov2 - uncompressed - copy staging") {
+
+        config "./nextflow.config"
+
+        setup {
+            run("TRANSDECODER_LONGORF") {
+                script "../../longorf/main.nf"
+                process {
+                    """
+                    input[0] = [
+                        [id: 'test'],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                input[1] = TRANSDECODER_LONGORF.out.folder
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    // orfs are output in a random order; can't be easily sorted either.
+                    path(process.out.bed[0][1] ).getText().contains("ID=GENE.MT192765.1~~MT192765.1.p7"),
+                    path(process.out.cds[0][1] ).getText().contains("ID=GENE.MT192765.1~~MT192765.1.p7"),
+                    path(process.out.gff3[0][1]).getText().contains("ID=GENE.MT192765.1~~MT192765.1.p7"),
+                    path(process.out.pep[0][1] ).getText().contains("ID=GENE.MT192765.1~~MT192765.1.p7"),
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                    ).match() }
+            )
+        }
+
+    }
+
     test("sarscov2 - uncompressed - stub") {
 
         options "-stub"

--- a/modules/nf-core/transdecoder/predict/tests/main.nf.test.snap
+++ b/modules/nf-core/transdecoder/predict/tests/main.nf.test.snap
@@ -88,5 +88,27 @@
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"
         }
+    },
+    "sarscov2 - uncompressed - copy staging": {
+        "content": [
+            false,
+            false,
+            true,
+            false,
+            {
+                "versions_transdecoder": [
+                    [
+                        "TRANSDECODER_PREDICT",
+                        "transdecoder",
+                        "5.7.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-27T19:01:46.697535714",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     }
 }

--- a/modules/nf-core/transdecoder/predict/tests/nextflow.config
+++ b/modules/nf-core/transdecoder/predict/tests/nextflow.config
@@ -1,0 +1,7 @@
+process {
+
+    withName: 'TRANSDECODER_PREDICT' {
+        stageInMode = 'copy' // regression test for nf-core/modules#12799 and its cloud/copy-staging follow-up
+    }
+
+}


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`

## Description

Follow-up to #12829, flagged in review on the downstream nf-core/metatdenovo consumer PR ([nf-core/metatdenovo#480](https://github.com/nf-core/metatdenovo/pull/480), review by @piplus2 -- thanks for catching this).

#12829 fixed `TRANSDECODER_PREDICT`'s `-resume` failure by giving `Predict` a private, writable directory of symlinks instead of writing through the staged LongOrfs directory. That fix assumed the staged input (`$fold`) is always a symlink, which only holds for local/shared-filesystem staging.

Under `stageInMode 'copy'` -- the default for cloud storage (AWS/GCS/Azure) without Fusion, or whenever a user/institutional config sets `process.stageInMode` explicitly -- Nextflow stages directory inputs as real copies, not symlinks. `rm` on a real directory fails outright, and any pipeline with strict bash flags (`set -e`, which nf-core/metatdenovo among others sets) aborts the task right there. That turns a `-resume` fix into a hard failure on every cloud-executed run using this module.

### Fix

Replace `rm`+`mkdir` with `mv`, which handles both staging modes identically: it moves a symlink as a symlink, and renames a real directory in place -- so nothing is deleted before the symlink farm is built from it, regardless of staging mode.

Also add `shopt -s dotglob nullglob` before the glob-based `ln -s`: without it, a dot-prefixed file in the LongOrfs directory would be silently skipped, and an empty match would create a literal dangling `*` symlink rather than failing loudly. Latent today since TransDecoder 5.7.1 writes no dotfiles there, but worth guarding against a future version that does (the module's own bioconda-update warning already flags 5.7.1 -> 6.0.0 as available).

### Testing

- The module's own 3 tests (`sarscov2 - uncompressed`, `sarscov2 - compressed`, `sarscov2 - uncompressed - stub`) pass unmodified against the existing committed snapshot.
- Reproduced the actual failure mode the review flagged, not just reasoned about it: ran a full nf-core/metatdenovo pipeline (`-profile test,docker --orf_caller transdecoder`) with `-process.stageInMode copy` to simulate cloud staging, under that pipeline's own strict shell settings (`process.shell = ["bash", "-C", "-e", "-u", "-o", "pipefail"]`). The previous `rm`-based version aborts the task under copy staging; this version completes the full pipeline cleanly, including every task downstream of `Predict`.
- `nf-core modules lint transdecoder/predict` and `prek run`: clean (one pre-existing, unrelated bioconda-version warning, out of scope here).

Generated by Claude
