### PR TITLE
Improvements in `RCLONE_` modules

### DIFF
--- a/modules/nf-core/rclone/check/main.nf
+++ b/modules/nf-core/rclone/check/main.nf
@@ -29,8 +29,30 @@ process RCLONE_CHECK {
     prefix = task.ext.prefix ?: "${meta.id}"
     def configArg = rclone_config ? "--config ${rclone_config}" : ''
 
+    def sourceString = source.toString()
+    def normalizedSource = sourceString.replaceFirst('^([a-zA-Z][a-zA-Z0-9+.-]*)://', '$1:')
+    def sourceHttpUrlArg = ''
+
+    if (sourceString ==~ /^https?:\/\/.*/) {
+        def sourceMatcher = (sourceString =~ /^(https?:\/\/[^\/]+)(\/.*)?$/)
+        if (!sourceMatcher.matches()) {
+            throw new IllegalArgumentException("Invalid HTTP(S) source '${sourceString}' for sample '${meta.id}'.")
+        }
+        sourceHttpUrlArg = "--http-url '${sourceMatcher[0][1]}'"
+        normalizedSource = ":http:${(sourceMatcher[0][2] ?: '/').replaceFirst('^/', '')}"
+    }
+
     """
+    touch \\
+        ${prefix}.combined.txt \\
+        ${prefix}.differ.txt \\
+        ${prefix}.missing_on_dst.txt \\
+        ${prefix}.missing_on_src.txt \\
+        ${prefix}.match.txt \\
+        ${prefix}.error.txt
+
     rclone check ${configArg} \\
+        ${sourceHttpUrlArg} \\
         $args \\
         --combined ${prefix}.combined.txt \\
         --differ ${prefix}.differ.txt \\
@@ -39,8 +61,10 @@ process RCLONE_CHECK {
         --match ${prefix}.match.txt \\
         --error ${prefix}.error.txt \\
         --checkers $task.cpus \\
-        ${source} \\
-        ${destination} || echo \$? > ${prefix}.exit_code.txt
+        "${normalizedSource}" \\
+        ${destination} \\
+        && echo 0 > ${prefix}.exit_code.txt \\
+        || echo \$? > ${prefix}.exit_code.txt
 
     sort -k2 ${prefix}.combined.txt -o ${prefix}.combined.txt
     sort ${prefix}.differ.txt -o ${prefix}.differ.txt

--- a/modules/nf-core/rclone/check/tests/main.nf.test.snap
+++ b/modules/nf-core/rclone/check/tests/main.nf.test.snap
@@ -17,7 +17,12 @@
                     
                 ],
                 "exit_code": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.exit_code.txt:md5,897316929176464ebc9ad085f31e7284"
+                    ]
                 ],
                 "match": [
                     [
@@ -42,10 +47,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-04T11:26:36.792274751",
+        "timestamp": "2026-09-02T19:03:10.104368524",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "sarscov2 - fastq - stub": {

--- a/modules/nf-core/rclone/checksum/main.nf
+++ b/modules/nf-core/rclone/checksum/main.nf
@@ -29,9 +29,31 @@ process RCLONE_CHECKSUM {
     prefix = task.ext.prefix ?: "${meta.id}"
     def configArg = rclone_config ? "--config ${rclone_config}" : ''
 
+    def destinationString = destination.toString()
+    def normalizedDestination = destinationString.replaceFirst('^([a-zA-Z][a-zA-Z0-9+.-]*)://', '$1:')
+    def destinationHttpUrlArg = ''
+
+    if (destinationString ==~ /^https?:\/\/.*/) {
+        def destinationMatcher = (destinationString =~ /^(https?:\/\/[^\/]+)(\/.*)?$/)
+        if (!destinationMatcher.matches()) {
+            throw new IllegalArgumentException("Invalid HTTP(S) destination '${destinationString}' for sample '${meta.id}'.")
+        }
+        destinationHttpUrlArg = "--http-url '${destinationMatcher[0][1]}'"
+        normalizedDestination = ":http:${(destinationMatcher[0][2] ?: '/').replaceFirst('^/', '')}"
+    }
+
     """
+    touch \\
+        ${prefix}.combined.txt \\
+        ${prefix}.differ.txt \\
+        ${prefix}.missing_on_dst.txt \\
+        ${prefix}.missing_on_src.txt \\
+        ${prefix}.match.txt \\
+        ${prefix}.error.txt
+
     rclone checksum ${configArg} \\
         --copy-links \\
+        ${destinationHttpUrlArg} \\
         $args \\
         --combined ${prefix}.combined.txt \\
         --differ ${prefix}.differ.txt \\
@@ -42,7 +64,9 @@ process RCLONE_CHECKSUM {
         --checkers $task.cpus \\
         $hash \\
         $sumfile \\
-        ${destination} || echo \$? > ${prefix}.exit_code.txt
+        "${normalizedDestination}" \\
+        && echo 0 > ${prefix}.exit_code.txt \\
+        || echo \$? > ${prefix}.exit_code.txt
 
     sort -k2 ${prefix}.combined.txt -o ${prefix}.combined.txt
     sort ${prefix}.differ.txt -o ${prefix}.differ.txt

--- a/modules/nf-core/rclone/checksum/tests/main.nf.test.snap
+++ b/modules/nf-core/rclone/checksum/tests/main.nf.test.snap
@@ -17,7 +17,12 @@
                     
                 ],
                 "exit_code": [
-                    
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.exit_code.txt:md5,897316929176464ebc9ad085f31e7284"
+                    ]
                 ],
                 "match": [
                     [
@@ -42,10 +47,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-04T11:27:09.176178267",
+        "timestamp": "2026-09-02T19:03:42.461174852",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "test - md5 - differs": {

--- a/modules/nf-core/rclone/copy/environment.yml
+++ b/modules/nf-core/rclone/copy/environment.yml
@@ -2,6 +2,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 channels:
   - conda-forge
-  - bioconda
 dependencies:
-  - conda-forge::rclone=1.65.0
+  - "conda-forge::rclone=1.74.3"

--- a/modules/nf-core/rclone/copy/main.nf
+++ b/modules/nf-core/rclone/copy/main.nf
@@ -3,9 +3,9 @@ process RCLONE_COPY {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/c9/c947c1a7171daf074310295417d0f0afe879275e1543fa5fc2a9711e7c2c72ab/data'
-        : 'community.wave.seqera.io/library/rclone:1.65.0--ff88b2e0040147be'}"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+            ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/5d/5dfd28fd0090c69f57c9bd93ea3235d8df194e8f269b5cb3027b6b59bff567d5/data'
+            : 'community.wave.seqera.io/library/rclone:1.74.3--2ef33c5b9132aa97' }"
 
     input:
     tuple val(meta), val(source_path), val(destination_path), path(filter_file)
@@ -30,9 +30,12 @@ process RCLONE_COPY {
     def http_url_arg = ''
 
     if (source_string ==~ /^https?:\/\/.*/) {
-        def matcher = (source_string =~ /^(https?:\/\/[^\/]+)(\/.*)$/)
+        def matcher = (source_string =~ /^(https?:\/\/[^\/]+)(\/.*)?$/)
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid HTTP(S) source '${source_string}' for sample '${meta.id}'.")
+        }
         http_url_arg = "--http-url '${matcher[0][1]}'"
-        rclone_source = ":http:${matcher[0][2].replaceFirst('^/', '')}"
+        rclone_source = ":http:${(matcher[0][2] ?: '/').replaceFirst('^/', '')}"
     } else {
         rclone_source = source_string.replaceFirst('^([a-zA-Z][a-zA-Z0-9+.-]*)://', '$1:')
     }

--- a/modules/nf-core/rclone/copy/tests/main.nf.test.snap
+++ b/modules/nf-core/rclone/copy/tests/main.nf.test.snap
@@ -14,15 +14,15 @@
                     [
                         "RCLONE_COPY",
                         "rclone",
-                        "1.65.0-DEV"
+                        "1.74.3-DEV"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-13T23:23:37.720920849",
+        "timestamp": "2026-09-02T19:04:23.232858558",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.4"
+            "nextflow": "26.04.6"
         }
     },
     "homo_sapiens - gvcf - copy from https - dry-run": {
@@ -40,15 +40,15 @@
                     [
                         "RCLONE_COPY",
                         "rclone",
-                        "1.65.0-DEV"
+                        "1.74.3-DEV"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-15T14:53:00.158291805",
+        "timestamp": "2026-09-02T19:04:05.861448709",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.6"
         }
     },
     "homo_sapiens - gvcf - filter - dry-run": {
@@ -66,15 +66,15 @@
                     [
                         "RCLONE_COPY",
                         "rclone",
-                        "1.65.0-DEV"
+                        "1.74.3-DEV"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-07-28T15:53:02.864977147",
+        "timestamp": "2026-09-02T19:04:13.800329186",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.1"
+            "nextflow": "26.04.6"
         }
     }
 }


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Required for https://github.com/nf-core/datasync/pull/84. Implementing bugfixes and suggestions required for the release of `datasync`.  These changes include:
- Update `rclone copy` container version
- Improve handling of error codes
- Improve HTTP source handling

---

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
