### PR TITLE
New module: tobias/bindetect

### DIFF
--- a/modules/nf-core/tobias/bindetect/environment.yml
+++ b/modules/nf-core/tobias/bindetect/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::tobias=0.17.5"

--- a/modules/nf-core/tobias/bindetect/main.nf
+++ b/modules/nf-core/tobias/bindetect/main.nf
@@ -1,0 +1,53 @@
+process TOBIAS_BINDETECT {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/tobias:0.17.5--py310h3479294_0':
+        'quay.io/biocontainers/tobias:0.17.5--py310h3479294_0' }"
+
+    input:
+    tuple val(meta), path(signals), path(peaks), path(motifs), path(fasta)
+
+    output:
+    tuple val(meta), path("bindetect")                , emit: outdir
+    tuple val(meta), path("bindetect/*_results.txt")  , emit: results, optional: true
+    tuple val(meta), path("bindetect/*_results.xlsx") , emit: results_xlsx, optional: true
+    tuple val(meta), path("bindetect/*_distances.txt"), emit: distances, optional: true
+    tuple val(meta), path("bindetect/*_figures.pdf")  , emit: figures, optional: true
+    tuple val("${task.process}"), val('tobias'), eval('TOBIAS --version'), topic: versions, emit: versions_tobias
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p .matplotlib
+    export MPLCONFIGDIR="\${PWD}/.matplotlib"
+
+    TOBIAS BINDetect \\
+        --signals $signals \\
+        --motifs $motifs \\
+        --genome $fasta \\
+        --peaks $peaks \\
+        --outdir bindetect \\
+        --prefix $prefix \\
+        --cores ${task.cpus} \\
+        $args
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p bindetect/TF1/beds
+    touch bindetect/${prefix}_results.txt
+    touch bindetect/${prefix}_results.xlsx
+    touch bindetect/${prefix}_distances.txt
+    touch bindetect/${prefix}_figures.pdf
+    touch bindetect/TF1/TF1_overview.txt
+    touch bindetect/TF1/beds/TF1_all.bed
+    """
+}

--- a/modules/nf-core/tobias/bindetect/meta.yml
+++ b/modules/nf-core/tobias/bindetect/meta.yml
@@ -1,0 +1,128 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "tobias_bindetect"
+description: Estimate transcription factor binding and differential binding from ATAC-seq footprint BigWig tracks with TOBIAS BINDetect
+keywords:
+  - ATAC-seq
+  - footprinting
+  - transcription factors
+  - differential binding
+tools:
+  - tobias:
+      description: "Transcription factor Occupancy prediction By Investigation of ATAC-seq Signal"
+      homepage: "https://github.com/loosolab/TOBIAS"
+      documentation: "https://github.com/loosolab/TOBIAS/wiki"
+      tool_dev_url: "https://github.com/loosolab/TOBIAS"
+      doi: "10.1038/s41467-020-18035-1"
+      licence: ["MIT"]
+      identifier: "biotools:tobias"
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing analysis information
+          e.g. `[ id:'all_samples' ]`
+    - signals:
+        type: file
+        description: One or more BigWig tracks containing TOBIAS footprint scores, one per condition or sample
+        pattern: "*.bw"
+        ontologies:
+          - edam: "http://edamontology.org/format_3006"
+    - peaks:
+        type: file
+        description: BED file containing the consensus open-chromatin regions
+        pattern: "*.bed"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003"
+    - motifs:
+        type: file
+        description: One or more transcription factor motif files in supported TOBIAS formats
+        pattern: "*"
+        ontologies: []
+    - fasta:
+        type: file
+        description: Reference genome FASTA file
+        pattern: "*.{fa,fasta,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929"
+output:
+  outdir:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing analysis information
+            e.g. `[ id:'all_samples' ]`
+      - "bindetect":
+          type: directory
+          description: Complete TOBIAS BINDetect output directory, including motif-specific results
+          pattern: "bindetect"
+          ontologies: []
+  results:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing analysis information
+            e.g. `[ id:'all_samples' ]`
+      - "bindetect/*_results.txt":
+          type: file
+          description: Tab-delimited global transcription factor binding results
+          pattern: "*_results.txt"
+          ontologies: []
+  results_xlsx:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing analysis information
+            e.g. `[ id:'all_samples' ]`
+      - "bindetect/*_results.xlsx":
+          type: file
+          description: Excel global transcription factor binding results
+          pattern: "*_results.xlsx"
+          ontologies: []
+  distances:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing analysis information
+            e.g. `[ id:'all_samples' ]`
+      - "bindetect/*_distances.txt":
+          type: file
+          description: Transcription factor motif-distance summary table
+          pattern: "*_distances.txt"
+          ontologies: []
+  figures:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing analysis information
+            e.g. `[ id:'all_samples' ]`
+      - "bindetect/*_figures.pdf":
+          type: file
+          description: TOBIAS BINDetect summary figure PDF
+          pattern: "*_figures.pdf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3508"
+  versions_tobias:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - tobias:
+          type: string
+          description: The name of the tool
+      - TOBIAS --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - tobias:
+          type: string
+          description: The name of the tool
+      - TOBIAS --version:
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@PFRoux"
+maintainers:
+  - "@PFRoux"

--- a/modules/nf-core/tobias/bindetect/tests/main.nf.test
+++ b/modules/nf-core/tobias/bindetect/tests/main.nf.test
@@ -1,0 +1,41 @@
+nextflow_process {
+
+    name "Test Process TOBIAS_BINDETECT"
+    script "../main.nf"
+    process "TOBIAS_BINDETECT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "tobias"
+    tag "tobias/bindetect"
+
+    test("sarscov2 - footprints - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'all_samples' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file('https://raw.githubusercontent.com/luisas/test-datasets/refs/heads/add-bedgraph-subset-illumina/data/genomics/sarscov2/illumina/bed/test.bed', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome_motifs.txt', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert process.out.outdir },
+                { assert process.out.results },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/tobias/bindetect/tests/main.nf.test.snap
+++ b/modules/nf-core/tobias/bindetect/tests/main.nf.test.snap
@@ -1,0 +1,129 @@
+{
+    "sarscov2 - footprints - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        [
+                            [
+                                "TF1_overview.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                                [
+                                    "TF1_all.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                                ]
+                            ],
+                            "all_samples_distances.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "all_samples_figures.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "all_samples_results.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "all_samples_results.xlsx:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        "all_samples_results.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        "all_samples_results.xlsx:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        "all_samples_distances.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        "all_samples_figures.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "5": [
+                    [
+                        "TOBIAS_BINDETECT",
+                        "tobias",
+                        "0.17.5"
+                    ]
+                ],
+                "distances": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        "all_samples_distances.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "figures": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        "all_samples_figures.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "outdir": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        [
+                            [
+                                "TF1_overview.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                                [
+                                    "TF1_all.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                                ]
+                            ],
+                            "all_samples_distances.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "all_samples_figures.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "all_samples_results.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "all_samples_results.xlsx:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "results": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        "all_samples_results.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "results_xlsx": [
+                    [
+                        {
+                            "id": "all_samples"
+                        },
+                        "all_samples_results.xlsx:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_tobias": [
+                    [
+                        "TOBIAS_BINDETECT",
+                        "tobias",
+                        "0.17.5"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-10T19:21:22.409255",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    }
+}


### PR DESCRIPTION
## PR checklist

Closes #12924


## Design

BINDetect is intentionally separate from TOBIAS ATACorrect and ScoreBigwig. It accepts one or more footprint score BigWigs and emits reusable global and motif-specific transcription factor binding results. The three commands can be composed in a TOBIAS footprinting subworkflow.

## Local validation

- nf-test Docker stub test: passed.
- nf-core modules lint tobias/bindetect: 51 checks passed; no warnings or failures.
- The Biocontainers image quay.io/biocontainers/tobias:0.17.5--py310h3479294_0 was verified locally.

Conda and Singularity test profiles are left to the automated CI matrix.