### PR TITLE
Add raxmlng/search: ML tree search with integrated model testing (MOOSE)

### DIFF
--- a/modules/nf-core/raxmlng/search/environment.yml
+++ b/modules/nf-core/raxmlng/search/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bioconda::raxml-ng=2.0.3

--- a/modules/nf-core/raxmlng/search/main.nf
+++ b/modules/nf-core/raxmlng/search/main.nf
@@ -1,0 +1,61 @@
+process RAXMLNG_SEARCH {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/raxml-ng:2.0.3--h870a6a7_0' :
+        'quay.io/biocontainers/raxml-ng:2.0.3--h870a6a7_0' }"
+
+    input:
+    tuple val(meta), path(alignment), val(model)
+    path(tree)
+    path(tree_constraint)
+    path(partitions)
+    path(site_weights)
+
+    output:
+    tuple val(meta), path("*.raxml.bestTree") , emit: phylogeny
+    tuple val(meta), path("*.raxml.bestModel"), emit: best_model
+    tuple val(meta), path("*.raxml.mlTrees")  , emit: ml_trees  , optional: true
+    tuple val(meta), path("*.raxml.startTree"), emit: start_tree, optional: true
+    tuple val(meta), path("*.raxml.log")      , emit: log
+    tuple val("${task.process}"), val('raxmlng'), eval("raxml-ng --version 2>&1 | sed '/RAxML-NG v/!d;s/.*v. //;s/ .*//'"), emit: versions_raxmlng, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    // fix random seed for reproducibility if not specified in command line
+    if (!(args ==~ /.*--seed.*/)) {args += " --seed=42"}
+    def tree_arg             = tree             ? "--tree ${tree}"                       : ''
+    def tree_constraint_arg  = tree_constraint  ? "--tree-constraint ${tree_constraint}"  : ''
+    // a partitions/model-definition file takes the place of a literal model string;
+    // --model only ever takes one or the other, never both
+    def model_arg            = partitions       ? "--model ${partitions}"                : "--model ${model}"
+    def site_weights_arg     = site_weights     ? "--site-weights ${site_weights}"        : ''
+    """
+    raxml-ng \\
+        --search \\
+        ${args} \\
+        --msa ${alignment} \\
+        ${model_arg} \\
+        ${tree_arg} \\
+        ${tree_constraint_arg} \\
+        ${site_weights_arg} \\
+        --threads ${task.cpus} \\
+        --prefix ${prefix}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.raxml.bestTree
+    touch ${prefix}.raxml.bestModel
+    touch ${prefix}.raxml.mlTrees
+    touch ${prefix}.raxml.startTree
+    touch ${prefix}.raxml.log
+    """
+}

