### PR TITLE
fix(clustalo/align): wait for compression and propagate pigz failures

### DIFF
--- a/modules/nf-core/clustalo/align/main.nf
+++ b/modules/nf-core/clustalo/align/main.nf
@@ -32,12 +32,11 @@ process CLUSTALO_ALIGN {
     def fhmm_batch   = hmm_batch ? "--hmm-batch=${hmm_batch}" : ""
     def fprofile1    = profile1  ? "--profile1=${profile1}"   : ""
     def fprofile2    = profile2  ? "--profile2=${profile2}"   : ""
-    def write_output = compress ? "--force -o >(pigz -cp ${task.cpus} > ${prefix}.aln.gz)" : "-o ${prefix}.aln"
-    // using >() is necessary to preserve the return value,
-    // so nextflow knows to display an error when it failed
-    // the --force -o is necessary, as clustalo expands the commandline input,
-    // causing it to treat the pipe as a parameter and fail
-    // this way, the command expands to /dev/fd/<id>, and --force allows writing output to an already existing file
+    def write_output = compress ? "--force -o >(pigz -cp ${task.cpus} > ${prefix}.aln.gz) && wait \$!" : "-o ${prefix}.aln"
+    // Process substitution keeps alignment data separate from verbose stdout.
+    // Its status is not part of clustalo's status: wait for pigz before success.
+    // && preserves clustalo failures; wait propagates compression failures.
+    // --force permits opening the existing /dev/fd/<id> path.
     """
     clustalo \
         -i ${fasta} \

--- a/modules/nf-core/clustalo/align/tests/test_compression.py
+++ b/modules/nf-core/clustalo/align/tests/test_compression.py
@@ -1,0 +1,108 @@
+"""Exercise the CLUSTALO_ALIGN output shell expression without Nextflow.
+
+Clustalo and pigz are stand-ins: these tests cover process completion and error
+propagation, not alignment or pigz correctness. Run directly with Python 3.
+Set CLUSTALO_MODULE to compare the same tests against an unpatched main.nf.
+"""
+
+import gzip
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+MODULE = Path(os.environ.get("CLUSTALO_MODULE", Path(__file__).parents[1] / "main.nf"))
+ALIGNMENT = b">first\nAAAA-A\n>second\nAAATAA\n"
+
+CLUSTALO = r'''
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+if os.environ.get("PRODUCER_STATUS"):
+    sys.exit(int(os.environ["PRODUCER_STATUS"]))
+output = args[args.index("-o") + 1]
+with open(output, "wb") as handle:
+    handle.write(b">first\nAAAA-A\n>second\nAAATAA\n")
+print("alignment progress message")
+'''
+
+PIGZ = r'''
+import gzip
+import os
+from pathlib import Path
+import sys
+import time
+
+data = sys.stdin.buffer.read()
+if os.environ.get("CONSUMER_STATUS"):
+    sys.exit(int(os.environ["CONSUMER_STATUS"]))
+if os.environ.get("DELAY_CONSUMER"):
+    time.sleep(0.2)
+sys.stdout.buffer.write(gzip.compress(data, mtime=0))
+sys.stdout.buffer.flush()
+Path("compression-complete").touch()
+'''
+
+
+class CompressionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.work = Path(self.temp.name)
+        for name, source in (("clustalo", CLUSTALO), ("pigz", PIGZ)):
+            executable = self.work / name
+            executable.write_text("#!" + sys.executable + "\n" + source)
+            executable.chmod(0o755)
+
+    def run_output(self, compress=True, **environment):
+        match = re.search(
+            r'def write_output = compress \? "((?:\\.|[^"\\])*)" : "((?:\\.|[^"\\])*)"',
+            MODULE.read_text(),
+        )
+        self.assertIsNotNone(match, "could not locate the module output expression")
+        expression = match.group(1 if compress else 2)
+        expression = expression.replace("${task.cpus}", "1").replace("${prefix}", "test")
+        expression = expression.replace(r"\$", "$")
+        env = dict(os.environ, PATH=str(self.work) + os.pathsep + os.environ["PATH"])
+        for key in ("PRODUCER_STATUS", "CONSUMER_STATUS", "DELAY_CONSUMER"):
+            env.pop(key, None)
+        env.update(environment)
+        # Files, not capture_output: inherited pipes can make subprocess wait for
+        # an unwaited process substitution and accidentally hide the original bug.
+        with (self.work / "stdout").open("w") as out, (self.work / "stderr").open("w") as err:
+            return subprocess.run(
+                ["bash", "-euo", "pipefail", "-c", "clustalo " + expression],
+                cwd=self.work, env=env, stdout=out, stderr=err, timeout=10,
+            ).returncode
+
+    def test_compressed_output_is_complete(self):
+        self.assertEqual(self.run_output(DELAY_CONSUMER="1"), 0)
+        self.assertTrue((self.work / "compression-complete").exists())
+        self.assertEqual(gzip.decompress((self.work / "test.aln.gz").read_bytes()), ALIGNMENT)
+
+    def test_compressor_failure_is_propagated(self):
+        # Drain all input before failing, so the producer cannot detect this via SIGPIPE.
+        self.assertEqual(self.run_output(CONSUMER_STATUS="42"), 42)
+
+    def test_producer_failure_is_preserved(self):
+        self.assertEqual(self.run_output(PRODUCER_STATUS="17"), 17)
+
+    def test_uncompressed_output_is_unchanged(self):
+        self.assertEqual(self.run_output(compress=False, CONSUMER_STATUS="42"), 0)
+        self.assertEqual((self.work / "test.aln").read_bytes(), ALIGNMENT)
+        self.assertFalse((self.work / "test.aln.gz").exists())
+
+    def test_stdout_messages_do_not_enter_alignment(self):
+        self.assertEqual(self.run_output(), 0)
+        self.assertIn("alignment progress message", (self.work / "stdout").read_text())
+        self.assertEqual(gzip.decompress((self.work / "test.aln.gz").read_bytes()), ALIGNMENT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The compressed output expression uses `clustalo ... -o >(pigz ... > result.aln.gz)`. Bash does not wait for that process substitution as part of the foreground command, and the compressor's status is not included in the Clustal Omega exit status, even with `set -euo pipefail`.

This can report task success before compression finishes, or after a compressor failure when the producer has already successfully written its buffered output. The `.aln.gz` file may exist but be incomplete or invalid.

## Fix

Append `&& wait $!` to the compressed-output command, with the dollar sign escaped in the Groovy string. The producer's failure is preserved by `&&`; after producer success, Bash waits for the compressor and returns its failure status. This keeps streaming, avoids an intermediate uncompressed file, and preserves the separation of alignment data from verbose stdout. The uncompressed branch and existing nf-test snapshots are unchanged.

## Reproduction and tests

```bash
bash -euo pipefail -c 'printf alignment > >(cat >/dev/null; exit 42)'
# exit 0 before
bash -euo pipefail -c 'printf alignment > >(cat >/dev/null; exit 42) && wait $!'
# exit 42 after
```

Added a dependency-free regression test that extracts the actual module output expression and runs it in Bash with stand-in executables:

```bash
python modules/nf-core/clustalo/align/tests/test_compression.py -v
```

Five cases cover delayed compression completion, compressor failure after draining all input (no SIGPIPE assumption), producer failure, uncompressed output, and separation of stdout progress messages from the compressed alignment. Executed against the pinned original and patched source: **2 failures before; all 5 pass after**.

These are shell lifecycle tests, not an alignment-engine or full Nextflow validation. Nextflow/nf-test and the native tools are unavailable in this execution environment; the existing native integration tests still need CI. The standalone regression is run with the command above and is not claimed to be automatically wired into nf-test.

Prepared with AI assistance. Based on upstream commit `781f2625386fe0bf2f337c7b99f56e618c59fc99`.