### PR TITLE
Update to add flag for dot replacement

### DIFF
--- a/subworkflows/nf-core/fasta_clean_faidx/main.nf
+++ b/subworkflows/nf-core/fasta_clean_faidx/main.nf
@@ -7,6 +7,7 @@ include { SAMTOOLS_DICT                 } from "../../../modules/nf-core/samtool
 workflow FASTA_CLEAN_FAIDX {
     take:
     ch_reference          // channel.of( [meta], reference )
+    val_replace_dots      // boolean: replace dots in headers with underscores in trimmed reference
     val_get_chromsizes    // boolean: emit chromsizes
     val_get_dict          // boolean: emit dict
 
@@ -50,11 +51,19 @@ workflow FASTA_CLEAN_FAIDX {
     //
     // MODULE: REPLACE `.` IN HEADERS WITH `_`
     //         `.` CAN CAUSE ISSUES FOR SOME DOWNSTREAM TOOLS
+    //         CONTROLLING THIS ON val_replace_dots ALLOWS US TO STAY INSIDE OF
+    //         SOME STANDARDS (e.g. ONLY TAKE FIRST WORK IN HEADER)
     //
-    SEQKIT_DOTS (
-        SEQKIT_SEQ.out.fastx,
-        "fasta"
-    )
+    if (val_replace_dots) {
+        SEQKIT_DOTS (
+            SEQKIT_SEQ.out.fastx,
+            "fasta"
+        )
+
+        renamed_fasta = SEQKIT_DOTS.out.fastx
+    } else {
+        renamed_fasta = SEQKIT_SEQ.out.fastx
+    }
 
 
     //
@@ -62,7 +71,7 @@ workflow FASTA_CLEAN_FAIDX {
     //         OPTIONALLY EMIT CHROMOSOME SIZES FILE
     //
     SAMTOOLS_FAIDX (
-        SEQKIT_DOTS.out.fastx.map { meta, file -> [meta, file, []] },
+        renamed_fasta.map { meta, file -> [meta, file, []] },
         val_get_chromsizes
     )
 
@@ -79,12 +88,12 @@ workflow FASTA_CLEAN_FAIDX {
     // MODULE: GENERATE A SAMTOOLS DICT FILE BASED ON THE CORRECTED FASTA FILE
     //
     SAMTOOLS_DICT (
-        SEQKIT_DOTS.out.fastx.filter { meta, file -> val_get_dict }
+        renamed_fasta.filter { meta, file -> val_get_dict }
     )
 
 
     emit:
-    reference               = SEQKIT_DOTS.out.fastx
+    reference               = renamed_fasta
     fai                     = SAMTOOLS_FAIDX.out.fai
     sizes                   = SAMTOOLS_FAIDX.out.sizes
     dict                    = SAMTOOLS_DICT.out.dict

--- a/subworkflows/nf-core/fasta_clean_faidx/meta.yml
+++ b/subworkflows/nf-core/fasta_clean_faidx/meta.yml
@@ -22,10 +22,20 @@ input:
 
         Structure: [ val(meta), path(fasta) ]
       pattern: "*.{(fasta,fa,fna)(.gz)}"
+
+  - val_replace_dots:
+      type: boolean
+      description: |
+        Whether to replace dots in the fasta reference name with underscores.
+
+        Some tools can't handle dots in the fasta name, however,
+        sometimes the ID must remain unchanged.
+
   - val_get_chromsizes:
       type: boolean
       description: |
         Whether to generate a chromosome sizes file from the fasta reference.
+
   - val_get_dict:
       type: boolean
       description: |

--- a/subworkflows/nf-core/fasta_clean_faidx/tests/main.nf.test
+++ b/subworkflows/nf-core/fasta_clean_faidx/tests/main.nf.test
@@ -31,6 +31,7 @@ nextflow_workflow {
                 )
                 input[1] = true
                 input[2] = true
+                input[3] = true
                 """
             }
 
@@ -41,6 +42,45 @@ nextflow_workflow {
                 { assert workflow.success },
                 { assert snapshot(
                     path(workflow.out.dict[0][1]).readLines()[0],
+                    path(workflow.out.reference[0][1]).readLines()[0],
+                    workflow.out.reference,
+                    workflow.out.fai,
+                    workflow.out.sizes,
+                    workflow.out.sequence_description
+                ).match() }
+            )
+        }
+    }
+
+    test("Bacteroides fragilis genome [fasta] w/ index - keep dots") {
+        when {
+
+            params {
+                outdir = "test"
+            }
+
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                    ]
+                )
+                input[1] = false
+                input[2] = true
+                input[3] = true
+                """
+            }
+
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.dict[0][1]).readLines()[0],
+                    path(workflow.out.reference[0][1]).readLines()[0],
                     workflow.out.reference,
                     workflow.out.fai,
                     workflow.out.sizes,
@@ -65,8 +105,9 @@ nextflow_workflow {
                         file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
                     ]
                 )
-                input[1] = false
-                input[2] = true
+                input[1] = true
+                input[2] = false
+                input[3] = true
                 """
             }
 
@@ -77,6 +118,7 @@ nextflow_workflow {
                 { assert workflow.success },
                 { assert snapshot(
                     path(workflow.out.dict[0][1]).readLines()[0],
+                    path(workflow.out.reference[0][1]).readLines()[0],
                     workflow.out.reference,
                     workflow.out.fai,
                     workflow.out.sequence_description
@@ -99,8 +141,9 @@ nextflow_workflow {
                         file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
                     ]
                 )
-                input[1] = false
+                input[1] = true
                 input[2] = false
+                input[3] = false
                 """
             }
 
