### PR TITLE
CI: test composite change detection action

### DIFF
--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -62,7 +62,7 @@ jobs:
       # Detect gpu and gpu_highmem tests separately
       - name: List gpu test files
         id: list-gpu
-        uses: adamrtalbot/detect-nf-test-changes@de3c3c8e113031b4f15a3c1104b5f135e8346997 # v0.0.6
+        uses: adamrtalbot/detect-nf-test-changes@6f00d8e49a49566f07828368af32a293a96afd48 # unreleased composite action
         with:
           head: ${{ github.sha }}
           base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/master' }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: List gpu_highmem test files
         id: list-gpu-highmem
-        uses: adamrtalbot/detect-nf-test-changes@de3c3c8e113031b4f15a3c1104b5f135e8346997 # v0.0.6
+        uses: adamrtalbot/detect-nf-test-changes@6f00d8e49a49566f07828368af32a293a96afd48 # unreleased composite action
         with:
           head: ${{ github.sha }}
           base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/master' }}

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: List nf-test files
         id: list
-        uses: adamrtalbot/detect-nf-test-changes@de3c3c8e113031b4f15a3c1104b5f135e8346997 # v0.0.6
+        uses: adamrtalbot/detect-nf-test-changes@6f00d8e49a49566f07828368af32a293a96afd48 # unreleased composite action
         with:
           head: ${{ github.sha }}
           base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'origin/master' }}

--- a/modules/nf-core/parabricks/dbsnp/main.nf
+++ b/modules/nf-core/parabricks/dbsnp/main.nf
@@ -1,3 +1,4 @@
+// Temporary change to exercise GPU module detection.
 process PARABRICKS_DBSNP {
     tag "${meta.id}"
     label 'process_high'

--- a/modules/nf-core/samtools/sort/main.nf
+++ b/modules/nf-core/samtools/sort/main.nf
@@ -1,3 +1,4 @@
+// Temporary change to exercise CPU module detection.
 process SAMTOOLS_SORT {
     tag "${meta.id}"
     label 'process_medium'


### PR DESCRIPTION
## Why

The pinned `detect-nf-test-changes` v0.0.6 action cannot build because its Debian Bullseye base can no longer install Git. This draft tests the replacement uv-backed composite action without changing the existing workflow behaviour.

Related to #12893. This is an alternative to #12897; the two PRs should not both be merged.

## What

- Update all three CPU and GPU workflow references to the tested composite-action commit
- Keep the action pinned to a full immutable SHA
- Add temporary comment-only changes to CPU and GPU modules to exercise non-empty detection outputs

## Before marking ready

- [ ] Release the composite version of `adamrtalbot/detect-nf-test-changes`
- [ ] Replace the temporary commit reference and comment with the released version's immutable SHA
- [ ] Remove the temporary comments from `samtools/sort` and `parabricks/dbsnp`
- [ ] Confirm all nf-core/modules CI checks pass

## PR checklist

- [x] This comment contains a description of changes with the reason.
- [x] The changed files pass repository formatting and validation hooks.
- [x] Remove all TODO statements.