### PR TITLE
Upgrade gappa modules from 0.8.0 to 0.9.0

### DIFF
--- a/modules/nf-core/gappa/examineassign/environment.yml
+++ b/modules/nf-core/gappa/examineassign/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::gappa=0.8.0
+  - bioconda::gappa=0.9.0

--- a/modules/nf-core/gappa/examineassign/main.nf
+++ b/modules/nf-core/gappa/examineassign/main.nf
@@ -4,8 +4,8 @@ process GAPPA_EXAMINEASSIGN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gappa:0.8.0--h9a82719_0':
-        'quay.io/biocontainers/gappa:0.8.0--h9a82719_0' }"
+        'https://depot.galaxyproject.org/singularity/gappa:0.9.0--h077b44d_0':
+        'quay.io/biocontainers/gappa:0.9.0--h077b44d_0' }"
 
     input:
     tuple val(meta), path(jplace), path(taxonomy)

--- a/modules/nf-core/gappa/examineassign/tests/main.nf.test.snap
+++ b/modules/nf-core/gappa/examineassign/tests/main.nf.test.snap
@@ -46,15 +46,15 @@
                     [
                         "GAPPA_EXAMINEASSIGN",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:50:47.764043445",
+        "timestamp": "2026-08-31T20:55:49.294390021",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "test-gappa-examineassign-stub": {
@@ -89,15 +89,15 @@
                     [
                         "GAPPA_EXAMINEASSIGN",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:50:54.909308378",
+        "timestamp": "2026-08-31T20:55:53.721697033",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/modules/nf-core/gappa/examinegraft/environment.yml
+++ b/modules/nf-core/gappa/examinegraft/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::gappa=0.8.0
+  - bioconda::gappa=0.9.0

--- a/modules/nf-core/gappa/examinegraft/main.nf
+++ b/modules/nf-core/gappa/examinegraft/main.nf
@@ -4,8 +4,8 @@ process GAPPA_EXAMINEGRAFT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gappa:0.8.0--h9a82719_0':
-        'quay.io/biocontainers/gappa:0.8.0--h9a82719_0' }"
+        'https://depot.galaxyproject.org/singularity/gappa:0.9.0--h077b44d_0':
+        'quay.io/biocontainers/gappa:0.9.0--h077b44d_0' }"
 
     input:
     tuple val(meta), path(jplace)

--- a/modules/nf-core/gappa/examinegraft/tests/main.nf.test.snap
+++ b/modules/nf-core/gappa/examinegraft/tests/main.nf.test.snap
@@ -14,15 +14,15 @@
                     [
                         "GAPPA_EXAMINEGRAFT",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:49:05.576434267",
+        "timestamp": "2026-08-31T20:56:02.547524327",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "test-gappa-examinegraft": {
@@ -40,15 +40,15 @@
                     [
                         "GAPPA_EXAMINEGRAFT",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:48:58.46483027",
+        "timestamp": "2026-08-31T20:55:58.116946211",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/modules/nf-core/gappa/examineheattree/environment.yml
+++ b/modules/nf-core/gappa/examineheattree/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::gappa=0.8.0
+  - bioconda::gappa=0.9.0

--- a/modules/nf-core/gappa/examineheattree/main.nf
+++ b/modules/nf-core/gappa/examineheattree/main.nf
@@ -4,8 +4,8 @@ process GAPPA_EXAMINEHEATTREE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gappa:0.8.0--h9a82719_0':
-        'quay.io/biocontainers/gappa:0.8.0--h9a82719_0' }"
+        'https://depot.galaxyproject.org/singularity/gappa:0.9.0--h077b44d_0':
+        'quay.io/biocontainers/gappa:0.9.0--h077b44d_0' }"
 
     input:
     tuple val(meta), path(jplace)

--- a/modules/nf-core/gappa/examineheattree/tests/main.nf.test.snap
+++ b/modules/nf-core/gappa/examineheattree/tests/main.nf.test.snap
@@ -54,7 +54,7 @@
                     [
                         "GAPPA_EXAMINEHEATTREE",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             },
@@ -71,10 +71,10 @@
                 "    At 1.000: Label '1', Color #000000"
             ]
         ],
-        "timestamp": "2026-05-06T09:52:18.235753136",
+        "timestamp": "2026-08-31T20:56:07.182550046",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "test-gappa-examineheattree-stub": {
@@ -112,15 +112,15 @@
                     [
                         "GAPPA_EXAMINEHEATTREE",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:52:25.361266042",
+        "timestamp": "2026-08-31T20:56:11.975526384",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Closes #XXX <!-- If this PR fixes an issue, please link it here! -->

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`

## Description

Brings `gappa/examinegraft`, `gappa/examineassign` and `gappa/examineheattree` from gappa 0.8.0 to **0.9.0**, the current bioconda release.

`gappa/editmerge` (#12849) was added at 0.9.0, which left the four gappa modules split across two versions. After this they all share one version and one container, `gappa:0.9.0--h077b44d_0`. They are single-tool modules with no other dependencies, so nothing else needed reconciling, and these four are all the gappa modules in the repository.

### No output changed

Worth stating explicitly, because these modules ship inside the `fasta_newick_epang_gappa` subworkflow used by nf-core/phyloplace and nf-core/ampliseq, so a content change would ripple into pipeline snapshots.

Every md5 in the three snapshots is **identical** before and after. The complete non-version diff across all three files is:

- the two `gappa` version strings per snapshot;
- the nf-test `timestamp` and `nextflow` metadata, which move whenever snapshots are regenerated — the `nextflow` value shifts 26.04.0 -> 26.04.6 simply because my Nextflow is newer than whatever generated the originals.

So updating these in a pipeline should not move any pipeline snapshot.

### Lint

All three previously carried the `bioconda_latest` warning (`bioconda::gappa 0.8.0 -> 0.9.0`). That is now gone and each lints with 59 passed, 0 warnings, 0 failures.

Tested locally under docker, singularity and conda.

Generated by Claude
