### PR TITLE
Fix pygenprop linting

### DIFF
--- a/modules/nf-core/pygenprop/info/main.nf
+++ b/modules/nf-core/pygenprop/info/main.nf
@@ -8,7 +8,8 @@ process PYGENPROP_INFO {
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/02/025a1b9aa4f0042c0af7e3a8acc54635876014f2b247ac801d91874d97440c99/data':
         'community.wave.seqera.io/library/pip_python_pygenprop:829a7d86185a9fd4' }"
 
-    input:tuple val(meta), path(meda)
+    input:
+    tuple val(meta), path(meda)
 
     output:
     tuple val(meta), path("*.info"), emit: info
@@ -32,7 +33,7 @@ process PYGENPROP_INFO {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    echo $args
+    echo ${args}
 
     touch ${prefix}.info
     """

--- a/modules/nf-core/pygenprop/info/meta.yml
+++ b/modules/nf-core/pygenprop/info/meta.yml
@@ -55,9 +55,10 @@ output:
       - pygenprop:
           type: string
           description: The name of the tool
-      - '"1.1"':
+      - "1.1":
           type: string
           description: The expression to obtain the version of the tool
+
   versions_python:
     - - ${task.process}:
           type: string
@@ -76,9 +77,10 @@ topics:
       - pygenprop:
           type: string
           description: The name of the tool
-      - '"1.1"':
+      - "1.1":
           type: string
           description: The expression to obtain the version of the tool
+
     - - ${task.process}:
           type: string
           description: The name of the process


### PR DESCRIPTION
Cleans up pygenprop from having `input:` on the same line as the actual input and fixes linting.