### PR TITLE
fix(galah): correct DOI in meta.yml

### DIFF
--- a/modules/nf-core/galah/meta.yml
+++ b/modules/nf-core/galah/meta.yml
@@ -12,7 +12,7 @@ tools:
       homepage: "https://github.com/wwood/galah"
       documentation: "https://github.com/wwood/galah"
       tool_dev_url: "https://github.com/wwood/galah"
-      doi: "10.1111/NODOI"
+      doi: "10.5281/zenodo.13637856"
       licence:
         - "GPL v3"
       identifier: ""


### PR DESCRIPTION
<!--
# nf-core/modules pull request

Many thanks for contributing to nf-core/modules!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the master branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests! (not applicable -- one metadata field, no code path affected)
- [ ] If you've added a new tool - have you followed the module conventions in the [contribution docs](https://github.com/nf-core/modules/tree/master/.github/CONTRIBUTING.md) (not applicable)
- [ ] If necessary, include test data in your PR. (not applicable)
- [x] Remove all TODO statements.
- [x] Follow the naming conventions.

## Description

`galah/meta.yml`'s `doi` field was set to the `10.1111/NODOI` placeholder nf-core/modules uses for tools without a real DOI. Galah does have one -- its own Zenodo release, `10.5281/zenodo.13637856` -- verified via DOI content negotiation before filling it in.

Found while adding Galah-based dereplication to nf-core/mag ([nf-core/mag#1110](https://github.com/nf-core/mag/pull/1110)): a reviewer there noted Galah's citation wasn't surfacing in the pipeline's MultiQC report the way other tools' citations do, and this placeholder DOI is why -- it's the same field other modules (e.g. `dastool/dastool`) populate with a real DOI to get that automatic citation surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
