### PR TITLE
[Superseded] Add easypqp/convert and easypqp/library modules

### DIFF
--- a/modules/nf-core/easypqp/convert/environment.yml
+++ b/modules/nf-core/easypqp/convert/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::easypqp=0.1.59"

--- a/modules/nf-core/easypqp/convert/main.nf
+++ b/modules/nf-core/easypqp/convert/main.nf
@@ -1,0 +1,45 @@
+process EASYPQP_CONVERT {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/easypqp:0.1.59--pyhdfd78af_0'
+        : 'quay.io/biocontainers/easypqp:0.1.59--pyhdfd78af_0'}"
+
+    input:
+    tuple val(meta), path(psms), path(spectra)
+    path unimod
+
+    output:
+    tuple val(meta), path("*.psmpkl") , emit: psmpkl
+    tuple val(meta), path("*.peakpkl"), emit: peakpkl
+    tuple val("${task.process}"), val('easypqp'), eval("easypqp --version 2>&1 | sed -nE 's/.*version ([0-9.]+).*/\\1/p'"), topic: versions, emit: versions_easypqp
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def unimod_arg = unimod ? "--unimod ${unimod}" : ''
+    // Output basenames are derived from the spectra file by easypqp and must not be
+    // changed: easypqp library pairs peak and PSM pickles to runs by this basename.
+    """
+    export MPLCONFIGDIR=\$PWD/.matplotlib
+    export XDG_CACHE_HOME=\$PWD/.cache
+    mkdir -p \$MPLCONFIGDIR \$XDG_CACHE_HOME
+
+    easypqp convert \\
+        --pepxml ${psms} \\
+        --spectra ${spectra} \\
+        ${unimod_arg} \\
+        ${args}
+    """
+
+    stub:
+    def prefix = spectra.baseName
+    """
+    touch ${prefix}.psmpkl
+    touch ${prefix}.peakpkl
+    """
+}

