### PR TITLE
fix(krakenuniq/preloadedkrakenuniq): fix --preload-size handling, report optionality, and simplify stub

### DIFF
--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -20,7 +20,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
     tuple val(meta), path("*.classified.${sequence_type}.gz"), optional: true, emit: classified_reads
     tuple val(meta), path("*.unclassified.${sequence_type}.gz"), optional: true, emit: unclassified_reads
     tuple val(meta), path('*.krakenuniq.classified.txt'), optional: true, emit: classified_assignment
-    tuple val(meta), path('*.krakenuniq.report.txt'), emit: report
+    tuple val(meta), path('*.krakenuniq.report.txt'), optional: true, emit: report
     tuple val("${task.process}"), val('krakenuniq'), eval("krakenuniq --version | sed '1!d;s/KrakenUniq version //'"), emit: versions_krakenuniq, topic: versions
 
     when:

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -32,7 +32,7 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
 
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
-    def preload_mode = !task.ext.args.toString().contains('--preload-size')
+    def preload_mode = !args2.contains('--preload-size')
     def preload_cmd = preload_mode ? "krakenuniq ${args} --db ${db} --preload --threads ${task.cpus}" : ''
 
     classified = meta.single_end ? "\${PREFIX}.classified.${sequence_type}" : "\${PREFIX}.merged.classified.${sequence_type}"
@@ -108,8 +108,8 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
     sequences = sequences instanceof List ? sequences : [sequences]
 
     def args = task.ext.args ?: ''
-    def args2 = task.ext.args ?: ''
-    def preload_mode = !task.ext.args.toString().contains('--preload-size')
+    def args2 = task.ext.args2 ?: ''
+    def preload_mode = !args2.contains('--preload-size')
     def preload_cmd = preload_mode ? "echo krakenuniq ${args} --db ${db} --preload --threads ${task.cpus}" : ''
 
     classified = meta.single_end ? "\${PREFIX}.classified.${sequence_type}" : "\${PREFIX}.merged.classified.${sequence_type}"

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/main.nf
@@ -106,102 +106,17 @@ process KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
     stub:
     assert sequence_type in ['fasta', 'fastq']
     sequences = sequences instanceof List ? sequences : [sequences]
+    assert (meta.single_end ? sequences.size() : sequences.size() / 2) == prefixes.size()
 
-    def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
-    def preload_mode = !args2.contains('--preload-size')
-    def preload_cmd = preload_mode ? "echo krakenuniq ${args} --db ${db} --preload --threads ${task.cpus}" : ''
+    def merged_suffix = meta.single_end ? '' : '.merged'
+    def prefix_list = prefixes.collect { "'${it}'" }.join(' ')
 
-    classified = meta.single_end ? "\${PREFIX}.classified.${sequence_type}" : "\${PREFIX}.merged.classified.${sequence_type}"
-    unclassified = meta.single_end ? "\${PREFIX}.unclassified.${sequence_type}" : "\${PREFIX}.merged.unclassified.${sequence_type}"
-    classified_option = save_output_reads ? "--classified-out \"${classified}\"" : ''
-    unclassified_option = save_output_reads ? "--unclassified-out \"${unclassified}\"" : ''
-    def output_option = save_output ? '--output "\${PREFIX}.krakenuniq.classified.txt"' : ''
-    def report = report_file ? '--report-file "\${PREFIX}.krakenuniq.report.txt"' : ''
-    compress_reads_command = save_output_reads ? "find . -name '*.${sequence_type}' -print0 | xargs -0 -t -P ${task.cpus} -I % gzip --no-name %" : ''
-    def command_inputs_file = '.inputs.txt'
-
-    if (meta.single_end) {
-        assert sequences.size() == prefixes.size()
-        command_inputs = [sequences, prefixes].transpose().collect { seq, prefix -> "${seq}\t${prefix}" }
-
-        """
-        # Store the batch of samples for later command input.
-        cat <<-END_INPUTS > ${command_inputs_file}
-        ${command_inputs.join('\n        ')}
-        END_INPUTS
-
-        ${preload_cmd}
-
-        create_file() {
-            echo '<3 nf-core' > "\$1"
-        }
-
-        create_gzip_file() {
-            echo '<3 nf-core' | gzip -n > "\$1"
-        }
-
-        # Run the KrakenUniq classification on each sample in the batch.
-        while IFS='\t' read -r SEQ PREFIX; do
-            echo krakenuniq \\
-                --db ${db} \\
-                --threads ${task.cpus} \\
-                ${report} \\
-                ${output_option} \\
-                ${unclassified_option} \\
-                ${classified_option} \\
-                ${args2} \\
-                "\${SEQ}"
-
-            create_file "\${PREFIX}.krakenuniq.classified.txt"
-            create_file "\${PREFIX}.krakenuniq.report.txt"
-            create_gzip_file "\${PREFIX}.classified.${sequence_type}.gz"
-            create_gzip_file "\${PREFIX}.unclassified.${sequence_type}.gz"
-        done < ${command_inputs_file}
-
-        echo "${compress_reads_command}"
-        """
-    }
-    else {
-        assert sequences.size() / 2 == prefixes.size()
-        command_inputs = [sequences.collate(2), prefixes].transpose().collect { pair, prefix -> "${pair[0]}\t${pair[1]}\t${prefix}" }
-
-        """
-        # Store the batch of samples for later command input.
-        cat <<-END_INPUTS > ${command_inputs_file}
-        ${command_inputs.join('\n        ')}
-        END_INPUTS
-
-        ${preload_cmd}
-
-        create_file() {
-            echo '<3 nf-core' > "\$1"
-        }
-
-        create_gzip_file() {
-            echo '<3 nf-core' | gzip -n > "\$1"
-        }
-
-        # Run the KrakenUniq classification on each sample in the batch.
-        while IFS='\t' read -r FIRST_SEQ SECOND_SEQ PREFIX; do
-            echo krakenuniq \\
-                --db ${db} \\
-                --threads ${task.cpus} \\
-                ${report} \\
-                ${output_option} \\
-                ${unclassified_option} \\
-                ${classified_option} \\
-                --paired \\
-                ${args2} \\
-                "\${FIRST_SEQ}" "\${SECOND_SEQ}"
-
-            create_file "\${PREFIX}.krakenuniq.classified.txt"
-            create_file "\${PREFIX}.krakenuniq.report.txt"
-            create_gzip_file "\${PREFIX}.merged.classified.${sequence_type}.gz"
-            create_gzip_file "\${PREFIX}.merged.unclassified.${sequence_type}.gz"
-        done < ${command_inputs_file}
-
-        echo "${compress_reads_command}"
-        """
-    }
+    """
+    for PREFIX in ${prefix_list}; do
+        echo '<3 nf-core' > "\${PREFIX}.krakenuniq.classified.txt"
+        echo '<3 nf-core' > "\${PREFIX}.krakenuniq.report.txt"
+        echo '<3 nf-core' | gzip -n > "\${PREFIX}${merged_suffix}.classified.${sequence_type}.gz"
+        echo '<3 nf-core' | gzip -n > "\${PREFIX}${merged_suffix}.unclassified.${sequence_type}.gz"
+    done
+    """
 }

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test
@@ -164,6 +164,42 @@ nextflow_process {
 
     }
 
