### PR TITLE
Add samtools version topic to hisat2/extractsplicesites

### DIFF
--- a/modules/nf-core/hisat2/extractsplicesites/main.nf
+++ b/modules/nf-core/hisat2/extractsplicesites/main.nf
@@ -13,6 +13,7 @@ process HISAT2_EXTRACTSPLICESITES {
     output:
     tuple val(meta), path("*.splice_sites.txt"), emit: txt
     tuple val("${task.process}"), val('hisat2'), eval('hisat2 --version | grep -o "version [^ ]*" | cut -d " " -f 2'), topic: versions, emit: versions_hisat2
+    tuple val("${task.process}"), val('samtools'), eval("samtools --version | sed -n '1s/samtools //p'"), emit: versions_samtools, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/hisat2/extractsplicesites/meta.yml
+++ b/modules/nf-core/hisat2/extractsplicesites/meta.yml
@@ -11,7 +11,8 @@ tools:
       homepage: https://daehwankimlab.github.io/hisat2/
       documentation: https://daehwankimlab.github.io/hisat2/manual/
       doi: "10.1038/s41587-019-0201-4"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:hisat2
 input:
   - - meta:
@@ -39,11 +40,22 @@ output:
   versions_hisat2:
     - - ${task.process}:
           type: string
-          description: The process the versions were collected from
+          description: The name of the process
       - hisat2:
           type: string
-          description: The tool name
+          description: The name of the tool
       - hisat2 --version | grep -o "version [^ ]*" | cut -d " " -f 2:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools --version | sed -n '1s/samtools //p':
           type: eval
           description: The expression to obtain the version of the tool
 
@@ -51,11 +63,21 @@ topics:
   versions:
     - - ${task.process}:
           type: string
-          description: The process the versions were collected from
+          description: The name of the process
       - hisat2:
           type: string
-          description: The tool name
+          description: The name of the tool
       - hisat2 --version | grep -o "version [^ ]*" | cut -d " " -f 2:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - samtools:
+          type: string
+          description: The name of the tool
+      - samtools --version | sed -n '1s/samtools //p':
           type: eval
           description: The expression to obtain the version of the tool
 

--- a/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test
+++ b/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test
@@ -11,9 +11,6 @@ nextflow_process {
     test("Should run without failures") {
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
                 input[0] = Channel.of([
@@ -25,10 +22,9 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert path("${process.out.txt[0][1]}").exists() },
-                { assert snapshot(process.out.findAll { key, val -> key.startsWith("versions") }).match() }
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["txt"])).match() }
             )
         }
     }
@@ -38,9 +34,6 @@ nextflow_process {
         options "-stub"
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
                 input[0] = Channel.of([
@@ -52,9 +45,9 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test.snap
+++ b/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test.snap
@@ -2,21 +2,6 @@
     "test - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "genome"
-                        },
-                        "genome.splice_sites.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        "HISAT2_EXTRACTSPLICESITES",
-                        "hisat2",
-                        "2.2.3"
-                    ]
-                ],
                 "txt": [
                     [
                         {
@@ -31,10 +16,17 @@
                         "hisat2",
                         "2.2.3"
                     ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_EXTRACTSPLICESITES",
+                        "samtools",
+                        "1.24"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2026-08-31T09:49:15.953865046",
+        "timestamp": "2026-09-01T14:27:57.496546312",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.08.0"
@@ -43,16 +35,31 @@
     "Should run without failures": {
         "content": [
             {
+                "txt": [
+                    [
+                        {
+                            "id": "genome"
+                        },
+                        "genome.splice_sites.txt"
+                    ]
+                ],
                 "versions_hisat2": [
                     [
                         "HISAT2_EXTRACTSPLICESITES",
                         "hisat2",
                         "2.2.3"
                     ]
+                ],
+                "versions_samtools": [
+                    [
+                        "HISAT2_EXTRACTSPLICESITES",
+                        "samtools",
+                        "1.24"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2026-08-31T09:49:10.908340554",
+        "timestamp": "2026-09-01T14:27:14.726466124",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.08.0"


### PR DESCRIPTION
Add samtools version topic to hisat2/extractsplicesites to report the version of the samtools dependency that is pinned in environment.yml.

- Update main.nf to add samtools version output topic
- Update meta.yml to document the new output
- Update tests and snapshots

Generated by opencode
verified by @maxulysse