### PR TITLE
Bump isoseq/refine 4.0.0 -> 26.2.0

### DIFF
--- a/modules/nf-core/isoseq/refine/environment.yml
+++ b/modules/nf-core/isoseq/refine/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::isoseq=4.0.0
+  - bioconda::isoseq=26.2.0

--- a/modules/nf-core/isoseq/refine/main.nf
+++ b/modules/nf-core/isoseq/refine/main.nf
@@ -4,8 +4,8 @@ process ISOSEQ_REFINE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/isoseq:4.0.0--h9ee0642_0' :
-        'quay.io/biocontainers/isoseq:4.0.0--h9ee0642_0' }"
+        'https://depot.galaxyproject.org/singularity/isoseq:26.2.0--h9ee0642_0' :
+        'quay.io/biocontainers/isoseq:26.2.0--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(bam)
@@ -17,7 +17,7 @@ process ISOSEQ_REFINE {
     tuple val(meta), path("*.consensusreadset.xml")      , emit: consensusreadset
     tuple val(meta), path("*.filter_summary.report.json"), emit: summary
     tuple val(meta), path("*.report.csv")                , emit: report
-    tuple val("${task.process}"), val('isoseq'), eval("isoseq refine --version | head -n 1 | sed 's/isoseq refine //' | sed 's/ (commit.\\+//'"), emit: versions_isoseq, topic: versions
+    tuple val("${task.process}"), val('isoseq'), eval("isoseq refine --version | sed -n '1s/isoseq refine \\([0-9.]*\\).*/\\1/p'"), emit: versions_isoseq, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/nf-core/isoseq/refine/meta.yml
+++ b/modules/nf-core/isoseq/refine/meta.yml
@@ -100,7 +100,7 @@ output:
       - isoseq:
           type: string
           description: The name of the tool
-      - isoseq refine --version | head -n 1 | sed 's/isoseq refine //' | sed 's/ (commit.\+//':
+      - isoseq refine --version | sed -n '1s/isoseq refine \([0-9.]*\).*/\1/p':
           type: eval
           description: The expression to obtain the version of the tool
 topics:
@@ -111,7 +111,7 @@ topics:
       - isoseq:
           type: string
           description: The name of the tool
-      - isoseq refine --version | head -n 1 | sed 's/isoseq refine //' | sed 's/ (commit.\+//':
+      - isoseq refine --version | sed -n '1s/isoseq refine \([0-9.]*\).*/\1/p':
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/modules/nf-core/isoseq/refine/tests/main.nf.test.snap
+++ b/modules/nf-core/isoseq/refine/tests/main.nf.test.snap
@@ -6,7 +6,7 @@
                     {
                         "id": "test"
                     },
-                    "test.refine.bam:md5,4a666931c2c8843d8a8f0d901e1ba15f"
+                    "test.refine.bam:md5,e87acbb921049c0a506a5f7588f610be"
                 ]
             ],
             [
@@ -14,7 +14,7 @@
                     {
                         "id": "test"
                     },
-                    "test.refine.bam.pbi:md5,fcd3c9b9c7efea71732591ff1271a3b5"
+                    "test.refine.bam.pbi:md5,5ed2cba7b7059040bbf0e3db48a39528"
                 ]
             ],
             [
@@ -22,7 +22,7 @@
                     {
                         "id": "test"
                     },
-                    "test.refine.report.csv:md5,d42a139e5d9b08396bdb087c01243ea9"
+                    "test.refine.report.csv:md5,bbe3165430ec86f500cca980e22a8f82"
                 ]
             ],
             {
@@ -30,15 +30,15 @@
                     [
                         "ISOSEQ_REFINE",
                         "isoseq",
-                        "4.0.0"
+                        "26.2.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-03T14:05:40.492223379",
+        "timestamp": "2026-09-02T15:46:37.88068",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.0"
         }
     },
     "PacBio isoseq refine - Chimeras Removing test - stub": {
@@ -88,15 +88,15 @@
                     [
                         "ISOSEQ_REFINE",
                         "isoseq",
-                        "4.0.0"
+                        "26.2.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-06-03T14:05:45.050914829",
+        "timestamp": "2026-09-02T15:46:41.984139",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.0"
         }
     }
 }


### PR DESCRIPTION
CLI is unchanged (refine, same flags, same output shapes). Also simplifies
the version-string extraction to a single minimal sed.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test isoseq/refine --profile docker`
    - [ ] `nf-core modules test isoseq/refine --profile singularity`
    - [ ] `nf-core modules test isoseq/refine --profile conda`

Generated by Claude Sonnet 5