### PR TITLE
feat(semibin): add GPU support to single_easy_bin and multi_easy_bin

### DIFF
--- a/modules/nf-core/semibin/multieasybin/environment.gpu.yml
+++ b/modules/nf-core/semibin/multieasybin/environment.gpu.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::semibin=2.4.1
+  # lowest CUDA pytorch 2.13 ships on linux-64, so it runs on the widest range of hosts
+  - conda-forge::pytorch-gpu=2.13.0
+  - conda-forge::cuda-version=12.9

--- a/modules/nf-core/semibin/multieasybin/main.nf
+++ b/modules/nf-core/semibin/multieasybin/main.nf
@@ -1,11 +1,16 @@
 process SEMIBIN_MULTIEASYBIN {
     tag "${meta.id}"
     label 'process_medium'
+    label 'process_gpu'
 
-    conda "${moduleDir}/environment.yml"
+    conda "${task.accelerator ? "${moduleDir}/environment.gpu.yml" : "${moduleDir}/environment.yml"}"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4c/4c049230e87478349b2ecca53156faedfb077df85a4f6deaa8d0b22bd8a975c4/data'
-        : 'community.wave.seqera.io/library/semibin:2.4.1--594344a862aee1b8'}"
+        ? (task.accelerator
+            ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fb/fbd557d49df87acd78159a1be8a78dc8fec2030a0ab3e26b11b16ed112ad5e57/data'
+            : 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4c/4c049230e87478349b2ecca53156faedfb077df85a4f6deaa8d0b22bd8a975c4/data')
+        : (task.accelerator
+            ? 'community.wave.seqera.io/library/semibin_pytorch-gpu_cuda-version:d7e398c7556966b1'
+            : 'community.wave.seqera.io/library/semibin:2.4.1--594344a862aee1b8')}"
 
     input:
     tuple val(meta), path(fasta), path(bam), path(depths)