--- a/modules/nf-core/raxmlng/search/meta.yml
+++ b/modules/nf-core/raxmlng/search/meta.yml
@@ -1,0 +1,142 @@
+name: "raxmlng_search"
+description: Maximum-likelihood tree search with RAxML-NG, optionally combined with its integrated automatic model selection (MOOSE)
+keywords:
+  - phylogeny
+  - newick
+  - maximum likelihood
+  - model selection
+tools:
+  - "raxmlng":
+      description: RAxML-NG is a phylogenetic tree inference tool which uses maximum-likelihood (ML) optimality criterion.
+      homepage: https://github.com/amkozlov/raxml-ng
+      documentation: https://github.com/amkozlov/raxml-ng/wiki
+      tool_dev_url: https://github.com/amkozlov/raxml-ng
+      doi: 10.1093/bioinformatics/btz305
+      licence:
+        - "GPL v2-or-later"
+      identifier: ""
+
+input:
+  - - meta:
+        type: map
+        description: Groovy Map containing sample information (e.g. [ id:'sample1' ])
+    - alignment:
+        type: file
+        description: A FASTA/PHYLIP format multiple sequence alignment file
+        pattern: "*.{fasta,fas,fa,mfa,phy}"
+        ontologies: []
+    - model:
+        type: string
+        description: |
+          The substitution model to use for the phylogenetic inference (e.g. "GTR+G"),
+          or "DNA"/"AA"/"auto" to trigger RAxML-NG's integrated automatic model selection
+          (MOOSE) instead of a fixed model. Ignored if `partitions` is also given.
+  - tree:
+      type: file
+      description: |
+        Optional starting tree in Newick format. If not given, RAxML-NG generates its
+        own starting tree(s) (parsimony/random, auto-detected count based on MSA
+        difficulty).
+      pattern: "*.{nwk,newick,tree,treefile}"
+      ontologies: []
+      optional: true
+  - tree_constraint:
+      type: file
+      description: A backbone/topology constraint tree in Newick format
+      pattern: "*.{nwk,newick,tree,treefile}"
+      ontologies: []
+      optional: true
+  - partitions:
+      type: file
+      description: |
+        A RAxML-NG partition/model-definition file, used in place of the `model`
+        string input when given (e.g. for partitioned analyses, or `--model auto=FILE`
+        for MOOSE on partitioned data).
+      pattern: "*.{txt,part,partitions}"
+      ontologies: []
+      optional: true
+  - site_weights:
+      type: file
+      description: A file of positive-integer MSA column weights
+      pattern: "*.{txt}"
+      ontologies: []
+      optional: true
+
+output:
+  phylogeny:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.raxml.bestTree":
+          type: file
+          description: The best-scoring ML tree found, in Newick format
+          pattern: "*.raxml.bestTree"
+          ontologies: []
+  best_model:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.raxml.bestModel":
+          type: file
+          description: |
+            The optimized substitution model in RAxML-NG's own machine-readable model
+            string format -- whether `model` was a fixed model string or MOOSE picked it
+            automatically
+          pattern: "*.raxml.bestModel"
+          ontologies: []
+  ml_trees:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.raxml.mlTrees":
+          type: file
+          description: All ML trees from every independent tree search, in Newick format
+          pattern: "*.raxml.mlTrees"
+          optional: true
+          ontologies: []
+  start_tree:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.raxml.startTree":
+          type: file
+          description: The starting tree(s) used for the search, in Newick format
+          pattern: "*.raxml.startTree"
+          optional: true
+          ontologies: []
+  log:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.raxml.log":
+          type: file
+          description: RAxML-NG's run log
+          pattern: "*.raxml.log"
+          ontologies: []
+  versions_raxmlng:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - raxmlng:
+          type: string
+          description: The name of the tool
+      - raxml-ng --version 2>&1 | sed '/RAxML-NG v/!d;s/.*v. //;s/ .*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - raxmlng:
+          type: string
+          description: The name of the tool
+      - raxml-ng --version 2>&1 | sed '/RAxML-NG v/!d;s/.*v. //;s/ .*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@erikrikarddaniel"
+maintainers:
+  - "@erikrikarddaniel"

