### PR TITLE
CI: detect changed components with nf-test instead of detect-nf-test-changes

### DIFF
--- a/.github/actions/detect-nf-test-changes/action.yml
+++ b/.github/actions/detect-nf-test-changes/action.yml
@@ -1,5 +1,5 @@
 name: "Detect nf-test changes"
-description: "List nf-core components whose nf-tests are related to the changes since the merge base with a base ref"
+description: "List nf-test files of nf-core components related to the changes since the merge base with a base ref"
 inputs:
   base:
     description: "Base ref or SHA; the merge base with HEAD is used as diff start"
@@ -14,7 +14,7 @@ inputs:
     default: ""
 outputs:
   components:
-    description: "JSON array of component directories"
+    description: "JSON array of nf-test file paths"
     value: ${{ steps.detect.outputs.components }}
 runs:
   using: "composite"

--- a/.github/actions/detect-nf-test-changes/action.yml
+++ b/.github/actions/detect-nf-test-changes/action.yml
@@ -1,0 +1,39 @@
+name: "Detect nf-test changes"
+description: "List nf-core components whose nf-tests are related to the changes since the merge base with a base ref"
+inputs:
+  base:
+    description: "Base ref or SHA; the merge base with HEAD is used as diff start"
+    required: true
+  tags:
+    description: "Comma-separated tags; keep only tests carrying at least one of them"
+    required: false
+    default: ""
+  exclude_tags:
+    description: "Comma-separated tags; drop tests carrying any of them"
+    required: false
+    default: ""
+outputs:
+  components:
+    description: "JSON array of component directories"
+    value: ${{ steps.detect.outputs.components }}
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
+      with:
+        distribution: "temurin"
+        java-version: "17"
+
+    - name: Set up nf-test
+      uses: nf-core/setup-nf-test@4069fbbaabe94c08faba4ad261bfa88225ba133f # v2
+      with:
+        version: ${{ env.NFT_VER }}
+        install-fast-diff: true
+
+    - name: Detect changed components
+      id: detect
+      shell: bash
+      run: |
+        components=$(${{ github.action_path }}/detect.sh "${{ inputs.base }}" "${{ inputs.tags }}" "${{ inputs.exclude_tags }}")
+        echo "components=$components"
+        echo "components=$components" >> $GITHUB_OUTPUT