@@ -132,6 +175,7 @@ nextflow_workflow {
                 )
                 input[1] = true
                 input[2] = true
+                input[3] = true
                 """
             }
         }

--- a/subworkflows/nf-core/fasta_clean_faidx/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_clean_faidx/tests/main.nf.test.snap
@@ -1,7 +1,51 @@
 {
+    "Bacteroides fragilis genome [fasta] w/ index - keep dots": {
+        "content": [
+            "@HD\tVN:1.0\tSO:unsorted",
+            ">NZ_CP069563.1",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.fasta:md5,96aa7707b864499745e8946f169ae8e0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.fasta.fai:md5,f1373ef38f3777bcf9567be2e1f5c468"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.fasta.sizes:md5,acc65893c145aa8385e4afb4f4662623"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.json:md5,1e536d080509f7fc34114f0bc58a514d"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-28T17:29:22.581741203",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    },
     "Bacteroides fragilis genome [fasta] w/ index": {
         "content": [
             "@HD\tVN:1.0\tSO:unsorted",
+            ">NZ_CP069563_1",
             [
                 [
                     {
@@ -35,10 +79,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-08-26T10:00:11.358890143",
+        "timestamp": "2026-08-28T12:57:01.005284326",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "25.04.6"
         }
     },
     "Bacteroides fragilis genome - stub": {
@@ -148,15 +192,16 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-26T10:00:31.191958515",
+        "timestamp": "2026-08-28T17:29:42.76692073",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "25.04.6"
         }
     },
     "Bacteroides fragilis genome [fasta] w/ index no sizes": {
         "content": [
             "@HD\tVN:1.0\tSO:unsorted",
+            ">NZ_CP069563_1",
             [
                 [
                     {
@@ -182,10 +227,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-08-26T10:00:21.054412137",
+        "timestamp": "2026-08-28T17:29:32.864768835",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "25.04.6"
         }
     }
 }


### PR DESCRIPTION
It came up in a team meeting that the dots will be required to stay in our case to maintain links between our outputs and external DB's and conventions.

I've added a boolean flag for this, which works well enough for this case.

Added the fasta's first line to the test to ensure it is working.