### PR TITLE
Remove duplicate lines in sentieon/coveragemetrics

### DIFF
--- a/modules/nf-core/sentieon/coveragemetrics/main.nf
+++ b/modules/nf-core/sentieon/coveragemetrics/main.nf
@@ -60,8 +60,5 @@ process SENTIEON_COVERAGEMETRICS {
     touch ${prefix}.sample_cumulative_coverage_counts
     touch ${prefix}.sample_cumulative_coverage_proportions
     touch ${prefix}.sample_interval_summary
-    touch ${prefix}.sample_cumulative_coverage_counts
-    touch ${prefix}.sample_cumulative_coverage_proportions
-    touch ${prefix}.sample_interval_summary
     """
 }

--- a/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test
+++ b/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test
@@ -35,7 +35,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -64,7 +64,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -93,12 +93,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out.per_locus).match() },
-                { assert process.out.sample_summary == [] },
-                { assert process.out.statistics == [] },
-                { assert process.out.coverage_counts == [] },
-                { assert process.out.coverage_proportions == [] },
-                { assert process.out.interval_summary == [] }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -127,7 +122,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -163,7 +158,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -195,15 +190,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(
-                    process.out.per_locus,
-                    process.out.statistics,
-                    process.out.coverage_counts,
-                    process.out.coverage_proportions,
-                    process.out.interval_summary,
-                    process.out.versions_sentieon
-                ).match() },
-                { assert process.out.sample_summary == [] }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test
+++ b/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test
@@ -93,7 +93,12 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(process.out.per_locus).match() },
+                { assert process.out.sample_summary == [] },
+                { assert process.out.statistics == [] },
+                { assert process.out.coverage_counts == [] },
+                { assert process.out.coverage_proportions == [] },
+                { assert process.out.interval_summary == [] }
             )
         }
     }
@@ -190,7 +195,15 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert snapshot(
+                    process.out.per_locus,
+                    process.out.statistics,
+                    process.out.coverage_counts,
+                    process.out.coverage_proportions,
+                    process.out.interval_summary,
+                    process.out.versions_sentieon
+                ).match() },
+                { assert process.out.sample_summary == [] }
             )
         }
     }

--- a/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test.snap
+++ b/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test.snap
@@ -1,16 +1,40 @@
 {
     "Test omit outputs": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
+            {
+                "coverage_counts": [
+                    
+                ],
+                "coverage_proportions": [
+                    
+                ],
+                "interval_summary": [
+                    
+                ],
+                "per_locus": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
+                    ]
+                ],
+                "sample_summary": [
+                    
+                ],
+                "statistics": [
+                    
+                ],
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_COVERAGEMETRICS",
+                        "sentieon",
+                        "202503.02"
+                    ]
                 ]
-            ]
+            }
         ],
-        "timestamp": "2026-08-27T11:41:26.424937739",
+        "timestamp": "2026-08-27T19:04:10.651905039",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.7"
@@ -19,61 +43,6 @@
     "Test with interval": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,8c11df3f3356340a202fa0dc77fe35f8"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_summary:md5,22af430203047071b0ab751136f73fb9"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_statistics:md5,4eeb041ef4b6f23318a5cb27ded8d185"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_counts:md5,8602322f76c594e1bd95b737892f757a"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_proportions:md5,a81d27266e65db6836be14fe36cb703e"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_summary:md5,2848c49bfff5bee333887df8168c0dfa"
-                    ]
-                ],
-                "6": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
-                ],
                 "coverage_counts": [
                     [
                         {
@@ -131,70 +100,15 @@
                 ]
             }
         ],
-        "timestamp": "2026-01-21T06:54:48.537598623",
+        "timestamp": "2026-08-27T19:06:00.150430369",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.7"
         }
     },
     "Test multiple BAMs": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,a822ad7d35372f51285ad667ae126b3c"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_summary:md5,860e084915ae9ddd24f1924777f3241a"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_statistics:md5,fbde27e69eb60da6929f84cde88fa71d"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_counts:md5,acce67fbb95e0f8f3e214d10f3a4a94a"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_proportions:md5,de4e0551213d838dcb194486e18ac622"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_summary:md5,b26dbff23a11347eeab7400b7461140e"
-                    ]
-                ],
-                "6": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
-                ],
                 "coverage_counts": [
                     [
                         {
@@ -252,63 +166,68 @@
                 ]
             }
         ],
-        "timestamp": "2026-01-21T06:55:15.632397339",
+        "timestamp": "2026-08-27T19:15:34.64509302",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.7"
         }
     },
     "Test - stub": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test:md5,d41d8cd98f00b204e9800998ecf8427e"
+            {
+                "coverage_counts": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sample_cumulative_coverage_counts:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "coverage_proportions": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sample_cumulative_coverage_proportions:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "interval_summary": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sample_interval_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "per_locus": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "sample_summary": [
+                    
+                ],
+                "statistics": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.sample_interval_statistics:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_sentieon": [
+                    [
+                        "SENTIEON_COVERAGEMETRICS",
+                        "sentieon",
+                        "202503.02"
+                    ]
                 ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.sample_interval_statistics:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.sample_cumulative_coverage_counts:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.sample_cumulative_coverage_proportions:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ],
-            [
-                [
-                    {
-                        "id": "test"
-                    },
-                    "test.sample_interval_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ],
-            [
-                [
-                    "SENTIEON_COVERAGEMETRICS",
-                    "sentieon",
-                    "202503.02"
-                ]
-            ]
+            }
         ],
-        "timestamp": "2026-08-27T12:01:35.56802115",
+        "timestamp": "2026-08-27T19:13:27.453752632",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.7"
@@ -317,61 +236,6 @@
     "Test per sample": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_summary:md5,4bfcab63ec143ca34b7e7898428cdd18"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_statistics:md5,fbde27e69eb60da6929f84cde88fa71d"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_counts:md5,e499e70ef92c4a32bae6c84aa8fda864"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_proportions:md5,921bffb4de4fd4b59273e93c744e3c6c"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_summary:md5,ea6331fa0d429b9a97322cb6e3412a06"
-                    ]
-                ],
-                "6": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
-                ],
                 "coverage_counts": [
                     [
                         {
@@ -429,70 +293,15 @@
                 ]
             }
         ],
-        "timestamp": "2026-01-21T06:54:39.444896549",
+        "timestamp": "2026-08-27T19:11:09.933000931",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.7"
         }
     },
     "Test readgroup partition": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,c08b425fb089cee927407d31043a1f4f"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_library_platform_center_summary:md5,0ffa52a475028b1c722812958ef7b0ff"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_library_platform_center_interval_statistics:md5,fbde27e69eb60da6929f84cde88fa71d"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_library_platform_center_cumulative_coverage_counts:md5,e499e70ef92c4a32bae6c84aa8fda864"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_library_platform_center_cumulative_coverage_proportions:md5,b2247ac6696bf8d20d55661a6a5456dc"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_library_platform_center_interval_summary:md5,a19085c2f8bd0cc0773d1bb0fd5f32dd"
-                    ]
-                ],
-                "6": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
-                ],
                 "coverage_counts": [
                     [
                         {
@@ -550,10 +359,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-01-21T06:55:06.47413819",
+        "timestamp": "2026-08-27T19:08:14.515695512",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.7"
         }
     }
 }

--- a/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test.snap
+++ b/modules/nf-core/sentieon/coveragemetrics/tests/main.nf.test.snap
@@ -1,74 +1,20 @@
 {
     "Test omit outputs": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    
-                ],
-                "6": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
-                ],
-                "coverage_counts": [
-                    
-                ],
-                "coverage_proportions": [
-                    
-                ],
-                "interval_summary": [
-                    
-                ],
-                "per_locus": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
-                    ]
-                ],
-                "sample_summary": [
-                    
-                ],
-                "statistics": [
-                    
-                ],
-                "versions_sentieon": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test:md5,b9a842bad25d3d134a1f06ad69ffc877"
                 ]
-            }
+            ]
         ],
+        "timestamp": "2026-08-27T11:41:26.424937739",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:54:57.611594148"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.7"
+        }
     },
     "Test with interval": {
         "content": [
@@ -185,11 +131,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-21T06:54:48.537598623",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:54:48.537598623"
+        }
     },
     "Test multiple BAMs": {
         "content": [
@@ -306,122 +252,67 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-21T06:55:15.632397339",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:55:15.632397339"
+        }
     },
     "Test - stub": {
         "content": [
-            {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_statistics:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_counts:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_proportions:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
-                ],
-                "coverage_counts": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_counts:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "coverage_proportions": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_cumulative_coverage_proportions:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "interval_summary": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "per_locus": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "sample_summary": [
-                    
-                ],
-                "statistics": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.sample_interval_statistics:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "versions_sentieon": [
-                    [
-                        "SENTIEON_COVERAGEMETRICS",
-                        "sentieon",
-                        "202503.02"
-                    ]
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ]
-            }
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.sample_interval_statistics:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.sample_cumulative_coverage_counts:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.sample_cumulative_coverage_proportions:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.sample_interval_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    "SENTIEON_COVERAGEMETRICS",
+                    "sentieon",
+                    "202503.02"
+                ]
+            ]
         ],
+        "timestamp": "2026-08-27T12:01:35.56802115",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:55:22.931782396"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.7"
+        }
     },
     "Test per sample": {
         "content": [
@@ -538,11 +429,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-21T06:54:39.444896549",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:54:39.444896549"
+        }
     },
     "Test readgroup partition": {
         "content": [
@@ -659,10 +550,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-01-21T06:55:06.47413819",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T06:55:06.47413819"
+        }
     }
 }


### PR DESCRIPTION
This PR removes duplicated lines from the `stub` block, and updates the test in order to remove empty lines in the produced test snapshot.

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test <MODULE> --profile docker`
    - [x] `nf-core modules test <MODULE> --profile singularity`
    - [x] `nf-core modules test <MODULE> --profile conda`