--- a/.github/actions/detect-nf-test-changes/detect.sh
+++ b/.github/actions/detect-nf-test-changes/detect.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Usage: detect.sh <base-ref> [include-tags] [exclude-tags]
+# Prints a JSON array of nf-core component directories whose nf-tests are related
+# to the changes between merge-base(<base-ref>, HEAD) and HEAD.
+set -euo pipefail
+
+base_ref="$1"
+include_tags="${2:-}"
+exclude_tags="${3:-}"
+
+base=$(git merge-base "$base_ref" HEAD)
+
+tests=$(nf-test test --dry-run --changed-since "$base" --related-tests --filter process,workflow 2>&1 \
+    | awk '/related test\(s\)/ {f=1; next} /Dry run mode/ {f=0} f && /\.nf\.test$/ {sub(/^[[:space:]]*•[[:space:]]*/, ""); print}' \
+    | sed "s#^$PWD/##")
+
+has_tag() { grep -qE "^[[:space:]]*tag[[:space:]]+[\"']$2[\"']" "$1"; }
+
+components=()
+for t in $tests; do
+    keep=1
+    if [ -n "$include_tags" ]; then
+        keep=0
+        for tag in ${include_tags//,/ }; do has_tag "$t" "$tag" && keep=1; done
+    fi
+    for tag in ${exclude_tags//,/ }; do has_tag "$t" "$tag" && keep=0; done
+    [ "$keep" = 1 ] || continue
+    comp=$(dirname "$(dirname "$t")")
+    [[ "$comp" =~ ^(modules|subworkflows)/nf-core/ ]] && components+=("$comp")
+done
+
+printf '%s\n' "${components[@]+"${components[@]}"}" | { grep . || true; } | sort -u | jq -R . | jq -cs .

--- a/.github/actions/detect-nf-test-changes/detect.sh
+++ b/.github/actions/detect-nf-test-changes/detect.sh
@@ -8,6 +8,7 @@ include_tags="${2:-}"
 exclude_tags="${3:-}"
 
 base=$(git merge-base "$base_ref" HEAD)
+echo "TEMP: simulated detector failure for the fail-closed CI check" >&2 && exit 3
 csv=$(mktemp)
 rm -f "$csv"
 

--- a/.github/actions/detect-nf-test-changes/detect.sh
+++ b/.github/actions/detect-nf-test-changes/detect.sh
@@ -8,7 +8,6 @@ include_tags="${2:-}"
 exclude_tags="${3:-}"
 
 base=$(git merge-base "$base_ref" HEAD)
-echo "TEMP: simulated detector failure for the fail-closed CI check" >&2 && exit 3
 csv=$(mktemp)
 rm -f "$csv"
 

--- a/.github/actions/detect-nf-test-changes/detect.sh
+++ b/.github/actions/detect-nf-test-changes/detect.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Usage: detect.sh <base-ref> [include-tags] [exclude-tags]
-# Prints a JSON array of nf-core component directories whose nf-tests are related
-# to the changes between merge-base(<base-ref>, HEAD) and HEAD.
+# Prints a JSON array of nf-test files related to the changes between merge-base(<base-ref>, HEAD) and HEAD.
 set -euo pipefail
 
 base_ref="$1"
@@ -9,24 +8,38 @@ include_tags="${2:-}"
 exclude_tags="${3:-}"
 
 base=$(git merge-base "$base_ref" HEAD)
+csv=$(mktemp)
+rm -f "$csv"
 
-tests=$(nf-test test --dry-run --changed-since "$base" --related-tests --filter process,workflow 2>&1 \
-    | awk '/related test\(s\)/ {f=1; next} /Dry run mode/ {f=0} f && /\.nf\.test$/ {sub(/^[[:space:]]*•[[:space:]]*/, ""); print}' \
-    | sed "s#^$PWD/##")
+log=$(nf-test test --dry-run --changed-since "$base" --related-tests --filter process,workflow --csv "$csv" 2>&1) || {
+    echo "$log" >&2
+    echo "nf-test dry run failed" >&2
+    exit 1
+}
+
+if [ -s "$csv" ]; then
+    tests=$(tail -n +2 "$csv" | cut -d'"' -f2 | sed "s#^$PWD/##" | sort -u)
+elif grep -q "Nothing to do" <<<"$log"; then
+    tests=""
+else
+    echo "$log" >&2
+    echo "unrecognised nf-test output: neither a CSV report nor 'Nothing to do'" >&2
+    exit 1
+fi
+rm -f "$csv"
 
 has_tag() { grep -qE "^[[:space:]]*tag[[:space:]]+[\"']$2[\"']" "$1"; }
 
-components=()
+selected=()
 for t in $tests; do
+    [[ "$t" =~ ^(modules|subworkflows)/nf-core/ ]] || continue
     keep=1
     if [ -n "$include_tags" ]; then
         keep=0
         for tag in ${include_tags//,/ }; do has_tag "$t" "$tag" && keep=1; done
     fi
     for tag in ${exclude_tags//,/ }; do has_tag "$t" "$tag" && keep=0; done
-    [ "$keep" = 1 ] || continue
-    comp=$(dirname "$(dirname "$t")")
-    [[ "$comp" =~ ^(modules|subworkflows)/nf-core/ ]] && components+=("$comp")
+    [ "$keep" = 1 ] && selected+=("$t")
 done
 
-printf '%s\n' "${components[@]+"${components[@]}"}" | { grep . || true; } | sort -u | jq -R . | jq -cs .
+printf '%s\n' "${selected[@]+"${selected[@]}"}" | { grep . || true; } | jq -R . | jq -cs .

--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -62,20 +62,20 @@ jobs:
       # Detect gpu and gpu_highmem tests separately
       - name: List gpu test files
         id: list-gpu
-        uses: adamrtalbot/detect-nf-test-changes@de3c3c8e113031b4f15a3c1104b5f135e8346997 # v0.0.6
+        uses: ./.github/actions/detect-nf-test-changes
+        env:
+          NFT_VER: ${{ env.NFT_VER }}
         with:
-          head: ${{ github.sha }}
-          base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/master' }}
-          n_parents: 0
+          base: origin/master
           tags: "gpu"
 
       - name: List gpu_highmem test files
         id: list-gpu-highmem
-        uses: adamrtalbot/detect-nf-test-changes@de3c3c8e113031b4f15a3c1104b5f135e8346997 # v0.0.6
+        uses: ./.github/actions/detect-nf-test-changes
+        env:
+          NFT_VER: ${{ env.NFT_VER }}
         with:
-          head: ${{ github.sha }}
-          base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/master' }}
-          n_parents: 0
+          base: origin/master
           tags: "gpu_highmem"
 
       # Shard each tag independently

--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -185,9 +185,13 @@ jobs:
       - runs-on=${{ github.run_id }}-confirm-pass-gpu
       - runner=2cpu-linux-x64
       - image=ubuntu22-full-x64
-    needs: [nf-test-gpu, nf-test-gpu-highmem]
+    needs: [nf-test-changes, nf-test-gpu, nf-test-gpu-highmem]
     if: always()
     steps:
+      - name: Change detection did not succeed
+        if: ${{ needs.nf-test-changes.result != 'success' }}
+        run: exit 1
+
       - name: One or more tests failed
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -177,9 +177,13 @@ jobs:
       - runs-on=${{ github.run_id }}-confirm-pass-nf-test
       - runner=4cpu-linux-x64
       - image=ubuntu22-full-x64
-    needs: [nf-test]
+    needs: [nf-test-changes, nf-test]
     if: always()
     steps:
+      - name: Change detection did not succeed
+        if: ${{ needs.nf-test-changes.result != 'success' }}
+        run: exit 1
+
       - name: One or more tests failed
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -57,12 +57,12 @@ jobs:
 
       - name: List nf-test files
         id: list
-        uses: adamrtalbot/detect-nf-test-changes@de3c3c8e113031b4f15a3c1104b5f135e8346997 # v0.0.6
+        uses: ./.github/actions/detect-nf-test-changes
+        env:
+          NFT_VER: ${{ env.NFT_VER }}
         with:
-          head: ${{ github.sha }}
-          base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/master' }}
-          n_parents: 0
-          exclude_tags: "gpu"
+          base: origin/master
+          exclude_tags: "gpu,gpu_highmem"
 
       - name: Separate modules and subworkflows
         id: components

--- a/modules/nf-core/amulety/antiberta2/main.nf
+++ b/modules/nf-core/amulety/antiberta2/main.nf
@@ -41,3 +41,5 @@ The new 'embed' command now covers the embedding functionality for all embedding
 """
     assert false: deprecation_message
 }
+
+// CI check: temporary, reverted before merge

--- a/modules/nf-core/amulety/antiberta2/main.nf
+++ b/modules/nf-core/amulety/antiberta2/main.nf
@@ -41,5 +41,3 @@ The new 'embed' command now covers the embedding functionality for all embedding
 """
     assert false: deprecation_message
 }
-
-// CI check: temporary, reverted before merge


### PR DESCRIPTION
Fixes #12893. The pinned `detect-nf-test-changes` action builds a Debian bullseye image that no longer installs, breaking `nf-test-changes` on every PR.

Replaces it with a local composite action that runs `nf-test test --dry-run --changed-since <merge-base> --related-tests` and maps the related test files to component directories. Same `components` output, so `get-shards` and the test matrix are unchanged.

- No Docker build in CI any more.
- Diff starts at the merge base with `origin/master`, so changes merged to master since the branch diverged are no longer tested.
- Tests that directly include a changed module (e.g. subworkflows) are now picked up too.
- Tag filtering kept via `tags` / `exclude_tags`; the CPU workflow now excludes `gpu_highmem` as well as `gpu`.
- Checked locally against a module-only branch, a GPU-tagged module, and a no-change case.