--- a/modules/nf-core/raxmlng/search/tests/main.nf.test
+++ b/modules/nf-core/raxmlng/search/tests/main.nf.test
@@ -1,0 +1,125 @@
+nextflow_process {
+
+    name "Test Process RAXMLNG_SEARCH"
+    script "../main.nf"
+    process "RAXMLNG_SEARCH"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "raxmlng"
+    tag "raxmlng/search"
+
+    test("sarscov2 - fixed model") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/informative_sites.fas', checkIfExists: true),
+                    'GTR+G'
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["log"])).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - moose automatic model selection") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/informative_sites.fas', checkIfExists: true),
+                    'DNA'
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["log"])).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - tree constraint") {
+
+        when {
+            process {
+                """
+                // A comprehensive (fully-resolved) tree is rejected by raxml-ng as a
+                // topological constraint ("almost certainly not what you intended"), so
+                // this is deliberately an unresolved polytomy over the same four sample
+                // names as informative_sites.fas -- a minimal, valid constraint, not a
+                // fixture file.
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/informative_sites.fas', checkIfExists: true),
+                    'GTR+G'
+                ]
+                input[1] = []
+                def constraint_tree = new File(System.getProperty('java.io.tmpdir'), "raxmlng_search_constraint_test.nwk")
+                constraint_tree.text = '(sample1,sample2,sample3,sample4);'
+                input[2] = file(constraint_tree)
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["log"])).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - fixed model - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/alignment/informative_sites.fas', checkIfExists: true),
+                    'GTR+G'
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["log"])).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/raxmlng/search/tests/main.nf.test.snap
+++ b/modules/nf-core/raxmlng/search/tests/main.nf.test.snap
@@ -1,0 +1,234 @@
+{
+    "sarscov2 - moose automatic model selection": {
+        "content": [
+            {
+                "best_model": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.bestModel:md5,7a3dd4935298027fa00ab2ae7029578e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.log"
+                    ]
+                ],
+                "ml_trees": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.mlTrees:md5,a28e741361b95cc621d43a632d4470fe"
+                    ]
+                ],
+                "phylogeny": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.bestTree:md5,a54d4b81a070b40e956ddc52d7dd5fd5"
+                    ]
+                ],
+                "start_tree": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.startTree:md5,3d3d4e9db7205fc29a2f73fa47b79b97"
+                    ]
+                ],
+                "versions_raxmlng": [
+                    [
+                        "RAXMLNG_SEARCH",
+                        "raxmlng",
+                        "2.0.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-08T12:26:30.185039143",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "sarscov2 - fixed model": {
+        "content": [
+            {
+                "best_model": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.bestModel:md5,9a25808c8c439b003e666031880feb6a"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.log"
+                    ]
+                ],
+                "ml_trees": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.mlTrees:md5,347cfaeb9902ca0a400fda45b44f23fe"
+                    ]
+                ],
+                "phylogeny": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.bestTree:md5,0fc0572363f95613347cb7c76a9a1160"
+                    ]
+                ],
+                "start_tree": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.startTree:md5,3d3d4e9db7205fc29a2f73fa47b79b97"
+                    ]
+                ],
+                "versions_raxmlng": [
+                    [
+                        "RAXMLNG_SEARCH",
+                        "raxmlng",
+                        "2.0.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-08T12:26:24.725777272",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "sarscov2 - tree constraint": {
+        "content": [
+            {
+                "best_model": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.bestModel:md5,43f6293f0b5e38f49a71644e98594f4a"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.log"
+                    ]
+                ],
+                "ml_trees": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.mlTrees:md5,af1bf22272d5367455ef89b014ce53bf"
+                    ]
+                ],
+                "phylogeny": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.bestTree:md5,f0e328c9d0d1d8b0d0aaea48cdd7503c"
+                    ]
+                ],
+                "start_tree": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.raxml.startTree:md5,3526072deae6f4ec4ceb0a395c117ef3"
+                    ]
+                ],
+                "versions_raxmlng": [
+                    [
+                        "RAXMLNG_SEARCH",
+                        "raxmlng",
+                        "2.0.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-08T12:26:35.334247801",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "sarscov2 - fixed model - stub": {
+        "content": [
+            {
+                "best_model": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.raxml.bestModel:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.raxml.log"
+                    ]
+                ],
+                "ml_trees": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.raxml.mlTrees:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "phylogeny": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.raxml.bestTree:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "start_tree": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.raxml.startTree:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_raxmlng": [
+                    [
+                        "RAXMLNG_SEARCH",
+                        "raxmlng",
+                        "2.0.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-08T12:26:40.472130586",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    }
+}


### PR DESCRIPTION
## PR checklist

Closes #12865

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, include test data in your PR. <!-- uses existing sarscov2 test data already vendored in the repo -->
- [x] Remove all TODO statements.
- [x] Broadcast software version numbers to `topic: versions` - [See version_topics](https://nf-co.re/blog/2025/version_topics)
- [x] Follow the naming conventions.
- [x] Follow the parameters requirements.
- [x] Follow the input/output options guidelines.
- [x] Add a resource `label`
- [x] Use BioConda and BioContainers if possible to fulfil software requirements.
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test raxmlng/search --profile docker`
    - [x] `nf-core modules test raxmlng/search --profile singularity`
    - [ ] `nf-core modules test raxmlng/search --profile conda` <!-- env creation timed out locally; docker+singularity both pass -->

## Note

A `raxmlng` module already exists. It's based on version 1.3 of the tool. The tool actually supports subcommands, so instead of just updating the tool version, this PR adds a parallel module `raxmlng/search`. An added advantage of this is that pipelines depending on the old tool's syntax could keep using that. No nf-core pipelines are listed as users of the old module, but a non nf-core pipeline is: `CDCgov/mycosnp-nf`.

## Description

RAxML-NG 2.0 adds "MOOSE" (built-in automatic model selection combined with tree search
in one call), writing a machine-readable `*.raxml.bestModel` file. The existing flat
`raxmlng` module (pinned to 1.2.2) predates this, requires a caller-supplied fixed model
string, and has no `bestModel` output.

Per the naming spec for tools with mode-selecting flags (`angsd/docounts`, `angsd/gl`;
`vsearch/*`), this adds `raxmlng/search` as a namespaced submodule rather than growing the
flat module further, leaving room for sibling submodules (`raxmlng/evaluate`,
`raxmlng/bootstrap`, ...) later. The existing flat `raxmlng` module is left untouched.

Inputs beyond the alignment (`tree`, `tree_constraint`, `partitions`, `site_weights`) are
exposed as proper path inputs, mirroring the vendored `iqtree` module's convention for a
tool with several independent optional file arguments -- these need Nextflow staging and
can't be reached via `ext.args`.

Tested against real Docker and Singularity execution (`raxml-ng:2.0.3--h870a6a7_0`);
fixed-model, MOOSE automatic-model-selection, and tree-constraint cases all produce
byte-identical scientific output (tree/model/phylogeny files) across both engines --
only RAxML-NG's own log file differs between runs/engines (environment-dependent
content), so it's excluded from strict snapshot comparison via `unstableKeys` (same
pattern the sibling flat `raxmlng` module already uses for its own nondeterministic
output), while still asserting the file itself is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eSqkuYZXfNiWy87y3srup
