### PR TITLE
Add telomerehunter2 module

### DIFF
--- a/modules/nf-core/telomerehunter2/environment.yml
+++ b/modules/nf-core/telomerehunter2/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::telomerehunter2=1.0.11"

--- a/modules/nf-core/telomerehunter2/main.nf
+++ b/modules/nf-core/telomerehunter2/main.nf
@@ -1,0 +1,65 @@
+process TELOMEREHUNTER2 {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/telomerehunter2:1.0.11--pyhdfd78af_0':
+        'quay.io/biocontainers/telomerehunter2:1.0.11--pyhdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(bam), path(bai), path(banding_file)
+
+    output:
+    tuple val(meta), path("*.telomerehunter2_summary.tsv")        , emit: summary, optional: true
+    tuple val(meta), path("*.telomerehunter2_TVR_top_contexts.tsv"), emit: tvr_top_contexts, optional: true
+    tuple val(meta), path("*.telomerehunter2_singletons.tsv")     , emit: singletons, optional: true
+    tuple val(meta), path("*.telomerehunter2_files.txt")          , emit: file_index
+    tuple val(meta), path("*.telomerehunter2")                    , emit: outdir
+    tuple val("${task.process}"), val('telomerehunter2'), eval("python -c 'import importlib.metadata; print(importlib.metadata.version(\"telomerehunter2\"))'"), topic: versions, emit: versions_telomerehunter2
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def banding = banding_file ? "-b $banding_file" : ''
+    """
+    ln -s $bam ${prefix}.bam
+    if [[ "$bai" == *.csi ]]; then
+        ln -s $bai ${prefix}.bam.csi
+    else
+        ln -s $bai ${prefix}.bam.bai
+    fi
+
+    telomerehunter2 \\
+        -ibt ${prefix}.bam \\
+        -o ${prefix}.telomerehunter2 \\
+        -p ${prefix} \\
+        -c ${task.cpus} \\
+        $banding \\
+        $args
+
+    find ${prefix}.telomerehunter2 -type f | sort > ${prefix}.telomerehunter2_files.txt
+    find ${prefix}.telomerehunter2 -name '*summary.tsv' -exec cp {} ${prefix}.telomerehunter2_summary.tsv \\; -quit
+    find ${prefix}.telomerehunter2 -name '*TVR_top_contexts.tsv' -exec cp {} ${prefix}.telomerehunter2_TVR_top_contexts.tsv \\; -quit
+    find ${prefix}.telomerehunter2 -name '*singletons.tsv' -exec cp {} ${prefix}.telomerehunter2_singletons.tsv \\; -quit
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p ${prefix}.telomerehunter2/plots
+    echo "PID	sample	tel_content	total_reads	intratelomeric_reads" > ${prefix}.telomerehunter2/summary.tsv
+    echo "${prefix}	tumor	0	0	0" >> ${prefix}.telomerehunter2/summary.tsv
+    echo "repeat	count" > ${prefix}.telomerehunter2/TVR_top_contexts.tsv
+    echo "TTAGGG	0" >> ${prefix}.telomerehunter2/TVR_top_contexts.tsv
+    echo "repeat	count" > ${prefix}.telomerehunter2/singletons.tsv
+    echo "TTAGGG	0" >> ${prefix}.telomerehunter2/singletons.tsv
+    find ${prefix}.telomerehunter2 -type f | sort > ${prefix}.telomerehunter2_files.txt
+    cp ${prefix}.telomerehunter2/summary.tsv ${prefix}.telomerehunter2_summary.tsv
+    cp ${prefix}.telomerehunter2/TVR_top_contexts.tsv ${prefix}.telomerehunter2_TVR_top_contexts.tsv
+    cp ${prefix}.telomerehunter2/singletons.tsv ${prefix}.telomerehunter2_singletons.tsv
+    """
+}

