### PR TITLE
Add nucleoatac run module

### DIFF
--- a/modules/nf-core/nucleoatac/run/environment.yml
+++ b/modules/nf-core/nucleoatac/run/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::nucleoatac=1.0.0"

--- a/modules/nf-core/nucleoatac/run/main.nf
+++ b/modules/nf-core/nucleoatac/run/main.nf
@@ -1,0 +1,77 @@
+process NUCLEOATAC_RUN {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/nucleoatac:1.0.0--py310h3479294_0':
+        'quay.io/biocontainers/nucleoatac:1.0.0--py310h3479294_0' }"
+
+    input:
+    tuple val(meta), path(bam), path(bai), path(bed), path(fasta), path(fai)
+
+    output:
+    tuple val(meta), path("*.nucpos.bed*")                       , emit: nucpos, optional: true
+    tuple val(meta), path("*.nucpos.redundant.bed*")             , emit: nucpos_redundant, optional: true
+    tuple val(meta), path("*.nfrpos.bed*")                       , emit: nfrpos, optional: true
+    tuple val(meta), path("*.nucmap_combined.bed*")              , emit: nucmap_combined, optional: true
+    tuple val(meta), path("*.occpeaks.bed*")                     , emit: occpeaks, optional: true
+    tuple val(meta), path("*.occ.bedgraph*")                     , emit: occupancy, optional: true
+    tuple val(meta), path("*.occ.lower_bound.bedgraph*")         , emit: occupancy_lower_bound, optional: true
+    tuple val(meta), path("*.occ.upper_bound.bedgraph*")         , emit: occupancy_upper_bound, optional: true
+    tuple val(meta), path("*.nucleoatac_signal.bedgraph*")       , emit: signal, optional: true
+    tuple val(meta), path("*.nucleoatac_signal.smooth.bedgraph*"), emit: signal_smooth, optional: true
+    tuple val(meta), path("*.fragmentsizes.txt")                 , emit: fragment_sizes, optional: true
+    tuple val(meta), path("*.nuc_dist.txt")                      , emit: nuc_dist, optional: true
+    tuple val(meta), path("*.VMat")                              , emit: vmat, optional: true
+    tuple val(meta), path("*.eps")                               , emit: plots, optional: true
+    tuple val("${task.process}"), val('nucleoatac'), eval('nucleoatac --version | sed "s/^nucleoatac //"'), topic: versions, emit: versions_nucleoatac
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args_line = args ? " \\\n        ${args}" : ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    ln -s $bam ${prefix}.bam
+    if [[ "$bai" == *.csi ]]; then
+        ln -s $bai ${prefix}.bam.csi
+    else
+        ln -s $bai ${prefix}.bam.bai
+    fi
+
+    nucleoatac run \\
+        --bed $bed \\
+        --bam ${prefix}.bam \\
+        --fasta $fasta \\
+        --out ${prefix} \\
+        --cores ${task.cpus}${args_line}
+
+    for file in ${prefix}*.bed ${prefix}*.bedgraph; do
+        if [[ -f "\$file" ]]; then
+            gzip -f "\$file"
+        fi
+    done
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.nucpos.bed.gz
+    echo "" | gzip > ${prefix}.nucpos.redundant.bed.gz
+    echo "" | gzip > ${prefix}.nfrpos.bed.gz
+    echo "" | gzip > ${prefix}.nucmap_combined.bed.gz
+    echo "" | gzip > ${prefix}.occpeaks.bed.gz
+    echo "" | gzip > ${prefix}.occ.bedgraph.gz
+    echo "" | gzip > ${prefix}.occ.lower_bound.bedgraph.gz
+    echo "" | gzip > ${prefix}.occ.upper_bound.bedgraph.gz
+    echo "" | gzip > ${prefix}.nucleoatac_signal.bedgraph.gz
+    echo "" | gzip > ${prefix}.nucleoatac_signal.smooth.bedgraph.gz
+    printf "insert_size\\tcount\\n150\\t1\\n" > ${prefix}.fragmentsizes.txt
+    printf "insert_size\\tdensity\\n150\\t1\\n" > ${prefix}.nuc_dist.txt
+    printf "position\\tsignal\\n0\\t0\\n" > ${prefix}.VMat
+    touch ${prefix}.nuc_dist.eps ${prefix}.occ_fit.eps
+    """
+}

--- a/modules/nf-core/nucleoatac/run/meta.yml
+++ b/modules/nf-core/nucleoatac/run/meta.yml
@@ -1,0 +1,241 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "nucleoatac_run"
+description: Call nucleosome positions and occupancy from paired-end ATAC-seq data
+keywords:
+  - atac-seq
+  - nucleosome
+  - occupancy
+  - positioning
+tools:
+  - nucleoatac:
+      description: "Python package for calling nucleosomes using ATAC-seq data"
+      homepage: "https://github.com/GreenleafLab/NucleoATAC"
+      documentation: "https://nucleoatac.readthedocs.io/en/latest/"
+      tool_dev_url: "https://github.com/GreenleafLab/NucleoATAC"
+      doi: "10.1101/gr.192294.115"
+      licence: ["MIT"]
+      identifier: "biotools:nucleoatac"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - bam:
+        type: file
+        description: Coordinate-sorted BAM file
+        pattern: "*.bam"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572"
+    - bai:
+        type: file
+        description: BAM index file
+        pattern: "*.{bai,csi}"
+        ontologies: []
+    - bed:
+        type: file
+        description: Sorted non-overlapping BED file with regions for nucleosome analysis
+        pattern: "*.bed"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - fasta:
+        type: file
+        description: Reference genome FASTA used for alignment
+        pattern: "*.{fa,fasta}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929"
+    - fai:
+        type: file
+        description: FASTA index file
+        pattern: "*.fai"
+        ontologies: []
+output:
+  nucpos:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.nucpos.bed*":
+          type: file
+          description: Nucleosome dyad calls
+          pattern: "*.nucpos.bed*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003"
+  nucpos_redundant:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.nucpos.redundant.bed*":
+          type: file
+          description: Redundant nucleosome dyad calls
+          pattern: "*.nucpos.redundant.bed*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003"
+  nfrpos:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.nfrpos.bed*":
+          type: file
+          description: Nucleosome-free region positions
+          pattern: "*.nfrpos.bed*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003"
+  nucmap_combined:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.nucmap_combined.bed*":
+          type: file
+          description: Combined low- and high-resolution nucleosome calls
+          pattern: "*.nucmap_combined.bed*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003"
+  occpeaks:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.occpeaks.bed*":
+          type: file
+          description: Low-resolution nucleosome occupancy peaks
+          pattern: "*.occpeaks.bed*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3003"
+  occupancy:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.occ.bedgraph*":
+          type: file
+          description: Nucleosome occupancy score bedGraph
+          pattern: "*.occ.bedgraph*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3583"
+  occupancy_lower_bound:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.occ.lower_bound.bedgraph*":
+          type: file
+          description: Lower-bound nucleosome occupancy score bedGraph
+          pattern: "*.occ.lower_bound.bedgraph*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3583"
+  occupancy_upper_bound:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.occ.upper_bound.bedgraph*":
+          type: file
+          description: Upper-bound nucleosome occupancy score bedGraph
+          pattern: "*.occ.upper_bound.bedgraph*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3583"
+  signal:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.nucleoatac_signal.bedgraph*":
+          type: file
+          description: Normalized NucleoATAC cross-correlation signal bedGraph
+          pattern: "*.nucleoatac_signal.bedgraph*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3583"
+  signal_smooth:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.nucleoatac_signal.smooth.bedgraph*":
+          type: file
+          description: Smoothed normalized NucleoATAC signal bedGraph
+          pattern: "*.nucleoatac_signal.smooth.bedgraph*"
+          ontologies:
+            - edam: "http://edamontology.org/format_3583"
+  fragment_sizes:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.fragmentsizes.txt":
+          type: file
+          description: Fragment size distribution in the input regions
+          pattern: "*.fragmentsizes.txt"
+          ontologies: []
+  nuc_dist:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.nuc_dist.txt":
+          type: file
+          description: Estimated nucleosomal fragment size distribution
+          pattern: "*.nuc_dist.txt"
+          ontologies: []
+  vmat:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.VMat":
+          type: file
+          description: Normalized V-plot matrix for cross-correlation
+          pattern: "*.VMat"
+          ontologies: []
+  plots:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.eps":
+          type: file
+          description: EPS diagnostic plots
+          pattern: "*.eps"
+          ontologies: []
+  versions_nucleoatac:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - nucleoatac:
+          type: string
+          description: The name of the tool
+      - nucleoatac --version | sed "s/^nucleoatac //":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - nucleoatac:
+          type: string
+          description: The name of the tool
+      - nucleoatac --version | sed "s/^nucleoatac //":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@PFRoux"
+maintainers:
+  - "@PFRoux"

--- a/modules/nf-core/nucleoatac/run/tests/main.nf.test
+++ b/modules/nf-core/nucleoatac/run/tests/main.nf.test
@@ -1,0 +1,44 @@
+nextflow_process {
+
+    name "Test Process NUCLEOATAC_RUN"
+    script "../main.nf"
+    process "NUCLEOATAC_RUN"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "nucleoatac"
+    tag "nucleoatac/run"
+
+    test("sarscov2 - bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    file('https://raw.githubusercontent.com/luisas/test-datasets/refs/heads/add-bedgraph-subset-illumina/data/genomics/sarscov2/illumina/bed/test.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.fai', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert process.out.nucpos },
+                { assert process.out.nfrpos },
+                { assert process.out.occupancy },
+                { assert process.out.signal },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/nucleoatac/run/tests/main.nf.test.snap
+++ b/modules/nf-core/nucleoatac/run/tests/main.nf.test.snap
@@ -1,0 +1,285 @@
+{
+    "sarscov2 - bam - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucpos.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucpos.redundant.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "10": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fragmentsizes.txt:md5,4b147241a9c7198eaf687cda3b067d8c"
+                    ]
+                ],
+                "11": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nuc_dist.txt:md5,ed0fd4816bb91ec839e291ff3341b799"
+                    ]
+                ],
+                "12": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.VMat:md5,f675e20dabac92c117f39ea78b03382b"
+                    ]
+                ],
+                "13": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.nuc_dist.eps:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.occ_fit.eps:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "14": [
+                    [
+                        "NUCLEOATAC_RUN",
+                        "nucleoatac",
+                        "1.0.0"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nfrpos.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucmap_combined.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.occpeaks.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "5": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.occ.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "6": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.occ.lower_bound.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "7": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.occ.upper_bound.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucleoatac_signal.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "9": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucleoatac_signal.smooth.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "fragment_sizes": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.fragmentsizes.txt:md5,4b147241a9c7198eaf687cda3b067d8c"
+                    ]
+                ],
+                "nfrpos": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nfrpos.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "nuc_dist": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nuc_dist.txt:md5,ed0fd4816bb91ec839e291ff3341b799"
+                    ]
+                ],
+                "nucmap_combined": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucmap_combined.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "nucpos": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucpos.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "nucpos_redundant": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucpos.redundant.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "occpeaks": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.occpeaks.bed.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "occupancy": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.occ.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "occupancy_lower_bound": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.occ.lower_bound.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "occupancy_upper_bound": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.occ.upper_bound.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "plots": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.nuc_dist.eps:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.occ_fit.eps:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "signal": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucleoatac_signal.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "signal_smooth": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.nucleoatac_signal.smooth.bedgraph.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_nucleoatac": [
+                    [
+                        "NUCLEOATAC_RUN",
+                        "nucleoatac",
+                        "1.0.0"
+                    ]
+                ],
+                "vmat": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.VMat:md5,f675e20dabac92c117f39ea78b03382b"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-10T14:14:40.843717",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    }
+}


### PR DESCRIPTION
## PR checklist

Closes issue number #12914 

This PR adds a new `nucleoatac/run` module.

NucleoATAC calls nucleosome positions, nucleosome-free regions and occupancy tracks from paired-end ATAC-seq data.

Local checks:
- [x] `nf-core modules lint nucleoatac/run --plain-text`
- [x] `nf-test test --tag nucleoatac/run --profile docker --update-snapshot`

Lint result:
- 52 tests passed
- 0 warnings
- 0 failures

Notes:
- Uses `bioconda::nucleoatac=1.0.0`
- Uses `quay.io/biocontainers/nucleoatac:1.0.0--py310h3479294_0`