### PR TITLE
Fix miniconda version

### DIFF
--- a/.github/actions/nf-test-action/action.yml
+++ b/.github/actions/nf-test-action/action.yml
@@ -58,7 +58,7 @@ runs:
       if: ${{contains(inputs.profile, 'conda')}}
       uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
       with:
-        auto-update-conda: true
+        miniconda-version: "py312_24.11.1-0"
         conda-solver: libmamba
         conda-remove-defaults: true
 


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

This PR fix the miniconda_version used in nf-test action.
The issue arose with phyloflash module with the following error for conda test:
https://github.com/nf-core/modules/actions/runs/31088940040/job/92575211202

```
Installing package 'bioconda::spades-3.15.5-h95f258a_1'
...
LinkError: post-link script failed
.../.spades-post-link.sh
...
deactivate-gxx_linux-64.sh: line 68:
CONDA_BACKUP_CXX: unbound variable
```

This seems to be linked to
https://github.com/conda/conda/issues/9966

But i couldn't manage to fix it with `set +eu` flags.

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR.
- [ ] Remove all TODO statements.
- [ ] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [ ] Follow the naming conventions.
- [ ] Follow the parameters requirements.
- [ ] Follow the input/output options guidelines.
- [ ] Add a resource `label`
- [ ] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [ ] `nf-core modules test <MODULE> --profile docker`
    - [ ] `nf-core modules test <MODULE> --profile singularity`
    - [ ] `nf-core modules test <MODULE> --profile conda`
  - For subworkflows:
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile docker`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile singularity`
    - [ ] `nf-core subworkflows test <SUBWORKFLOW> --profile conda`
