### PR TITLE
fix(bbmap/repair): restore task.ext.args dropped by missing line continuation

### DIFF
--- a/modules/nf-core/bbmap/repair/main.nf
+++ b/modules/nf-core/bbmap/repair/main.nf
@@ -31,7 +31,7 @@ process BBMAP_REPAIR {
         -Xmx\$maxmem \\
         $in_reads \\
         $out_reads \\
-        threads=${task.cpus}
+        threads=${task.cpus} \\
         ${args} \\
         &> ${prefix}.repair.sh.log
     """


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] `nf-core modules test bbmap/repair --profile docker`

## Description

`bbmap/repair`'s `script:` block builds the `repair.sh` invocation with a `\` line continuation after every line except one:

```groovy
repair.sh \\
    -Xmx\$maxmem \\
    $in_reads \\
    $out_reads \\
    threads=${task.cpus}
    ${args} \\
    &> ${prefix}.repair.sh.log
```

`threads=${task.cpus}` is missing its trailing `\`. Rendered to bash, the `repair.sh ... threads=N` command terminates on that line, and `${args} \` becomes a separate, dangling statement on the next line that is never actually appended to the `repair.sh` invocation. The practical effect: **`task.ext.args` is silently dropped and never reaches `repair.sh`**, regardless of what a downstream pipeline sets it to.

Fix: add the missing `\` so `${args}` actually continues the `repair.sh` command, matching every other line in the block:

```groovy
repair.sh \\
    -Xmx\$maxmem \\
    $in_reads \\
    $out_reads \\
    threads=${task.cpus} \\
    ${args} \\
    &> ${prefix}.repair.sh.log
```

That's the only functional change. No reformatting or other logic changes.

### How I found this

I was wiring `bbmap/repair` into a pipeline outside nf-core and set `ext.args = { "ziplevel=${params.repairZiplevel}" }`. The setting had no effect at all on the compressed output until I traced it back to this missing backslash. I worked around it locally with `nf-core modules patch` before submitting this fix upstream.

### Why the module's own tests didn't catch it

The module's test does set `ext.args` (via `params.module_args = 'qin=33'` in `tests/nextflow.config`), but `qin=33` is a no-op against the test data (already Phred+33 encoded), so silently dropping it produces no visible difference in test output — the bug has no observable effect on this specific test case either way.

### Testing

Ran the module's existing nf-test suite both before and after the fix (`nf-test test modules/nf-core/bbmap/repair/tests/main.nf.test --profile docker`) — all 4 tests pass unmodified in both cases, and no snapshot changes were needed. Also ran `nf-core modules lint bbmap/repair`; the only warnings reported (bioconda update available, container registry connectivity, container version mismatch) are pre-existing and unrelated to this change.