### PR TITLE
smncopynumbercaller: add optional fasta input for CRAM support

### DIFF
--- a/modules/nf-core/smncopynumbercaller/main.nf
+++ b/modules/nf-core/smncopynumbercaller/main.nf
@@ -9,6 +9,7 @@ process SMNCOPYNUMBERCALLER {
 
     input:
     tuple val(meta), path(bam), path(bai)
+    tuple val(meta2), path(fasta), path(fai)
 
     output:
     tuple val(meta), path("out/*.tsv"),  emit: smncopynumber
@@ -22,11 +23,13 @@ process SMNCOPYNUMBERCALLER {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference = fasta ? "--reference ${fasta}" : ''
     """
     echo $bam | tr ' ' '
     ' > manifest.txt
     smn_caller.py \\
         $args \\
+        $reference \\
         --manifest manifest.txt \\
         --prefix $prefix \\
         --outDir "out" \\

--- a/modules/nf-core/smncopynumbercaller/meta.yml
+++ b/modules/nf-core/smncopynumbercaller/meta.yml
@@ -33,6 +33,26 @@ input:
         description: BAM/CRAM index file
         pattern: "*.{bai,crai}"
         ontologies: []
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome' ]
+    - fasta:
+        type: file
+        description: |
+          Reference FASTA the alignments were made against. Required for CRAM
+          input; pass `[[],[],[]]` when the input is BAM.
+        pattern: "*.{fa,fna,fasta}"
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
+    - fai:
+        type: file
+        description: |
+          FASTA index (`samtools faidx`), required alongside `fasta` so htslib
+          does not have to rebuild it per task.
+        pattern: "*.fai"
+        ontologies: []
 output:
   smncopynumber:
     - - meta:

--- a/modules/nf-core/smncopynumbercaller/tests/main.nf.test
+++ b/modules/nf-core/smncopynumbercaller/tests/main.nf.test
@@ -20,6 +20,7 @@ nextflow_process {
 				    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.rna.paired_end.sorted.chr6.bam', checkIfExists: true),
 				    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.rna.paired_end.sorted.chr6.bam.bai', checkIfExists: true),
 				]
+                input[1] = [[],[],[]]
 
                 """
             }
@@ -43,6 +44,7 @@ nextflow_process {
 				    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.rna.paired_end.sorted.chr6.bam', checkIfExists: true),
 				    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/bam/test.rna.paired_end.sorted.chr6.bam.bai', checkIfExists: true),
 				]
+                input[1] = [[],[],[]]
 
                 """
             }
@@ -56,4 +58,35 @@ nextflow_process {
         }
     }
 
+    // CRAM input. Stub only: smn_caller.py fetches the SMN regions on
+    // chromosome 5, and every CRAM in nf-core/test-datasets is single-contig
+    // (chr21/chr22), so a functional run fails with `invalid contig '5'`
+    // regardless of --genome. This still covers the new input channel and the
+    // staging of cram/crai/fasta/fai. See the PR description.
+    test("test-smncopynumbercaller-cram-stub") {
+        options '-stub'
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.rna.paired_end.sorted.cram', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.rna.paired_end.sorted.cram.crai', checkIfExists: true),
+                ]
+                input[1] = [
+                    [ id:'genome' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
 }

--- a/modules/nf-core/smncopynumbercaller/tests/main.nf.test
+++ b/modules/nf-core/smncopynumbercaller/tests/main.nf.test
@@ -29,7 +29,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -53,7 +53,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -85,7 +85,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/smncopynumbercaller/tests/main.nf.test.snap
+++ b/modules/nf-core/smncopynumbercaller/tests/main.nf.test.snap
@@ -2,29 +2,6 @@
     "test-smncopynumbercaller-cram-stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        "SMNCOPYNUMBERCALLER",
-                        "smncopynumbercaller",
-                        "1.1.2"
-                    ]
-                ],
                 "run_metrics": [
                     [
                         {
@@ -50,7 +27,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-27T15:02:17.539339",
+        "timestamp": "2026-08-31T11:35:51.367835",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -59,29 +36,6 @@
     "test-smncopynumbercaller-stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        "SMNCOPYNUMBERCALLER",
-                        "smncopynumbercaller",
-                        "1.1.2"
-                    ]
-                ],
                 "run_metrics": [
                     [
                         {
@@ -107,38 +61,15 @@
                 ]
             }
         ],
-        "timestamp": "2026-02-11T21:26:46.783248",
+        "timestamp": "2026-08-31T11:35:45.500239",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "test-smncopynumbercaller": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.tsv:md5,0de62f196972c17e1701aa8cea0849f9"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.json:md5,95f026f441e81a4b345316d980c3570a"
-                    ]
-                ],
-                "2": [
-                    [
-                        "SMNCOPYNUMBERCALLER",
-                        "smncopynumbercaller",
-                        "1.1.2"
-                    ]
-                ],
                 "run_metrics": [
                     [
                         {
@@ -164,10 +95,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-02-11T21:26:43.145754",
+        "timestamp": "2026-08-31T11:35:39.6893",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/modules/nf-core/smncopynumbercaller/tests/main.nf.test.snap
+++ b/modules/nf-core/smncopynumbercaller/tests/main.nf.test.snap
@@ -1,4 +1,61 @@
 {
+    "test-smncopynumbercaller-cram-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "SMNCOPYNUMBERCALLER",
+                        "smncopynumbercaller",
+                        "1.1.2"
+                    ]
+                ],
+                "run_metrics": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "smncopynumber": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_smncopynumbercaller": [
+                    [
+                        "SMNCOPYNUMBERCALLER",
+                        "smncopynumbercaller",
+                        "1.1.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-27T15:02:17.539339",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
     "test-smncopynumbercaller-stub": {
         "content": [
             {
@@ -50,11 +107,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-02-11T21:26:46.783248",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-11T21:26:46.783248"
+        }
     },
     "test-smncopynumbercaller": {
         "content": [
@@ -107,10 +164,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-02-11T21:26:43.145754",
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-11T21:26:43.145754"
+        }
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-c
o.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test smncopynumbercaller--profile docker`
    - [ ] `nf-core modules test smncopynumbercaller--profile singularity`
    - [ ] `nf-core modules test smncopynumbercaller --profile conda`