--- a/modules/nf-core/telomerehunter2/meta.yml
+++ b/modules/nf-core/telomerehunter2/meta.yml
@@ -1,0 +1,121 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "telomerehunter2"
+description: Estimate telomere content and telomeric variant repeats from aligned sequencing data
+keywords:
+  - telomere
+  - repeats
+  - bam
+  - cram
+  - single-cell
+tools:
+  - telomerehunter2:
+      description: "Python 3 implementation of TelomereHunter for telomere content and telomeric variant repeat analysis"
+      homepage: "https://ferdinand-popp.github.io/telomerehunter2/"
+      documentation: "https://ferdinand-popp.github.io/telomerehunter2/"
+      tool_dev_url: "https://github.com/ferdinand-popp/telomerehunter2"
+      doi: "10.1093/bioadv/vbag187"
+      licence: ["GPL-3.0-or-later"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - bam:
+        type: file
+        description: Coordinate-sorted BAM file
+        pattern: "*.bam"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572"
+    - bai:
+        type: file
+        description: BAM index file
+        pattern: "*.{bai,csi}"
+        ontologies: []
+    - banding_file:
+        type: file
+        description: Optional chromosome banding file or empty list
+        pattern: "*"
+        ontologies: []
+output:
+  summary:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.telomerehunter2_summary.tsv":
+          type: file
+          description: TelomereHunter2 summary table
+          pattern: "*.telomerehunter2_summary.tsv"
+          ontologies: []
+  tvr_top_contexts:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.telomerehunter2_TVR_top_contexts.tsv":
+          type: file
+          description: Telomeric variant repeat top contexts table
+          pattern: "*.telomerehunter2_TVR_top_contexts.tsv"
+          ontologies: []
+  singletons:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.telomerehunter2_singletons.tsv":
+          type: file
+          description: Telomeric variant repeat singleton table
+          pattern: "*.telomerehunter2_singletons.tsv"
+          ontologies: []
+  file_index:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.telomerehunter2_files.txt":
+          type: file
+          description: Index of files generated in the TelomereHunter2 output directory
+          pattern: "*.telomerehunter2_files.txt"
+          ontologies: []
+  outdir:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.telomerehunter2":
+          type: directory
+          description: Complete TelomereHunter2 output directory
+          pattern: "*.telomerehunter2"
+          ontologies: []
+  versions_telomerehunter2:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - telomerehunter2:
+          type: string
+          description: The name of the tool
+      - python -c 'import importlib.metadata; print(importlib.metadata.version("telomerehunter2"))':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - telomerehunter2:
+          type: string
+          description: The name of the tool
+      - python -c 'import importlib.metadata; print(importlib.metadata.version("telomerehunter2"))':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@PFRoux"
+maintainers:
+  - "@PFRoux"

--- a/modules/nf-core/telomerehunter2/tests/main.nf.test
+++ b/modules/nf-core/telomerehunter2/tests/main.nf.test
@@ -1,0 +1,40 @@
+nextflow_process {
+
+    name "Test Process TELOMEREHUNTER2"
+    script "../main.nf"
+    process "TELOMEREHUNTER2"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "telomerehunter2"
+
+    test("sarscov2 - bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    [],
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert process.out.summary },
+                { assert process.out.file_index },
+                { assert process.out.outdir },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/telomerehunter2/tests/main.nf.test.snap
+++ b/modules/nf-core/telomerehunter2/tests/main.nf.test.snap
@@ -1,0 +1,131 @@
+{
+    "sarscov2 - bam - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.telomerehunter2_summary.tsv:md5,3d011b935e50aeb0be8457dd81e05a37"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.telomerehunter2_TVR_top_contexts.tsv:md5,eba3bf37e006f8597ecf10a717000c45"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.telomerehunter2_singletons.tsv:md5,eba3bf37e006f8597ecf10a717000c45"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.telomerehunter2_files.txt:md5,b7862284bc45b96263284bbb1bdf3a62"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "TVR_top_contexts.tsv:md5,eba3bf37e006f8597ecf10a717000c45",
+                            [
+                                
+                            ],
+                            "singletons.tsv:md5,eba3bf37e006f8597ecf10a717000c45",
+                            "summary.tsv:md5,3d011b935e50aeb0be8457dd81e05a37"
+                        ]
+                    ]
+                ],
+                "5": [
+                    [
+                        "TELOMEREHUNTER2",
+                        "telomerehunter2",
+                        "1.0.11"
+                    ]
+                ],
+                "file_index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.telomerehunter2_files.txt:md5,b7862284bc45b96263284bbb1bdf3a62"
+                    ]
+                ],
+                "outdir": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "TVR_top_contexts.tsv:md5,eba3bf37e006f8597ecf10a717000c45",
+                            [
+                                
+                            ],
+                            "singletons.tsv:md5,eba3bf37e006f8597ecf10a717000c45",
+                            "summary.tsv:md5,3d011b935e50aeb0be8457dd81e05a37"
+                        ]
+                    ]
+                ],
+                "singletons": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.telomerehunter2_singletons.tsv:md5,eba3bf37e006f8597ecf10a717000c45"
+                    ]
+                ],
+                "summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.telomerehunter2_summary.tsv:md5,3d011b935e50aeb0be8457dd81e05a37"
+                    ]
+                ],
+                "tvr_top_contexts": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.telomerehunter2_TVR_top_contexts.tsv:md5,eba3bf37e006f8597ecf10a717000c45"
+                    ]
+                ],
+                "versions_telomerehunter2": [
+                    [
+                        "TELOMEREHUNTER2",
+                        "telomerehunter2",
+                        "1.0.11"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-10T14:42:17.037613",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    }
+}


### PR DESCRIPTION
## PR checklist

Closes issue number #12916 

This PR adds a new `telomerehunter2` module.

TelomereHunter2 estimates telomere content and telomeric variant repeats from indexed BAM/CRAM sequencing data. It is a Python 3 implementation and extension of the original TelomereHunter workflow.

The module takes a coordinate-sorted BAM file, BAM index and optional chromosome banding file, then emits:

- TelomereHunter2 summary table
- telomeric variant repeat top-context table
- singleton repeat table
- full TelomereHunter2 output directory
- output file index
- version information

Software requirements:

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json

channels:
  - conda-forge
  - bioconda

dependencies:
  - bioconda::telomerehunter2=1.0.11