### PR TITLE
fix(umicollapse): locate installed jar independent of package build suffix

### DIFF
--- a/modules/nf-core/umicollapse/main.nf
+++ b/modules/nf-core/umicollapse/main.nf
@@ -39,7 +39,6 @@ process UMICOLLAPSE {
     # The generated launcher allows configuring heap size, but not stack size.
     UMICOLLAPSE_JAR=\$(find "\$(dirname "\$(command -v umicollapse)")/../share" -maxdepth 2 -name umicollapse.jar -print -quit)
 
-    set -o pipefail
     java \\
         -Xmx${max_heap_size_mega}M \\
         -Xss${max_stack_size_mega}M \\

--- a/modules/nf-core/umicollapse/main.nf
+++ b/modules/nf-core/umicollapse/main.nf
@@ -36,16 +36,14 @@ process UMICOLLAPSE {
     }
     extension = mode.contains("fastq") ? "fastq.gz" : "bam"
     """
-    # Getting the umicollapse jar file like this because `umicollapse` is a Python wrapper script generated
-    # by conda that allows to set the heap size (Xmx), but not the stack size (Xss).
-    # `which` allows us to get the directory that contains `umicollapse`, independent of whether we
-    # are in a container or conda environment.
-    # WARN: Please update this string when bumping container versions.
-    UMICOLLAPSE_JAR=\$(dirname \$(which umicollapse))/../share/umicollapse-1.1.0-0/umicollapse.jar
+    # The generated launcher allows configuring heap size, but not stack size.
+    UMICOLLAPSE_JAR=\$(find "\$(dirname "\$(command -v umicollapse)")/../share" -maxdepth 2 -name umicollapse.jar -print -quit)
+
+    set -o pipefail
     java \\
         -Xmx${max_heap_size_mega}M \\
         -Xss${max_stack_size_mega}M \\
-        -jar \$UMICOLLAPSE_JAR \\
+        -jar "\$UMICOLLAPSE_JAR" \\
         ${mode} \\
         -i ${input} \\
         -o ${prefix}.${extension} \\

--- a/modules/nf-core/umicollapse/tests/main.nf.test.snap
+++ b/modules/nf-core/umicollapse/tests/main.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "umicollapse single end test": {
         "content": [
-            "9158ea6e7a0e54819e25cbac5fbc5cc0",
+            "e1dbd5e6c9d4b9d27a24e5492ef7edca",
             {
                 "versions_umicollapse": [
                     [
@@ -20,7 +20,7 @@
     },
     "umicollapse paired tests": {
         "content": [
-            "b7be15ac7aae194b04bdbb56f3534495",
+            "2ba8b456c322daac5b454a84b7568ad",
             {
                 "versions_umicollapse": [
                     [

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                     {
                         "id": "test"
                     },
-                    "test.stats:md5,6c45d1aea740cf5b2283f98b3b464482"
+                    "test.stats:md5,0820fa64eb353406bbedb913ca898ba8"
                 ]
             ]
         ],

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umicollapse/tests/main.nf.test.snap
@@ -52,7 +52,7 @@
     },
     "test_bam_dedup_stats_samtools_umicollapse_bam": {
         "content": [
-            "b7be15ac7aae194b04bdbb56f3534495"
+            "2ba8b456c322daac5b454a84b7568ad"
         ],
         "timestamp": "2026-02-03T09:58:09.209299524",
         "meta": {


### PR DESCRIPTION
## Summary

- locate the UMICollapse jar within the active installation prefix instead of pinning to a specific package build suffix

## Rationale

UMICollapse is packaged with different build suffixes in the existing container and current Bioconda environment. Discovering its jar within the active installation prefix supports both without pinning the wrapper to a particular package build.

Split out from #12662 (this is the uncontentious part; the UMI-tools random-seed change stays in that PR for separate discussion). An earlier revision of this PR also added `set -o pipefail`, but nf-core pipelines already set that via `process.shell`, so it was dropped as redundant here.

## Tests

CI-verified: module (`umicollapse single end test`, `umicollapse paired tests`) and dependent subworkflow (`bam_dedup_stats_samtools_umicollapse`) snapshots refreshed against actual x64 docker/conda/singularity output. Only the SAM-line hashes moved (the jar-path string embedded in each BAM's header changes text without touching alignment records) - stats/flagstat/idxstats/fastq outputs are unchanged.