--- a/modules/nf-core/easypqp/convert/meta.yml
+++ b/modules/nf-core/easypqp/convert/meta.yml
@@ -1,0 +1,95 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "easypqp_convert"
+description: Convert peptide-spectrum matches (pepXML or idXML) and the matching spectra into EasyPQP pickle files for spectral library generation.
+keywords:
+  - proteomics
+  - spectral library
+  - dia
+  - pepxml
+  - idxml
+  - mzml
+tools:
+  - "easypqp":
+      description: "Python package to generate spectral libraries for data-independent acquisition (DIA) proteomics from DDA search results."
+      homepage: "https://github.com/grosenberger/easypqp"
+      documentation: "https://github.com/grosenberger/easypqp"
+      tool_dev_url: "https://github.com/grosenberger/easypqp"
+      licence: ["BSD-3-Clause"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - psms:
+        type: file
+        description: Peptide-spectrum matches in pepXML (interact-*.pep.xml, with PeptideProphet/iProphet probabilities) or OpenMS idXML format
+        pattern: "*.{pep.xml,idXML}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3655" # pepXML
+          - edam: "http://edamontology.org/format_3764" # idXML
+    - spectra:
+        type: file
+        description: Spectra file matching the identifications
+        pattern: "*.{mzML,mzXML,mgf}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3244" # mzML
+          - edam: "http://edamontology.org/format_3654" # mzXML
+          - edam: "http://edamontology.org/format_3651" # MGF
+  - unimod:
+      type: file
+      description: Optional UniMod XML file used to annotate modifications. EasyPQP's bundled UniMod is used when omitted.
+      pattern: "*.xml"
+      ontologies:
+        - edam: "http://edamontology.org/format_2332" # XML
+
+output:
+  psmpkl:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.psmpkl":
+          type: file
+          description: Pickled pandas DataFrame with the parsed PSMs. Named after the spectra file basename, which easypqp library uses to pair PSMs and peaks.
+          pattern: "*.psmpkl"
+  peakpkl:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.peakpkl":
+          type: file
+          description: Pickled pandas DataFrame with the annotated fragment ion peaks. Named after the spectra file basename, which easypqp library uses to pair PSMs and peaks.
+          pattern: "*.peakpkl"
+  versions_easypqp:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - easypqp:
+          type: string
+          description: The tool name
+      - "easypqp --version 2>&1 | sed -nE 's/.*version ([0-9.]+).*/\\1/p'":
+          type: string
+          description: The command used to generate the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - easypqp:
+          type: string
+          description: The tool name
+      - "easypqp --version 2>&1 | sed -nE 's/.*version ([0-9.]+).*/\\1/p'":
+          type: string
+          description: The command used to generate the version of the tool
+
+authors:
+  - "@jonasscheid"
+maintainers:
+  - "@jonasscheid"

--- a/modules/nf-core/easypqp/convert/tests/main.nf.test
+++ b/modules/nf-core/easypqp/convert/tests/main.nf.test
@@ -1,0 +1,63 @@
+nextflow_process {
+
+    name "Test Process EASYPQP_CONVERT"
+    script "../main.nf"
+    process "EASYPQP_CONVERT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "easypqp"
+    tag "easypqp/convert"
+
+    test("proteomics - idxml - mzml") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'proteomics/openms/HepG2_rep1_small.idXML', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'proteomics/msspectra/HepG2_rep1_small.mzML', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.psmpkl[0][1]).name,
+                    file(process.out.peakpkl[0][1]).name,
+                    process.out.versions_easypqp
+                ).match() }
+            )
+        }
+    }
+
+    test("proteomics - idxml - mzml - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'proteomics/openms/HepG2_rep1_small.idXML', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'proteomics/msspectra/HepG2_rep1_small.mzML', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/easypqp/convert/tests/main.nf.test.snap
+++ b/modules/nf-core/easypqp/convert/tests/main.nf.test.snap
@@ -1,0 +1,77 @@
+{
+    "proteomics - idxml - mzml": {
+        "content": [
+            "HepG2_rep1_small.psmpkl",
+            "HepG2_rep1_small.peakpkl",
+            [
+                [
+                    "EASYPQP_CONVERT",
+                    "easypqp",
+                    "0.1.59"
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-04T14:34:29.919514354",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "proteomics - idxml - mzml - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "HepG2_rep1_small.psmpkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "HepG2_rep1_small.peakpkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "EASYPQP_CONVERT",
+                        "easypqp",
+                        "0.1.59"
+                    ]
+                ],
+                "peakpkl": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "HepG2_rep1_small.peakpkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "psmpkl": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "HepG2_rep1_small.psmpkl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_easypqp": [
+                    [
+                        "EASYPQP_CONVERT",
+                        "easypqp",
+                        "0.1.59"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-04T14:34:49.589911212",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/easypqp/library/environment.yml
+++ b/modules/nf-core/easypqp/library/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::easypqp=0.1.59"

--- a/modules/nf-core/easypqp/library/main.nf
+++ b/modules/nf-core/easypqp/library/main.nf
@@ -1,0 +1,40 @@
+process EASYPQP_LIBRARY {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/easypqp:0.1.59--pyhdfd78af_0'
+        : 'quay.io/biocontainers/easypqp:0.1.59--pyhdfd78af_0'}"
+
+    input:
+    tuple val(meta), path(psmpkl), path(peakpkl)
+
+    output:
+    tuple val(meta), path("${prefix}.tsv")   , emit: tsv
+    tuple val(meta), path("*_run_peaks.tsv"), emit: run_peaks, optional: true
+    tuple val("${task.process}"), val('easypqp'), eval("easypqp --version 2>&1 | sed -nE 's/.*version ([0-9.]+).*/\\1/p'"), topic: versions, emit: versions_easypqp
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    export MPLCONFIGDIR=\$PWD/.matplotlib
+    export XDG_CACHE_HOME=\$PWD/.cache
+    mkdir -p \$MPLCONFIGDIR \$XDG_CACHE_HOME
+
+    easypqp library \\
+        --out ${prefix}.tsv \\
+        ${args} \\
+        ${psmpkl} ${peakpkl}
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.tsv
+    """
+}

--- a/modules/nf-core/easypqp/library/meta.yml
+++ b/modules/nf-core/easypqp/library/meta.yml
@@ -1,0 +1,85 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "easypqp_library"
+description: Generate a spectral library (TSV) from EasyPQP PSM and peak pickle files.
+keywords:
+  - proteomics
+  - spectral library
+  - dia
+  - openswath
+  - diann
+tools:
+  - "easypqp":
+      description: "Python package to generate spectral libraries for data-independent acquisition (DIA) proteomics from DDA search results."
+      homepage: "https://github.com/grosenberger/easypqp"
+      documentation: "https://github.com/grosenberger/easypqp"
+      tool_dev_url: "https://github.com/grosenberger/easypqp"
+      licence: ["BSD-3-Clause"]
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - psmpkl:
+        type: file
+        description: One or more PSM pickle files produced by easypqp convert
+        pattern: "*.psmpkl"
+    - peakpkl:
+        type: file
+        description: One or more peak pickle files produced by easypqp convert, matching the PSM pickle files
+        pattern: "*.peakpkl"
+
+output:
+  tsv:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - ${prefix}.tsv:
+          type: file
+          description: Spectral library in TSV format
+          pattern: "*.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  run_peaks:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*_run_peaks.tsv":
+          type: file
+          description: Per-run peak table written alongside the library
+          pattern: "*_run_peaks.tsv"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  versions_easypqp:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - easypqp:
+          type: string
+          description: The tool name
+      - "easypqp --version 2>&1 | sed -nE 's/.*version ([0-9.]+).*/\\1/p'":
+          type: string
+          description: The command used to generate the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - easypqp:
+          type: string
+          description: The tool name
+      - "easypqp --version 2>&1 | sed -nE 's/.*version ([0-9.]+).*/\\1/p'":
+          type: string
+          description: The command used to generate the version of the tool
+
+authors:
+  - "@jonasscheid"
+maintainers:
+  - "@jonasscheid"

--- a/modules/nf-core/easypqp/library/tests/main.nf.test
+++ b/modules/nf-core/easypqp/library/tests/main.nf.test
@@ -1,0 +1,71 @@
+nextflow_process {
+
+    name "Test Process EASYPQP_LIBRARY"
+    script "../main.nf"
+    process "EASYPQP_LIBRARY"
+    config "./nextflow.config"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "easypqp"
+    tag "easypqp/library"
+    tag "easypqp/convert"
+
+    setup {
+        run("EASYPQP_CONVERT") {
+            script "../../convert/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'proteomics/openms/HepG2_rep1_small.idXML', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'proteomics/msspectra/HepG2_rep1_small.mzML', checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+    }
+
+    test("proteomics - psmpkl - peakpkl") {
+
+        when {
+            process {
+                """
+                input[0] = EASYPQP_CONVERT.out.psmpkl.join(EASYPQP_CONVERT.out.peakpkl)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    path(process.out.tsv[0][1]).readLines().take(5),
+                    file(process.out.run_peaks[0][1]).name,
+                    process.out.versions_easypqp
+                ).match() }
+            )
+        }
+    }
+
+    test("proteomics - psmpkl - peakpkl - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = EASYPQP_CONVERT.out.psmpkl.join(EASYPQP_CONVERT.out.peakpkl)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/easypqp/library/tests/main.nf.test.snap
+++ b/modules/nf-core/easypqp/library/tests/main.nf.test.snap
@@ -1,0 +1,73 @@
+{
+    "proteomics - psmpkl - peakpkl": {
+        "content": [
+            [
+                "PrecursorMz\tProductMz\tAnnotation\tProteinId\tGeneName\tPeptideSequence\tModifiedPeptideSequence\tPrecursorCharge\tLibraryIntensity\tNormalizedRetentionTime\tPrecursorIonMobility",
+                "271.410568\t110.070828\tb4^3\tsp|Q96EN8|MOCOS_HUMAN\t-\tKAAGVLEGALGP\tKAAGVLEGALGP\t4\t10000.0\t93.0079411195042\t",
+                "271.410568\t116.070606\ty1^1\tsp|Q96EN8|MOCOS_HUMAN\t-\tKAAGVLEGALGP\tKAAGVLEGALGP\t4\t398.89114\t93.0079411195042\t",
+                "271.410568\t129.10224\tb1^1\tsp|Q96EN8|MOCOS_HUMAN\t-\tKAAGVLEGALGP\tKAAGVLEGALGP\t4\t3139.388\t93.0079411195042\t",
+                "271.410568\t271.176468\tb3^1\tsp|Q96EN8|MOCOS_HUMAN\t-\tKAAGVLEGALGP\tKAAGVLEGALGP\t4\t6836.362\t93.0079411195042\t"
+            ],
+            "HepG2_rep1_small_run_peaks.tsv",
+            [
+                [
+                    "EASYPQP_LIBRARY",
+                    "easypqp",
+                    "0.1.59"
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-04T14:35:36.020316058",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "proteomics - psmpkl - peakpkl - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        "EASYPQP_LIBRARY",
+                        "easypqp",
+                        "0.1.59"
+                    ]
+                ],
+                "run_peaks": [
+                    
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_easypqp": [
+                    [
+                        "EASYPQP_LIBRARY",
+                        "easypqp",
+                        "0.1.59"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-04T14:36:07.755543646",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/easypqp/library/tests/nextflow.config
+++ b/modules/nf-core/easypqp/library/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'EASYPQP_LIBRARY' {
+        ext.args = '--perform_rt_calibration False --perform_im_calibration False --nofdr'
+    }
+}


### PR DESCRIPTION
New modules wrapping [EasyPQP](https://github.com/grosenberger/easypqp) for spectral library generation from DDA search results, ported from nf-core/mhcquant local modules.

- `easypqp/convert`: pepXML/idXML + spectra -> PSM and peak pickles. Output basenames follow the spectra file because `easypqp library` pairs pickles to runs by basename.
- `easypqp/library`: pickles -> spectral library TSV.
- Tests depend on nf-core/test-datasets#2258 (matching mzML for the existing HepG2 idXML).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you have added a new module, follow the [nf-core modules guidelines](https://nf-co.re/docs/guidelines/components/modules).
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- [x] `nf-core modules test <MODULE> --profile docker`
- [ ] `nf-core modules test <MODULE> --profile singularity`
- [ ] `nf-core modules test <MODULE> --profile conda`
- [x] `nf-core modules lint <MODULE>`