### PR TITLE
pin python 3.11 in quast env

### DIFF
--- a/modules/nf-core/quast/environment.yml
+++ b/modules/nf-core/quast/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
+  - python=3.11
   - bioconda::quast=5.3.0


### PR DESCRIPTION
QUAST does not work with python >3.11 because `distutils` was deprecated in python 3.12. See https://github.com/ablab/quast/issues/298 and #12903 