### PR TITLE
New module: tobias/atacorrect

### DIFF
--- a/modules/nf-core/tobias/atacorrect/environment.yml
+++ b/modules/nf-core/tobias/atacorrect/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::tobias=0.17.5"

--- a/modules/nf-core/tobias/atacorrect/main.nf
+++ b/modules/nf-core/tobias/atacorrect/main.nf
@@ -1,0 +1,57 @@
+process TOBIAS_ATACORRECT {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/tobias:0.17.5--py310h3479294_0':
+        'quay.io/biocontainers/tobias:0.17.5--py310h3479294_0' }"
+
+    input:
+    tuple val(meta), path(bam), path(bai), path(peaks), path(fasta)
+
+    output:
+    tuple val(meta), path("*_corrected.bw")  , emit: corrected
+    tuple val(meta), path("*_expected.bw")   , emit: expected
+    tuple val(meta), path("*_uncorrected.bw"), emit: uncorrected, optional: true
+    tuple val(meta), path("*_bias.bw")       , emit: bias, optional: true
+    tuple val(meta), path("*_atacorrect.pdf"), emit: report, optional: true
+    tuple val("${task.process}"), val('tobias'), eval('TOBIAS --version'), topic: versions, emit: versions_tobias
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p .matplotlib
+    export MPLCONFIGDIR="\${PWD}/.matplotlib"
+
+    ln -s $bam ${prefix}.bam
+    if [[ "$bai" == *.csi ]]; then
+        ln -s $bai ${prefix}.bam.csi
+    else
+        ln -s $bai ${prefix}.bam.bai
+    fi
+
+    TOBIAS ATACorrect \\
+        --bam ${prefix}.bam \\
+        --genome $fasta \\
+        --peaks $peaks \\
+        --prefix $prefix \\
+        --outdir . \\
+        --cores ${task.cpus} \\
+        $args
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_corrected.bw
+    touch ${prefix}_expected.bw
+    touch ${prefix}_uncorrected.bw
+    touch ${prefix}_bias.bw
+    touch ${prefix}_atacorrect.pdf
+    """
+}

--- a/modules/nf-core/tobias/atacorrect/meta.yml
+++ b/modules/nf-core/tobias/atacorrect/meta.yml
@@ -1,0 +1,132 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "tobias_atacorrect"
+description: Correct ATAC-seq signal for Tn5 sequence bias with TOBIAS ATACorrect
+keywords:
+  - ATAC-seq
+  - footprinting
+  - Tn5
+  - bigWig
+tools:
+  - tobias:
+      description: "Transcription factor Occupancy prediction By Investigation of ATAC-seq Signal"
+      homepage: "https://github.com/loosolab/TOBIAS"
+      documentation: "https://github.com/loosolab/TOBIAS/wiki"
+      tool_dev_url: "https://github.com/loosolab/TOBIAS"
+      doi: "10.1038/s41467-020-18035-1"
+      licence: ["MIT"]
+      identifier: "biotools:tobias"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - bam:
+        type: file
+        description: Coordinate-sorted BAM file
+        pattern: "*.bam"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572"
+    - bai:
+        type: file
+        description: BAM index file
+        pattern: "*.{bai,csi}"
+        ontologies: []
+    - peaks:
+        type: file
+        description: BED file containing ATAC-seq peaks for bias correction
+        pattern: "*.bed"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - fasta:
+        type: file
+        description: Reference genome FASTA file
+        pattern: "*.{fa,fasta,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929"
+output:
+  corrected:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_corrected.bw":
+          type: file
+          description: Tn5 bias-corrected ATAC-seq signal track
+          pattern: "*_corrected.bw"
+          ontologies:
+            - edam: "http://edamontology.org/format_3006"
+  expected:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_expected.bw":
+          type: file
+          description: Expected ATAC-seq signal track estimated from Tn5 bias
+          pattern: "*_expected.bw"
+          ontologies:
+            - edam: "http://edamontology.org/format_3006"
+  uncorrected:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_uncorrected.bw":
+          type: file
+          description: Uncorrected ATAC-seq signal track
+          pattern: "*_uncorrected.bw"
+          ontologies:
+            - edam: "http://edamontology.org/format_3006"
+  bias:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_bias.bw":
+          type: file
+          description: Tn5 sequence-bias signal track
+          pattern: "*_bias.bw"
+          ontologies:
+            - edam: "http://edamontology.org/format_3006"
+  report:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_atacorrect.pdf":
+          type: file
+          description: TOBIAS ATACorrect diagnostic PDF
+          pattern: "*_atacorrect.pdf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3508"
+  versions_tobias:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - tobias:
+          type: string
+          description: The name of the tool
+      - TOBIAS --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - tobias:
+          type: string
+          description: The name of the tool
+      - TOBIAS --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@PFRoux"
+maintainers:
+  - "@PFRoux"

--- a/modules/nf-core/tobias/atacorrect/tests/main.nf.test
+++ b/modules/nf-core/tobias/atacorrect/tests/main.nf.test
@@ -1,0 +1,41 @@
+nextflow_process {
+
+    name "Test Process TOBIAS_ATACORRECT"
+    script "../main.nf"
+    process "TOBIAS_ATACORRECT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "tobias"
+    tag "tobias/atacorrect"
+
+    test("sarscov2 - bam - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true),
+                    file('https://raw.githubusercontent.com/luisas/test-datasets/refs/heads/add-bedgraph-subset-illumina/data/genomics/sarscov2/illumina/bed/test.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert process.out.corrected },
+                { assert process.out.expected },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/tobias/atacorrect/tests/main.nf.test.snap
+++ b/modules/nf-core/tobias/atacorrect/tests/main.nf.test.snap
@@ -1,0 +1,117 @@
+{
+    "sarscov2 - bam - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_corrected.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_expected.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_uncorrected.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_bias.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_atacorrect.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        "TOBIAS_ATACORRECT",
+                        "tobias",
+                        "0.17.5"
+                    ]
+                ],
+                "bias": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_bias.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "corrected": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_corrected.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "expected": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_expected.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "report": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_atacorrect.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "uncorrected": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_uncorrected.bw:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_tobias": [
+                    [
+                        "TOBIAS_ATACORRECT",
+                        "tobias",
+                        "0.17.5"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-10T19:06:47.871358",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    }
+}


### PR DESCRIPTION
## PR checklist

Closes #12920

## Design

ATACorrect is intentionally submitted as a separate component from TOBIAS ScoreBigwig and BINDetect. Each command exposes reusable on-disk outputs and they will be combined in a downstream TOBIAS footprinting subworkflow.

## Local validation

- nf-test Docker stub test: passed.
- nf-core modules lint tobias/atacorrect: 51 checks passed; no warnings or failures.
- The Biocontainers image quay.io/biocontainers/tobias:0.17.5--py310h3479294_0 was verified locally.

Conda and Singularity test profiles are left to the automated CI matrix.