+    test("sarscov2 - FASTA - no optional outputs") {
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                    [id:'test', single_end:true],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
+                    ],
+                    ['sample_1', 'sample.2']
+                ]
+                input[1] = 'fasta'
+                input[2] = UNTAR.out.untar.map { it[1] }
+                input[3] = false
+                input[4] = false
+                input[5] = false
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert process.out.classified_reads == [] },
+                { assert process.out.unclassified_reads == [] },
+                { assert process.out.classified_assignment == [] },
+                { assert process.out.report == [] },
+            )
+        }
+
+    }
+
     test("sarscov2 - Illumina FASTQ single") {
         when {
             params {

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test
@@ -73,6 +73,7 @@ nextflow_process {
         when {
             params {
                 outdir   = "$outputDir"
+                krakenuniq_args2 = '--preload-size 1GB'
             }
             process {
                 """
@@ -96,17 +97,68 @@ nextflow_process {
         then {
             def reports = process.out.report.get(0).get(1).collect { report -> file(report).name }
             def expected = ['sample_1.krakenuniq.report.txt', 'sample.2.krakenuniq.report.txt']
+            def commandSh = file(path(process.out.report.get(0).get(1)[0]).parent.toString() + '/.command.sh').text
 
             assertAll (
                 { assert process.success },
                 // Report contains a timestamp.
                 { assertContainsInAnyOrder(reports, expected) },
+                { assert !commandSh.contains('--preload --threads') },
+                { assert commandSh.contains('--preload-size 1GB') },
                 { assert snapshot(
                     process.out.classified_reads,
                     process.out.unclassified_reads,
                     process.out.classified_assignment,
                     process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match('fasta_ramchunksize') },
+            )
+        }
+
+    }
+
+    test("sarscov2 - FASTA - extra args") {
+
+        config './nextflow.config'
+
+        when {
+            params {
+                outdir   = "$outputDir"
+                krakenuniq_args = '--hll-precision 14'
+                krakenuniq_args2 = '--exact'
+            }
+            process {
+                """
+                input[0] = [
+                    [id:'test', single_end:true],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fasta/contigs.fasta', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
+                    ],
+                    ['sample_1', 'sample.2']
+                ]
+                input[1] = 'fasta'
+                input[2] = UNTAR.out.untar.map { it[1] }
+                input[3] = true
+                input[4] = true
+                input[5] = true
+                """
+            }
+        }
+
+        then {
+            def commandSh = file(path(process.out.report.get(0).get(1)[0]).parent.toString() + '/.command.sh').text
+
+            assertAll (
+                { assert process.success },
+                { assert commandSh.contains('krakenuniq --hll-precision 14 --db') },
+                { assert commandSh.contains('--exact \\') },
+                { assert !commandSh.contains('--hll-precision 14 \\') },
+                { assert snapshot(
+                    process.out.classified_reads,
+                    process.out.unclassified_reads,
+                    process.out.classified_assignment,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match('fasta_extra_args') },
             )
         }
 

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test.snap
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test.snap
@@ -1,4 +1,40 @@
 {
+    "fasta_extra_args": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    [
+                        "sample.2.krakenuniq.classified.txt:md5,8aafacd89a6aac98aaf512df0a7493d1",
+                        "sample_1.krakenuniq.classified.txt:md5,2bea6c2195c400a909a2d4cca2e3045e"
+                    ]
+                ]
+            ],
+            {
+                "versions_krakenuniq": [
+                    [
+                        "KRAKENUNIQ_PRELOADEDKRAKENUNIQ",
+                        "krakenuniq",
+                        "1.0.4"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-09T16:34:12.262194",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
     "fasta_ramchunksize": {
         "content": [
             [

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test.snap
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/main.nf.test.snap
@@ -1,40 +1,4 @@
 {
-    "fasta_extra_args": {
-        "content": [
-            [
-                
-            ],
-            [
-                
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    [
-                        "sample.2.krakenuniq.classified.txt:md5,8aafacd89a6aac98aaf512df0a7493d1",
-                        "sample_1.krakenuniq.classified.txt:md5,2bea6c2195c400a909a2d4cca2e3045e"
-                    ]
-                ]
-            ],
-            {
-                "versions_krakenuniq": [
-                    [
-                        "KRAKENUNIQ_PRELOADEDKRAKENUNIQ",
-                        "krakenuniq",
-                        "1.0.4"
-                    ]
-                ]
-            }
-        ],
-        "timestamp": "2026-09-09T16:34:12.262194",
-        "meta": {
-            "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
-        }
-    },
     "fasta_ramchunksize": {
         "content": [
             [
@@ -303,6 +267,42 @@
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
+        }
+    },
+    "fasta_extra_args": {
+        "content": [
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    [
+                        "sample.2.krakenuniq.classified.txt:md5,8aafacd89a6aac98aaf512df0a7493d1",
+                        "sample_1.krakenuniq.classified.txt:md5,2bea6c2195c400a909a2d4cca2e3045e"
+                    ]
+                ]
+            ],
+            {
+                "versions_krakenuniq": [
+                    [
+                        "KRAKENUNIQ_PRELOADEDKRAKENUNIQ",
+                        "krakenuniq",
+                        "1.0.4"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-09T16:34:12.262194",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     },
     "fasta": {

--- a/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/nextflow.config
+++ b/modules/nf-core/krakenuniq/preloadedkrakenuniq/tests/nextflow.config
@@ -1,5 +1,11 @@
+params {
+    krakenuniq_args  = ''
+    krakenuniq_args2 = ''
+}
+
 process {
     withName: KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
-        ext.args = '--preload-size 1GB'
+        ext.args = { params.krakenuniq_args }
+        ext.args2 = { params.krakenuniq_args2 }
     }
 }


### PR DESCRIPTION
## PR checklist

Three related fixes to `krakenuniq/preloadedkrakenuniq`, found while auditing the module.

### 1. `--preload-size` was silently dropped
`ext.args` feeds the module's separate preload warm-up call, `ext.args2`
feeds the actual classify call. Per KrakenUniq's own docs, `--preload-size`
overrides `--preload` and runs on the classify invocation itself, not a
separate step - so it belongs in `ext.args2`. But the code that decides
whether to skip the separate warm-up checked `task.ext.args` instead, so a
user setting `--preload-size` via `ext.args` (as the existing test did) had
it silently dropped entirely: the warm-up was skipped, and the flag never
reached classify either, since that only reads `ext.args2`.

Also fixes an independent typo in the stub, where `args2` read from
`task.ext.args` instead of `task.ext.args2` - a regression PR #11939 fixed
in `script:` but missed in `stub:`.

### 2. `report_file: false` crashed the process
The `report` output wasn't marked `optional: true` despite only being
created when `report_file` is true - so disabling it made Nextflow fail the
task with a missing-output-file error, even though the run itself succeeded.

### 3. Stub was needlessly complex
The stub duplicated the entire `script:` command-construction logic (preload
command, args, per-flag options, `--paired` branching) just to produce an
unused `echo krakenuniq ...` line - none of it affects which files actually
get created. Per the nf-core module spec, a stub only needs to produce
correctly named placeholder files. Simplified from ~100 duplicated lines to
an ~18-line loop over the batch's prefixes; verified byte-identical output
against the existing snapshots.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- Ensure that the test works with either Docker / Singularity. Conda CI tests can be quite flaky:
  - For modules:
    - [x] `nf-core modules test krakenuniq/preloadedkrakenuniq --profile docker`
    - [ ] `nf-core modules test krakenuniq/preloadedkrakenuniq --profile singularity`
    - [ ] `nf-core modules test krakenuniq/preloadedkrakenuniq --profile conda`

🤖 Generated with [Claude Code](https://claude.com/claude-code)