@@ -16,6 +21,7 @@ process SEMIBIN_MULTIEASYBIN {
     tuple val(meta), path("${prefix}/samples/*/*.tsv"), emit: tsv
     tuple val(meta), path("${prefix}/SemiBinRun.log"), emit: log
     tuple val("${task.process}"), val('SemiBin'), eval("SemiBin2 --version"), emit: versions_semibin, topic: versions
+    tuple val("${task.process}"), val('cuda'), eval('python -c "import torch; print(torch.version.cuda or \'no CUDA available\')"'), emit: versions_cuda, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,6 +30,7 @@ process SEMIBIN_MULTIEASYBIN {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ""
     prefix = task.ext.prefix ?: "${meta.id}"
+    def engine = task.accelerator ? 'gpu' : 'cpu'
 
     def input_depth = bam ? "--input-bam ${bam}" : "--abundance ${depths}"
     """
@@ -34,6 +41,7 @@ process SEMIBIN_MULTIEASYBIN {
         ${input_depth} \\
         --output ${prefix} \\
         -t ${task.cpus} \\
+        --engine ${engine} \\
         ${args2}
     """
 

--- a/modules/nf-core/semibin/multieasybin/meta.yml
+++ b/modules/nf-core/semibin/multieasybin/meta.yml
@@ -104,6 +104,16 @@ output:
       - SemiBin2 --version:
           type: eval
           description: The expression to obtain the version of the tool
+  versions_cuda:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - cuda:
+          type: string
+          description: The name of the runtime
+      - 'python -c "import torch; print(torch.version.cuda or ''no CUDA available'')"':
+          type: eval
+          description: CUDA version bundled with the task's pytorch build, or `no CUDA available` on the non-GPU path
 topics:
   versions:
     - - ${task.process}:
@@ -115,6 +125,15 @@ topics:
       - SemiBin2 --version:
           type: eval
           description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - cuda:
+          type: string
+          description: The name of the runtime
+      - 'python -c "import torch; print(torch.version.cuda or ''no CUDA available'')"':
+          type: eval
+          description: CUDA version bundled with the task's pytorch build, or `no CUDA available` on the non-GPU path
 authors:
   - "@prototaxites"
 maintainers:

--- a/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test
+++ b/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test
@@ -1,0 +1,47 @@
+nextflow_process {
+
+    name "Test Process SEMIBIN_MULTIEASYBIN (GPU)"
+
+    script "../main.nf"
+    process "SEMIBIN_MULTIEASYBIN"
+
+    tag "gpu"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "semibin"
+    tag "semibin/multieasybin"
+    config './nextflow.gpu.config'
+
+    test("semibin_data - bam - gpu") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:'test'],
+                    file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi.fasta.gz", checkIfExists:true),
+                    [
+                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted1.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted2.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted3.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted4.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted5.bam", checkIfExists:true)
+                    ],
+                    []
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                // number and names of bins are not stable
+                { assert process.out.bins.get(0).get(1).size() >= 1 },
+                { assert snapshot(
+                    sanitizeOutput(process.out, unstableKeys: ["csv", "tsv", "log"], ignoreKeys: ["bins"])
+                ).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test
+++ b/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test
@@ -33,10 +33,16 @@ nextflow_process {
             }
         }
         then {
+            assert process.success
+            // per sample: the contigs SemiBin featurised, and the contigs it wrote into that sample's bins
+            def featurised = process.out.csv.get(0).get(1).findAll { it.endsWith('/data.csv') }
+                .collectEntries { csv -> [csv.tokenize('/')[-2], path(csv).readLines().drop(1).collect { it.split(',')[0] }.sort()] }
+            def bins = process.out.bins.get(0).get(1).collectEntries { fa -> [fa, path(fa).fasta] }
+            def binned = bins.groupBy { fa, seqs -> fa.tokenize('/')[-1].tokenize('_')[0] }
+                .collectEntries { sample, group -> [sample, group.values().collectMany { it.keySet().toList() }.sort()] }
             assertAll(
-                { assert process.success },
-                // bin names and contents vary between machines
-                { assert process.out.bins.get(0).get(1).size() >= 1 },
+                // every contig lands in exactly one bin of its own sample. Which bin varies between machines
+                { assert featurised && binned == featurised },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv", "log"], ignoreKeys: ["bins"])
                 ).match() }

--- a/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test
+++ b/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test
@@ -35,7 +35,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                // number and names of bins are not stable
+                // bin names and contents vary between machines
                 { assert process.out.bins.get(0).get(1).size() >= 1 },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv", "log"], ignoreKeys: ["bins"])

--- a/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test
+++ b/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test
@@ -12,20 +12,20 @@ nextflow_process {
     tag "semibin/multieasybin"
     config './nextflow.gpu.config'
 
-    test("semibin_data - bam - gpu") {
+    test("metagenome - binning - bam - gpu") {
 
         when {
             process {
                 """
                 input[0] = [
                     [id:'test'],
-                    file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi.fasta.gz", checkIfExists:true),
+                    file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/contigs.fasta.gz", checkIfExists:true),
                     [
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted1.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted2.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted3.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted4.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted5.bam", checkIfExists:true)
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s1.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s2.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s3.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s4.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s5.sorted.bam", checkIfExists:true),
                     ],
                     []
                 ]

--- a/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test.snap
+++ b/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "semibin_data - bam - gpu": {
+    "metagenome - binning - bam - gpu": {
         "content": [
             {
                 "csv": [
@@ -8,26 +8,6 @@
                             "id": "test"
                         },
                         [
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
                             "data.csv",
                             "data_cov.csv",
                             "data_split.csv",
@@ -74,16 +54,6 @@
                             "contig_bins.tsv",
                             "recluster_bins_info.tsv",
                             "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
                             "recluster_bins_info.tsv"
                         ]
                     ]
@@ -104,7 +74,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-09-01T16:35:22.228383058",
+        "timestamp": "2026-09-02T01:33:50.539506466",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test.snap
+++ b/modules/nf-core/semibin/multieasybin/tests/main.gpu.nf.test.snap
@@ -1,0 +1,113 @@
+{
+    "semibin_data - bam - gpu": {
+        "content": [
+            {
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv",
+                            "data.csv",
+                            "data_cov.csv",
+                            "data_split.csv",
+                            "data_split_cov.csv"
+                        ]
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "SemiBinRun.log"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv",
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv"
+                        ]
+                    ]
+                ],
+                "versions_cuda": [
+                    [
+                        "SEMIBIN_MULTIEASYBIN",
+                        "cuda",
+                        "12.9"
+                    ]
+                ],
+                "versions_semibin": [
+                    [
+                        "SEMIBIN_MULTIEASYBIN",
+                        "SemiBin",
+                        "2.4.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-01T16:35:22.228383058",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/modules/nf-core/semibin/multieasybin/tests/main.nf.test
+++ b/modules/nf-core/semibin/multieasybin/tests/main.nf.test
@@ -37,9 +37,15 @@ nextflow_process {
         }
         then {
             assert process.success
+            // per sample: the contigs SemiBin featurised, and the contigs it wrote into that sample's bins
+            def featurised = process.out.csv.get(0).get(1).findAll { it.endsWith('/data.csv') }
+                .collectEntries { csv -> [csv.tokenize('/')[-2], path(csv).readLines().drop(1).collect { it.split(',')[0] }.sort()] }
+            def bins = process.out.bins.get(0).get(1).collectEntries { fa -> [fa, path(fa).fasta] }
+            def binned = bins.groupBy { fa, seqs -> fa.tokenize('/')[-1].tokenize('_')[0] }
+                .collectEntries { sample, group -> [sample, group.values().collectMany { it.keySet().toList() }.sort()] }
             assertAll(
-                // bin names and contents vary between machines
-                { assert process.out.bins.get(0).get(1).size() >= 1 },
+                // every contig lands in exactly one bin of its own sample. Which bin varies between machines
+                { assert featurised && binned == featurised },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv", "log"], ignoreKeys: ["bins"])
                 ).match() }
@@ -73,9 +79,15 @@ nextflow_process {
         }
         then {
             assert process.success
+            // per sample: the contigs SemiBin featurised, and the contigs it wrote into that sample's bins
+            def featurised = process.out.csv.get(0).get(1).findAll { it.endsWith('/data.csv') }
+                .collectEntries { csv -> [csv.tokenize('/')[-2], path(csv).readLines().drop(1).collect { it.split(',')[0] }.sort()] }
+            def bins = process.out.bins.get(0).get(1).collectEntries { fa -> [fa, path(fa).fasta] }
+            def binned = bins.groupBy { fa, seqs -> fa.tokenize('/')[-1].tokenize('_')[0] }
+                .collectEntries { sample, group -> [sample, group.values().collectMany { it.keySet().toList() }.sort()] }
             assertAll(
-                // bin names and contents vary between machines
-                { assert process.out.bins.get(0).get(1).size() >= 1 },
+                // every contig lands in exactly one bin of its own sample. Which bin varies between machines
+                { assert featurised && binned == featurised },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv", "log"], ignoreKeys: ["bins"])
                 ).match() }

--- a/modules/nf-core/semibin/multieasybin/tests/main.nf.test
+++ b/modules/nf-core/semibin/multieasybin/tests/main.nf.test
@@ -11,24 +11,24 @@ nextflow_process {
     tag "semibin/multieasybin"
     config './nextflow.config'
 
-    test("semibin_data - bam") {
+    test("metagenome - binning - bam") {
 
         when {
             params {
                 module_args  = ''
-                module_args2 = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
+                module_args2 = '-s C --ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
             }
             process {
                 """
                 input[0] = [
                     [id:'test'],
-                    file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi.fasta.gz", checkIfExists:true),
+                    file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/contigs.fasta.gz", checkIfExists:true),
                     [
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted1.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted2.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted3.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted4.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted5.bam", checkIfExists:true)
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s1.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s2.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s3.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s4.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s5.sorted.bam", checkIfExists:true),
                     ],
                     []
                 ]
@@ -47,25 +47,25 @@ nextflow_process {
         }
     }
 
-    test("semibin_data - abundance txt") {
+    test("metagenome - binning - abundance") {
 
         when {
             params {
                 module_args  = ''
-                module_args2 = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
+                module_args2 = '-s C --ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
             }
             process {
                 """
                 input[0] = [
                     [id:'test'],
-                    file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi.fasta.gz", checkIfExists:true),\
+                    file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/contigs.fasta.gz", checkIfExists:true),
                     [],
                     [
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/sample1.txt", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/sample2.txt", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/sample3.txt", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/sample4.txt", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/sample5.txt", checkIfExists:true)
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s1.aemb.tsv", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s2.aemb.tsv", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s3.aemb.tsv", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s4.aemb.tsv", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s5.aemb.tsv", checkIfExists:true),
                     ]
                 ]
                 """
@@ -83,24 +83,24 @@ nextflow_process {
         }
     }
 
-    test("semibin_data - stub") {
+    test("metagenome - binning - stub") {
         options '-stub'
         when {
             params {
                 module_args  = ''
-                module_args2 = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0'
+                module_args2 = '-s C --ml-threshold 0 --minfasta-kbs 0 --min-len 0'
             }
             process {
                 """
                 input[0] = [
                     [id:'test'],
-                    file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi.fasta.gz", checkIfExists:true),
+                    file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/contigs.fasta.gz", checkIfExists:true),
                     [
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted1.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted2.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted3.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted4.bam", checkIfExists:true),
-                        file(params.modules_testdata_base_path + "delete_me/semibin2/input_multi_sorted5.bam", checkIfExists:true)
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s1.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s2.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s3.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s4.sorted.bam", checkIfExists:true),
+                        file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/multisample/s5.sorted.bam", checkIfExists:true),
                     ],
                     []
                 ]

--- a/modules/nf-core/semibin/multieasybin/tests/main.nf.test
+++ b/modules/nf-core/semibin/multieasybin/tests/main.nf.test
@@ -38,7 +38,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                // number and names of bins are not stable
+                // bin names and contents vary between machines
                 { assert process.out.bins.get(0).get(1).size() >= 1 },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv", "log"], ignoreKeys: ["bins"])
@@ -74,7 +74,7 @@ nextflow_process {
         then {
             assert process.success
             assertAll(
-                // number and names of bins are not stable
+                // bin names and contents vary between machines
                 { assert process.out.bins.get(0).get(1).size() >= 1 },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv", "log"], ignoreKeys: ["bins"])

--- a/modules/nf-core/semibin/multieasybin/tests/main.nf.test.snap
+++ b/modules/nf-core/semibin/multieasybin/tests/main.nf.test.snap
@@ -58,6 +58,13 @@
                         "2.4.1"
                     ]
                 ],
+                "5": [
+                    [
+                        "SEMIBIN_MULTIEASYBIN",
+                        "cuda",
+                        "no CUDA available"
+                    ]
+                ],
                 "bins": [
                     [
                         {
@@ -107,6 +114,13 @@
                         ]
                     ]
                 ],
+                "versions_cuda": [
+                    [
+                        "SEMIBIN_MULTIEASYBIN",
+                        "cuda",
+                        "no CUDA available"
+                    ]
+                ],
                 "versions_semibin": [
                     [
                         "SEMIBIN_MULTIEASYBIN",
@@ -116,7 +130,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-21T09:28:50.740583",
+        "timestamp": "2026-09-01T16:32:52.404082549",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -211,6 +225,13 @@
                         ]
                     ]
                 ],
+                "versions_cuda": [
+                    [
+                        "SEMIBIN_MULTIEASYBIN",
+                        "cuda",
+                        "no CUDA available"
+                    ]
+                ],
                 "versions_semibin": [
                     [
                         "SEMIBIN_MULTIEASYBIN",
@@ -220,7 +241,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-21T11:10:38.69282",
+        "timestamp": "2026-09-01T16:32:43.536046301",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -315,6 +336,13 @@
                         ]
                     ]
                 ],
+                "versions_cuda": [
+                    [
+                        "SEMIBIN_MULTIEASYBIN",
+                        "cuda",
+                        "no CUDA available"
+                    ]
+                ],
                 "versions_semibin": [
                     [
                         "SEMIBIN_MULTIEASYBIN",
@@ -324,7 +352,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-21T11:07:08.183204",
+        "timestamp": "2026-09-01T16:31:23.851229672",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/modules/nf-core/semibin/multieasybin/tests/main.nf.test.snap
+++ b/modules/nf-core/semibin/multieasybin/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "semibin_data - stub": {
+    "metagenome - binning - stub": {
         "content": [
             {
                 "0": [
@@ -130,13 +130,13 @@
                 ]
             }
         ],
-        "timestamp": "2026-09-01T16:32:52.404082549",
+        "timestamp": "2026-09-02T01:28:40.724008028",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
         }
     },
-    "semibin_data - abundance txt": {
+    "metagenome - binning - abundance": {
         "content": [
             {
                 "csv": [
@@ -145,26 +145,6 @@
                             "id": "test"
                         },
                         [
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
                             "data.csv",
                             "data_cov.csv",
                             "data_split.csv",
@@ -211,16 +191,6 @@
                             "contig_bins.tsv",
                             "recluster_bins_info.tsv",
                             "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
                             "recluster_bins_info.tsv"
                         ]
                     ]
@@ -241,13 +211,13 @@
                 ]
             }
         ],
-        "timestamp": "2026-09-01T16:32:43.536046301",
+        "timestamp": "2026-09-02T01:28:32.695814176",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
         }
     },
-    "semibin_data - bam": {
+    "metagenome - binning - bam": {
         "content": [
             {
                 "csv": [
@@ -256,26 +226,6 @@
                             "id": "test"
                         },
                         [
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
-                            "data.csv",
-                            "data_cov.csv",
-                            "data_split.csv",
-                            "data_split_cov.csv",
                             "data.csv",
                             "data_cov.csv",
                             "data_split.csv",
@@ -322,16 +272,6 @@
                             "contig_bins.tsv",
                             "recluster_bins_info.tsv",
                             "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
-                            "recluster_bins_info.tsv",
-                            "contig_bins.tsv",
                             "recluster_bins_info.tsv"
                         ]
                     ]
@@ -352,7 +292,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-09-01T16:31:23.851229672",
+        "timestamp": "2026-09-02T01:26:48.668337309",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/modules/nf-core/semibin/multieasybin/tests/nextflow.gpu.config
+++ b/modules/nf-core/semibin/multieasybin/tests/nextflow.gpu.config
@@ -4,6 +4,6 @@ process {
         // SemiBin uses one device, so serialise to avoid GPU contention
         maxForks    = 1
         ext.args    = ''
-        ext.args2   = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
+        ext.args2   = '-s C --ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
     }
 }

--- a/modules/nf-core/semibin/multieasybin/tests/nextflow.gpu.config
+++ b/modules/nf-core/semibin/multieasybin/tests/nextflow.gpu.config
@@ -1,0 +1,9 @@
+process {
+    withName: 'SEMIBIN_MULTIEASYBIN' {
+        accelerator = 1
+        // SemiBin uses one device, so serialise to avoid GPU contention
+        maxForks    = 1
+        ext.args    = ''
+        ext.args2   = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
+    }
+}

--- a/modules/nf-core/semibin/singleeasybin/environment.gpu.yml
+++ b/modules/nf-core/semibin/singleeasybin/environment.gpu.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::semibin=2.4.1
+  # lowest CUDA pytorch 2.13 ships on linux-64, so it runs on the widest range of hosts
+  - conda-forge::pytorch-gpu=2.13.0
+  - conda-forge::cuda-version=12.9

--- a/modules/nf-core/semibin/singleeasybin/main.nf
+++ b/modules/nf-core/semibin/singleeasybin/main.nf
@@ -1,11 +1,16 @@
 process SEMIBIN_SINGLEEASYBIN {
     tag "${meta.id}"
     label 'process_medium'
+    label 'process_gpu'
 
-    conda "${moduleDir}/environment.yml"
+    conda "${task.accelerator ? "${moduleDir}/environment.gpu.yml" : "${moduleDir}/environment.yml"}"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4c/4c049230e87478349b2ecca53156faedfb077df85a4f6deaa8d0b22bd8a975c4/data'
-        : 'community.wave.seqera.io/library/semibin:2.4.1--594344a862aee1b8'}"
+        ? (task.accelerator
+            ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/fb/fbd557d49df87acd78159a1be8a78dc8fec2030a0ab3e26b11b16ed112ad5e57/data'
+            : 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4c/4c049230e87478349b2ecca53156faedfb077df85a4f6deaa8d0b22bd8a975c4/data')
+        : (task.accelerator
+            ? 'community.wave.seqera.io/library/semibin_pytorch-gpu_cuda-version:d7e398c7556966b1'
+            : 'community.wave.seqera.io/library/semibin:2.4.1--594344a862aee1b8')}"
 
     input:
     tuple val(meta), path(fasta), path(bam)
@@ -16,6 +21,7 @@ process SEMIBIN_SINGLEEASYBIN {
     tuple val(meta), path("${prefix}/*.tsv"), emit: tsv
     tuple val(meta), path("${prefix}/output_bins/*.fa.gz"), emit: output_fasta
     tuple val("${task.process}"), val('SemiBin'), eval("SemiBin2 --version"), emit: versions_semibin, topic: versions
+    tuple val("${task.process}"), val('cuda'), eval('python -c "import torch; print(torch.version.cuda or \'no CUDA available\')"'), emit: versions_cuda, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,6 +30,7 @@ process SEMIBIN_SINGLEEASYBIN {
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ""
     prefix = task.ext.prefix ?: "${meta.id}"
+    def engine = task.accelerator ? 'gpu' : 'cpu'
     """
 
     SemiBin2 \\
@@ -33,6 +40,7 @@ process SEMIBIN_SINGLEEASYBIN {
         --input-bam ${bam} \\
         --output ${prefix} \\
         -t ${task.cpus} \\
+        --engine ${engine} \\
         ${args2}
     """
 

--- a/modules/nf-core/semibin/singleeasybin/meta.yml
+++ b/modules/nf-core/semibin/singleeasybin/meta.yml
@@ -86,6 +86,16 @@ output:
       - "SemiBin2 --version":
           type: eval
           description: The expression to obtain the version of the tool
+  versions_cuda:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - cuda:
+          type: string
+          description: The name of the runtime
+      - 'python -c "import torch; print(torch.version.cuda or ''no CUDA available'')"':
+          type: eval
+          description: CUDA version bundled with the task's pytorch build, or `no CUDA available` on the non-GPU path
 topics:
   versions:
     - - ${task.process}:
@@ -97,6 +107,15 @@ topics:
       - "SemiBin2 --version":
           type: eval
           description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - cuda:
+          type: string
+          description: The name of the runtime
+      - 'python -c "import torch; print(torch.version.cuda or ''no CUDA available'')"':
+          type: eval
+          description: CUDA version bundled with the task's pytorch build, or `no CUDA available` on the non-GPU path
 authors:
   - "@BigDataBiology"
 maintainers:

--- a/modules/nf-core/semibin/singleeasybin/tests/main.gpu.nf.test
+++ b/modules/nf-core/semibin/singleeasybin/tests/main.gpu.nf.test
@@ -28,7 +28,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                // number and names of bins are not stable
+                // bin names and contents vary between machines
                 { assert process.out.output_fasta.get(0).get(1).size() >= 1 },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv"], ignoreKeys: ["output_fasta"])

--- a/modules/nf-core/semibin/singleeasybin/tests/main.gpu.nf.test
+++ b/modules/nf-core/semibin/singleeasybin/tests/main.gpu.nf.test
@@ -26,10 +26,13 @@ nextflow_process {
             }
         }
         then {
+            assert process.success
+            def bins = process.out.output_fasta.get(0).get(1).collect { path(it).fasta }
+            def featurised = path(process.out.csv.get(0).get(1).find { it.endsWith('/data.csv') })
+                .readLines().drop(1).collect { it.split(',')[0] }
             assertAll(
-                { assert process.success },
-                // bin names and contents vary between machines
-                { assert process.out.output_fasta.get(0).get(1).size() >= 1 },
+                // every contig SemiBin featurised lands in exactly one bin. Which bin varies between machines
+                { assert featurised && bins.collectMany { it.keySet().toList() }.sort() == featurised.sort() },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv"], ignoreKeys: ["output_fasta"])
                 ).match() }

--- a/modules/nf-core/semibin/singleeasybin/tests/main.gpu.nf.test
+++ b/modules/nf-core/semibin/singleeasybin/tests/main.gpu.nf.test
@@ -1,0 +1,40 @@
+nextflow_process {
+
+    name "Test Process SEMIBIN_SINGLEEASYBIN (GPU)"
+
+    script "../main.nf"
+    process "SEMIBIN_SINGLEEASYBIN"
+
+    tag "gpu"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "semibin"
+    tag "semibin/singleeasybin"
+    config './nextflow.gpu.config'
+
+    test("metagenome - binning - gpu") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id:'test'],
+                    file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/contigs.fasta.gz", checkIfExists:true),
+                    file(params.modules_testdata_base_path + "genomics/prokaryotes/metagenome/binning/s1.sorted.bam", checkIfExists:true)
+                ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                // number and names of bins are not stable
+                { assert process.out.output_fasta.get(0).get(1).size() >= 1 },
+                { assert snapshot(
+                    sanitizeOutput(process.out, unstableKeys: ["csv", "tsv"], ignoreKeys: ["output_fasta"])
+                ).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/semibin/singleeasybin/tests/main.gpu.nf.test.snap
+++ b/modules/nf-core/semibin/singleeasybin/tests/main.gpu.nf.test.snap
@@ -1,0 +1,53 @@
+{
+    "metagenome - binning - gpu": {
+        "content": [
+            {
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "data.csv",
+                            "data_split.csv",
+                            "s1.sorted.bam_0_data_cov.csv"
+                        ]
+                    ]
+                ],
+                "model": [
+                    
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        [
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv"
+                        ]
+                    ]
+                ],
+                "versions_cuda": [
+                    [
+                        "SEMIBIN_SINGLEEASYBIN",
+                        "cuda",
+                        "12.9"
+                    ]
+                ],
+                "versions_semibin": [
+                    [
+                        "SEMIBIN_SINGLEEASYBIN",
+                        "SemiBin",
+                        "2.4.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-01T16:34:31.337136254",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}

--- a/modules/nf-core/semibin/singleeasybin/tests/main.nf.test
+++ b/modules/nf-core/semibin/singleeasybin/tests/main.nf.test
@@ -33,10 +33,13 @@ nextflow_process {
             }
         }
         then {
+            assert process.success
+            def bins = process.out.output_fasta.get(0).get(1).collect { path(it).fasta }
+            def featurised = path(process.out.csv.get(0).get(1).find { it.endsWith('/data.csv') })
+                .readLines().drop(1).collect { it.split(',')[0] }
             assertAll(
-                { assert process.success },
-                // bin names and contents vary between machines
-                { assert process.out.output_fasta.get(0).get(1).size() >= 1 },
+                // every contig SemiBin featurised lands in exactly one bin. Which bin varies between machines
+                { assert featurised && bins.collectMany { it.keySet().toList() }.sort() == featurised.sort() },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv"], ignoreKeys: ["output_fasta"])
                 ).match() }

--- a/modules/nf-core/semibin/singleeasybin/tests/main.nf.test
+++ b/modules/nf-core/semibin/singleeasybin/tests/main.nf.test
@@ -11,44 +11,56 @@ nextflow_process {
     tag "semibin/singleeasybin"
     config './nextflow.config'
 
-    test("bacteroides_fragilis") {
+    test("metagenome - binning") {
 
         when {
             params {
                 module_args  = ''
-                module_args2 = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --environment global'
+                module_args2 = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
             }
             process {
                 """
                 input[0] = [
                     [id:'test'],
-                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fasta/test1.contigs.fa.gz', checkIfExists:true),
-                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/bam/test1_contigs.sorted.bam', checkIfExists:true)
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/metagenome/binning/contigs.fasta.gz', checkIfExists:true),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/metagenome/binning/s1.sorted.bam', checkIfExists:true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/metagenome/binning/s2.sorted.bam', checkIfExists:true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/metagenome/binning/s3.sorted.bam', checkIfExists:true)
+                    ]
                 ]
                 """
             }
         }
         then {
-            assert process.success
             assertAll(
-                { assert snapshot(process.out).match() }
+                { assert process.success },
+                // number and names of bins are not stable
+                { assert process.out.output_fasta.get(0).get(1).size() >= 1 },
+                { assert snapshot(
+                    sanitizeOutput(process.out, unstableKeys: ["csv", "tsv"], ignoreKeys: ["output_fasta"])
+                ).match() }
             )
         }
     }
 
-    test("bacteroides_fragilis - stub") {
+    test("metagenome - binning - stub") {
         options '-stub'
         when {
             params {
                 module_args  = ''
-                module_args2 = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --environment global'
+                module_args2 = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
             }
             process {
                 """
                 input[0] = [
                     [id:'test'],
-                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fasta/test1.contigs.fa.gz', checkIfExists:true),
-                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/bam/test1_contigs.sorted.bam', checkIfExists:true)
+                    file(params.modules_testdata_base_path + 'genomics/prokaryotes/metagenome/binning/contigs.fasta.gz', checkIfExists:true),
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/metagenome/binning/s1.sorted.bam', checkIfExists:true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/metagenome/binning/s2.sorted.bam', checkIfExists:true),
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/metagenome/binning/s3.sorted.bam', checkIfExists:true)
+                    ]
                 ]
                 """
             }

--- a/modules/nf-core/semibin/singleeasybin/tests/main.nf.test
+++ b/modules/nf-core/semibin/singleeasybin/tests/main.nf.test
@@ -35,7 +35,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                // number and names of bins are not stable
+                // bin names and contents vary between machines
                 { assert process.out.output_fasta.get(0).get(1).size() >= 1 },
                 { assert snapshot(
                     sanitizeOutput(process.out, unstableKeys: ["csv", "tsv"], ignoreKeys: ["output_fasta"])

--- a/modules/nf-core/semibin/singleeasybin/tests/main.nf.test.snap
+++ b/modules/nf-core/semibin/singleeasybin/tests/main.nf.test.snap
@@ -1,130 +1,23 @@
 {
-    "bacteroides_fragilis": {
+    "metagenome - binning": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "data.csv:md5,eff24dad52ab76b8a030335c938a64f6",
-                            "data_split.csv:md5,6f05c805f4e696315d104de6cc0c8f23",
-                            "test1_contigs.sorted.bam_0_data_cov.csv:md5,fd0978a81966ee7c817dfeff79d082ae"
-                        ]
-                    ]
-                ],
-                "1": [
-                    
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "contig_bins.tsv:md5,4ca344a6afd99ec00b364998e88f8860",
-                            "recluster_bins_info.tsv:md5,18975f1d33e4d060eae440ccf88a339b"
-                        ]
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "SemiBin_0.fa.gz:md5,d03dbf09afa367f26b76c7cf8506a471",
-                            "SemiBin_1.fa.gz:md5,f44ce9c34e8ed8743e82c9597dfa4d7c",
-                            "SemiBin_10.fa.gz:md5,26d8fb83db377abef7d62d291d6dedc4",
-                            "SemiBin_11.fa.gz:md5,caaec1412eabe5bc7099f7fe883e7998",
-                            "SemiBin_12.fa.gz:md5,55b5482682aec7baa33c0646569f82b1",
-                            "SemiBin_13.fa.gz:md5,846f8abe86d0c61f4a081f000f210608",
-                            "SemiBin_14.fa.gz:md5,d37c5fa58bd3cffe82e5f3300fb26c27",
-                            "SemiBin_15.fa.gz:md5,01989981cb1babaced4e6fd7cb2eb865",
-                            "SemiBin_16.fa.gz:md5,e71afaed93b6ebb242ca52b9e19fcd70",
-                            "SemiBin_17.fa.gz:md5,4a4057a5a4f44eb05153bfa5f26a360d",
-                            "SemiBin_18.fa.gz:md5,860cbaad1593e63d7f5650770048be66",
-                            "SemiBin_19.fa.gz:md5,92856be26acf7185e2c99fe461a7b5e4",
-                            "SemiBin_2.fa.gz:md5,f6bc31606e2000ac30e637089f922bcd",
-                            "SemiBin_20.fa.gz:md5,8c56b7b493a22f55b96c73a7ad62a617",
-                            "SemiBin_21.fa.gz:md5,36b479ebec9e88e7ace3ae6cad4f4e7c",
-                            "SemiBin_22.fa.gz:md5,c98a8752771d62d966a88fec80edc4c2",
-                            "SemiBin_23.fa.gz:md5,c9ab00537eee994d2ad326998ddd559d",
-                            "SemiBin_24.fa.gz:md5,039495af6b66f05d415e7de7fe0a20fb",
-                            "SemiBin_25.fa.gz:md5,679d9fbca921a242fa36c4eb58439d17",
-                            "SemiBin_26.fa.gz:md5,9a204ce83ea1fa70934cd0dc78953a02",
-                            "SemiBin_27.fa.gz:md5,63750434b3295487ea7c3f747347ea18",
-                            "SemiBin_28.fa.gz:md5,00e61d0c6a894debb626d97a7a468163",
-                            "SemiBin_3.fa.gz:md5,4730f1e32e5323283fe885884f10699e",
-                            "SemiBin_4.fa.gz:md5,546de9f41e32277068eb27a18eb5455c",
-                            "SemiBin_5.fa.gz:md5,d94e4065dfb334eb34f04f4f06af648e",
-                            "SemiBin_6.fa.gz:md5,27ad83d85184527847a2cc13b1c990b0",
-                            "SemiBin_7.fa.gz:md5,1741f7cac38fb8c5b03600ec2fe027c0",
-                            "SemiBin_8.fa.gz:md5,406697b0e472cf577b6b265466ab73af",
-                            "SemiBin_9.fa.gz:md5,f1c9b082977bf100918591b489fd03e2"
-                        ]
-                    ]
-                ],
-                "4": [
-                    [
-                        "SEMIBIN_SINGLEEASYBIN",
-                        "SemiBin",
-                        "2.4.1"
-                    ]
-                ],
                 "csv": [
                     [
                         {
                             "id": "test"
                         },
                         [
-                            "data.csv:md5,eff24dad52ab76b8a030335c938a64f6",
-                            "data_split.csv:md5,6f05c805f4e696315d104de6cc0c8f23",
-                            "test1_contigs.sorted.bam_0_data_cov.csv:md5,fd0978a81966ee7c817dfeff79d082ae"
+                            "data.csv",
+                            "data_split.csv",
+                            "s1.sorted.bam_0_data_cov.csv",
+                            "s2.sorted.bam_1_data_cov.csv",
+                            "s3.sorted.bam_2_data_cov.csv"
                         ]
                     ]
                 ],
                 "model": [
                     
-                ],
-                "output_fasta": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            "SemiBin_0.fa.gz:md5,d03dbf09afa367f26b76c7cf8506a471",
-                            "SemiBin_1.fa.gz:md5,f44ce9c34e8ed8743e82c9597dfa4d7c",
-                            "SemiBin_10.fa.gz:md5,26d8fb83db377abef7d62d291d6dedc4",
-                            "SemiBin_11.fa.gz:md5,caaec1412eabe5bc7099f7fe883e7998",
-                            "SemiBin_12.fa.gz:md5,55b5482682aec7baa33c0646569f82b1",
-                            "SemiBin_13.fa.gz:md5,846f8abe86d0c61f4a081f000f210608",
-                            "SemiBin_14.fa.gz:md5,d37c5fa58bd3cffe82e5f3300fb26c27",
-                            "SemiBin_15.fa.gz:md5,01989981cb1babaced4e6fd7cb2eb865",
-                            "SemiBin_16.fa.gz:md5,e71afaed93b6ebb242ca52b9e19fcd70",
-                            "SemiBin_17.fa.gz:md5,4a4057a5a4f44eb05153bfa5f26a360d",
-                            "SemiBin_18.fa.gz:md5,860cbaad1593e63d7f5650770048be66",
-                            "SemiBin_19.fa.gz:md5,92856be26acf7185e2c99fe461a7b5e4",
-                            "SemiBin_2.fa.gz:md5,f6bc31606e2000ac30e637089f922bcd",
-                            "SemiBin_20.fa.gz:md5,8c56b7b493a22f55b96c73a7ad62a617",
-                            "SemiBin_21.fa.gz:md5,36b479ebec9e88e7ace3ae6cad4f4e7c",
-                            "SemiBin_22.fa.gz:md5,c98a8752771d62d966a88fec80edc4c2",
-                            "SemiBin_23.fa.gz:md5,c9ab00537eee994d2ad326998ddd559d",
-                            "SemiBin_24.fa.gz:md5,039495af6b66f05d415e7de7fe0a20fb",
-                            "SemiBin_25.fa.gz:md5,679d9fbca921a242fa36c4eb58439d17",
-                            "SemiBin_26.fa.gz:md5,9a204ce83ea1fa70934cd0dc78953a02",
-                            "SemiBin_27.fa.gz:md5,63750434b3295487ea7c3f747347ea18",
-                            "SemiBin_28.fa.gz:md5,00e61d0c6a894debb626d97a7a468163",
-                            "SemiBin_3.fa.gz:md5,4730f1e32e5323283fe885884f10699e",
-                            "SemiBin_4.fa.gz:md5,546de9f41e32277068eb27a18eb5455c",
-                            "SemiBin_5.fa.gz:md5,d94e4065dfb334eb34f04f4f06af648e",
-                            "SemiBin_6.fa.gz:md5,27ad83d85184527847a2cc13b1c990b0",
-                            "SemiBin_7.fa.gz:md5,1741f7cac38fb8c5b03600ec2fe027c0",
-                            "SemiBin_8.fa.gz:md5,406697b0e472cf577b6b265466ab73af",
-                            "SemiBin_9.fa.gz:md5,f1c9b082977bf100918591b489fd03e2"
-                        ]
-                    ]
                 ],
                 "tsv": [
                     [
@@ -132,9 +25,16 @@
                             "id": "test"
                         },
                         [
-                            "contig_bins.tsv:md5,4ca344a6afd99ec00b364998e88f8860",
-                            "recluster_bins_info.tsv:md5,18975f1d33e4d060eae440ccf88a339b"
+                            "contig_bins.tsv",
+                            "recluster_bins_info.tsv"
                         ]
+                    ]
+                ],
+                "versions_cuda": [
+                    [
+                        "SEMIBIN_SINGLEEASYBIN",
+                        "cuda",
+                        "no CUDA available"
                     ]
                 ],
                 "versions_semibin": [
@@ -146,13 +46,13 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-20T16:56:09.208087",
+        "timestamp": "2026-09-01T16:23:52.139674978",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
         }
     },
-    "bacteroides_fragilis - stub": {
+    "metagenome - binning - stub": {
         "content": [
             {
                 "0": [
@@ -200,6 +100,13 @@
                         "2.4.1"
                     ]
                 ],
+                "5": [
+                    [
+                        "SEMIBIN_SINGLEEASYBIN",
+                        "cuda",
+                        "no CUDA available"
+                    ]
+                ],
                 "csv": [
                     [
                         {
@@ -238,6 +145,13 @@
                         ]
                     ]
                 ],
+                "versions_cuda": [
+                    [
+                        "SEMIBIN_SINGLEEASYBIN",
+                        "cuda",
+                        "no CUDA available"
+                    ]
+                ],
                 "versions_semibin": [
                     [
                         "SEMIBIN_SINGLEEASYBIN",
@@ -247,7 +161,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-20T16:56:14.645767",
+        "timestamp": "2026-09-01T16:23:59.040464326",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/modules/nf-core/semibin/singleeasybin/tests/nextflow.gpu.config
+++ b/modules/nf-core/semibin/singleeasybin/tests/nextflow.gpu.config
@@ -1,0 +1,9 @@
+process {
+    withName: 'SEMIBIN_SINGLEEASYBIN' {
+        accelerator = 1
+        // SemiBin uses one device, so serialise to avoid GPU contention
+        maxForks    = 1
+        ext.args    = ''
+        ext.args2   = '--ml-threshold 0 --minfasta-kbs 0 --min-len 0 --random-seed 0'
+    }
+}

--- a/nf-test.config
+++ b/nf-test.config
@@ -17,6 +17,7 @@ config {
         load "nft-bam@0.7.0"
         load "nft-csv@0.1.0"
         load "nft-compress@0.1.0"
+        load "nft-fasta@1.0.0"
         load "nft-fastq@0.1.0"
         load "nft-vcf@1.0.7"
         load "nft-utils@1.1.1"


### PR DESCRIPTION
Same treatment COMEBin got in #12796, now for SemiBin2.

Both `semibin/singleeasybin` and `semibin/multieasybin` pick their container and conda environment from `task.accelerator`, add the `process_gpu` label, and pass the resolved device to SemiBin2 with `--engine`. Both also emit the CUDA runtime version to the versions topic.

The `singleeasybin` test moves to the shared metagenome binning dataset, with all three BAMs. That meant dropping `--environment global`: the pretrained model only supports single-sample binning, and it skips the training the GPU is for. Training makes bin names and contents vary across machines, so the snapshot now keeps the stable outputs plus a bin count assertion, as `multieasybin` already does.

`multieasybin` moves off `delete_me/semibin2/` to `binning/multisample/`, which has the five samples SemiBin2 requires before it accepts `--abundance` instead of BAMs. Its contigs use `C` as the sample separator, Vamb's default, so the tests pass `-s C`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If necessary, include test data in your PR.
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions`
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] `nf-core modules test semibin/singleeasybin --profile singularity`
- [x] `nf-core modules test semibin/multieasybin --profile singularity`