### PR TITLE
Update fastaguard to 1.0.0

### DIFF
--- a/modules/nf-core/fastaguard/environment.yml
+++ b/modules/nf-core/fastaguard/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::fastaguard=0.7.0
+  - bioconda::fastaguard=1.0.0

--- a/modules/nf-core/fastaguard/main.nf
+++ b/modules/nf-core/fastaguard/main.nf
@@ -4,8 +4,8 @@ process FASTAGUARD {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastaguard:0.7.0--hfa8f182_0':
-        'quay.io/biocontainers/fastaguard:0.7.0--hfa8f182_0' }"
+        'https://depot.galaxyproject.org/singularity/fastaguard:1.0.0--hfa8f182_0':
+        'quay.io/biocontainers/fastaguard:1.0.0--hfa8f182_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/fastaguard/tests/main.nf.test.snap
+++ b/modules/nf-core/fastaguard/tests/main.nf.test.snap
@@ -38,7 +38,7 @@
                     [
                         "FASTAGUARD",
                         "fastaguard",
-                        "0.7.0"
+                        "1.0.0"
                     ]
                 ]
             }
@@ -88,7 +88,7 @@
                     [
                         "FASTAGUARD",
                         "fastaguard",
-                        "0.7.0"
+                        "1.0.0"
                     ]
                 ]
             }
@@ -138,7 +138,7 @@
                     [
                         "FASTAGUARD",
                         "fastaguard",
-                        "0.7.0"
+                        "1.0.0"
                     ]
                 ]
             }
@@ -188,7 +188,7 @@
                     [
                         "FASTAGUARD",
                         "fastaguard",
-                        "0.7.0"
+                        "1.0.0"
                     ]
                 ]
             }


### PR DESCRIPTION
## Summary

Updates the FastaGuard module to the published 1.0.0 Bioconda package and matching BioContainers images. The module interface and execution behaviour are unchanged.

## PR checklist

- [x] This comment contains a description of changes and the reason for them.
- [x] Software versions are broadcast through `versions.yml`.
- [x] Naming, parameters, input/output options, and the existing resource label are unchanged.
- [x] BioConda and BioContainers are used for the software requirements.
- Test coverage:
  - [x] `nf-test test modules/nf-core/fastaguard/tests --profile=+docker --stop-on-first-failure`
  - [ ] `nf-test test modules/nf-core/fastaguard/tests --profile=+singularity --stop-on-first-failure` (not run locally: no Singularity-compatible runtime installed)
  - [x] `nf-test test modules/nf-core/fastaguard/tests --profile=+conda --stop-on-first-failure`